### PR TITLE
make swap functions of optimizedHop payable

### DIFF
--- a/src/Facets/HopFacetOptimized.sol
+++ b/src/Facets/HopFacetOptimized.sol
@@ -100,7 +100,7 @@ contract HopFacetOptimized is ILiFi, SwapperV2 {
         ILiFi.BridgeData memory _bridgeData,
         LibSwap.SwapData[] calldata _swapData,
         HopData calldata _hopData
-    ) external {
+    ) external payable {
         // Deposit and swap assets
         _bridgeData.minAmount = _depositAndSwap(
             _bridgeData.transactionId,
@@ -209,7 +209,7 @@ contract HopFacetOptimized is ILiFi, SwapperV2 {
         ILiFi.BridgeData memory _bridgeData,
         LibSwap.SwapData[] calldata _swapData,
         HopData calldata _hopData
-    ) external {
+    ) external payable {
         // Deposit and swap assets
         _bridgeData.minAmount = _depositAndSwap(
             _bridgeData.transactionId,

--- a/test/solidity/Facets/HopFacetOptimizedL1.t.sol
+++ b/test/solidity/Facets/HopFacetOptimizedL1.t.sol
@@ -26,8 +26,6 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
         0x3d4Cc8A61c7528Fd86C55cfe061a78dCBA48EDd1;
     address internal constant NATIVE_BRIDGE =
         0xb8901acB165ed027E32754E0FFe830802919727f;
-    address internal constant CONNEXT_HANDLER =
-        0xB4C1340434920d70aD774309C75f9a4B679d801e;
     uint256 internal constant DSTCHAIN_ID = 137;
     // -----
 
@@ -70,6 +68,9 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
         );
         hopFacet.setFunctionApprovalBySignature(
             uniswap.swapETHForExactTokens.selector
+        );
+        hopFacet.setFunctionApprovalBySignature(
+            uniswap.swapExactETHForTokens.selector
         );
         setFacetAddressInTestBase(address(hopFacet), "HopFacet");
 
@@ -127,6 +128,39 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
                 validHopData
             );
         }
+    }
+
+    function testCanSwapNativeAndBridgeTokens() public {
+        vm.startPrank(USER_SENDER);
+
+        // prepare bridgeData
+        bridgeData.hasSourceSwaps = true;
+
+        // reset swap data
+        setDefaultSwapDataSingleETHtoUSDC();
+
+        // update HopData
+        validHopData.amountOutMin = defaultUSDCAmount;
+        validHopData.hopBridge = IHopBridge(USDC_BRIDGE);
+
+        //prepare check for events
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit AssetSwapped(
+            bridgeData.transactionId,
+            ADDRESS_UNISWAP,
+            address(0),
+            ADDRESS_USDC,
+            swapData[0].fromAmount,
+            bridgeData.minAmount,
+            block.timestamp
+        );
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        // execute call in child contract
+        hopFacet.swapAndStartBridgeTokensViaHopL1ERC20{
+            value: swapData[0].fromAmount
+        }(bridgeData, swapData, validHopData);
     }
 
     function testBase_Revert_BridgeWithInvalidDestinationCallFlag()

--- a/test/solidity/utils/Interfaces.sol
+++ b/test/solidity/utils/Interfaces.sol
@@ -25,6 +25,13 @@ interface UniswapV2Router02 {
         uint256 deadline
     ) external returns (uint256[] memory amounts);
 
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256[] memory amounts);
+
     function swapTokensForExactETH(
         uint256 amountOut,
         uint256 amountInMax,

--- a/test/solidity/utils/TestBase.sol
+++ b/test/solidity/utils/TestBase.sol
@@ -290,6 +290,39 @@ abstract contract TestBase is Test, DiamondTest, ILiFi {
         );
     }
 
+    // @dev: be careful that _facetTestContractAddress is set before calling this function
+    function setDefaultSwapDataSingleETHtoUSDC() internal virtual {
+        delete swapData;
+        // Swap ETH -> USDC
+        address[] memory path = new address[](2);
+        path[0] = ADDRESS_WETH;
+        path[1] = ADDRESS_USDC;
+
+        uint256 amountOut = defaultUSDCAmount;
+
+        // Calculate DAI amount
+        uint256[] memory amounts = uniswap.getAmountsIn(amountOut, path);
+        uint256 amountIn = amounts[0];
+
+        swapData.push(
+            LibSwap.SwapData({
+                callTo: address(uniswap),
+                approveTo: address(uniswap),
+                sendingAssetId: address(0),
+                receivingAssetId: ADDRESS_USDC,
+                fromAmount: amountIn,
+                callData: abi.encodeWithSelector(
+                    uniswap.swapExactETHForTokens.selector,
+                    amountOut,
+                    path,
+                    _facetTestContractAddress,
+                    block.timestamp + 20 minutes
+                ),
+                requiresDeposit: true
+            })
+        );
+    }
+
     //@dev: be careful that _facetTestContractAddress is set before calling this function
     function setDefaultSwapDataSingleDAItoETH() internal virtual {
         delete swapData;


### PR DESCRIPTION
The swap functions have to be able to accept any token, including native token that are then swapped into an ERC20.

- [x] Add L1 Test: swap ETH in USDC and bridge with hopOptimized
- [x] Add L2 Test: swap MATIC in USDC and bridge with hopOptimized