### PR TITLE
Simple fix for a non-working swap function

### DIFF
--- a/script/demoScripts/demoChainflip.ts
+++ b/script/demoScripts/demoChainflip.ts
@@ -79,7 +79,7 @@ async function executeWithSourceSwap(
     ADDRESS_USDT_ARB,
     ADDRESS_USDC_ARB,
     amount,
-    lifiDiamondAddress,
+    lifiDiamondAddress.address,
     true
   )
 


### PR DESCRIPTION
Replaced the undefined variable `lifiDiamondAddress` with `lifiDiamondContract.address` in the `executeWithSourceSwap function`.

I chose this particular correction option because:
- it is a working option
- it is minimal