### PR TITLE
Add a refund address to pioneer facet [PioneerFacet v1.1.0]

### DIFF
--- a/docs/PioneerFacet.md
+++ b/docs/PioneerFacet.md
@@ -14,14 +14,21 @@ graph LR;
 
 ## Public Methods
 
-- `function startBridgeTokensViaPioneer(BridgeData calldata _bridgeData)`
+- `function startBridgeTokensViaPioneer(BridgeData calldata _bridgeData, PioneerData calldata _pioneerData)`
   - Simply bridges tokens using pioneer
-- `swapAndStartBridgeTokensViaPioneer(BridgeData memory _bridgeData, LibSwap.SwapData[] calldata _swapData)`
+- `swapAndStartBridgeTokensViaPioneer(BridgeData memory _bridgeData, LibSwap.SwapData[] calldata _swapData, PioneerData calldata _pioneerData)`
   - Performs swap(s) before bridging tokens using pioneer
 
 ## pioneer Specific Parameters
 
-Pioneer does not take specific parameters. The transaction ID is used to index information about the destinaton.
+The Pioneer takes a PioneerData struct to provide context on the transaction originator; If the transaction fails and a refund has to be issued, the refund will be sent to `PioneerData.refundAddress`.
+```solidity
+struct PioneerData {
+  address payable refundAddress;
+}
+```
+
+Additionally, it is expected that the transaction ID of matches the quoteId from the Pioneer api.
 
 ## Swap Data
 

--- a/script/demoScripts/demoPioneer.ts
+++ b/script/demoScripts/demoPioneer.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv'
 import { parseUnits, zeroAddress, type Narrow } from 'viem'
 
 import pioneerFacetArtifact from '../../out/PioneerFacet.sol/PioneerFacet.json'
-import type { ILiFi } from '../../typechain'
+import type { ILiFi, PioneerFacet } from '../../typechain'
 import type { SupportedChain } from '../common/types'
 
 import { executeTransaction, setupEnvironment } from './utils/demoScriptHelpers'
@@ -118,7 +118,12 @@ async function main() {
     hasSourceSwaps: false,
     hasDestinationCall: false,
   }
-  console.log(bridgeData)
+
+  const pioneerData: PioneerFacet.PioneerDataStruct = {
+    refundAddress: signerAddress,
+  }
+
+  console.log(bridgeData, pioneerData)
 
   // === Start bridging ===
   if (!lifiDiamondContract) throw new Error('LiFi Diamond contract not found')
@@ -126,7 +131,7 @@ async function main() {
   await executeTransaction(
     () =>
       (lifiDiamondContract as any).write.startBridgeTokensViaPioneer(
-        [bridgeData],
+        [bridgeData, pioneerData],
         {
           value: amount,
         }

--- a/src/Facets/PioneerFacet.sol
+++ b/src/Facets/PioneerFacet.sol
@@ -12,7 +12,7 @@ import { InvalidConfig } from "../Errors/GenericErrors.sol";
 /// @title Pioneer Facet
 /// @author LI.FI (https://li.fi)
 /// @notice Main entry point to send bridge requests to Pioneer
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract PioneerFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable {
     /// @notice Describes a refund address. Emitted after LiFiTransferStarted.
     /// @param refundTo If transaction failed, send inputs to this address.

--- a/test/solidity/Facets/PioneerFacet.t.sol
+++ b/test/solidity/Facets/PioneerFacet.t.sol
@@ -75,6 +75,8 @@ contract PioneerFacetTest is TestBaseFacet {
 
         usdc.approve(address(basePioneerFacet), bridgeData.minAmount);
 
+        vm.expectEmit();
+        emit PioneerFacet.RefundAddress(pioneerData.refundAddress);
         basePioneerFacet.startBridgeTokensViaPioneer(bridgeData, pioneerData);
 
         assertEq(
@@ -88,6 +90,8 @@ contract PioneerFacetTest is TestBaseFacet {
 
         bridgeData.sendingAssetId = address(0);
 
+        vm.expectEmit();
+        emit PioneerFacet.RefundAddress(pioneerData.refundAddress);
         basePioneerFacet.startBridgeTokensViaPioneer{
             value: bridgeData.minAmount
         }(bridgeData, pioneerData);

--- a/test/solidity/Facets/PioneerFacet.t.sol
+++ b/test/solidity/Facets/PioneerFacet.t.sol
@@ -26,6 +26,8 @@ contract PioneerFacetTest is TestBaseFacet {
 
     address payable internal destination;
 
+    PioneerFacet.PioneerData internal pioneerData;
+
     function setUp() public {
         customBlockNumberForForking = 17130542;
         initTestBase();
@@ -63,6 +65,9 @@ contract PioneerFacetTest is TestBaseFacet {
         // adjust bridgeData
         bridgeData.bridge = "pioneer";
         bridgeData.destinationChainId = 137;
+
+        // Set a refund address.
+        pioneerData.refundAddress = payable(address(0xdeaddeadff77));
     }
 
     function test_transfer_to_pioneer() external {
@@ -70,7 +75,7 @@ contract PioneerFacetTest is TestBaseFacet {
 
         usdc.approve(address(basePioneerFacet), bridgeData.minAmount);
 
-        basePioneerFacet.startBridgeTokensViaPioneer(bridgeData);
+        basePioneerFacet.startBridgeTokensViaPioneer(bridgeData, pioneerData);
 
         assertEq(
             IERC20(bridgeData.sendingAssetId).balanceOf(destination),
@@ -85,7 +90,7 @@ contract PioneerFacetTest is TestBaseFacet {
 
         basePioneerFacet.startBridgeTokensViaPioneer{
             value: bridgeData.minAmount
-        }(bridgeData);
+        }(bridgeData, pioneerData);
 
         assertEq(destination.balance, bridgeData.minAmount);
     }
@@ -94,9 +99,9 @@ contract PioneerFacetTest is TestBaseFacet {
         if (isNative) {
             pioneerFacet.startBridgeTokensViaPioneer{
                 value: bridgeData.minAmount
-            }(bridgeData);
+            }(bridgeData, pioneerData);
         } else {
-            pioneerFacet.startBridgeTokensViaPioneer(bridgeData);
+            pioneerFacet.startBridgeTokensViaPioneer(bridgeData, pioneerData);
         }
     }
 
@@ -106,11 +111,12 @@ contract PioneerFacetTest is TestBaseFacet {
         if (isNative) {
             pioneerFacet.swapAndStartBridgeTokensViaPioneer{
                 value: swapData[0].fromAmount
-            }(bridgeData, swapData);
+            }(bridgeData, swapData, pioneerData);
         } else {
             pioneerFacet.swapAndStartBridgeTokensViaPioneer(
                 bridgeData,
-                swapData
+                swapData,
+                pioneerData
             );
         }
     }


### PR DESCRIPTION
# Which Jira task belongs to this PR?

xxx

# Why did I implement it this way?

Refund address added for failed transactions.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [x] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
