### PR TITLE
chore: enable hyperevm on kyberswap

### DIFF
--- a/config/dexs.json
+++ b/config/dexs.json
@@ -534,7 +534,8 @@
     "0x744489ee3d540777a66f2cf297479745e0852f7a",
     "0x6352a56caadc4f1e25cd6c75970fa768a3304e64",
     "0xbbbbbBB520d69a9775E85b458C58c648259FAD5F",
-    "0x4212a77e4533eCa49643d7B731F5FB1b2782FE94"
+    "0x4212a77e4533eCa49643d7B731F5FB1b2782FE94",
+    "0x6131b5fae19ea4f9d964eac0408e4408b66337b5"
   ],
   "immutablezkevm": [
     "0xAcD913Ad6936Bb662395ac9a66D75bFc77c165fF",
@@ -1092,7 +1093,9 @@
     "0xf91bb752490473b8342a3e964e855b9f9a2a668e"
   ],
   "avalancheFujiTestnet": [],
-  "bscTestnet": ["0x1b02da8cb0d097eb8d57a175b88c7d8b47997506"],
+  "bscTestnet": [
+    "0x1b02da8cb0d097eb8d57a175b88c7d8b47997506"
+  ],
   "localanvil": [],
   "mumbai": [
     "0x5215E9fd223BC909083fbdB2860213873046e45d",


### PR DESCRIPTION
# Which Jira task belongs to this PR?
https://lifi.atlassian.net/browse/LF-14655

# Why did I implement it this way?
Added kyberswap router to hyperevm dexes list

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
