### PR TITLE
Fix across [AcrossFacetPackedV3 v1.1.0,ReceiverAcrossV3 v1.1.0]

### DIFF
--- a/src/Facets/AcrossFacetPackedV3.sol
+++ b/src/Facets/AcrossFacetPackedV3.sol
@@ -11,7 +11,7 @@ import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 /// @title AcrossFacetPackedV3
 /// @author LI.FI (https://li.fi)
 /// @notice Provides functionality for bridging through Across in a gas-optimized way
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract AcrossFacetPackedV3 is ILiFi, TransferrableOwnership {
     using SafeTransferLib for ERC20;
 
@@ -85,7 +85,8 @@ contract AcrossFacetPackedV3 is ILiFi, TransferrableOwnership {
     function startBridgeTokensViaAcrossV3NativePacked() external payable {
         // call Across spoke pool to bridge assets
         spokePool.depositV3{ value: msg.value }(
-            msg.sender, // depositor
+            // we use tx.origin here to prevent refunds being sent to Metamask's contract
+            tx.origin, // depositor
             address(bytes20(msg.data[12:32])), // recipient
             wrappedNative, // inputToken
             address(bytes20(msg.data[36:56])), // outputToken
@@ -109,7 +110,8 @@ contract AcrossFacetPackedV3 is ILiFi, TransferrableOwnership {
     ) external payable {
         // call Across spoke pool to bridge assets
         spokePool.depositV3{ value: msg.value }(
-            msg.sender, // depositor
+            // we use tx.origin here to prevent refunds being sent to Metamask's contract
+            tx.origin, // depositor
             _parameters.receiver,
             wrappedNative, // inputToken
             _parameters.receivingAssetId, // outputToken
@@ -141,7 +143,8 @@ contract AcrossFacetPackedV3 is ILiFi, TransferrableOwnership {
 
         // call Across SpokePool
         spokePool.depositV3(
-            msg.sender, // depositor
+            // we use tx.origin here to prevent refunds being sent to Metamask's contract
+            tx.origin, // depositor
             address(bytes20(msg.data[12:32])), // recipient
             sendingAssetId, // inputToken
             address(bytes20(msg.data[72:92])), // outputToken
@@ -176,7 +179,8 @@ contract AcrossFacetPackedV3 is ILiFi, TransferrableOwnership {
 
         // call Across SpokePool
         spokePool.depositV3(
-            msg.sender, // depositor
+            // we use tx.origin here to prevent refunds being sent to Metamask's contract
+            tx.origin, // depositor
             _parameters.receiver,
             sendingAssetId, // inputToken
             _parameters.receivingAssetId, // outputToken

--- a/src/Periphery/ReceiverAcrossV3.sol
+++ b/src/Periphery/ReceiverAcrossV3.sol
@@ -12,17 +12,13 @@ import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 /// @title ReceiverAcrossV3
 /// @author LI.FI (https://li.fi)
 /// @notice Arbitrary execution contract used for cross-chain swaps and message passing via AcrossV3
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     using SafeTransferLib for address;
-
-    /// Error ///
-    error InsufficientGasLimit();
 
     /// Storage ///
     IExecutor public immutable executor;
     address public immutable spokepool;
-    uint256 public immutable recoverGas;
 
     /// Modifiers ///
     modifier onlySpokepool() {
@@ -36,13 +32,11 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     constructor(
         address _owner,
         address _executor,
-        address _spokepool,
-        uint256 _recoverGas
+        address _spokepool
     ) TransferrableOwnership(_owner) {
         owner = _owner;
         executor = IExecutor(_executor);
         spokepool = _spokepool;
-        recoverGas = _recoverGas;
     }
 
     /// External Methods ///
@@ -98,6 +92,7 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
     /// Private Methods ///
 
     /// @notice Performs a swap before completing a cross-chain transaction
+    //  @notice Since Across will always send wrappedNative to contract, we do not need a native handling here
     /// @param _transactionId the transaction id associated with the operation
     /// @param _swapData array of data needed for swaps
     /// @param assetId address of the token received from the source chain (not to be confused with StargateV2's assetIds which are uint16 values)
@@ -110,34 +105,16 @@ contract ReceiverAcrossV3 is ILiFi, TransferrableOwnership {
         address payable receiver,
         uint256 amount
     ) private {
-        // since Across will always send wrappedNative to contract, we do not need a native handling here
-        uint256 cacheGasLeft = gasleft();
-
-        // We introduced this handling to prevent relayers from under-estimating our destination transactions and then
-        // running into out-of-gas errors which would cause the bridged tokens to be refunded to the receiver. This is
-        // an emergency behaviour but testing showed that this would happen very frequently.
-        // Reverting transactions that dont have enough gas helps to make sure that transactions will get correctly estimated
-        // by the relayers on source chain and thus improves the success rate of destination calls.
-        if (cacheGasLeft < recoverGas) {
-            // case A: not enough gas left to execute calls
-            // @dev: we removed the handling to send bridged funds to receiver in case of insufficient gas
-            //       as it's better for AcrossV3 to revert these cases instead
-            revert InsufficientGasLimit();
-        }
-
-        // case 2b: enough gas left to execute calls
         assetId.safeApprove(address(executor), 0);
         assetId.safeApprove(address(executor), amount);
         try
-            executor.swapAndCompleteBridgeTokens{
-                gas: cacheGasLeft - recoverGas
-            }(_transactionId, _swapData, assetId, receiver)
+            executor.swapAndCompleteBridgeTokens(
+                _transactionId,
+                _swapData,
+                assetId,
+                receiver
+            )
         {} catch {
-            cacheGasLeft = gasleft();
-            // if the only gas left here is the recoverGas then the swap must have failed due to out-of-gas error and in this
-            // case we want to revert (again, to force relayers to estimate our destination calls with sufficient gas limit)
-            if (cacheGasLeft <= recoverGas) revert InsufficientGasLimit();
-
             // send the bridged (and unswapped) funds to receiver address
             assetId.safeTransfer(receiver, amount);
 

--- a/test/solidity/Periphery/ReceiverAcrossV3.t.sol
+++ b/test/solidity/Periphery/ReceiverAcrossV3.t.sol
@@ -52,57 +52,6 @@ contract ReceiverAcrossV3Test is TestBase {
         assertEq(receiver.spokepool() == SPOKEPOOL_MAINNET, true);
     }
 
-    function test_OwnerCanPullERC20Token() public {
-        // fund receiver with ERC20 tokens
-        deal(ADDRESS_DAI, address(receiver), 1000);
-
-        uint256 initialBalance = dai.balanceOf(USER_RECEIVER);
-
-        // pull token
-        vm.startPrank(USER_DIAMOND_OWNER);
-
-        receiver.pullToken(ADDRESS_DAI, payable(USER_RECEIVER), 1000);
-
-        assertEq(dai.balanceOf(USER_RECEIVER), initialBalance + 1000);
-    }
-
-    function test_OwnerCanPullNativeToken() public {
-        // fund receiver with native tokens
-        vm.deal(address(receiver), 1 ether);
-
-        uint256 initialBalance = USER_RECEIVER.balance;
-
-        // pull token
-        vm.startPrank(USER_DIAMOND_OWNER);
-
-        receiver.pullToken(address(0), payable(USER_RECEIVER), 1 ether);
-
-        assertEq(USER_RECEIVER.balance, initialBalance + 1 ether);
-    }
-
-    function test_PullTokenWillRevertIfExternalCallFails() public {
-        vm.deal(address(receiver), 1 ether);
-
-        // deploy contract that cannot receive ETH
-        NonETHReceiver nonETHReceiver = new NonETHReceiver();
-
-        vm.startPrank(USER_DIAMOND_OWNER);
-
-        vm.expectRevert(ExternalCallFailed.selector);
-
-        receiver.pullToken(
-            address(0),
-            payable(address(nonETHReceiver)),
-            1 ether
-        );
-    }
-
-    function test_revert_PullTokenNonOwner() public {
-        vm.startPrank(USER_SENDER);
-        vm.expectRevert(UnAuthorized.selector);
-        receiver.pullToken(ADDRESS_DAI, payable(USER_RECEIVER), 1000);
-    }
-
     function test_revert_OnlySpokepoolCanCallHandleV3AcrossMessage() public {
         // mock-send bridged funds to receiver contract
         deal(ADDRESS_USDC, address(receiver), defaultUSDCAmount);

--- a/test/solidity/Periphery/ReceiverAcrossV3.t.sol
+++ b/test/solidity/Periphery/ReceiverAcrossV3.t.sol
@@ -19,15 +19,11 @@ contract ReceiverAcrossV3Test is TestBase {
     bytes32 guid = bytes32("12345");
     address receiverAddress = USER_RECEIVER;
 
-    uint256 public constant RECOVER_GAS_VALUE = 100000;
     address stargateRouter;
     Executor executor;
     ERC20Proxy erc20Proxy;
 
     event ExecutorSet(address indexed executor);
-    event RecoverGasSet(uint256 indexed recoverGas);
-
-    error InsufficientGasLimit();
 
     function setUp() public {
         customBlockNumberForForking = 20024274;
@@ -38,8 +34,7 @@ contract ReceiverAcrossV3Test is TestBase {
         receiver = new ReceiverAcrossV3(
             address(this),
             address(executor),
-            SPOKEPOOL_MAINNET,
-            RECOVER_GAS_VALUE
+            SPOKEPOOL_MAINNET
         );
         vm.label(address(receiver), "ReceiverAcrossV3");
         vm.label(address(executor), "Executor");
@@ -50,13 +45,11 @@ contract ReceiverAcrossV3Test is TestBase {
         receiver = new ReceiverAcrossV3(
             address(this),
             address(executor),
-            SPOKEPOOL_MAINNET,
-            RECOVER_GAS_VALUE
+            SPOKEPOOL_MAINNET
         );
 
         assertEq(address(receiver.executor()) == address(executor), true);
         assertEq(receiver.spokepool() == SPOKEPOOL_MAINNET, true);
-        assertEq(receiver.recoverGas() == RECOVER_GAS_VALUE, true);
     }
 
     function test_OwnerCanPullERC20Token() public {
@@ -168,52 +161,6 @@ contract ReceiverAcrossV3Test is TestBase {
         assertTrue(dai.balanceOf(receiverAddress) == amountOutMin);
     }
 
-    function test_willRevertIfGasIsLessThanRecoverGas() public {
-        // mock-send bridged funds to receiver contract
-        deal(ADDRESS_USDC, address(receiver), defaultUSDCAmount);
-
-        // encode payload with mock data like Stargate would according to:
-        (bytes memory payload, ) = _getValidAcrossV3Payload(
-            ADDRESS_USDC,
-            ADDRESS_DAI
-        );
-
-        // fake a sendCompose from USDC pool on ETH mainnet
-        vm.startPrank(SPOKEPOOL_MAINNET);
-
-        vm.expectRevert(abi.encodeWithSelector(InsufficientGasLimit.selector));
-
-        receiver.handleV3AcrossMessage{ gas: RECOVER_GAS_VALUE }(
-            ADDRESS_USDC,
-            defaultUSDCAmount,
-            address(0),
-            payload
-        );
-    }
-
-    function test_willRevertIfDestCallRunsOutOfGas() public {
-        // mock-send bridged funds to receiver contract
-        deal(ADDRESS_USDC, address(receiver), defaultUSDCAmount);
-
-        // encode payload with mock data like Stargate would according to:
-        (bytes memory payload, ) = _getValidAcrossV3Payload(
-            ADDRESS_USDC,
-            ADDRESS_DAI
-        );
-
-        // fake a sendCompose from USDC pool on ETH mainnet
-        vm.startPrank(SPOKEPOOL_MAINNET);
-
-        vm.expectRevert(abi.encodeWithSelector(InsufficientGasLimit.selector));
-
-        receiver.handleV3AcrossMessage{ gas: RECOVER_GAS_VALUE + 150000 }(
-            ADDRESS_USDC,
-            defaultUSDCAmount,
-            address(0),
-            payload
-        );
-    }
-
     function test_willReturnFundsToUserIfDstCallFails() public {
         // mock-send bridged funds to receiver contract
         deal(ADDRESS_USDC, address(receiver), defaultUSDCAmount);
@@ -248,7 +195,49 @@ contract ReceiverAcrossV3Test is TestBase {
             defaultUSDCAmount,
             block.timestamp
         );
-        receiver.handleV3AcrossMessage{ gas: RECOVER_GAS_VALUE + 200000 }(
+        receiver.handleV3AcrossMessage(
+            ADDRESS_USDC,
+            defaultUSDCAmount,
+            address(0),
+            payload
+        );
+
+        assertTrue(usdc.balanceOf(receiverAddress) == defaultUSDCAmount);
+    }
+
+    function test_willReturnFundsToUserIfDstCallRunsOutOfGas() public {
+        // mock-send bridged funds to receiver contract
+        deal(ADDRESS_USDC, address(receiver), defaultUSDCAmount);
+
+        // encode payload with mock data like Stargate would according to:
+        MockUniswapDEX mockDEX = new MockUniswapDEX();
+
+        LibSwap.SwapData[] memory swapData = new LibSwap.SwapData[](1);
+        swapData[0] = LibSwap.SwapData({
+            callTo: address(mockDEX),
+            approveTo: address(mockDEX),
+            sendingAssetId: ADDRESS_USDC,
+            receivingAssetId: ADDRESS_USDC,
+            fromAmount: defaultUSDCAmount,
+            callData: abi.encodeWithSelector(
+                mockDEX.mockSwapWillRunOutOfGas.selector
+            ),
+            requiresDeposit: false
+        });
+
+        bytes memory payload = abi.encode(guid, swapData, receiverAddress);
+
+        vm.startPrank(SPOKEPOOL_MAINNET);
+
+        vm.expectEmit(true, true, true, true, address(receiver));
+        emit LiFiTransferRecovered(
+            guid,
+            ADDRESS_USDC,
+            receiverAddress,
+            defaultUSDCAmount,
+            block.timestamp
+        );
+        receiver.handleV3AcrossMessage(
             ADDRESS_USDC,
             defaultUSDCAmount,
             address(0),

--- a/test/solidity/utils/MockUniswapDEX.sol
+++ b/test/solidity/utils/MockUniswapDEX.sol
@@ -106,6 +106,12 @@ contract MockUniswapDEX {
         revert(reason);
     }
 
+    function mockSwapWillRunOutOfGas() external payable {
+        while (true) {
+            // infinite loop
+        }
+    }
+
     // UNISWAP-LIKE FUNCTION SELECTORS FOR BETTER COMPATIBILITY WITH EXISTING CODE
 
     // ERC20 to ERC20


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
Our AcrossV3 implementation is currently running into two separate issues: 

1) when Metamask uses the packed facet and a refund is being sent to the "depositor" then the refund ends up in Metamask's contract but should be sent to the user. Using tx.origin as depositor instead of msg.sender will mitigate this issue

2) the gas introspection handling in our ReceiverAcrossV3 contract is causing issues for the Across relayers to estimate gas and execute the dest tx correctly. We have been asked to remove the gas introspection.  

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
