### PR TITLE
Fixed no lintable files for solhint

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     ],
     "*.sol": [
       "prettier --write",
-      "solhint --noPrompt --fix"
+      "bash -c 'if [ \"$#\" -gt 0 ]; then output=$(bunx solhint --noPrompt --fix \"$@\" 2>&1); ret=$?; if echo \"$output\" | grep -q \"No files to lint!\"; then exit 0; else echo \"$output\"; exit $ret; fi; else exit 0; fi # If no lintable files, exit silently to avoid commit errors' _"
     ]
   }
 }


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
Fixed commit errors when only ignored .sol files are staged. The bash command now checks solhint’s output and exits quietly if it finds “No files to lint!” (exit code 0). 
# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
