### PR TITLE
run update periphery before synching whitelist

### DIFF
--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -13,7 +13,7 @@ function diamondSyncWhitelist {
   # Update whitelist periphery and composer entries before syncing
   echo ""
   echo "[info] Updating whitelist periphery and composer entries..."
-  bunx tsx ./script/tasks/updateWhitelistPeriphery.ts || checkFailure $? "update whitelist periphery"
+  bunx tsx script/tasks/updateWhitelistPeriphery.ts || checkFailure $? "update whitelist periphery"
   echo "[info] Whitelist periphery update completed"
   echo ""
 


### PR DESCRIPTION
# Why did I implement it this way?
This makes sure that the whitelist party maintained by the SC team are always up to date when running the sync whitelist command

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
