### PR TITLE
Update pre-commit hook to build contracts and exclude 'test' directory

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ echo "Running 'forge build' and 'typechain generation'..."
 
 # Run forge build first (required for typechain)
 echo "Building contracts with forge..."
-forge build src
+forge build --skip test
 
 if [ $? -ne 0 ]; then
   printf '\n%s\n\n' "Forge build failed. Aborting commit."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ echo "Running 'forge build' and 'typechain generation'..."
 
 # Run forge build first (required for typechain)
 echo "Building contracts with forge..."
-forge build
+forge build src
 
 if [ $? -ne 0 ]; then
   printf '\n%s\n\n' "Forge build failed. Aborting commit."


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?

<img width="795" height="429" alt="image" src="https://github.com/user-attachments/assets/e46d23ca-1b00-47e2-b703-6b720439a729" />

Implemented changes to avoid generating ts types for test contracts during the pre-commit hook. Previously, building all contracts caused typechain to create types for both production and test contracts, which led to duplicate ts identifiers like Ownable and ERC20Permit during local type-checks. By restricting the pre-commit build contracts excluding `test` folder, we ensure that typechain only generates types for the production contracts, eliminating these duplicate identifier errors. At the same time, we still compile and check test contracts on CI, so no verification is lost.


# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
