### PR TITLE
grant deployer wallet CANCELLER_ROLE in timelock (safe will automatically get this role as it's a PROPOSER)

### DIFF
--- a/script/deploy/facets/DeployLiFiTimelockController.s.sol
+++ b/script/deploy/facets/DeployLiFiTimelockController.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
 import { DeployScriptBase } from "./utils/DeployScriptBase.sol";
@@ -62,14 +62,19 @@ contract DeployScript is DeployScriptBase {
         address[] memory executors = new address[](1);
         executors[0] = address(0);
 
-        // TODO: we need to renounce the admin role from multisig safe,
-        // otherwise it has too much rights and can bypass the timelock
+        // get deployer wallet from global.json
+        path = string.concat(root, "/config/global.json");
+        string memory globalConfigJson = vm.readFile(path);
+        address deployerWallet = globalConfigJson.readAddress(
+            ".deployerWallet"
+        );
 
         return
             abi.encode(
                 minDelay,
                 proposers,
                 executors,
+                deployerWallet,
                 safeAddress,
                 diamondAddress
             );

--- a/script/deploy/zksync/DeployLiFiTimelockController.zksync.s.sol
+++ b/script/deploy/zksync/DeployLiFiTimelockController.zksync.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
 import { DeployScriptBase } from "./utils/DeployScriptBase.sol";
@@ -62,11 +62,19 @@ contract DeployScript is DeployScriptBase {
         address[] memory executors = new address[](1);
         executors[0] = address(0);
 
+        // get deployer wallet from global.json
+        path = string.concat(root, "/config/global.json");
+        string memory globalConfigJson = vm.readFile(path);
+        address deployerWallet = globalConfigJson.readAddress(
+            ".deployerWallet"
+        );
+
         return
             abi.encode(
                 minDelay,
                 proposers,
                 executors,
+                deployerWallet,
                 safeAddress,
                 diamondAddress
             );


### PR DESCRIPTION
# Why did I implement it this way?
During Monad deployment it became clear that our deployer wallet does not have the rights to cancel timelock proposals which are ready for execution. We can only do that via multisig safe which is a bit cumbersome. 
Granting this role to deployer wallet does not pose any risks. 


# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
