### PR TITLE
refactor: moved generic errors to generic errors file  #19

### DIFF
--- a/src/Errors/GenericErrors.sol
+++ b/src/Errors/GenericErrors.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.13;
 
-error InvalidAmount();
 error TokenAddressIsZero();
 error CannotBridgeToSameNetwork();
 error ZeroPostSwapBalance();
-error InvalidBridgeConfigLength();
 error NoSwapDataProvided();
 error NativeValueWithERC();
 error ContractCallNotAllowed();
@@ -13,11 +11,18 @@ error NullAddrIsNotAValidSpender();
 error NullAddrIsNotAnERC20Token();
 error NoTransferToNullAddress();
 error NativeAssetTransferFailed();
+error InvalidBridgeConfigLength();
+error InvalidAmount();
 error InvalidContract();
 error InvalidConfig();
 error InvalidReceiver();
+error InvalidDestinationChain();
+error InvalidSendingToken();
+error InvalidCaller();
 error OnlyContractOwner();
 error CannotAuthoriseSelf();
 error RecoveryAddressCannotBeZero();
 error CannotDepositNativeToken();
 error ZeroAmount();
+error UnAuthorized();
+error NoSwapFromZeroBalance();

--- a/src/Facets/AcrossFacet.sol
+++ b/src/Facets/AcrossFacet.sol
@@ -27,10 +27,6 @@ contract AcrossFacet is ILiFi, ReentrancyGuard, SwapperV2 {
         uint32 quoteTimestamp;
     }
 
-    /// Errors ///
-
-    error UseWethInstead();
-
     /// External Methods ///
 
     /// @notice Bridges tokens via Across

--- a/src/Facets/ArbitrumBridgeFacet.sol
+++ b/src/Facets/ArbitrumBridgeFacet.sol
@@ -5,7 +5,7 @@ import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { IGatewayRouter } from "../Interfaces/IGatewayRouter.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidReceiver } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title Arbitrum Bridge Facet
@@ -24,10 +24,6 @@ contract ArbitrumBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         uint256 maxGas;
         uint256 maxGasPrice;
     }
-
-    /// Errors ///
-
-    error InvalidReceiver();
 
     /// External Methods ///
 

--- a/src/Facets/GnosisBridgeFacet.sol
+++ b/src/Facets/GnosisBridgeFacet.sol
@@ -5,7 +5,7 @@ import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { IXDaiBridge } from "../Interfaces/IXDaiBridge.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidSendingToken, InvalidDestinationChain } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title Gnosis Bridge Facet
@@ -25,11 +25,6 @@ contract GnosisBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         uint256 amount;
     }
 
-    /// Errors ///
-
-    error InvalidDstChainId();
-    error InvalidSendingToken();
-
     /// External Methods ///
 
     /// @notice Bridges tokens via XDaiBridge
