### PR TITLE
Changed git secret name

### DIFF
--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: lifinance/lifi-contract-types
           path: lifi-contract-types
-          ssh-key: ${{ secrets.SSH_REPO_TOKEN }}
+          ssh-key: ${{ secrets.TYPINGS_REPO_SSH_TOKEN }}
           ref: main
 
       # Step 9: Copy generated types and ABI into the lifi-contract-types repo


### PR DESCRIPTION
# Which Jira task belongs to this PR?

# Why did I implement it this way?
The previous name was too generic (`SSH_TOKEN`). The new name (`TYPINGS_REPO_SSH_TOKEN`) better shows what this SSH key is used for. We are changing it while rotating this secret.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
