### PR TITLE
fix: correct okx sign

### DIFF
--- a/config/sigs.json
+++ b/config/sigs.json
@@ -150,6 +150,6 @@
     "0x6678ec1f",
     "0x30eef8bd",
     "0x4dcebcba",
-    "0xb80c2f09"
+    "0x03b87e5f"
   ]
 }


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
- Correct the sign for okx router

Error from local BE: `[Signature Allowlist] Unknown signature: 0x03b87e5f, chain: 42161, contract: 0xf332761c673b59B21fF6dfa8adA44d78c12dEF09`
# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
