### PR TITLE
pull only the latest 100 items from git API

### DIFF
--- a/.github/workflows/protectSecurityRelevantCode.yml
+++ b/.github/workflows/protectSecurityRelevantCode.yml
@@ -136,6 +136,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pullNumber,
+              per_page: 100, // makes sure that only the LATEST 100 items are fetched (without this flag it gets all, starting with the first items)
             });
 
             // make sure that reviews are available


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
The git API returns all items (comments, responses, reviews, etc) and if there are more than a 100 then this action fails. This update makes sure that only the latest 100 items are pulled which always will include the approving reviews

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
