### PR TITLE
LF-11929 - Moved core facets to global.json and made adjustments

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -59,6 +59,8 @@
     "PeripheryRegistryFacet",
     "GenericSwapFacet",
     "StandardizedCallFacet",
-    "CalldataVerificationFacet"
+    "CalldataVerificationFacet",
+    "GenericSwapFacetV3",
+    "EmergencyPauseFacet"
   ]
 }

--- a/config/global.json
+++ b/config/global.json
@@ -58,7 +58,6 @@
     "WithdrawFacet",
     "PeripheryRegistryFacet",
     "GenericSwapFacet",
-    "StandardizedCallFacet",
     "CalldataVerificationFacet",
     "GenericSwapFacetV3",
     "EmergencyPauseFacet"

--- a/config/global.json
+++ b/config/global.json
@@ -48,5 +48,17 @@
     "LiFuelFeeCollector",
     "TokenWrapper",
     "LiFiDEXAggregator"
+  ],
+  "coreFacets": [
+    "DiamondCutFacet",
+    "DiamondLoupeFacet",
+    "OwnershipFacet",
+    "DexManagerFacet",
+    "AccessManagerFacet",
+    "WithdrawFacet",
+    "PeripheryRegistryFacet",
+    "GenericSwapFacet",
+    "StandardizedCallFacet",
+    "CalldataVerificationFacet"
   ]
 }

--- a/script/config.example.sh
+++ b/script/config.example.sh
@@ -68,7 +68,7 @@ DO_NOT_VERIFY_IN_THESE_NETWORKS="gnosis,testNetwork,aurora,localanvil"
 NETWORKS_FILE_PATH="./networks"
 
 # the path to the file that contains a list of all networks
-GLOBAL_FILE_PATH="./global"
+GLOBAL_FILE_PATH="$(dirname "$0")/../config/global.json"
 
 # script will use all periphery contracts by default, unless excluded here (must match exact filename without .sol, comma-separated without space)
 EXCLUDE_PERIPHERY_CONTRACTS=""

--- a/script/config.example.sh
+++ b/script/config.example.sh
@@ -67,14 +67,14 @@ DO_NOT_VERIFY_IN_THESE_NETWORKS="gnosis,testNetwork,aurora,localanvil"
 # the path to the file that contains a list of all networks
 NETWORKS_FILE_PATH="./networks"
 
+# the path to the file that contains a list of all networks
+GLOBAL_FILE_PATH="./global"
+
 # script will use all periphery contracts by default, unless excluded here (must match exact filename without .sol, comma-separated without space)
 EXCLUDE_PERIPHERY_CONTRACTS=""
 
 # scripts will use all facet contracts by default, unless excluded here (must match exact filename without .sol, comma-separated without space)
 EXCLUDE_FACET_CONTRACTS=""
