### PR TITLE
fix: new_version edge cases

### DIFF
--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -123,6 +123,7 @@ jobs:
           echo "Current version: $CURRENT_VERSION"
 
           VERSION_FRAGMENT=""
+          BETA=""
 
           # Determine the type of version bump
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -151,10 +152,9 @@ jobs:
             PATCH=$((PATCH + 1))
           elif [[ "$VERSION_FRAGMENT" == "beta" ]]; then
             PATCH=$((PATCH + 1))
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-beta"
-          else
-            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            BETA="-beta"
           fi
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}${BETA}"
 
           echo "New version: $NEW_VERSION"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
# Which Jira task belongs to this PR?
None

# Why did I implement it this way?
Fix the creation of NEW_VERSION: The if/else will set the MAJOR/MINOR/PATH/BETA variables, and then we append all of them to NEW_VERSION

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
