### PR TITLE
Convert DISMISS_COMMENT to single line

### DIFF
--- a/.github/workflows/securityAlertsReview.yml
+++ b/.github/workflows/securityAlertsReview.yml
@@ -210,7 +210,7 @@ jobs:
 
               # we convert the dismissal comment to a single line because:
               # 1. newlines in this context dont render properly (or get escaped) in the final github PR comment
-              # 2) it keeps the format consistent with how github code scanning alerts display these comments.
+              # 2. it keeps the format consistent with how github code scanning alerts display these comments.
               DISMISS_COMMENT_SINGLE_LINE=$(echo "$DISMISS_COMMENT" | tr '\n' ' ' | tr '\r' ' ')
 
               COMMENT_BODY+="🟢 [View Alert]($ALERT_URL) - **File:** \`$ALERT_FILE\`\n"

--- a/.github/workflows/securityAlertsReview.yml
+++ b/.github/workflows/securityAlertsReview.yml
@@ -208,10 +208,15 @@ jobs:
               DISMISS_COMMENT=$(echo "$row" | jq -r '.dismissed_comment')
               CAPITALIZED_REASON=$(echo "$DISMISS_REASON" | sed 's/^\(.\)/\U\1/')
 
+              # we convert the dismissal comment to a single line because:
+              # 1. newlines in this context dont render properly (or get escaped) in the final github PR comment
+              # 2) it keeps the format consistent with how github code scanning alerts display these comments.
+              DISMISS_COMMENT_SINGLE_LINE=$(echo "$DISMISS_COMMENT" | tr '\n' ' ' | tr '\r' ' ')
+
               COMMENT_BODY+="🟢 [View Alert]($ALERT_URL) - **File:** \`$ALERT_FILE\`\n"
               COMMENT_BODY+="   🔹 $ALERT_DESCRIPTION\n"
               COMMENT_BODY+="   🔹 Dismiss Reason: **$CAPITALIZED_REASON**\n"
-              COMMENT_BODY+="   🔹 Dismiss Comment: $DISMISS_COMMENT\n\n"
+              COMMENT_BODY+="   🔹 Dismiss Comment: $DISMISS_COMMENT_SINGLE_LINE\n\n"
             done < <(echo "$RESOLVED_ALERTS" | jq -c '.[]')
           fi
 


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?

Added convertion of the dismissal comment to a single line because:
1. newlines in this context dont render properly (or get escaped) in the final github PR comment
2. it keeps the format consistent with how github code scanning alerts display these comments.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
