### PR TITLE
Update quote endpoint link

### DIFF
--- a/archive/docs/LIFuelFacet.md
+++ b/archive/docs/LIFuelFacet.md
@@ -39,7 +39,7 @@ This parameter is strictly for analytics purposes. It's used to emit events that
 
 In the following some sample calls are shown that allow you to retrieve a populated transaction that can be sent to our contract via your wallet.
 
-All examples use our [/quote endpoint](https://apidocs.li.fi/reference/get_quote) to retrieve a quote which contains a `transactionRequest`. This request can directly be sent to your wallet to trigger the transaction.
+All examples use our [/quote endpoint](https://apidocs.li.fi/reference/get_v1-quote) to retrieve a quote which contains a `transactionRequest`. This request can directly be sent to your wallet to trigger the transaction.
 
 The quote result looks like the following:
 


### PR DESCRIPTION
This pull request updates the outdated link to the /quote endpoint in the LIFuelFacet.md documentation. The link now correctly points to the get_vi_quote reference, ensuring developers are directed to the correct API documentation.