### PR TITLE
fix: amarok should reserve native for fees when swapping from native

### DIFF
--- a/src/Facets/AmarokFacet.sol
+++ b/src/Facets/AmarokFacet.sol
@@ -90,7 +90,8 @@ contract AmarokFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable {
             _bridgeData.transactionId,
             _bridgeData.minAmount,
             _swapData,
-            payable(msg.sender)
+            payable(msg.sender),
+            _amarokData.relayerFee
         );
         _startBridge(_bridgeData, _amarokData);
     }

--- a/src/Facets/AmarokFacet.sol
+++ b/src/Facets/AmarokFacet.sol
@@ -12,7 +12,7 @@ import { Validatable } from "../Helpers/Validatable.sol";
 /// @title Amarok Facet
 /// @author LI.FI (https://li.fi)
 /// @notice Provides functionality for bridging through Connext Amarok
-/// @custom:version 1.0.0
+/// @custom:version 1.0.1
 contract AmarokFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable {
     /// Storage ///
 


### PR DESCRIPTION
We should reserve the fee whenever we swap from native, otherwise funds are sent back to the user.