-
-# contains a list of all facets that are considered core facets (and will be deployed to every network)
-CORE_FACETS="DiamondCutFacet,DiamondLoupeFacet,OwnershipFacet,DexManagerFacet,AccessManagerFacet,WithdrawFacet,PeripheryRegistryFacet,LIFuelFacet,GenericSwapFacet,StandardizedCallFacet,CalldataVerificationFacet"
 
 # enable/disable notification sounds for long-running scripts
 NOTIFICATION_SOUNDS=true

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -83,7 +83,13 @@ deployAllContracts() {
   local FACETS_PATH="$CONTRACT_DIRECTORY""Facets/"
 
   # prepare regExp to exclude core facets
-  local EXCLUDED_FACETS_REGEXP="^($(getCoreFacetsArray | xargs | tr ' ' '|'))$"
+  CORE_FACETS_OUTPUT=$(getCoreFacetsArray)
+  checkFailure $? "retrieve core facets array from global.json"
+
+  # process the output:
+  # 1. use xargs to collapse the multi-line output into a single line with space-separated facets.
+  # 2. use tr to replace spaces with pipe characters.
+  local EXCLUDED_FACETS_REGEXP="^($(echo "$CORE_FACETS_OUTPUT" | xargs | tr ' ' '|'))$"
 
   # loop through facet contract names
   for FACET_NAME in $(getContractNamesInFolder "$FACETS_PATH"); do

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -83,7 +83,7 @@ deployAllContracts() {
   local FACETS_PATH="$CONTRACT_DIRECTORY""Facets/"
 
   # prepare regExp to exclude core facets
-  local EXCLUDED_FACETS_REGEXP="^($(echo "$CORE_FACETS" | tr ',' '|'))$"
+  local EXCLUDED_FACETS_REGEXP="^($(getCoreFacetsArray | xargs | tr ' ' '|'))$"
 
   # loop through facet contract names
   for FACET_NAME in $(getContractNamesInFolder "$FACETS_PATH"); do

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -86,9 +86,6 @@ deployAllContracts() {
   CORE_FACETS_OUTPUT=$(getCoreFacetsArray)
   checkFailure $? "retrieve core facets array from global.json"
 
-  # process the output:
-  # 1. use xargs to collapse the multi-line output into a single line with space-separated facets.
-  # 2. use tr to replace spaces with pipe characters.
   local EXCLUDED_FACETS_REGEXP="^($(echo "$CORE_FACETS_OUTPUT" | xargs | tr ' ' '|'))$"
 
   # loop through facet contract names

--- a/script/deploy/deployCoreFacets.sh
+++ b/script/deploy/deployCoreFacets.sh
@@ -31,7 +31,8 @@ deployCoreFacets() {
   echo ""
 
   # get list of all core facet contracts
-  local FACETS_ARRAY=($(getCoreFacetsArray))
+  FACETS_ARRAY=($(getCoreFacetsArray))
+  checkFailure $? "retrieve core facets array from global.json"
 
   # loop through all contracts
   for CONTRACT in "${FACETS_ARRAY[@]}"; do

--- a/script/deploy/deployCoreFacets.sh
+++ b/script/deploy/deployCoreFacets.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # deploys all "core facet" contracts to the given network/environment
-# core facets are contracts that are listed under CORE_FACETS in config.sh
+# core facets are contracts that are listed under coreFacets in global.json
 deployCoreFacets() {
   echo ""
   echo ""
@@ -31,7 +31,7 @@ deployCoreFacets() {
   echo ""
 
   # get list of all core facet contracts
-  IFS=',' read -ra FACETS_ARRAY <<< "$CORE_FACETS"
+  local FACETS_ARRAY=($(getCoreFacetsArray))
 
   # loop through all contracts
   for CONTRACT in "${FACETS_ARRAY[@]}"; do

--- a/script/deploy/healthCheck.ts
+++ b/script/deploy/healthCheck.ts
@@ -22,25 +22,11 @@ import {
   getViemChainForNetworkName,
   type NetworksObject,
 } from '../utils/viemScriptHelpers'
+import { coreFacets } from '../../config/global.json'
 
 const SAFE_THRESHOLD = 3
 
 const louperCmd = 'louper-cli'
-
-const coreFacets = [
-  'DiamondCutFacet',
-  'DiamondLoupeFacet',
-  'OwnershipFacet',
-  'WithdrawFacet',
-  'DexManagerFacet',
-  'PeripheryRegistryFacet',
-  'AccessManagerFacet',
-  'PeripheryRegistryFacet',
-  'GenericSwapFacet',
-  'GenericSwapFacetV3',
-  'CalldataVerificationFacet',
-  'StandardizedCallFacet',
-]
 
 const corePeriphery = [
   'ERC20Proxy',

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2001,6 +2001,12 @@ function getCoreFacetsArray() {
     return 1
   fi
 
+  # check if the array is empty
+  if [[ ${#ARRAY[@]} -eq 0 ]]; then
+    error "The coreFacets array is empty in $GLOBAL_FILE_PATH." >&2
+    return 1
+  fi
+
   printf '%s\n' "${ARRAY[@]}"
 }
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -1978,30 +1978,27 @@ function getAllNetworksArray() {
   printf '%s\n' "${ARRAY[@]}"
 }
 
-# Function to retrieve coreFacets from global.json
+# function to retrieve coreFacets from global.json
 function getCoreFacetsArray() {
-  # Ensure GLOBAL_FILE_PATH is set and not empty
+  # ensure GLOBAL_FILE_PATH is set and not empty
   if [[ -z "$GLOBAL_FILE_PATH" ]]; then
-    echo "Error: GLOBAL_FILE_PATH is not set or empty."
-    exit 1
+    error "GLOBAL_FILE_PATH is not set or empty." >&2
+    return 1
   fi
 
-  local FILE="$GLOBAL_FILE_PATH"
   local ARRAY=()
 
-  # Ensure the global file exists
-  if [[ ! -f "$FILE" ]]; then
-    echo "Error: Global configuration file $FILE not found at $FILE."
-    exit 1
+  # ensure the global file exists
+  if [[ ! -f "$GLOBAL_FILE_PATH" ]]; then
+    error "Global configuration file not found at $GLOBAL_FILE_PATH ." >&2
+    return 1
   fi
 
-  # Read coreFacets array from JSON using jq
-  ARRAY=($(jq -r '.coreFacets[]' "$FILE"))
-
-  # Ensure the coreFacets array is not empty
-  if [[ ${#ARRAY[@]} -eq 0 ]]; then
-    echo "Error: coreFacets array is empty in $FILE."
-    exit 1
+  # read coreFacets array from JSON using jq
+  ARRAY=($(jq -r '.coreFacets[]' "$GLOBAL_FILE_PATH"))
+  if [[ $? -ne 0 ]]; then
+    error "Failed to parse coreFacets array from $GLOBAL_FILE_PATH." >&2
+    return 1
   fi
 
   printf '%s\n' "${ARRAY[@]}"
@@ -2090,6 +2087,7 @@ function getIncludedAndSortedFacetContractsArray() {
 
   # Get core facets from global.json
   CORE_FACETS_ARRAY=($(getCoreFacetsArray))
+  checkFailure $? "retrieve core facets array from global.json"
 
   # initialize empty arrays for core and non-core facet contracts
   CORE_FACET_CONTRACTS=()
@@ -2448,8 +2446,9 @@ function doesDiamondHaveCoreFacetsRegistered() {
   # get RPC URL for given network
   RPC_URL=$(getRPCUrl "$NETWORK")
 
-  # Get list of all core facet contracts from global.json
-  local FACETS_NAMES=($(getCoreFacetsArray))
+  # get list of all core facet contracts from global.json
+  FACETS_NAMES=($(getCoreFacetsArray))
+  checkFailure $? "retrieve core facets array from global.json"
 
 
   # get a list of all facets that the diamond knows


### PR DESCRIPTION
# Which Jira task belongs to this PR?
[LF-11929]

# Why did I implement it this way?

Instead of maintaining duplicate arrays of core facets in both the health check and bash script we decided to keep them in a single source of truth within `global.json`.

Additionally, the GLOBAL_FILE_PATH variable should be defined in config.sh for scripts, with the value:

`GLOBAL_FILE_PATH="$(dirname "$0")/../config/global.json"`

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


[LF-11929]: https://lifi.atlassian.net/browse/LF-11929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