### PR TITLE
fix natspec comments (to silence foundry errors)

### DIFF
--- a/docs/RelayFacet.md
+++ b/docs/RelayFacet.md
@@ -28,9 +28,9 @@ The methods listed above take a variable labeled `_relayData`. This data is spec
 /// @dev Relay specific parameters
 /// @param requestId Realy API request ID
 /// @param nonEVMReceiver set only if bridging to non-EVM chain
-/// @params receivingAssetId address of receiving asset
-/// @params callData calldata provided by Relay API
-/// @params signature attestation signature provided by the Relay solver
+/// @param receivingAssetId address of receiving asset
+/// @param callData calldata provided by Relay API
+/// @param signature attestation signature provided by the Relay solver
 struct RelayData {
   bytes32 requestId;
   bytes32 nonEVMReceiver;

--- a/src/Facets/RelayFacet.sol
+++ b/src/Facets/RelayFacet.sol
@@ -39,8 +39,8 @@ contract RelayFacet is
     /// @dev Relay specific parameters
     /// @param requestId Relay API request ID
     /// @param nonEVMReceiver set only if bridging to non-EVM chain
-    /// @params receivingAssetId address of receiving asset
-    /// @params signature attestation signature provided by the Relay solver
+    /// @param receivingAssetId address of receiving asset
+    /// @param signature attestation signature provided by the Relay solver
     struct RelayData {
         bytes32 requestId;
         bytes32 nonEVMReceiver;

--- a/src/Interfaces/IConnextHandler.sol
+++ b/src/Interfaces/IConnextHandler.sol
@@ -7,9 +7,7 @@ pragma solidity ^0.8.17;
 interface IConnextHandler {
     /// @notice These are the call parameters that will remain constant between the
     /// two chains. They are supplied on `xcall` and should be asserted on `execute`
-    /// @property to - The account that receives funds, in the event of a crosschain call,
-    /// will receive funds if the call fails.
-    /// @param to - The address you are sending funds (and potentially data) to
+    /// @param to - The address that will receive funds/refunds
     /// @param callData - The data to execute on the receiving chain. If no crosschain call is needed, then leave empty.
     /// @param originDomain - The originating domain (i.e. where `xcall` is called). Must match nomad domain schema
     /// @param destinationDomain - The final domain (i.e. where `execute` / `reconcile` are called).


### PR DESCRIPTION
# Why did I implement it this way?
Foundry 1.4.4 was made stable version and is causing errors on git actions for invalid natspec comments. 
This PR fixes the invalid natspec comments. 

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
