### PR TITLE
Confirm-safe-tx script to log explorer for address on 'registerPeripheryContract'

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -335,6 +335,36 @@ async function decodeNestedTimelockCall(
                     nestedDecodedData.args,
                     network
                   )
+                } else if (
+                  nestedDecodedData.functionName === 'registerPeripheryContract'
+                ) {
+                  consola.info('Nested Decoded Arguments:')
+                  nestedDecodedData.args.forEach(
+                    (arg: unknown, index: number) => {
+                      // Handle different types of arguments
+                      let displayValue = arg
+                      if (typeof arg === 'bigint') displayValue = arg.toString()
+                      else if (typeof arg === 'object' && arg !== null)
+                        displayValue = JSON.stringify(arg)
+
+                      // Special handling for address argument (index 1)
+                      if (index === 1 && typeof arg === 'string') {
+                        const address = arg as string
+                        let addressLine = `  [${index}]: \u001b[33m${address}\u001b[0m`
+                        const explorerUrl = buildExplorerContractPageUrl(
+                          network,
+                          address
+                        )
+                        if (explorerUrl)
+                          addressLine += ` \u001b[36m${explorerUrl}\u001b[0m`
+                        consola.info(addressLine)
+                      } else {
+                        consola.info(
+                          `  [${index}]: \u001b[33m${displayValue}\u001b[0m`
+                        )
+                      }
+                    }
+                  )
                 } else {
                   consola.info('Nested Decoded Arguments:')
                   nestedDecodedData.args.forEach(


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
Improve confirm-safe-tx script to log explorer for address on 'registerPeripheryContract' proposal

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
