### PR TITLE
fix erroneous flags in deployRequirements

### DIFF
--- a/script/deploy/resources/deployRequirements.json
+++ b/script/deploy/resources/deployRequirements.json
@@ -412,7 +412,7 @@
   "Executor": {
     "contractAddresses": {
       "ERC20Proxy": {
-        "allowToDeployWithZeroAddress": "true"
+        "allowToDeployWithZeroAddress": "false"
       }
     }
   },
@@ -436,7 +436,7 @@
     },
     "contractAddresses": {
       "Executor": {
-        "allowToDeployWithZeroAddress": "true"
+        "allowToDeployWithZeroAddress": "false"
       }
     }
   },
@@ -460,7 +460,7 @@
     },
     "contractAddresses": {
       "Executor": {
-        "allowToDeployWithZeroAddress": "true"
+        "allowToDeployWithZeroAddress": "false"
       }
     }
   },
@@ -534,7 +534,7 @@
       "_relaySolver": {
         "configFileName": "relay.json",
         "keyInConfigFile": ".<NETWORK>.relaySolver",
-          "allowToDeployWithZeroAddress": "false"
+        "allowToDeployWithZeroAddress": "false"
       }
     }
   },


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
some contracts should not deployed with missing (i.e. address(0) for) parameters as they wont function otherwise. This was not correctly reflected in the deployRequirements.json

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
