### PR TITLE
Audit gh action check only on main branch

### DIFF
--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -1,14 +1,14 @@
 # This git action combines version control and audit checks
-# Version Control:
+# Version Control (runs on all branches):
 # - will check all modified or new contracts in src/*
 # - makes sure that all contracts that have changes in audit-relevant code require a contract version update
 # - relevant changes => anything except for single (//) or multi-line (/*) comments and changes in solidity pragma
 # - fails if contract version was not updated despite relevant changes
 # - fails if a new contract was added without a ///custom:version tag
 # - will update the PR title to contain contract names with version changes (incl. their new version)
-# Audit Checker:
+# Audit Checker (runs only on PRs targeting main branch):
 # - will check all modified or new contracts in src/*, except for interfaces (src/Interfaces/**) as these do not require an audit
-# - will only run if version-control job passed successfully
+# - will only run if version-control job passed successfully AND PR targets main branch
 # - will remove the (protected) "AuditCompleted" label in the beginning to prevent erroneous states
 # - reuses the list of relevant contracts identified by the version-control job
 # - will assign "AuditRequired" label if relevant contracts were identified, otherwise it wil assign "AuditNotRequired"

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -308,7 +308,7 @@ jobs:
         # ------------------------ end of version control checker ------------------------
 
   audit-verification:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' }}
     needs: version-control
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
Currently, the version control and audit verification github action runs on all PRs regardless of their target branch, which creates a blocking situation for epic/feature branches where we want to merge sub-PRs without requiring full audit verification. This issue was identified during LDA 2.0 development where sub-PRs targeting epic branches were being blocked by audit requirements. After team discussion we agreed that audit verification should only be enforced when targeting the main branch

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
