### PR TITLE
Adjust version contraol and audit check action

### DIFF
--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -61,7 +61,7 @@ jobs:
           echo "" > contracts_for_audit.txt
 
           ##### get all files modified by this PR
-          # --diff-filter=AM argument to only include files that were added or modified
+          # --diff-filter=AM argument to only include files that were added or modified not deleted
           FILES="$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}" HEAD)"
 
           ##### make sure that there are modified files

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -61,6 +61,7 @@ jobs:
           echo "" > contracts_for_audit.txt
 
           ##### get all files modified by this PR
+          # --diff-filter=AM argument to only include files that were added or modified
           FILES="$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}" HEAD)"
 
           ##### make sure that there are modified files

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -592,17 +592,22 @@ jobs:
             fi
             echo -e "\033[32mThe audit log contains all required information for contract $FILE\033[0m"
 
-            echo "now checking if audit commit hash $AUDIT_COMMIT_HASH is associated with PR $PR_NUMBER"
-            ##### Fetch the list of commits associated with the PR
-            COMMIT_LIST=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
+            # NOTE: This check is disabled because it can cause issues when reverting PRs.
+            # For example, if a PR is mistakenly merged and needs to be reverted,
+            # the revert PR would fail this check since the audit commit hash would not be
+            # part of the revert PR's commit history. This would make it impossible to
+            # revert changes through the normal PR process.
+            # echo "now checking if audit commit hash $AUDIT_COMMIT_HASH is associated with PR $PR_NUMBER"
+            # ##### Fetch the list of commits associated with the PR
+            # COMMIT_LIST=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
 
-            ##### Check if the target commit is in the list
-            if echo "$COMMIT_LIST" | grep -q "$AUDIT_COMMIT_HASH"; then
-              echo -e "\033[32mCommit $AUDIT_COMMIT_HASH is associated with PR #$PR_NUMBER.\033[0m"
-            else
-              echo -e "\033[31mCommit $AUDIT_COMMIT_HASH is NOT associated with PR #$PR_NUMBER.\033[0m"
-              exit 1
-            fi
+            # ##### Check if the target commit is in the list
+            # if echo "$COMMIT_LIST" | grep -q "$AUDIT_COMMIT_HASH"; then
+            #   echo -e "\033[32mCommit $AUDIT_COMMIT_HASH is associated with PR #$PR_NUMBER.\033[0m"
+            # else
+            #   echo -e "\033[31mCommit $AUDIT_COMMIT_HASH is NOT associated with PR #$PR_NUMBER.\033[0m"
+            #   exit 1
+            # fi
 
 
             ##### Check if the auditor git handle exists on github

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -61,7 +61,7 @@ jobs:
           echo "" > contracts_for_audit.txt
 
           ##### get all files modified by this PR
-          FILES="$(git diff --name-only "origin/${BASE_REF}" HEAD)"
+          FILES="$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}" HEAD)"
 
           ##### make sure that there are modified files
           if [[ -z "$FILES" ]]; then


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?

The first change adds the `--diff-filter=AM` flag to the git diff command to only include added or modified files, excluding deleted ones. This was necessary because the action was previously trying to check for `custom::version` tags in deleted contracts, which doesn't make sense since these files no longer exist and shouldn't be part of the version control check.
The second change disables the commit hash verification in the audit check. when trying to revert a PR (for example after discovering an post merge issue ) the action would fail because the revert PR's commit history wouldn't contain the original audit commit hash. This is blocking the ability to revert changes through github normal PR process. By disabling this check we maintain the ability to revert PRs when needed

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