@@ -41,7 +36,7 @@ contract GnosisBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         nonReentrant
     {
         if (lifiData.destinationChainId != GNOSIS_CHAIN_ID) {
-            revert InvalidDstChainId();
+            revert InvalidDestinationChain();
         }
         if (lifiData.sendingAssetId != DAI) {
             revert InvalidSendingToken();
@@ -80,7 +75,7 @@ contract GnosisBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         GnosisBridgeData memory gnosisBridgeData
     ) external payable nonReentrant {
         if (lifiData.destinationChainId != GNOSIS_CHAIN_ID) {
-            revert InvalidDstChainId();
+            revert InvalidDestinationChain();
         }
         if (lifiData.sendingAssetId != DAI || swapData[swapData.length - 1].receivingAssetId != DAI) {
             revert InvalidSendingToken();

--- a/src/Facets/OmniBridgeFacet.sol
+++ b/src/Facets/OmniBridgeFacet.sol
@@ -5,7 +5,7 @@ import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { IOmniBridge } from "../Interfaces/IOmniBridge.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidReceiver } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title OmniBridge Facet
@@ -20,10 +20,6 @@ contract OmniBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         address receiver;
         uint256 amount;
     }
-
-    /// Errors ///
-
-    error InvalidReceiver();
 
     /// External Methods ///
 

--- a/src/Facets/OptimismBridgeFacet.sol
+++ b/src/Facets/OptimismBridgeFacet.sol
@@ -5,7 +5,7 @@ import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { IL1StandardBridge } from "../Interfaces/IL1StandardBridge.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidReceiver } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title Optimism Bridge Facet
@@ -23,10 +23,6 @@ contract OptimismBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         uint32 l2Gas;
         bool isSynthetix;
     }
-
-    /// Errors ///
-
-    error InvalidReceiver();
 
     /// External Methods ///
 

--- a/src/Facets/PolygonBridgeFacet.sol
+++ b/src/Facets/PolygonBridgeFacet.sol
@@ -5,7 +5,7 @@ import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { IRootChainManager } from "../Interfaces/IRootChainManager.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidReceiver } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title Polygon Bridge Facet
@@ -21,11 +21,6 @@ contract PolygonBridgeFacet is ILiFi, SwapperV2, ReentrancyGuard {
         address receiver;
         uint256 amount;
     }
-
-    /// Errors ///
-
-    error InvalidConfig();
-    error InvalidReceiver();
 
     /// External Methods ///
 

--- a/src/Facets/StargateFacet.sol
+++ b/src/Facets/StargateFacet.sol
@@ -6,7 +6,7 @@ import { IStargateRouter, IFactory, IPool } from "../Interfaces/IStargateRouter.
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { LibDiamond } from "../Libraries/LibDiamond.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
-import { InvalidAmount, TokenAddressIsZero } from "../Errors/GenericErrors.sol";
+import { InvalidAmount, InvalidConfig, InvalidCaller, TokenAddressIsZero } from "../Errors/GenericErrors.sol";
 import { SwapperV2, LibSwap } from "../Helpers/SwapperV2.sol";
 
 /// @title Stargate Facet
@@ -36,9 +36,7 @@ contract StargateFacet is ILiFi, SwapperV2, ReentrancyGuard {
 
     /// Errors ///
 
-    error InvalidConfig();
     error InvalidStargateRouter();
-    error InvalidCaller();
 
     /// Events ///
 

--- a/src/Libraries/LibAccess.sol
+++ b/src/Libraries/LibAccess.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.13;
 
-import { CannotAuthoriseSelf } from "../Errors/GenericErrors.sol";
+import { CannotAuthoriseSelf, UnAuthorized } from "../Errors/GenericErrors.sol";
 
 /// @title Access Library
 /// @author LI.FI (https://li.fi)
@@ -14,9 +14,6 @@ library LibAccess {
     struct AccessStorage {
         mapping(bytes4 => mapping(address => bool)) execAccess;
     }
-
-    /// Errors ///
-    error UnAuthorized();
 
     /// Events ///
     event AccessGranted(address indexed account, bytes4 indexed method);

--- a/src/Libraries/LibSwap.sol
+++ b/src/Libraries/LibSwap.sol
@@ -3,11 +3,9 @@ pragma solidity 0.8.13;
 
 import { LibAsset, IERC20 } from "./LibAsset.sol";
 import { LibUtil } from "./LibUtil.sol";
-import { InvalidContract } from "../Errors/GenericErrors.sol";
+import { InvalidContract, NoSwapFromZeroBalance } from "../Errors/GenericErrors.sol";
 
 library LibSwap {
-    error NoSwapFromZeroBalance();
-
     struct SwapData {
         address callTo;
         address approveTo;

--- a/test/solidity/Facets/AccessManagerFacet.t.sol
+++ b/test/solidity/Facets/AccessManagerFacet.t.sol
@@ -7,6 +7,7 @@ import { DiamondTest, LiFiDiamond } from "../utils/DiamondTest.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { AccessManagerFacet } from "lifi/Facets/AccessManagerFacet.sol";
 import { LibAccess } from "lifi/Libraries/LibAccess.sol";
+import { UnAuthorized } from "lifi/Errors/GenericErrors.sol";
 
 contract RestrictedContract {
     function restrictedMethod() external view returns (bool) {
@@ -38,7 +39,7 @@ contract AccessManagerFacetTest is DSTest, DiamondTest {
     }
 
     function testAccessIsRestricted() public {
-        vm.expectRevert(LibAccess.UnAuthorized.selector);
+        vm.expectRevert(UnAuthorized.selector);
         vm.prank(address(0xb33f));
         restricted.restrictedMethod();
     }
@@ -52,7 +53,7 @@ contract AccessManagerFacetTest is DSTest, DiamondTest {
     function testCanRemoveAccess() public {
         accessMgr.setCanExecute(RestrictedContract.restrictedMethod.selector, address(0xb33f), true);
         accessMgr.setCanExecute(RestrictedContract.restrictedMethod.selector, address(0xb33f), false);
-        vm.expectRevert(LibAccess.UnAuthorized.selector);
+        vm.expectRevert(UnAuthorized.selector);
         vm.prank(address(0xb33f));
         restricted.restrictedMethod();
     }


### PR DESCRIPTION
Some were kept in the original file as they arguably they are not generic. @ezynda3 please let me know if you have other preferences here.


