### PR TITLE
Version control gh action check only on main branch

### DIFF
--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   version-control:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
     concurrency:
       group: sc-core-dev-approval-${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
Currently, the version control GitHub Action runs on all PRs regardless of their target branch, which creates a blocking situation for epic/feature branches where we want to merge sub-PRs without requiring full version control validation. This issue was identified during LDA 2.0 development where sub-PRs targeting epic branches were being blocked by version control requirements.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
