### PR TITLE
fix foundry version in git action (due to error in latest foundry stable)

### DIFF
--- a/.github/workflows/healthCheckForNewNetworkDeployment.yml
+++ b/.github/workflows/healthCheckForNewNetworkDeployment.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Install Foundry (provides cast)
         if: env.CONTINUE == 'true' && env.SKIP_CHECK != 'true'
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.0.0
 
       - name: Install dependencies
         if: env.CONTINUE == 'true' && env.SKIP_CHECK != 'true'


### PR DESCRIPTION
# Why did I implement it this way?
The latest foundry stable version (1.2.2) seems to have a bug that is causing our healthcheck script to fail as a simple cast call fails. 
An issue has been opened: https://github.com/foundry-rs/foundry/issues/10705

For now we will fix the version to make sure our git actions pass.

# Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
