### PR TITLE
improve multi-chain execution (and log output) for syncWhitelist script

### DIFF
--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -607,7 +607,7 @@ function diamondSyncWhitelist {
         local TX_OUTPUT
         echoSyncDebug "CONTRACTS_ARRAY: $CONTRACTS_ARRAY"
         echoSyncDebug "SELECTORS_ARRAY: $SELECTORS_ARRAY"
-        TX_OUTPUT=$(cast send "$DIAMOND_ADDRESS" "batchSetContractSelectorWhitelist(address[],bytes4[],bool)" "[$CONTRACTS_ARRAY]" "[$SELECTORS_ARRAY]" true --rpc-url "$RPC_URL" --private-key $(getPrivateKey "$NETWORK" "$ENVIRONMENT") --legacy 2>&1)
+        TX_OUTPUT=$(cast send "$DIAMOND_ADDRESS" "batchSetContractSelectorWhitelist(address[],bytes4[],bool)" "[$CONTRACTS_ARRAY]" "[$SELECTORS_ARRAY]" true --rpc-url "$RPC_URL" --private-key "$(getPrivateKey "$NETWORK" "$ENVIRONMENT")" --legacy 2>&1)
         local TX_EXIT_CODE=$?
 
         # Print transaction output for debugging (single-network runs only)


### PR DESCRIPTION
# Why did I implement it this way?
The existing implementation was clogging the log output with hundreds of messages which made it impossible to see which networks were done and which ran into errors

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
