### PR TITLE
Solana recipient extraction from Borsh-encoded routes

### DIFF
--- a/src/Facets/EcoFacet.sol
+++ b/src/Facets/EcoFacet.sol
@@ -253,10 +253,21 @@ contract EcoFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable, LiFiData {
     }
 
     function _validateSolanaReceiver(EcoData calldata _ecoData) private pure {
-        if (_ecoData.encodedRoute.length < 32) {
+        // Extract the Solana recipient address from a Borsh-encoded Route struct
+        // The Route struct contains TransferChecked instruction calldata where:
+        // - The entire Route struct is Borsh-serialized
+        // - Within the serialized Route, the TransferChecked instruction data is embedded
+        // - The recipient account (destination wallet) is located at bytes 251-282 (32 bytes)
+        // - This position is determined by the Route struct layout and the position of the
+        //   recipient pubkey within the TransferChecked instruction calldata
+        // - Borsh encoding preserves the exact byte positions for fixed-size fields like pubkeys
+        // - The total encoded route for Solana must be exactly 319 bytes
+        if (_ecoData.encodedRoute.length != 319) {
             revert InvalidCallData();
         }
-        bytes32 routeReceiver = bytes32(_ecoData.encodedRoute[0:32]);
+
+        // Extract bytes 251-282 (32 bytes) which contain the recipient address
+        bytes32 routeReceiver = bytes32(_ecoData.encodedRoute[251:283]);
         if (
             _ecoData.nonEVMReceiver.length == 0 ||
             _ecoData.nonEVMReceiver.length > 44


### PR DESCRIPTION
## Summary
- Validate Solana routes are exactly 319 bytes (Borsh-encoded Route struct size)
- Extract recipient address from correct position (bytes 251-282) within TransferChecked instruction
- Add comprehensive documentation explaining the Borsh encoding structure

## Changes
Updated `_validateSolanaReceiver` function in EcoFacet to properly extract Solana recipient addresses from Borsh-encoded routes. The previous implementation was attempting to read from an incorrect position in the encoded data.

## Technical Details
The Solana route is a Borsh-serialized Route struct containing TransferChecked instruction calldata. The recipient public key is located at a fixed position (bytes 251-282) within this structure due to Borsh's deterministic encoding of fixed-size fields.

### Complete Detailed Byte Ranges

This example shows a Route with one token and one SPL Token transfer call with CalldataWithAccounts.

| Byte Range | Field | Description | Example Value |
|------------|-------|-------------|---------------|
| **0-31** | `salt` | 32-byte random value | `0x0101...0101` (32 bytes of 0x01) |
| **32-39** | `deadline` | 8-byte Unix timestamp (LE) | `0x00EB6365 00000000` (1700000000) |
| **40-71** | `portal` | 32-byte portal program address | `0x0202...0202` (32 bytes of 0x02) |
| **72-79** | `native_amount` | 8-byte SOL amount in lamports (LE) | `0x00CA9A3B 00000000` (1,000,000,000) |
| **80-83** | `tokens.len` | 4-byte vector length (LE) | `0x01000000` (1 token) |
| **84-115** | `tokens[0].token` | 32-byte token mint pubkey | `0x0303...0303` (32 bytes of 0x03) |
| **116-123** | `tokens[0].amount` | 8-byte token amount (LE) | `0x404B4C00 00000000` (5,000,000) |
| **124-127** | `calls.len` | 4-byte vector length (LE) | `0x01000000` (1 call) |
| **128-159** | `calls[0].target` | 32-byte program ID | TOKEN_PROGRAM_ID bytes |
| **160-163** | `calls[0].data.len` | 4-byte data vector length (LE) | `0x9B000000` (155 bytes) |
| **164+** | `calls[0].data` | CalldataWithAccounts bytes | See detailed breakdown below |

### CalldataWithAccounts Encoding Within calls[0].data

Assuming a standard SPL token transfer_checked instruction with 4 accounts:

| Byte Range | Field | Description | Example Value |
|------------|-------|-------------|---------------|
| **164-167** | `calldata.data.len` | Length of SPL instruction data | `0x0A000000` (10 bytes) |
| **168-177** | `calldata.data` | SPL transfer_checked instruction | See instruction breakdown |
| **178** | `calldata.account_count` | Number of accounts | `0x04` (4 accounts) |
| **179-182** | `accounts.len` | Vector length | `0x04000000` (4 accounts) |
| **183-216** | `accounts[0]` | From token account | See account breakdown |
| **217-250** | `accounts[1]` | Token mint | See account breakdown |
| **251-284** | `accounts[2]` | To token account | See account breakdown |
| **285-318** | `accounts[3]` | Authority/Owner | See account breakdown |

### SPL Transfer_Checked Instruction Data (bytes 168-177)

| Byte Range | Field | Description | Example Value |
|------------|-------|-------------|---------------|
| **168** | Instruction discriminator | transfer_checked = 12 | `0x0C` |
| **169-176** | Amount | 8-byte transfer amount (LE) | `0x00E1F505 00000000` (100,000,000) |
| **177** | Decimals | Token decimals | `0x06` (6 for USDC) |

### Account Meta Encoding (34 bytes each)

Each account in the `accounts` vector is encoded as:

| Relative Byte | Field | Description | Size |
|---------------|-------|-------------|------|
| **0-31** | `pubkey` | Account public key | 32 bytes |
| **32** | `is_signer` | Whether account must sign | 1 byte (0x00/0x01) |
| **33** | `is_writable` | Whether account is writable | 1 byte (0x00/0x01) |

#### Example Account Encoding (accounts[0] - From Token Account):
| Byte Range | Field | Value |
|------------|-------|-------|
| **183-214** | Pubkey | From token account address (32 bytes) |
| **215** | is_signer | `0x00` (false) |
| **216** | is_writable | `0x01` (true) |

#### Example Account Encoding (accounts[1] - Token Mint):
| Byte Range | Field | Value |
|------------|-------|-------|
| **217-248** | Pubkey | Token mint address (32 bytes) |
| **249** | is_signer | `0x00` (false) |
| **250** | is_writable | `0x00` (false) |

#### Example Account Encoding (accounts[2] - To Token Account):
| Byte Range | Field | Value |
|------------|-------|-------|
| **251-282** | Pubkey | To token account address (32 bytes) |
| **283** | is_signer | `0x00` (false) |
| **284** | is_writable | `0x01` (true) |

#### Example Account Encoding (accounts[3] - Authority/Owner):
| Byte Range | Field | Value |
|------------|-------|-------|
| **285-316** | Pubkey | Authority/owner address (32 bytes) |
| **317** | is_signer | `0x01` (true) |
| **318** | is_writable | `0x00` (false) |

### Total Size Calculation

For this example Route:
- Fixed fields: 80 bytes (salt + deadline + portal + native_amount)
- Tokens vector: 4 (len) + 40 (1 token × 40 bytes) = 44 bytes
- Calls vector: 4 (len) + 32 (target) + 4 (data.len) + 155 (CalldataWithAccounts) = 195 bytes
- **Total: 319 bytes**

CalldataWithAccounts breakdown (155 bytes):
- calldata.data.len: 4 bytes
- calldata.data: 10 bytes (transfer_checked instruction)
- calldata.account_count: 1 byte
- accounts.len: 4 bytes
- accounts (4 × 34 bytes): 136 bytes
- **Total: 4 + 10 + 1 + 4 + 136 = 155 bytes**

Note: LE = Little-Endian encoding
