### PR TITLE
Fix - added paths for security alerts review

### DIFF
--- a/.github/workflows/securityAlertsReview.yml
+++ b/.github/workflows/securityAlertsReview.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     types:
       - ready_for_review
+    paths:
+      - 'src/**/*.sol'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?

I resolved the issue by configuring the `Security Alerts Review` action to trigger only on the same paths as the `Olympix Static Analysis` action. Previously the security review action was triggered on pull requests that didn’t include changes to .sol files which was failing because of the abstence of the required `Olympix Static Analysis` report

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
