### PR TITLE
actions updated to use stable version instead of nightly

### DIFF
--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -39,9 +39,7 @@ jobs:
         run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.2.0
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1.3.1
 
       - name: Install Dependencies
         run: forge install

--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -39,9 +39,7 @@ jobs:
         run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.2.0
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1.3.1
 
       - name: Install Dependencies
         run: forge install

--- a/.github/workflows_deactivated/enforceTestCoverage.yml
+++ b/.github/workflows_deactivated/enforceTestCoverage.yml
@@ -38,9 +38,7 @@ jobs:
         run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.2.0
-        with:
-          version: nightly
+        uses: foundry-rs/foundry-toolchain@v1.3.1
 
       - name: Install Dependencies
         run: forge install


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
nightly versions can be causing more trouble and change more frequently while we do not have any benefit. We need our git actions to run reliably and stable versions are well-suited for this

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
