### PR TITLE
add pagination flag to always get the latest reviews of a PR

### DIFF
--- a/.github/workflows/ensureSCCoreDevApproval.yml
+++ b/.github/workflows/ensureSCCoreDevApproval.yml
@@ -82,11 +82,12 @@ jobs:
               return;
             }
 
-            // get all reviewers that have approved this PR
+            // Fetch only the latest 100 reviews
             const { data: reviews } = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pullNumber,
+              per_page: 100, // makes sure that only the LATEST 100 items are fetched (without this flag it gets all, starting with the first items)
             });
 
             // make sure that reviews are available


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
When a PR has many comments (e.g. coderabbit) then the API returns all these items when we check for approving reviews. In cases where there are more than 100 items, the latest approving reviews are not found. This PR changes this behaviour so always the latest reviews are pulled

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
