### PR TITLE
improve(AcrossV3): Drop gas introspection in handler contract

### DIFF
--- a/src/Periphery/ReceiverAcrossV3.sol
+++ b/src/Periphery/ReceiverAcrossV3.sol
@@ -16,13 +16,9 @@ import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     using SafeTransferLib for address;
 
-    /// Error ///
-    error InsufficientGasLimit();
-
     /// Storage ///
     IExecutor public immutable executor;
     address public immutable spokepool;
-    uint256 public immutable recoverGas;
 
     /// Modifiers ///
     modifier onlySpokepool() {
@@ -36,13 +32,11 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     constructor(
         address _owner,
         address _executor,
-        address _spokepool,
-        uint256 _recoverGas
+        address _spokepool
     ) TransferrableOwnership(_owner) {
         owner = _owner;
         executor = IExecutor(_executor);
         spokepool = _spokepool;
-        recoverGas = _recoverGas;
     }
 
     /// External Methods ///
@@ -98,6 +92,7 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     /// Private Methods ///
 
     /// @notice Performs a swap before completing a cross-chain transaction
+    //  @notice Since Across will always send wrappedNative to contract, we do not need a native handling here
     /// @param _transactionId the transaction id associated with the operation
     /// @param _swapData array of data needed for swaps
     /// @param assetId address of the token received from the source chain (not to be confused with StargateV2's assetIds which are uint16 values)
@@ -110,34 +105,16 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
         address payable receiver,
         uint256 amount
     ) private {
-        // since Across will always send wrappedNative to contract, we do not need a native handling here
-        uint256 cacheGasLeft = gasleft();
-
-        // We introduced this handling to prevent relayers from under-estimating our destination transactions and then
-        // running into out-of-gas errors which would cause the bridged tokens to be refunded to the receiver. This is
-        // an emergency behaviour but testing showed that this would happen very frequently.
-        // Reverting transactions that dont have enough gas helps to make sure that transactions will get correctly estimated
-        // by the relayers on source chain and thus improves the success rate of destination calls.
-        if (cacheGasLeft < recoverGas) {
-            // case A: not enough gas left to execute calls
-            // @dev: we removed the handling to send bridged funds to receiver in case of insufficient gas
-            //       as it's better for AcrossV3 to revert these cases instead
-            revert InsufficientGasLimit();
-        }
-
-        // case 2b: enough gas left to execute calls
         assetId.safeApprove(address(executor), 0);
         assetId.safeApprove(address(executor), amount);
         try
-            executor.swapAndCompleteBridgeTokens{
-                gas: cacheGasLeft - recoverGas
-            }(_transactionId, _swapData, assetId, receiver)
+            executor.swapAndCompleteBridgeTokens(
+                _transactionId,
+                _swapData,
+                assetId,
+                receiver
+            )
         {} catch {
-            cacheGasLeft = gasleft();
-            // if the only gas left here is the recoverGas then the swap must have failed due to out-of-gas error and in this
-            // case we want to revert (again, to force relayers to estimate our destination calls with sufficient gas limit)
-            if (cacheGasLeft <= recoverGas) revert InsufficientGasLimit();
-
             // send the bridged (and unswapped) funds to receiver address
             assetId.safeTransfer(receiver, amount);
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?
n/a

# Why did I implement it this way?
The Across message handler function does not require any gas introspection. Cross-chain intents under Across instead outsource gas considerations on the destination chain to the relayer function.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
