### PR TITLE
Corrected the function name in demoMultichainTx.ts

### DIFF
--- a/scripts/demoScripts/demoMultichainTx.ts
+++ b/scripts/demoScripts/demoMultichainTx.ts
@@ -41,7 +41,7 @@ async function main() {
     toChainId: destinationChainId,
   }
 
-  await lifi.startBridgeTokensViaMultichasin(lifiData, Multichain, {
+  await lifi.startBridgeTokensViaMultichain(lifiData, Multichain, {
     gasLimit: 500000,
   })
 }


### PR DESCRIPTION
I found that the correct name for the function is `startBridgeTokensViaMultichain`, I think is a typo error here.