### PR TITLE
Fix tron deploy and confirm-safe-tx scripts

### DIFF
--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -20,5 +20,6 @@
   "FeeForwarder": "TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ",
   "WhitelistManagerFacet": "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn",
   "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q",
-  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu"
+  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu",
+  "NEARIntentsFacet": "TFFvFi3j5YBMrSBev6bm6ueEaq1XWJ1QJZ"
 }

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -20,6 +20,5 @@
   "FeeForwarder": "TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ",
   "WhitelistManagerFacet": "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn",
   "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q",
-  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu",
-  "NEARIntentsFacet": "TFFvFi3j5YBMrSBev6bm6ueEaq1XWJ1QJZ"
+  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu"
 }

--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -218,6 +218,23 @@ export interface IChainSimulateResult {
   resourceLabel: string
 }
 
+/** Options for proposing a Safe transaction (EVM). */
+export interface IProposeToSafeOptions {
+  network: string
+  to: string
+  calldata: Hex
+  timelock?: boolean
+  dryRun?: boolean
+  privateKey?: string
+  rpcUrl?: string
+  ledger?: boolean
+  ledgerLive?: boolean
+  accountIndex?: number
+  derivationPath?: string
+  safeAddress?: string
+  calldataFile?: string
+}
+
 /** Strategy interface for chain-specific generic contract call broadcasting. */
 export interface IChainCaller {
   /** The sender address used for broadcasting. */

--- a/script/demoScripts/utils/demoScriptHelpers.ts
+++ b/script/demoScripts/utils/demoScriptHelpers.ts
@@ -40,7 +40,7 @@ import { ERC20__factory } from '../../../typechain'
 import type { LibSwap } from '../../../typechain/AcrossFacetV3'
 import { EnvironmentEnum, type SupportedChain } from '../../common/types'
 import { isTronNetworkKey } from '../../deploy/shared/tron-network-keys'
-import { getRPCEnvVarName, node_url } from '../../utils/utils'
+import { getEnvVar, getRPCEnvVarName, node_url } from '../../utils/utils'
 import {
   getTransportConfigFromRpcUrl,
   getViemChainForNetworkName,
@@ -706,17 +706,6 @@ export function addressToBytes32RightPadded(address: string): `0x${string}` {
   return `0x${hex.padEnd(64, '0')}`
 }
 
-/**
- * Retrieve the value of an environment variable.
- * Throws an error if the environment variable is not defined.
- */
-export const getEnvVar = (varName: string): string => {
-  const value = process.env[varName]
-  if (!value)
-    throw new Error(`Missing required environment variable: ${varName}`)
-
-  return value
-}
 
 /**
  * Normalize a private key to ensure it starts with "0x".

--- a/script/deploy/query-deployment-logs.ts
+++ b/script/deploy/query-deployment-logs.ts
@@ -13,7 +13,7 @@ import { consola } from 'consola'
 import { MongoClient, type Db, type Collection, type Filter } from 'mongodb'
 
 import type { EnvironmentEnum } from '../common/types'
-import { getEnvVar } from '../demoScripts/utils/demoScriptHelpers'
+import { getEnvVar } from '../utils/utils'
 
 import { CachedDeploymentQuerier } from './shared/cached-deployment-querier'
 import {

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -31,149 +31,149 @@ export async function runPropose(options: IProposeToSafeOptions) {
   const { client: mongoClient, pendingTransactions } =
     await getSafeMongoCollection()
 
-  try {
-    if (!options.privateKey && !options.ledger)
-      throw new Error('Either privateKey or ledger must be provided')
+  if (!options.privateKey && !options.ledger)
+    throw new Error('Either privateKey or ledger must be provided')
 
-    const useLedger = options.ledger || false
-    let privateKey: string | undefined
+  const useLedger = options.ledger || false
+  let privateKey: string | undefined
 
-    if (options.derivationPath && options.ledgerLive)
+  if (options.derivationPath && options.ledgerLive)
+    throw new Error(
+      "Cannot use both 'derivationPath' and 'ledgerLive' options together"
+    )
+
+  if (useLedger) {
+    consola.info('Using Ledger hardware wallet for signing')
+    if (options.ledgerLive)
+      consola.info(
+        `Using Ledger Live derivation path with account index ${
+          options.accountIndex || 0
+        }`
+      )
+    else if (options.derivationPath)
+      consola.info(`Using custom derivation path: ${options.derivationPath}`)
+    else consola.info(`Using default derivation path: m/44'/60'/0'/0/0`)
+
+    privateKey = undefined
+  } else
+    privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION', options.privateKey)
+
+  const ledgerOptions = {
+    ledgerLive: options.ledgerLive || false,
+    accountIndex: options.accountIndex ?? 0,
+    derivationPath: options.derivationPath,
+  }
+
+  const safeAddressOverride = options.safeAddress
+    ? (getAddress(options.safeAddress) as Address)
+    : undefined
+  const { safe, chain, safeAddress } = await initializeSafeClient(
+    options.network,
+    privateKey,
+    options.rpcUrl,
+    useLedger,
+    ledgerOptions,
+    safeAddressOverride
+  )
+
+  const senderAddress = safe.account.address
+
+  const existingOwners = await safe.getOwners()
+  if (!isAddressASafeOwner(existingOwners, senderAddress)) {
+    consola.error('The current signer is not an owner of this Safe')
+    consola.error('Signer address:', senderAddress)
+    consola.error('Current owners:', existingOwners)
+    throw new Error('Cannot propose transactions - signer is not an owner')
+  }
+
+  let finalTo = options.to as Address
+
+  let finalCalldata: Hex
+  if (options.calldataFile) {
+    if (!fs.existsSync(options.calldataFile))
+      throw new Error(`Calldata file not found: ${options.calldataFile}`)
+    finalCalldata = fs
+      .readFileSync(options.calldataFile, 'utf8')
+      .trim() as Hex
+    consola.info(`Loaded calldata from file: ${options.calldataFile}`)
+  } else {
+    finalCalldata = options.calldata
+  }
+
+  if (options.timelock) {
+    const deploymentPath = path.join(
+      process.cwd(),
+      'deployments',
+      `${options.network}.json`
+    )
+
+    if (!fs.existsSync(deploymentPath))
+      throw new Error(`Deployment file not found: ${deploymentPath}`)
+
+    const deployments = JSON.parse(fs.readFileSync(deploymentPath, 'utf8'))
+    const timelockAddress = deployments.LiFiTimelockController
+
+    if (!timelockAddress || timelockAddress === '0x')
       throw new Error(
-        "Cannot use both 'derivationPath' and 'ledgerLive' options together"
+        `LiFiTimelockController not found in deployments for network ${options.network}`
       )
 
-    if (useLedger) {
-      consola.info('Using Ledger hardware wallet for signing')
-      if (options.ledgerLive)
-        consola.info(
-          `Using Ledger Live derivation path with account index ${
-            options.accountIndex || 0
-          }`
-        )
-      else if (options.derivationPath)
-        consola.info(`Using custom derivation path: ${options.derivationPath}`)
-      else consola.info(`Using default derivation path: m/44'/60'/0'/0/0`)
+    consola.info(`Using timelock controller at ${timelockAddress}`)
 
-      privateKey = undefined
-    } else
-      privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION', options.privateKey)
-
-    const ledgerOptions = {
-      ledgerLive: options.ledgerLive || false,
-      accountIndex: options.accountIndex ?? 0,
-      derivationPath: options.derivationPath,
-    }
-
-    const safeAddressOverride = options.safeAddress
-      ? (getAddress(options.safeAddress) as Address)
-      : undefined
-    const { safe, chain, safeAddress } = await initializeSafeClient(
+    const wrappedTransaction = await wrapWithTimelockSchedule(
       options.network,
-      privateKey,
-      options.rpcUrl,
-      useLedger,
-      ledgerOptions,
-      safeAddressOverride
+      options.rpcUrl || '',
+      getAddress(timelockAddress),
+      finalTo,
+      finalCalldata
     )
 
-    const senderAddress = safe.account.address
+    finalTo = wrappedTransaction.targetAddress
+    finalCalldata = wrappedTransaction.calldata
+  }
 
-    const existingOwners = await safe.getOwners()
-    if (!isAddressASafeOwner(existingOwners, senderAddress)) {
-      consola.error('The current signer is not an owner of this Safe')
-      consola.error('Signer address:', senderAddress)
-      consola.error('Current owners:', existingOwners)
-      throw new Error('Cannot propose transactions - signer is not an owner')
-    }
+  if (options.dryRun) {
+    consola.info('[DRY RUN] Would store proposal:')
+    consola.info('  network: ' + options.network)
+    consola.info('  to: ' + finalTo)
+    consola.info('  calldata: ' + finalCalldata.slice(0, 42) + '...')
+    consola.info('  timelock: ' + (options.timelock ? 'yes' : 'no'))
+    return
+  }
 
-    let finalTo = options.to as Address
+  const nextNonce = await getNextNonce(
+    pendingTransactions,
+    safeAddress,
+    options.network,
+    chain.id,
+    await safe.getNonce()
+  )
 
-    let finalCalldata: Hex
-    if (options.calldataFile) {
-      if (!fs.existsSync(options.calldataFile))
-        throw new Error(`Calldata file not found: ${options.calldataFile}`)
-      finalCalldata = fs
-        .readFileSync(options.calldataFile, 'utf8')
-        .trim() as Hex
-      consola.info(`Loaded calldata from file: ${options.calldataFile}`)
-    } else {
-      finalCalldata = options.calldata
-    }
+  const safeTransaction = await safe.createTransaction({
+    transactions: [
+      {
+        to: finalTo,
+        value: 0n,
+        data: finalCalldata,
+        operation: OperationTypeEnum.Call,
+        nonce: nextNonce,
+      },
+    ],
+  })
 
-    if (options.timelock) {
-      const deploymentPath = path.join(
-        process.cwd(),
-        'deployments',
-        `${options.network}.json`
-      )
+  const signedTx = await safe.signTransaction(safeTransaction)
+  const safeTxHash = await safe.getTransactionHash(signedTx)
 
-      if (!fs.existsSync(deploymentPath))
-        throw new Error(`Deployment file not found: ${deploymentPath}`)
+  consola.info('Signer Address', senderAddress)
+  consola.info('Safe Address', safeAddress)
+  consola.info('Network', chain.name)
+  consola.info('Proposing transaction to', finalTo)
+  if (options.timelock) {
+    consola.info('Original target was', options.to)
+    consola.info('Transaction wrapped in timelock schedule call')
+  }
 
-      const deployments = JSON.parse(fs.readFileSync(deploymentPath, 'utf8'))
-      const timelockAddress = deployments.LiFiTimelockController
-
-      if (!timelockAddress || timelockAddress === '0x')
-        throw new Error(
-          `LiFiTimelockController not found in deployments for network ${options.network}`
-        )
-
-      consola.info(`Using timelock controller at ${timelockAddress}`)
-
-      const wrappedTransaction = await wrapWithTimelockSchedule(
-        options.network,
-        options.rpcUrl || '',
-        getAddress(timelockAddress),
-        finalTo,
-        finalCalldata
-      )
-
-      finalTo = wrappedTransaction.targetAddress
-      finalCalldata = wrappedTransaction.calldata
-    }
-
-    if (options.dryRun) {
-      consola.info('[DRY RUN] Would store proposal:')
-      consola.info('  network: ' + options.network)
-      consola.info('  to: ' + finalTo)
-      consola.info('  calldata: ' + finalCalldata.slice(0, 42) + '...')
-      consola.info('  timelock: ' + (options.timelock ? 'yes' : 'no'))
-      return
-    }
-
-    const nextNonce = await getNextNonce(
-      pendingTransactions,
-      safeAddress,
-      options.network,
-      chain.id,
-      await safe.getNonce()
-    )
-
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to: finalTo,
-          value: 0n,
-          data: finalCalldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
-    })
-
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    consola.info('Signer Address', senderAddress)
-    consola.info('Safe Address', safeAddress)
-    consola.info('Network', chain.name)
-    consola.info('Proposing transaction to', finalTo)
-    if (options.timelock) {
-      consola.info('Original target was', options.to)
-      consola.info('Transaction wrapped in timelock schedule call')
-    }
-
+  try {
     const result = await storeTransactionInMongoDB(
       pendingTransactions,
       safeAddress,
@@ -194,6 +194,9 @@ export async function runPropose(options: IProposeToSafeOptions) {
 
     consola.success('Transaction successfully stored in MongoDB')
     consola.info('Transaction proposed')
+  } catch (error) {
+    consola.error('Failed to store transaction in MongoDB:', error)
+    throw error
   } finally {
     await mongoClient.close()
   }
@@ -297,4 +300,4 @@ const main = defineCommand({
   },
 })
 
-if (import.meta.main) runMain(main)
+runMain(main)

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -14,6 +14,8 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { getAddress, type Address, type Hex } from 'viem'
 
+import type { IProposeToSafeOptions } from '../../common/types'
+
 import {
   OperationTypeEnum,
   getNextNonce,
@@ -24,6 +26,178 @@ import {
   storeTransactionInMongoDB,
   wrapWithTimelockSchedule,
 } from './safe-utils'
+
+export async function runPropose(options: IProposeToSafeOptions) {
+  const { client: mongoClient, pendingTransactions } =
+    await getSafeMongoCollection()
+
+  try {
+    if (!options.privateKey && !options.ledger)
+      throw new Error('Either privateKey or ledger must be provided')
+
+    const useLedger = options.ledger || false
+    let privateKey: string | undefined
+
+    if (options.derivationPath && options.ledgerLive)
+      throw new Error(
+        "Cannot use both 'derivationPath' and 'ledgerLive' options together"
+      )
+
+    if (useLedger) {
+      consola.info('Using Ledger hardware wallet for signing')
+      if (options.ledgerLive)
+        consola.info(
+          `Using Ledger Live derivation path with account index ${
+            options.accountIndex || 0
+          }`
+        )
+      else if (options.derivationPath)
+        consola.info(`Using custom derivation path: ${options.derivationPath}`)
+      else consola.info(`Using default derivation path: m/44'/60'/0'/0/0`)
+
+      privateKey = undefined
+    } else
+      privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION', options.privateKey)
+
+    const ledgerOptions = {
+      ledgerLive: options.ledgerLive || false,
+      accountIndex: options.accountIndex ?? 0,
+      derivationPath: options.derivationPath,
+    }
+
+    const safeAddressOverride = options.safeAddress
+      ? (getAddress(options.safeAddress) as Address)
+      : undefined
+    const { safe, chain, safeAddress } = await initializeSafeClient(
+      options.network,
+      privateKey,
+      options.rpcUrl,
+      useLedger,
+      ledgerOptions,
+      safeAddressOverride
+    )
+
+    const senderAddress = safe.account.address
+
+    const existingOwners = await safe.getOwners()
+    if (!isAddressASafeOwner(existingOwners, senderAddress)) {
+      consola.error('The current signer is not an owner of this Safe')
+      consola.error('Signer address:', senderAddress)
+      consola.error('Current owners:', existingOwners)
+      throw new Error('Cannot propose transactions - signer is not an owner')
+    }
+
+    let finalTo = options.to as Address
+
+    let finalCalldata: Hex
+    if (options.calldataFile) {
+      if (!fs.existsSync(options.calldataFile))
+        throw new Error(`Calldata file not found: ${options.calldataFile}`)
+      finalCalldata = fs
+        .readFileSync(options.calldataFile, 'utf8')
+        .trim() as Hex
+      consola.info(`Loaded calldata from file: ${options.calldataFile}`)
+    } else {
+      finalCalldata = options.calldata
+    }
+
+    if (options.timelock) {
+      const deploymentPath = path.join(
+        process.cwd(),
+        'deployments',
+        `${options.network}.json`
+      )
+
+      if (!fs.existsSync(deploymentPath))
+        throw new Error(`Deployment file not found: ${deploymentPath}`)
+
+      const deployments = JSON.parse(fs.readFileSync(deploymentPath, 'utf8'))
+      const timelockAddress = deployments.LiFiTimelockController
+
+      if (!timelockAddress || timelockAddress === '0x')
+        throw new Error(
+          `LiFiTimelockController not found in deployments for network ${options.network}`
+        )
+
+      consola.info(`Using timelock controller at ${timelockAddress}`)
+
+      const wrappedTransaction = await wrapWithTimelockSchedule(
+        options.network,
+        options.rpcUrl || '',
+        getAddress(timelockAddress),
+        finalTo,
+        finalCalldata
+      )
+
+      finalTo = wrappedTransaction.targetAddress
+      finalCalldata = wrappedTransaction.calldata
+    }
+
+    if (options.dryRun) {
+      consola.info('[DRY RUN] Would store proposal:')
+      consola.info('  network: ' + options.network)
+      consola.info('  to: ' + finalTo)
+      consola.info('  calldata: ' + finalCalldata.slice(0, 42) + '...')
+      consola.info('  timelock: ' + (options.timelock ? 'yes' : 'no'))
+      return
+    }
+
+    const nextNonce = await getNextNonce(
+      pendingTransactions,
+      safeAddress,
+      options.network,
+      chain.id,
+      await safe.getNonce()
+    )
+
+    const safeTransaction = await safe.createTransaction({
+      transactions: [
+        {
+          to: finalTo,
+          value: 0n,
+          data: finalCalldata,
+          operation: OperationTypeEnum.Call,
+          nonce: nextNonce,
+        },
+      ],
+    })
+
+    const signedTx = await safe.signTransaction(safeTransaction)
+    const safeTxHash = await safe.getTransactionHash(signedTx)
+
+    consola.info('Signer Address', senderAddress)
+    consola.info('Safe Address', safeAddress)
+    consola.info('Network', chain.name)
+    consola.info('Proposing transaction to', finalTo)
+    if (options.timelock) {
+      consola.info('Original target was', options.to)
+      consola.info('Transaction wrapped in timelock schedule call')
+    }
+
+    const result = await storeTransactionInMongoDB(
+      pendingTransactions,
+      safeAddress,
+      options.network,
+      chain.id,
+      signedTx,
+      safeTxHash,
+      senderAddress
+    )
+
+    if (result === null) {
+      consola.info('Proposal already exists - no new proposal created')
+      return
+    }
+
+    if (!result.acknowledged)
+      throw new Error('MongoDB insert was not acknowledged')
+
+    consola.success('Transaction successfully stored in MongoDB')
+    consola.info('Transaction proposed')
+  } finally {
+    await mongoClient.close()
+  }
+}
 
 /**
  * Main command definition for proposing transactions to a Safe
@@ -89,6 +263,11 @@ const main = defineCommand({
       description: 'Wrap the transaction in a timelock schedule call',
       required: false,
     },
+    dryRun: {
+      type: 'boolean',
+      description: 'Do not write to MongoDB',
+      default: false,
+    },
     safeAddress: {
       type: 'string',
       description:
@@ -96,190 +275,26 @@ const main = defineCommand({
       required: false,
     },
   },
-  /**
-   * Executes the propose-to-safe command
-   * @param args - Command arguments including network, rpcUrl, privateKey, to address, and calldata
-   */
   async run({ args }) {
-    // Get MongoDB collection
-    const { client: mongoClient, pendingTransactions } =
-      await getSafeMongoCollection()
-
-    // Validate that we have either a private key or ledger
-    if (!args.privateKey && !args.ledger)
-      throw new Error('Either --privateKey or --ledger must be provided')
-
-    // Set up signing options
-    const useLedger = args.ledger || false
-    let privateKey: string | undefined
-
-    // Validate that incompatible Ledger options aren't provided together
-    if (args.derivationPath && args.ledgerLive)
-      throw new Error(
-        "Cannot use both 'derivationPath' and 'ledgerLive' options together"
-      )
-
-    if (useLedger) {
-      consola.info('Using Ledger hardware wallet for signing')
-      if (args.ledgerLive)
-        consola.info(
-          `Using Ledger Live derivation path with account index ${
-            args.accountIndex || 0
-          }`
-        )
-      else if (args.derivationPath)
-        consola.info(`Using custom derivation path: ${args.derivationPath}`)
-      else consola.info(`Using default derivation path: m/44'/60'/0'/0/0`)
-
-      privateKey = undefined
-    } else privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION', args.privateKey)
-
-    const ledgerOptions = {
-      ledgerLive: args.ledgerLive || false,
-      accountIndex: args.accountIndex ? Number(args.accountIndex) : 0,
-      derivationPath: args.derivationPath,
-    }
-
-    // Initialize Safe client (use --safeAddress override when proposing to a different Safe)
-    const safeAddressOverride = args.safeAddress
-      ? (getAddress(args.safeAddress) as Address)
-      : undefined
-    const { safe, chain, safeAddress } = await initializeSafeClient(
-      args.network,
-      privateKey,
-      args.rpcUrl,
-      useLedger,
-      ledgerOptions,
-      safeAddressOverride
-    )
-
-    // Get the account address
-    const senderAddress = safe.account.address
-
-    // Check if the current signer is an owner
-    const existingOwners = await safe.getOwners()
-    if (!isAddressASafeOwner(existingOwners, senderAddress)) {
-      consola.error('The current signer is not an owner of this Safe')
-      consola.error('Signer address:', senderAddress)
-      consola.error('Current owners:', existingOwners)
-      consola.error('Cannot propose transactions - exiting')
-      await mongoClient.close()
-      process.exit(1)
-    }
-
-    // Handle timelock wrapping if requested
-    let finalTo = args.to as Address
-
-    // Get calldata from file or argument
-    let finalCalldata: Hex
-    if (args.calldataFile) {
-      if (!fs.existsSync(args.calldataFile))
-        throw new Error(`Calldata file not found: ${args.calldataFile}`)
-      finalCalldata = fs.readFileSync(args.calldataFile, 'utf8').trim() as Hex
-      consola.info(`Loaded calldata from file: ${args.calldataFile}`)
-    } else if (args.calldata) {
-      finalCalldata = args.calldata as Hex
-    } else {
+    if (!args.calldata && !args.calldataFile)
       throw new Error('Either --calldata or --calldataFile must be provided')
-    }
 
-    if (args.timelock) {
-      // Look for timelock controller address in deployments (always use production)
-      const deploymentPath = path.join(
-        process.cwd(),
-        'deployments',
-        `${args.network}.json`
-      )
-
-      if (!fs.existsSync(deploymentPath))
-        throw new Error(`Deployment file not found: ${deploymentPath}`)
-
-      const deployments = JSON.parse(fs.readFileSync(deploymentPath, 'utf8'))
-      const timelockAddress = deployments.LiFiTimelockController
-
-      if (!timelockAddress || timelockAddress === '0x')
-        throw new Error(
-          `LiFiTimelockController not found in deployments for network ${args.network}`
-        )
-
-      consola.info(`Using timelock controller at ${timelockAddress}`)
-
-      const wrappedTransaction = await wrapWithTimelockSchedule(
-        args.network,
-        args.rpcUrl || '',
-        getAddress(timelockAddress),
-        finalTo,
-        finalCalldata
-      )
-
-      finalTo = wrappedTransaction.targetAddress
-      finalCalldata = wrappedTransaction.calldata
-    }
-
-    // Get the next nonce
-    const nextNonce = await getNextNonce(
-      pendingTransactions,
-      safeAddress,
-      args.network,
-      chain.id,
-      await safe.getNonce()
-    )
-
-    // Create and sign the Safe transaction
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to: finalTo,
-          value: 0n,
-          data: finalCalldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    await runPropose({
+      network: args.network,
+      to: args.to,
+      calldata: (args.calldata ?? '') as Hex,
+      calldataFile: args.calldataFile,
+      timelock: args.timelock,
+      dryRun: args.dryRun,
+      privateKey: args.privateKey,
+      rpcUrl: args.rpcUrl,
+      ledger: args.ledger,
+      ledgerLive: args.ledgerLive,
+      accountIndex: args.accountIndex ? Number(args.accountIndex) : undefined,
+      derivationPath: args.derivationPath,
+      safeAddress: args.safeAddress,
     })
-
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    consola.info('Signer Address', senderAddress)
-    consola.info('Safe Address', safeAddress)
-    consola.info('Network', chain.name)
-    consola.info('Proposing transaction to', finalTo)
-    if (args.timelock) {
-      consola.info('Original target was', args.to)
-      consola.info('Transaction wrapped in timelock schedule call')
-    }
-
-    // Store transaction in MongoDB using the utility function
-    try {
-      const result = await storeTransactionInMongoDB(
-        pendingTransactions,
-        safeAddress,
-        args.network,
-        chain.id,
-        signedTx,
-        safeTxHash,
-        senderAddress
-      )
-
-      if (result === null) {
-        consola.info('Proposal already exists - no new proposal created')
-        return
-      }
-
-      if (!result.acknowledged)
-        throw new Error('MongoDB insert was not acknowledged')
-
-      consola.success('Transaction successfully stored in MongoDB')
-    } catch (error) {
-      consola.error('Failed to store transaction in MongoDB:', error)
-      throw error
-    } finally {
-      await mongoClient.close()
-    }
-
-    consola.info('Transaction proposed')
   },
 })
 
-runMain(main)
+if (import.meta.main) runMain(main)

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -3,6 +3,13 @@
  *
  * This script proposes a transaction to a Gnosis Safe and stores it in MongoDB.
  * The transaction can later be confirmed and executed using the confirm-safe-tx script.
+ *
+ * Can be imported and called programmatically:
+ *   import { runPropose } from './propose-to-safe'
+ *   await runPropose({ network: 'mainnet', to: '0x...', calldata: '0x...', timelock: true, privateKey: '0x...' })
+ *
+ * Or run directly from the CLI:
+ *   bun run propose-to-safe.ts --network mainnet --to 0x... --calldata 0x... --timelock --privateKey 0x...
  */
 
 import 'dotenv/config'
@@ -27,16 +34,16 @@ import {
   wrapWithTimelockSchedule,
 } from './safe-utils'
 
+/**
+ * Executes the propose-to-safe command
+ * @param options - Options including network, rpcUrl, privateKey, to address, and calldata
+ */
 export async function runPropose(options: IProposeToSafeOptions) {
-  const { client: mongoClient, pendingTransactions } =
-    await getSafeMongoCollection()
-
-  if (!options.privateKey && !options.ledger)
-    throw new Error('Either privateKey or ledger must be provided')
-
+  // Set up signing options
   const useLedger = options.ledger || false
   let privateKey: string | undefined
 
+  // Validate that incompatible Ledger options aren't provided together
   if (options.derivationPath && options.ledgerLive)
     throw new Error(
       "Cannot use both 'derivationPath' and 'ledgerLive' options together"
@@ -60,10 +67,11 @@ export async function runPropose(options: IProposeToSafeOptions) {
 
   const ledgerOptions = {
     ledgerLive: options.ledgerLive || false,
-    accountIndex: options.accountIndex ?? 0,
+    accountIndex: options.accountIndex ? Number(options.accountIndex) : 0,
     derivationPath: options.derivationPath,
   }
 
+  // Initialize Safe client (use --safeAddress override when proposing to a different Safe)
   const safeAddressOverride = options.safeAddress
     ? (getAddress(options.safeAddress) as Address)
     : undefined
@@ -76,18 +84,23 @@ export async function runPropose(options: IProposeToSafeOptions) {
     safeAddressOverride
   )
 
+  // Get the account address
   const senderAddress = safe.account.address
 
+  // Check if the current signer is an owner
   const existingOwners = await safe.getOwners()
   if (!isAddressASafeOwner(existingOwners, senderAddress)) {
     consola.error('The current signer is not an owner of this Safe')
     consola.error('Signer address:', senderAddress)
     consola.error('Current owners:', existingOwners)
-    throw new Error('Cannot propose transactions - signer is not an owner')
+    consola.error('Cannot propose transactions - exiting')
+    process.exit(1)
   }
 
+  // Handle timelock wrapping if requested
   let finalTo = options.to as Address
 
+  // Get calldata from file or argument
   let finalCalldata: Hex
   if (options.calldataFile) {
     if (!fs.existsSync(options.calldataFile))
@@ -96,11 +109,14 @@ export async function runPropose(options: IProposeToSafeOptions) {
       .readFileSync(options.calldataFile, 'utf8')
       .trim() as Hex
     consola.info(`Loaded calldata from file: ${options.calldataFile}`)
+  } else if (options.calldata) {
+    finalCalldata = options.calldata as Hex
   } else {
-    finalCalldata = options.calldata
+    throw new Error('Either --calldata or --calldataFile must be provided')
   }
 
   if (options.timelock) {
+    // Look for timelock controller address in deployments (always use production)
     const deploymentPath = path.join(
       process.cwd(),
       'deployments',
@@ -132,15 +148,11 @@ export async function runPropose(options: IProposeToSafeOptions) {
     finalCalldata = wrappedTransaction.calldata
   }
 
-  if (options.dryRun) {
-    consola.info('[DRY RUN] Would store proposal:')
-    consola.info('  network: ' + options.network)
-    consola.info('  to: ' + finalTo)
-    consola.info('  calldata: ' + finalCalldata.slice(0, 42) + '...')
-    consola.info('  timelock: ' + (options.timelock ? 'yes' : 'no'))
-    return
-  }
+  // Get MongoDB collection
+  const { client: mongoClient, pendingTransactions } =
+    await getSafeMongoCollection()
 
+  // Get the next nonce
   const nextNonce = await getNextNonce(
     pendingTransactions,
     safeAddress,
@@ -149,6 +161,7 @@ export async function runPropose(options: IProposeToSafeOptions) {
     await safe.getNonce()
   )
 
+  // Create and sign the Safe transaction
   const safeTransaction = await safe.createTransaction({
     transactions: [
       {
@@ -173,6 +186,7 @@ export async function runPropose(options: IProposeToSafeOptions) {
     consola.info('Transaction wrapped in timelock schedule call')
   }
 
+  // Store transaction in MongoDB using the utility function
   try {
     const result = await storeTransactionInMongoDB(
       pendingTransactions,
@@ -193,13 +207,14 @@ export async function runPropose(options: IProposeToSafeOptions) {
       throw new Error('MongoDB insert was not acknowledged')
 
     consola.success('Transaction successfully stored in MongoDB')
-    consola.info('Transaction proposed')
   } catch (error) {
     consola.error('Failed to store transaction in MongoDB:', error)
     throw error
   } finally {
     await mongoClient.close()
   }
+
+  consola.info('Transaction proposed')
 }
 
 /**
@@ -266,11 +281,6 @@ const main = defineCommand({
       description: 'Wrap the transaction in a timelock schedule call',
       required: false,
     },
-    dryRun: {
-      type: 'boolean',
-      description: 'Do not write to MongoDB',
-      default: false,
-    },
     safeAddress: {
       type: 'string',
       description:
@@ -288,7 +298,6 @@ const main = defineCommand({
       calldata: (args.calldata ?? '') as Hex,
       calldataFile: args.calldataFile,
       timelock: args.timelock,
-      dryRun: args.dryRun,
       privateKey: args.privateKey,
       rpcUrl: args.rpcUrl,
       ledger: args.ledger,

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -32,12 +32,12 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 import data from '../../../config/networks.json'
 import type { IChainExecutionResult, IChainExecutor } from '../../common/types'
-import { getEnvVar } from '../../demoScripts/utils/demoScriptHelpers'
 import {
   DEFAULT_FETCH_TIMEOUT_MS,
   fetchWithTimeout,
 } from '../../utils/fetchWithTimeout'
 import { normalizeAddressForNetwork } from '../../utils/normalizeAddressStringForViem'
+import { getEnvVar } from '../../utils/utils'
 import {
   buildExplorerContractPageUrl,
   getTransportConfigFromRpcUrl,

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -192,16 +192,12 @@ export class SafeClient {
     walletClient: WalletClient,
     account: Account,
     tronWalletClient?: TronWalletClient
-  ): Promise<IChainExecutor> {
+  ): Promise<IChainExecutor | undefined> {
     const chainId = await publicClient.getChainId()
 
     if (isTronTvmChainId(chainId)) {
-      if (!tronWalletClient)
-        throw new Error(
-          'Tron Safe execution uses TronWeb (native protocol) and requires a private-key signer. ' +
-            'Use "Execute with Deployer", or run confirm-safe-tx with --no-ledger and PRIVATE_KEY_PRODUCTION / SAFE_SIGNER_PRIVATE_KEY in .env. ' +
-            'Ledger-only execution cannot broadcast Safe exec through the Tron HTTP API from this script.'
-        )
+      // No tronWalletClient means Ledger/signing-only mode — defer executor creation to execution time.
+      if (!tronWalletClient) return undefined
 
       const networkKey = getTronNetworkKeyForChainId(chainId)
       if (!networkKey)

--- a/script/deploy/shared/constants.ts
+++ b/script/deploy/shared/constants.ts
@@ -89,3 +89,26 @@ export const FOUNDRY_DEFAULT_EVM_VERSION_FALLBACK: EVMVersion = 'cancun'
  * Passed to deployment logging when `solc_version` cannot be read from `foundry.toml` (optional Mongo field).
  */
 export const FOUNDRY_DEFAULT_SOLC_VERSION_FALLBACK = ''
+
+/** Minimal ABI for `IDiamondCut.diamondCut`. */
+export const DIAMOND_CUT_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { name: 'facetAddress', type: 'address' },
+          { name: 'action', type: 'uint8' },
+          { name: 'functionSelectors', type: 'bytes4[]' },
+        ],
+        name: '_diamondCut',
+        type: 'tuple[]',
+      },
+      { name: '_init', type: 'address' },
+      { name: '_calldata', type: 'bytes' },
+    ],
+    name: 'diamondCut',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const

--- a/script/deploy/shared/deployment-logger.ts
+++ b/script/deploy/shared/deployment-logger.ts
@@ -27,7 +27,7 @@ import path from 'path'
 import { consola } from 'consola'
 
 import type { EnvironmentEnum } from '../../common/types'
-import { getEnvVar } from '../../demoScripts/utils/demoScriptHelpers'
+import { getEnvVar } from '../../utils/utils'
 
 import type { DeploymentCache } from './deployment-cache'
 import { createDefaultCache } from './deployment-cache'

--- a/script/deploy/shared/propose-diamond-cut.ts
+++ b/script/deploy/shared/propose-diamond-cut.ts
@@ -1,0 +1,84 @@
+/**
+ * Diamond Cut proposer — encodes and routes a diamondCut proposal to the
+ * correct Safe/Timelock proposer (EVM or Tron).
+ *
+ * Lives in the deployment domain so it can freely import proposer scripts
+ * without creating cycles back through utils.ts.
+ */
+
+import { consola } from 'consola'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
+
+import { getFacetSelectors } from '../../utils/utils'
+import type { TronTvmNetworkName } from '../tron/types'
+
+import { DIAMOND_CUT_ABI } from './constants'
+import { isTronNetworkKey } from './tron-network-keys'
+
+/**
+ * Encode a `diamondCut` calldata for adding a facet.
+ * Resolves selectors from Forge artifacts automatically.
+ */
+export async function encodeDiamondCutCalldata(
+  facetName: string,
+  facetAddressHex: Address
+): Promise<Hex> {
+  const selectors = await getFacetSelectors(facetName)
+
+  consola.info(
+    `Encoding diamondCut for ${facetName} (${selectors.length} selectors)`
+  )
+
+  return encodeFunctionData({
+    abi: DIAMOND_CUT_ABI,
+    functionName: 'diamondCut',
+    args: [
+      [
+        {
+          facetAddress: facetAddressHex,
+          action: 0,
+          functionSelectors: selectors as Hex[],
+        },
+      ],
+      '0x0000000000000000000000000000000000000000' as Address,
+      '0x' as Hex,
+    ],
+  })
+}
+
+/**
+ * Encode a diamondCut and propose it to Safe via Timelock.
+ * Routes to the correct propose script based on network (Tron vs EVM).
+ */
+export async function proposeDiamondCut(options: {
+  facetName: string
+  facetAddressHex: Address
+  diamondAddress: string
+  network: string
+  privateKey?: string
+}): Promise<void> {
+  const calldata = await encodeDiamondCutCalldata(
+    options.facetName,
+    options.facetAddressHex
+  )
+
+  if (isTronNetworkKey(options.network)) {
+    const { runPropose } = await import('../tron/propose-to-safe-tron')
+    await runPropose({
+      network: options.network as TronTvmNetworkName,
+      to: options.diamondAddress,
+      calldata,
+      timelock: true,
+      privateKey: options.privateKey,
+    })
+  } else {
+    const { runPropose } = await import('../safe/propose-to-safe')
+    await runPropose({
+      network: options.network,
+      to: options.diamondAddress,
+      calldata,
+      timelock: true,
+      privateKey: options.privateKey,
+    })
+  }
+}

--- a/script/deploy/tron/TronContractDeployer.ts
+++ b/script/deploy/tron/TronContractDeployer.ts
@@ -37,8 +37,8 @@ export class TronContractDeployer {
   private config: ITronDeploymentConfig
 
   public constructor(config: ITronDeploymentConfig) {
-    const pk = (config.privateKey ?? '').trim()
-    if (!pk || !/^0x?[0-9A-Fa-f]{64}$/.test(pk))
+    const pk = (config.privateKey ?? '').trim().replace(/^0x/, '')
+    if (!pk || !/^[0-9A-Fa-f]{64}$/.test(pk))
       throw new Error(
         'Invalid Tron private key format. Expected a 64-character hexadecimal string (with or without "0x" prefix). ' +
           'Example: 0x1234...abcd or 1234...abcd'

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -206,7 +206,11 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and proposal completed successfully!')
+    consola.success(
+      dryRun
+        ? '\nDry run completed successfully! (no Safe tx created)'
+        : '\nDeployment and proposal completed successfully!'
+    )
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -27,7 +27,7 @@ import { createTronWeb } from './helpers/tronWebFactory'
 import { tronAddressToHex } from './tronAddressHelpers'
 import {
   deployContractWithLogging,
-  registerFacetToDiamond,
+  proposeDiamondCut,
   validateBalance,
 } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
@@ -183,17 +183,13 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
         process.exit(1)
       }
 
-    // Register to Diamond
-    consola.info('\nRegistering AllBridgeFacet to Diamond...')
+    consola.info('\nProposing AllBridgeFacet diamondCut to Safe...')
 
-    // Get diamond address
     const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
     if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
 
-    // Get selectors for display
     const selectors = await getFacetSelectors('AllBridgeFacet')
 
-    // Display registration info
     displayRegistrationInfo(
       'AllBridgeFacet',
       facetAddress,
@@ -201,32 +197,17 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    // Register using new utility
-    const registrationResult = await registerFacetToDiamond(
+    await proposeDiamondCut(
       'AllBridgeFacet',
       facetAddress,
+      diamondAddress,
       tronWeb,
-      rpcUrl,
-      dryRun,
-      network
+      dryRun
     )
 
-    if (registrationResult.success) {
-      consola.success('AllBridgeFacet registered successfully!')
-      if (registrationResult.transactionId)
-        consola.info(`Transaction: ${registrationResult.transactionId}`)
-    } else {
-      consola.error(
-        'Failed to register AllBridgeFacet:',
-        registrationResult.error
-      )
-      process.exit(1)
-    }
-
-    // Print summary
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and registration completed successfully!')
+    consola.success('\nDeployment and proposal completed successfully!')
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -20,8 +20,8 @@ import {
   displayRegistrationInfo,
   getFacetSelectors,
 } from '../../utils/utils'
-import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { createTronWeb } from './helpers/tronWebFactory'

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -19,17 +19,14 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
+  proposeDiamondCut,
 } from '../../utils/utils'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { createTronWeb } from './helpers/tronWebFactory'
 import { tronAddressToHex } from './tronAddressHelpers'
-import {
-  deployContractWithLogging,
-  proposeDiamondCut,
-  validateBalance,
-} from './tronUtils'
+import { deployContractWithLogging, validateBalance } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
 
 /**
@@ -197,13 +194,13 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    await proposeDiamondCut(
-      'AllBridgeFacet',
-      facetAddress,
+    await proposeDiamondCut({
+      facetName: 'AllBridgeFacet',
+      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
       diamondAddress,
-      tronWeb,
-      dryRun
-    )
+      network: network,
+      dryRun,
+    })
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -6,10 +6,10 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import {
+  getEnvVar,
   getRPCEnvVarName,
   getEnvironment,
   getContractAddress,
@@ -19,8 +19,8 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
-  proposeDiamondCut,
 } from '../../utils/utils'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -194,13 +194,15 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    await proposeDiamondCut({
-      facetName: 'AllBridgeFacet',
-      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
-      diamondAddress,
-      network: network,
-      dryRun,
-    })
+    if (!dryRun)
+      await proposeDiamondCut({
+        facetName: 'AllBridgeFacet',
+        facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
+        diamondAddress,
+        network: network,
+      })
+    else
+      consola.info('Dry run - skipping diamondCut proposal for AllBridgeFacet')
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -28,7 +28,7 @@ import { createTronWeb } from './helpers/tronWebFactory'
 import { tronAddressToHex } from './tronAddressHelpers'
 import {
   deployContractWithLogging,
-  registerFacetToDiamond,
+  proposeDiamondCut,
   validateBalance,
 } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
@@ -164,7 +164,7 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
         process.exit(1)
       }
 
-    consola.info('\nRegistering EcoFacet to Diamond...')
+    consola.info('\nProposing EcoFacet diamondCut to Safe...')
 
     const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
     if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
@@ -173,27 +173,17 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
 
     displayRegistrationInfo('EcoFacet', facetAddress, diamondAddress, selectors)
 
-    const registrationResult = await registerFacetToDiamond(
+    await proposeDiamondCut(
       'EcoFacet',
       facetAddress,
+      diamondAddress,
       tronWeb,
-      rpcUrl,
-      dryRun,
-      network
+      dryRun
     )
-
-    if (registrationResult.success) {
-      consola.success('EcoFacet registered successfully!')
-      if (registrationResult.transactionId)
-        consola.info(`Transaction: ${registrationResult.transactionId}`)
-    } else {
-      consola.error('Failed to register EcoFacet:', registrationResult.error)
-      process.exit(1)
-    }
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and registration completed successfully!')
+    consola.success('\nDeployment and proposal completed successfully!')
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -19,6 +19,7 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
+  proposeDiamondCut,
 } from '../../utils/utils'
 import { getContractVersion } from '../shared/getContractVersion'
 
@@ -26,11 +27,7 @@ import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'
 import { createTronWeb } from './helpers/tronWebFactory'
 import { tronAddressToHex } from './tronAddressHelpers'
-import {
-  deployContractWithLogging,
-  proposeDiamondCut,
-  validateBalance,
-} from './tronUtils'
+import { deployContractWithLogging, validateBalance } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
 
 async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
@@ -173,13 +170,13 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
 
     displayRegistrationInfo('EcoFacet', facetAddress, diamondAddress, selectors)
 
-    await proposeDiamondCut(
-      'EcoFacet',
-      facetAddress,
+    await proposeDiamondCut({
+      facetName: 'EcoFacet',
+      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
       diamondAddress,
-      tronWeb,
-      dryRun
-    )
+      network: network,
+      dryRun,
+    })
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -181,7 +181,11 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and proposal completed successfully!')
+    consola.success(
+      dryRun
+        ? '\nDry run completed successfully! (no Safe tx created)'
+        : '\nDeployment and proposal completed successfully!'
+    )
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -6,10 +6,10 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import {
+  getEnvVar,
   getRPCEnvVarName,
   getEnvironment,
   getContractAddress,
@@ -19,8 +19,8 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
-  proposeDiamondCut,
 } from '../../utils/utils'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -170,13 +170,14 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
 
     displayRegistrationInfo('EcoFacet', facetAddress, diamondAddress, selectors)
 
-    await proposeDiamondCut({
-      facetName: 'EcoFacet',
-      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
-      diamondAddress,
-      network: network,
-      dryRun,
-    })
+    if (!dryRun)
+      await proposeDiamondCut({
+        facetName: 'EcoFacet',
+        facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
+        diamondAddress,
+        network: network,
+      })
+    else consola.info('Dry run - skipping diamondCut proposal for EcoFacet')
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -20,8 +20,8 @@ import {
   displayRegistrationInfo,
   getFacetSelectors,
 } from '../../utils/utils'
-import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -193,7 +193,11 @@ async function deployAndRegisterNEARIntentsFacet(options: {
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and proposal completed successfully!')
+    consola.success(
+      dryRun
+        ? '\nDry run completed successfully! (no Safe tx created)'
+        : '\nDeployment and proposal completed successfully!'
+    )
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -103,15 +103,17 @@ async function deployAndRegisterNEARIntentsFacet(options: {
         `Configuration for '${envKey}' not found in config/nearintents.json`
       )
 
-    const backendSigner = networkConfig.backendSigner
+    const backendSignerRaw = networkConfig.backendSigner
 
-    if (!backendSigner)
+    if (!backendSignerRaw)
       throw new Error(
         `backendSigner not found for '${envKey}' in config/nearintents.json`
       )
 
+    const backendSigner = tronAddressToHex(tronWeb, backendSignerRaw)
+
     consola.info('\nNEARIntents Configuration:')
-    consola.info(`Backend Signer: ${backendSigner}`)
+    consola.info(`Backend Signer: ${backendSignerRaw} (hex: ${backendSigner})`)
 
     const contracts = ['NEARIntentsFacet']
 
@@ -193,11 +195,7 @@ async function deployAndRegisterNEARIntentsFacet(options: {
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success(
-      dryRun
-        ? '\nDry run completed successfully! (no Safe tx created)'
-        : '\nDeployment and proposal completed successfully!'
-    )
+    consola.success('\nDeployment and proposal completed successfully!')
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env bun
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+
+import type { IDeploymentResult, SupportedChain } from '../../common/types'
+import { EnvironmentEnum } from '../../common/types'
+import {
+  getEnvVar,
+  getPrivateKeyForEnvironment,
+} from '../../demoScripts/utils/demoScriptHelpers'
+import {
+  getRPCEnvVarName,
+  getEnvironment,
+  getContractAddress,
+  checkExistingDeployment,
+  confirmDeployment,
+  printDeploymentSummary,
+  displayNetworkInfo,
+  displayRegistrationInfo,
+  getFacetSelectors,
+} from '../../utils/utils'
+import { getContractVersion } from '../shared/getContractVersion'
+
+import { TronContractDeployer } from './TronContractDeployer'
+import { MIN_BALANCE_WARNING } from './constants'
+import { createTronWeb } from './helpers/tronWebFactory'
+import {
+  deployContractWithLogging,
+  proposeDiamondCut,
+  validateBalance,
+} from './tronUtils'
+import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
+
+async function deployAndRegisterNEARIntentsFacet(options: {
+  dryRun?: boolean
+}) {
+  consola.start('TRON NEARIntentsFacet Deployment & Registration')
+
+  const environment = getEnvironment()
+
+  const dryRun = options.dryRun ?? false
+  let verbose = true
+
+  try {
+    verbose = getEnvVar('VERBOSE') !== 'false'
+  } catch {}
+
+  const networkName =
+    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+
+  const network = networkName as SupportedChain
+
+  const envVarName = getRPCEnvVarName(network)
+  const rpcUrl = getEnvVar(envVarName)
+
+  let privateKey: string
+  try {
+    privateKey = getPrivateKeyForEnvironment(environment)
+  } catch (error: any) {
+    consola.error(error.message)
+    consola.error(
+      `Please ensure ${
+        environment === EnvironmentEnum.production
+          ? 'PRIVATE_KEY_PRODUCTION'
+          : 'PRIVATE_KEY'
+      } is set in your .env file`
+    )
+    process.exit(1)
+  }
+
+  const config: ITronDeploymentConfig = {
+    fullHost: rpcUrl,
+    tvmNetworkKey: networkName as TronTvmNetworkName,
+    privateKey,
+    verbose,
+    dryRun,
+    safetyMargin: 1.5,
+    maxRetries: 3,
+    confirmationTimeout: 120000,
+  }
+
+  const deployer = new TronContractDeployer(config)
+
+  try {
+    const networkInfo = await deployer.getNetworkInfo()
+
+    displayNetworkInfo(networkInfo, environment, rpcUrl)
+
+    const tronWeb = createTronWeb({
+      rpcUrl,
+      networkKey: networkName as TronTvmNetworkName,
+      privateKey,
+    })
+
+    await validateBalance(tronWeb, MIN_BALANCE_WARNING)
+
+    const nearIntentsConfig = await Bun.file('config/nearintents.json').json()
+    const envKey =
+      environment === EnvironmentEnum.production ? 'production' : 'staging'
+    const networkConfig = nearIntentsConfig[envKey]
+
+    if (!networkConfig)
+      throw new Error(
+        `Configuration for '${envKey}' not found in config/nearintents.json`
+      )
+
+    const backendSigner = networkConfig.backendSigner
+
+    if (!backendSigner)
+      throw new Error(
+        `backendSigner not found for '${envKey}' in config/nearintents.json`
+      )
+
+    consola.info('\nNEARIntents Configuration:')
+    consola.info(`Backend Signer: ${backendSigner}`)
+
+    const contracts = ['NEARIntentsFacet']
+
+    if (!(await confirmDeployment(environment, network, contracts)))
+      process.exit(0)
+
+    const deploymentResults: IDeploymentResult[] = []
+
+    consola.info('\nDeploying NEARIntentsFacet...')
+
+    const { exists, address, shouldRedeploy } = await checkExistingDeployment(
+      network,
+      'NEARIntentsFacet',
+      dryRun
+    )
+
+    let facetAddress: string
+    if (exists && !shouldRedeploy && address) {
+      facetAddress = address
+      deploymentResults.push({
+        contract: 'NEARIntentsFacet',
+        address: address,
+        txId: 'existing',
+        cost: 0,
+        version: await getContractVersion('NEARIntentsFacet'),
+        status: 'existing',
+      })
+    } else
+      try {
+        const constructorArgs = [backendSigner]
+
+        const result = await deployContractWithLogging(
+          deployer,
+          'NEARIntentsFacet',
+          constructorArgs,
+          dryRun,
+          network
+        )
+
+        facetAddress = result.address
+        deploymentResults.push(result)
+      } catch (error: any) {
+        consola.error('Failed to deploy NEARIntentsFacet:', error.message)
+        deploymentResults.push({
+          contract: 'NEARIntentsFacet',
+          address: 'FAILED',
+          txId: 'FAILED',
+          cost: 0,
+          version: '0.0.0',
+          status: 'failed',
+        })
+        printDeploymentSummary(deploymentResults, dryRun)
+        process.exit(1)
+      }
+
+    consola.info('\nProposing NEARIntentsFacet diamondCut to Safe...')
+
+    const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
+    if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
+
+    const selectors = await getFacetSelectors('NEARIntentsFacet')
+
+    displayRegistrationInfo(
+      'NEARIntentsFacet',
+      facetAddress,
+      diamondAddress,
+      selectors
+    )
+
+    await proposeDiamondCut(
+      'NEARIntentsFacet',
+      facetAddress,
+      diamondAddress,
+      tronWeb,
+      dryRun
+    )
+
+    printDeploymentSummary(deploymentResults, dryRun)
+
+    consola.success('\nDeployment and proposal completed successfully!')
+  } catch (error: any) {
+    consola.error('Deployment failed:', error.message)
+    if (error.stack) consola.error(error.stack)
+    process.exit(1)
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'deploy-and-register-near-intents-facet',
+    description: 'Deploy and register NEARIntentsFacet to Tron Diamond',
+  },
+  args: {
+    dryRun: {
+      type: 'boolean',
+      description: 'Perform a dry run without actual deployment',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    await deployAndRegisterNEARIntentsFacet({
+      dryRun: args.dryRun,
+    })
+  },
+})
+
+runMain(main)

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -6,10 +6,10 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import {
+  getEnvVar,
   getRPCEnvVarName,
   getEnvironment,
   getContractAddress,
@@ -19,8 +19,8 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
-  proposeDiamondCut,
 } from '../../utils/utils'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -19,17 +19,15 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
+  proposeDiamondCut,
 } from '../../utils/utils'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'
 import { createTronWeb } from './helpers/tronWebFactory'
-import {
-  deployContractWithLogging,
-  proposeDiamondCut,
-  validateBalance,
-} from './tronUtils'
+import { tronAddressToHex } from './tronAddressHelpers'
+import { deployContractWithLogging, validateBalance } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
 
 async function deployAndRegisterNEARIntentsFacet(options: {
@@ -183,13 +181,13 @@ async function deployAndRegisterNEARIntentsFacet(options: {
       selectors
     )
 
-    await proposeDiamondCut(
-      'NEARIntentsFacet',
-      facetAddress,
+    await proposeDiamondCut({
+      facetName: 'NEARIntentsFacet',
+      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
       diamondAddress,
-      tronWeb,
-      dryRun
-    )
+      network: network,
+      dryRun,
+    })
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -20,8 +20,8 @@ import {
   displayRegistrationInfo,
   getFacetSelectors,
 } from '../../utils/utils'
-import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -181,13 +181,15 @@ async function deployAndRegisterNEARIntentsFacet(options: {
       selectors
     )
 
-    await proposeDiamondCut({
-      facetName: 'NEARIntentsFacet',
-      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
-      diamondAddress,
-      network: network,
-      dryRun,
-    })
+    if (!dryRun)
+      await proposeDiamondCut({
+        facetName: 'NEARIntentsFacet',
+        facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
+        diamondAddress,
+        network: network,
+      })
+    else
+      consola.info('Dry run - skipping diamondCut proposal for NEARIntentsFacet')
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -8,11 +8,11 @@ import { consola } from 'consola'
 import type { SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import { sleep } from '../../utils/delay'
 import {
+  getEnvVar,
   getRPCEnvVarName,
   checkExistingDeployment,
   getContractAddress,

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -204,13 +204,15 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    await proposeDiamondCut({
-      facetName: 'SymbiosisFacet',
-      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
-      diamondAddress,
-      network: network,
-      dryRun,
-    })
+    if (!dryRun)
+      await proposeDiamondCut({
+        facetName: 'SymbiosisFacet',
+        facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
+        diamondAddress,
+        network: network,
+      })
+    else
+      consola.info('Dry run - skipping diamondCut proposal for SymbiosisFacet')
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -28,7 +28,7 @@ import { createTronWeb } from './helpers/tronWebFactory'
 import { evmHexToTronBase58 } from './tronAddressHelpers'
 import {
   deployContractWithLogging,
-  registerFacetToDiamond,
+  proposeDiamondCut,
   validateBalance,
 } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
@@ -192,16 +192,14 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       }
 
     // Register to Diamond
-    consola.info('\nRegistering SymbiosisFacet to Diamond...')
+    consola.info('\nProposing SymbiosisFacet diamondCut to Safe...')
 
     // Get diamond address
     const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
     if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
 
-    // Get selectors for display
     const selectors = await getFacetSelectors('SymbiosisFacet')
 
-    // Display registration info
     displayRegistrationInfo(
       'SymbiosisFacet',
       facetAddress,
@@ -209,32 +207,17 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    // Register using new utility
-    const registrationResult = await registerFacetToDiamond(
+    await proposeDiamondCut(
       'SymbiosisFacet',
       facetAddress,
+      diamondAddress,
       tronWeb,
-      rpcUrl,
-      dryRun,
-      network
+      dryRun
     )
 
-    if (registrationResult.success) {
-      consola.success('SymbiosisFacet registered successfully!')
-      if (registrationResult.transactionId)
-        consola.info(`Transaction: ${registrationResult.transactionId}`)
-    } else {
-      consola.error(
-        'Failed to register SymbiosisFacet:',
-        registrationResult.error
-      )
-      process.exit(1)
-    }
-
-    // Print summary
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and registration completed successfully!')
+    consola.success('\nDeployment and proposal completed successfully!')
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -6,10 +6,10 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import {
+  getEnvVar,
   getRPCEnvVarName,
   getEnvironment,
   getContractAddress,
@@ -19,8 +19,8 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
-  proposeDiamondCut,
 } from '../../utils/utils'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -19,18 +19,15 @@ import {
   displayNetworkInfo,
   displayRegistrationInfo,
   getFacetSelectors,
+  proposeDiamondCut,
 } from '../../utils/utils'
 import { getContractVersion } from '../shared/getContractVersion'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'
 import { createTronWeb } from './helpers/tronWebFactory'
-import { evmHexToTronBase58 } from './tronAddressHelpers'
-import {
-  deployContractWithLogging,
-  proposeDiamondCut,
-  validateBalance,
-} from './tronUtils'
+import { evmHexToTronBase58, tronAddressToHex } from './tronAddressHelpers'
+import { deployContractWithLogging, validateBalance } from './tronUtils'
 import type { ITronDeploymentConfig, TronTvmNetworkName } from './types'
 
 /**
@@ -207,13 +204,13 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    await proposeDiamondCut(
-      'SymbiosisFacet',
-      facetAddress,
+    await proposeDiamondCut({
+      facetName: 'SymbiosisFacet',
+      facetAddressHex: tronAddressToHex(tronWeb, facetAddress) as `0x${string}`,
       diamondAddress,
-      tronWeb,
-      dryRun
-    )
+      network: network,
+      dryRun,
+    })
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -216,7 +216,11 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
 
     printDeploymentSummary(deploymentResults, dryRun)
 
-    consola.success('\nDeployment and proposal completed successfully!')
+    consola.success(
+      dryRun
+        ? '\nDry run completed successfully! (no Safe tx created)'
+        : '\nDeployment and proposal completed successfully!'
+    )
   } catch (error: any) {
     consola.error('Deployment failed:', error.message)
     if (error.stack) consola.error(error.stack)

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -20,8 +20,8 @@ import {
   displayRegistrationInfo,
   getFacetSelectors,
 } from '../../utils/utils'
-import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 import { getContractVersion } from '../shared/getContractVersion'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
 import { TronContractDeployer } from './TronContractDeployer'
 import { MIN_BALANCE_WARNING } from './constants'

--- a/script/deploy/tron/deploy-core-facets.ts
+++ b/script/deploy/tron/deploy-core-facets.ts
@@ -6,10 +6,10 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import {
-  getEnvVar,
   getPrivateKeyForEnvironment,
 } from '../../demoScripts/utils/demoScriptHelpers'
 import {
+  getEnvVar,
   saveDiamondDeployment,
   getEnvironment,
   checkExistingDeployment,

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -23,8 +23,8 @@ import type { TronWeb } from 'tronweb'
 
 import globalConfig from '../../../config/global.json'
 import networks from '../../../config/networks.json'
-import { getEnvVar } from '../../demoScripts/utils/demoScriptHelpers'
 import { sleep } from '../../utils/delay'
+import { getEnvVar } from '../../utils/utils'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
 import { TronContractDeployer } from './TronContractDeployer.js'

--- a/script/deploy/tron/helpers/tronRpcConfig.ts
+++ b/script/deploy/tron/helpers/tronRpcConfig.ts
@@ -1,7 +1,6 @@
 import { consola } from 'consola'
 
-import { getEnvVar } from '../../../demoScripts/utils/demoScriptHelpers'
-import { getRPCEnvVarName } from '../../../utils/utils'
+import { getEnvVar, getRPCEnvVarName } from '../../../utils/utils'
 import { TRON_PRO_API_KEY_HEADER } from '../constants'
 
 import { isTronGridRpcUrl } from './isTronGridRpcUrl'

--- a/script/deploy/tron/propose-to-safe-tron.ts
+++ b/script/deploy/tron/propose-to-safe-tron.ts
@@ -201,6 +201,13 @@ async function runPropose(options: IProposeToSafeTronOptions) {
     }
   }
 
+  if (options.dryRun) {
+    consola.info('[DRY RUN] Would propose to Tron Safe:')
+    consola.info('  to: ' + safeTxToBase58)
+    consola.info('  data: ' + dryRunDescription)
+    return
+  }
+
   // 2) Get current Safe nonce on chain
   const safeAbiNonce = [
     {
@@ -282,16 +289,6 @@ async function runPropose(options: IProposeToSafeTronOptions) {
       ? txHashHex
       : `0x${txHashHex.replace(/^0x/, '').padStart(64, '0')}`
   ) as Hex
-
-  if (options.dryRun) {
-    consola.info('[DRY RUN] Would store proposal:')
-    consola.info('  to: ' + String(safeTxData.to))
-    consola.info('  data: ' + dryRunDescription)
-    consola.info('  nonce: ' + nextNonce.toString())
-    consola.info('  safeTxHash: ' + txHashBytes32)
-    await mongoClient.close()
-    return
-  }
 
   // 4) Sign hash (EIP-191 over tx hash bytes32, then r+s+v with v+4 for Safe eth_sign)
   const pk = privateKey.startsWith('0x')

--- a/script/deploy/tron/propose-to-safe-tron.ts
+++ b/script/deploy/tron/propose-to-safe-tron.ts
@@ -49,24 +49,28 @@ import {
 import type { IProposeToSafeTronOptions, TronTvmNetworkName } from './types.js'
 
 async function runPropose(options: IProposeToSafeTronOptions) {
-  const networkName = 'tron'
-  const deploymentPath = path.join(process.cwd(), 'deployments', 'tron.json')
+  const networkName: TronTvmNetworkName = options.network ?? 'tron'
+  const deploymentPath = path.join(
+    process.cwd(),
+    'deployments',
+    `${networkName}.json`
+  )
   if (!fs.existsSync(deploymentPath))
-    throw new Error('deployments/tron.json not found')
+    throw new Error(`deployments/${networkName}.json not found`)
 
   const deployments = JSON.parse(fs.readFileSync(deploymentPath, 'utf8'))
   const diamondAddressBase58 = deployments.LiFiDiamond
   const timelockAddressBase58 = deployments.LiFiTimelockController
   if (!diamondAddressBase58 || !timelockAddressBase58)
     throw new Error(
-      'LiFiDiamond or LiFiTimelockController missing in deployments/tron.json'
+      `LiFiDiamond or LiFiTimelockController missing in deployments/${networkName}.json`
     )
 
   const networksPath = path.join(process.cwd(), 'config', 'networks.json')
   const networks = JSON.parse(fs.readFileSync(networksPath, 'utf8'))
   const safeAddressBase58 = networks[networkName]?.safeAddress
   if (!safeAddressBase58)
-    throw new Error('tron.safeAddress not set in config/networks.json')
+    throw new Error(`${networkName}.safeAddress not set in config/networks.json`)
 
   const genericMode = Boolean(options.to && options.calldata)
   if ((options.to && !options.calldata) || (!options.to && options.calldata)) {
@@ -77,9 +81,11 @@ async function runPropose(options: IProposeToSafeTronOptions) {
   if (options.direct && options.timelock)
     throw new Error('Use either --direct or --timelock, not both')
 
-  const privateKey = options.privateKey ?? getEnvVar('PRIVATE_KEY_PRODUCTION')
+  const privateKeyEnvVar =
+    networkName === 'tron' ? 'PRIVATE_KEY_PRODUCTION' : 'PRIVATE_KEY'
+  const privateKey = options.privateKey ?? getEnvVar(privateKeyEnvVar)
   const tronWeb = createTronWebForTvmNetworkKey({
-    networkKey: networkName as TronTvmNetworkName,
+    networkKey: networkName,
     privateKey,
   })
   const proposerBase58 =
@@ -100,7 +106,7 @@ async function runPropose(options: IProposeToSafeTronOptions) {
   const diamondAddressEvm = tronBase58ToEvm20Hex(tronWeb, diamondAddressBase58)
   const proposerEvm = tronBase58ToEvm20Hex(tronWeb, proposerBase58)
 
-  consola.info('Network: tron')
+  consola.info(`Network: ${networkName}`)
   consola.info(`Safe: ${safeAddressBase58}`)
   consola.info(`Timelock: ${timelockAddressBase58}`)
   consola.info(`Diamond: ${diamondAddressBase58}`)

--- a/script/deploy/tron/propose-to-safe-tron.ts
+++ b/script/deploy/tron/propose-to-safe-tron.ts
@@ -26,7 +26,7 @@ import { consola } from 'consola'
 import { encodeFunctionData, type Address, type Hex } from 'viem'
 import { signMessage } from 'viem/accounts'
 
-import { getEnvVar } from '../../demoScripts/utils/demoScriptHelpers'
+import { getEnvVar } from '../../utils/utils'
 import {
   getNextNonce,
   getSafeMongoCollection,

--- a/script/deploy/tron/transfer-ownership-to-timelock.ts
+++ b/script/deploy/tron/transfer-ownership-to-timelock.ts
@@ -6,11 +6,8 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 
 import { EnvironmentEnum } from '../../common/types'
-import {
-  getEnvVar,
-  getPrivateKeyForEnvironment,
-} from '../../demoScripts/utils/demoScriptHelpers'
-import { getEnvironment } from '../../utils/utils'
+import { getPrivateKeyForEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import { getEnvVar, getEnvironment } from '../../utils/utils'
 
 import { TRON_DIAMOND_CONFIRM_OWNERSHIP_SELECTOR } from './constants.js'
 import { formatAddressForNetworkCliDisplay } from './helpers/formatAddressForCliDisplay.js'

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -12,6 +12,7 @@ import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { sleep } from '../../utils/delay'
 import { spawnAndCapture } from '../../utils/spawnAndCapture'
 import {
+  encodeDiamondCutCalldata,
   getContractAddress,
   getFacetSelectors,
   logDeployment,
@@ -35,6 +36,7 @@ import {
   TRON_ZERO_ADDRESS,
 } from './constants'
 import { estimateContractCallEnergy } from './helpers/estimateContractEnergy'
+import { runPropose } from './propose-to-safe-tron'
 import { loadForgeArtifact } from './helpers/loadForgeArtifact'
 import { getCurrentPrices } from './helpers/tronPricing'
 import {
@@ -735,6 +737,26 @@ export function parseTroncastNestedArray(
  * @param tronWeb - TronWeb instance
  * @param logError - Function to log errors
  */
+/**
+ * Tron-specific: encode a diamondCut and propose to Safe via Timelock.
+ * Converts the Base58 facet address to hex, encodes calldata, then proposes.
+ */
+export async function proposeDiamondCut(
+  facetName: string,
+  facetAddress: string,
+  diamondAddress: string,
+  tronWeb: any,
+  dryRun = false
+): Promise<void> {
+  const facetAddressHex = tronAddressToHex(tronWeb, facetAddress)
+  const calldata = await encodeDiamondCutCalldata(
+    facetName,
+    facetAddressHex as `0x${string}`
+  )
+
+  await runPropose({ dryRun, to: diamondAddress, calldata, timelock: true })
+}
+
 export async function checkOwnershipTron(
   name: string,
   expectedOwner: string,

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -369,6 +369,11 @@ export async function registerFacetToDiamond(
     const selectors = await getFacetSelectors(facetName)
     consola.info(`Found ${selectors.length} function selectors`)
 
+    if (dryRun) {
+      consola.info('Dry run mode - not executing registration')
+      return { success: true }
+    }
+
     const facetAddressHex = tronAddressToHex(tronWeb, facetAddress)
 
     // Check each selector and group by action needed
@@ -450,11 +455,6 @@ export async function registerFacetToDiamond(
     const { energyPrice } = await getCurrentPrices(tronWeb)
     const estimatedCost = estimatedEnergy * energyPrice
     consola.info(`Estimated registration cost: ${estimatedCost.toFixed(4)} TRX`)
-
-    if (dryRun) {
-      consola.info('Dry run mode - not executing registration')
-      return { success: true }
-    }
 
     // Check balance
     const balance = await tronWeb.trx.getBalance(tronWeb.defaultAddress.base58)

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -12,7 +12,6 @@ import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { sleep } from '../../utils/delay'
 import { spawnAndCapture } from '../../utils/spawnAndCapture'
 import {
-  encodeDiamondCutCalldata,
   getContractAddress,
   getFacetSelectors,
   logDeployment,
@@ -36,7 +35,6 @@ import {
   TRON_ZERO_ADDRESS,
 } from './constants'
 import { estimateContractCallEnergy } from './helpers/estimateContractEnergy'
-import { runPropose } from './propose-to-safe-tron'
 import { loadForgeArtifact } from './helpers/loadForgeArtifact'
 import { getCurrentPrices } from './helpers/tronPricing'
 import {
@@ -737,25 +735,6 @@ export function parseTroncastNestedArray(
  * @param tronWeb - TronWeb instance
  * @param logError - Function to log errors
  */
-/**
- * Tron-specific: encode a diamondCut and propose to Safe via Timelock.
- * Converts the Base58 facet address to hex, encodes calldata, then proposes.
- */
-export async function proposeDiamondCut(
-  facetName: string,
-  facetAddress: string,
-  diamondAddress: string,
-  tronWeb: any,
-  dryRun = false
-): Promise<void> {
-  const facetAddressHex = tronAddressToHex(tronWeb, facetAddress)
-  const calldata = await encodeDiamondCutCalldata(
-    facetName,
-    facetAddressHex as `0x${string}`
-  )
-
-  await runPropose({ dryRun, to: diamondAddress, calldata, timelock: true })
-}
 
 export async function checkOwnershipTron(
   name: string,

--- a/script/deploy/tron/types.ts
+++ b/script/deploy/tron/types.ts
@@ -7,6 +7,8 @@ export type TronTvmNetworkName = 'tron' | 'tronshasta'
 /** Options for the propose-to-safe-tron CLI script. */
 export interface IProposeToSafeTronOptions {
   dryRun?: boolean
+  /** Tron network to use — defaults to 'tron' (mainnet). Pass 'tronshasta' for staging. */
+  network?: TronTvmNetworkName
   /** Base58 contract address for generic proposals */
   to?: string
   /** Hex calldata for generic proposals */

--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -22,8 +22,8 @@ import {
 } from 'mongodb'
 
 import type { EnvironmentEnum } from '../common/types'
-import { getEnvVar } from '../demoScripts/utils/demoScriptHelpers'
 import { sleep } from '../utils/delay'
+import { getEnvVar } from '../utils/utils'
 
 import { createDefaultCache } from './shared/deployment-cache'
 import {

--- a/script/deploy/validate-deployment-logs.ts
+++ b/script/deploy/validate-deployment-logs.ts
@@ -22,7 +22,7 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 
 import type { EnvironmentEnum } from '../common/types'
-import { getEnvVar } from '../demoScripts/utils/demoScriptHelpers'
+import { getEnvVar } from '../utils/utils'
 
 import type { DeploymentCache } from './shared/deployment-cache'
 import { createDefaultCache } from './shared/deployment-cache'

--- a/script/troncast/utils/tronweb.ts
+++ b/script/troncast/utils/tronweb.ts
@@ -20,9 +20,8 @@ if (
 import { consola } from 'consola'
 import { TronWeb } from 'tronweb'
 
-import { getEnvVar } from '../../demoScripts/utils/demoScriptHelpers'
 import { sleep } from '../../utils/delay'
-import { getRPCEnvVarName } from '../../utils/utils'
+import { getEnvVar, getRPCEnvVarName } from '../../utils/utils'
 import type { Environment } from '../types'
 /* eslint-enable import/first */
 

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -965,7 +965,6 @@ export async function proposeDiamondCut(options: {
   facetAddressHex: Address
   diamondAddress: string
   network: string
-  dryRun?: boolean
   privateKey?: string
 }): Promise<void> {
   const calldata = await encodeDiamondCutCalldata(
@@ -978,7 +977,7 @@ export async function proposeDiamondCut(options: {
       '../deploy/tron/propose-to-safe-tron'
     )
     await runPropose({
-      dryRun: options.dryRun,
+      network: options.network as import('../deploy/tron/types').TronTvmNetworkName,
       to: options.diamondAddress,
       calldata,
       timelock: true,
@@ -991,7 +990,6 @@ export async function proposeDiamondCut(options: {
       to: options.diamondAddress,
       calldata,
       timelock: true,
-      dryRun: options.dryRun,
       privateKey: options.privateKey,
     })
   }

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -10,7 +10,7 @@ import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
 import { consola } from 'consola'
-import type { Hex } from 'viem'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
 
 import networksConfig from '../../config/networks.json'
 import type {
@@ -24,7 +24,7 @@ import type {
   SupportedChain,
 } from '../common/types'
 import { EnvironmentEnum } from '../common/types'
-import { EVM_VERSIONS } from '../deploy/shared/constants'
+import { DIAMOND_CUT_ABI, EVM_VERSIONS } from '../deploy/shared/constants'
 import { getContractVersion } from '../deploy/shared/getContractVersion'
 
 import { spawnAndCapture } from './spawnAndCapture'
@@ -920,5 +920,37 @@ Selectors: ${selectors.length} functions
     style: {
       borderColor: 'cyan',
     },
+  })
+}
+
+/**
+ * Encode a `diamondCut` calldata for adding a facet.
+ * Resolves selectors from Forge artifacts automatically.
+ * Chain-agnostic — works for both EVM and Tron proposals.
+ */
+export async function encodeDiamondCutCalldata(
+  facetName: string,
+  facetAddressHex: Address
+): Promise<Hex> {
+  const selectors = await getFacetSelectors(facetName)
+
+  consola.info(
+    `Encoding diamondCut for ${facetName} (${selectors.length} selectors)`
+  )
+
+  return encodeFunctionData({
+    abi: DIAMOND_CUT_ABI,
+    functionName: 'diamondCut',
+    args: [
+      [
+        {
+          facetAddress: facetAddressHex,
+          action: 0,
+          functionSelectors: selectors as Hex[],
+        },
+      ],
+      '0x0000000000000000000000000000000000000000' as Address,
+      '0x' as Hex,
+    ],
   })
 }

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -75,15 +75,30 @@ const FOUNDRY_TOML_PATH = resolve(
 )
 
 function readFoundryProfileDefaultConfig(): IFoundryProfileDefaultConfig {
-  const parsed = Bun.TOML.parse(
-    readFileSync(FOUNDRY_TOML_PATH, 'utf8')
-  ) as IFoundryTomlConfig
+  const content = readFileSync(FOUNDRY_TOML_PATH, 'utf8')
 
-  const defaultProfile = parsed.profile?.default
-  if (!defaultProfile)
-    throw new Error('Missing [profile.default] section in foundry.toml')
+  try {
+    const parsed = Bun.TOML.parse(content) as IFoundryTomlConfig
+    const defaultProfile = parsed.profile?.default
+    if (!defaultProfile)
+      throw new Error('Missing [profile.default] section in foundry.toml')
+    return defaultProfile
+  } catch {
+    // Bun's TOML parser rejects keys starting with digits (e.g. "0g" in rpc_endpoints).
+    // Fall back to regex extraction of [profile.default] values.
+    const extract = (key: string): string | undefined =>
+      content.match(
+        new RegExp(`^\\[profile\\.default\\][\\s\\S]*?^${key}\\s*=\\s*['"]([^'"]+)['"]`, 'm')
+      )?.[1]
 
-  return defaultProfile
+    const solc_version = extract('solc_version')
+    const evm_version = extract('evm_version')
+
+    if (!solc_version && !evm_version)
+      throw new Error('Missing [profile.default] section in foundry.toml')
+
+    return { solc_version, evm_version } as IFoundryProfileDefaultConfig
+  }
 }
 
 /**

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -26,6 +26,7 @@ import type {
 import { EnvironmentEnum } from '../common/types'
 import { DIAMOND_CUT_ABI, EVM_VERSIONS } from '../deploy/shared/constants'
 import { getContractVersion } from '../deploy/shared/getContractVersion'
+import { isTronNetworkKey } from '../deploy/shared/tron-network-keys'
 
 import { spawnAndCapture } from './spawnAndCapture'
 
@@ -953,4 +954,45 @@ export async function encodeDiamondCutCalldata(
       '0x' as Hex,
     ],
   })
+}
+
+/**
+ * Encode a diamondCut and propose it to Safe via Timelock.
+ * Routes to the correct propose script based on network (Tron vs EVM).
+ */
+export async function proposeDiamondCut(options: {
+  facetName: string
+  facetAddressHex: Address
+  diamondAddress: string
+  network: string
+  dryRun?: boolean
+  privateKey?: string
+}): Promise<void> {
+  const calldata = await encodeDiamondCutCalldata(
+    options.facetName,
+    options.facetAddressHex
+  )
+
+  if (isTronNetworkKey(options.network)) {
+    const { runPropose } = await import(
+      '../deploy/tron/propose-to-safe-tron'
+    )
+    await runPropose({
+      dryRun: options.dryRun,
+      to: options.diamondAddress,
+      calldata,
+      timelock: true,
+      privateKey: options.privateKey,
+    })
+  } else {
+    const { runPropose } = await import('../deploy/safe/propose-to-safe')
+    await runPropose({
+      network: options.network,
+      to: options.diamondAddress,
+      calldata,
+      timelock: true,
+      dryRun: options.dryRun,
+      privateKey: options.privateKey,
+    })
+  }
 }

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -10,7 +10,7 @@ import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 
 import { consola } from 'consola'
-import { encodeFunctionData, type Address, type Hex } from 'viem'
+import type { Hex } from 'viem'
 
 import networksConfig from '../../config/networks.json'
 import type {
@@ -24,9 +24,8 @@ import type {
   SupportedChain,
 } from '../common/types'
 import { EnvironmentEnum } from '../common/types'
-import { DIAMOND_CUT_ABI, EVM_VERSIONS } from '../deploy/shared/constants'
+import { EVM_VERSIONS } from '../deploy/shared/constants'
 import { getContractVersion } from '../deploy/shared/getContractVersion'
-import { isTronNetworkKey } from '../deploy/shared/tron-network-keys'
 
 import { spawnAndCapture } from './spawnAndCapture'
 
@@ -87,16 +86,20 @@ function readFoundryProfileDefaultConfig(): IFoundryProfileDefaultConfig {
   } catch {
     // Bun's TOML parser rejects keys starting with digits (e.g. "0g" in rpc_endpoints).
     // Fall back to regex extraction of [profile.default] values.
+    // Extract only the section body (up to the next section header or end of file)
+    // so keys from other profiles are never matched.
+    const sectionBody =
+      content.match(/\[profile\.default\]\n([\s\S]*?)(?=\n\[|$)/)?.[1] ?? ''
+    if (!sectionBody)
+      throw new Error('Missing [profile.default] section in foundry.toml')
+
     const extract = (key: string): string | undefined =>
-      content.match(
-        new RegExp(`^\\[profile\\.default\\][\\s\\S]*?^${key}\\s*=\\s*['"]([^'"]+)['"]`, 'm')
+      sectionBody.match(
+        new RegExp(`^${key}\\s*=\\s*['"]([^'"]+)['"]`, 'm')
       )?.[1]
 
     const solc_version = extract('solc_version')
     const evm_version = extract('evm_version')
-
-    if (!solc_version && !evm_version)
-      throw new Error('Missing [profile.default] section in foundry.toml')
 
     return { solc_version, evm_version } as IFoundryProfileDefaultConfig
   }
@@ -165,6 +168,17 @@ export function getNetworkConfig(networkName: string): Omit<INetwork, 'id'> {
  * @param command The shell command to execute
  * @returns The command output
  */
+/**
+ * Returns the value of a required environment variable.
+ * @throws If the variable is not set.
+ */
+export const getEnvVar = (varName: string): string => {
+  const value = process.env[varName]
+  if (!value)
+    throw new Error(`Missing required environment variable: ${varName}`)
+  return value
+}
+
 export async function executeShellCommand(command: string): Promise<string> {
   return spawnAndCapture('bash', ['-c', command])
 }
@@ -924,73 +938,3 @@ Selectors: ${selectors.length} functions
   })
 }
 
-/**
- * Encode a `diamondCut` calldata for adding a facet.
- * Resolves selectors from Forge artifacts automatically.
- * Chain-agnostic — works for both EVM and Tron proposals.
- */
-export async function encodeDiamondCutCalldata(
-  facetName: string,
-  facetAddressHex: Address
-): Promise<Hex> {
-  const selectors = await getFacetSelectors(facetName)
-
-  consola.info(
-    `Encoding diamondCut for ${facetName} (${selectors.length} selectors)`
-  )
-
-  return encodeFunctionData({
-    abi: DIAMOND_CUT_ABI,
-    functionName: 'diamondCut',
-    args: [
-      [
-        {
-          facetAddress: facetAddressHex,
-          action: 0,
-          functionSelectors: selectors as Hex[],
-        },
-      ],
-      '0x0000000000000000000000000000000000000000' as Address,
-      '0x' as Hex,
-    ],
-  })
-}
-
-/**
- * Encode a diamondCut and propose it to Safe via Timelock.
- * Routes to the correct propose script based on network (Tron vs EVM).
- */
-export async function proposeDiamondCut(options: {
-  facetName: string
-  facetAddressHex: Address
-  diamondAddress: string
-  network: string
-  privateKey?: string
-}): Promise<void> {
-  const calldata = await encodeDiamondCutCalldata(
-    options.facetName,
-    options.facetAddressHex
-  )
-
-  if (isTronNetworkKey(options.network)) {
-    const { runPropose } = await import(
-      '../deploy/tron/propose-to-safe-tron'
-    )
-    await runPropose({
-      network: options.network as import('../deploy/tron/types').TronTvmNetworkName,
-      to: options.diamondAddress,
-      calldata,
-      timelock: true,
-      privateKey: options.privateKey,
-    })
-  } else {
-    const { runPropose } = await import('../deploy/safe/propose-to-safe')
-    await runPropose({
-      network: options.network,
-      to: options.diamondAddress,
-      calldata,
-      timelock: true,
-      privateKey: options.privateKey,
-    })
-  }
-}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

# Why did I implement it this way?

## Problems Encountered & Solutions

## 1. TOML Parsing Crash in readFoundryProfileDefaultConfig

### Problem
Bun’s TOML parser rejects keys that start with digits (e.g. "0g" in rpc_endpoints inside foundry.toml).
This caused deployment scripts to fail with:

“Failed to determine SOLC version from foundry.toml: Failed to parse toml” - even though the contract had already been successfully deployed.

### Solution
Implemented a regex-based fallback parser that:

- Extracts only solc_version and evm_version
- Targets the [profile.default] section
- Bypasses Bun’s faulty TOML parsing

## 2. Invalid Private Key Handling in TronContractDeployer

### Problem
The validation regex: 0x?[a-f]{64} incorrectly counted the optional 0x prefix as part of the 64 required hex characters, causing valid keys (with 0x) to fail validation.

### Solution

- Strip the 0x prefix before validation
- Validate only the raw 64-character hex string

## 3. Broken Ledger Signing for Tron Safe Transactions

### Problem

Failure during SafeClient.init when using ledger on tron because TronWalletClient is only available with a private key

### Solution

Return undefined if tronWalletClient is missing (instead of throwing)

## 4. Unsafe Deployment Flow (Bypassing Safe Multisig)

### Problem
Deployment scripts directly called: registerFacetToDiamond but tron's diamond has ownership already on timelock

### Solution

- Replaced with a Safe-based flow:
- Introduced shared proposeDiamondCut utility
- Encodes calldata and routes through: propose-to-safe (EVM) and propose-to-safe-tron (Tron)
- Wraps execution in timelock scheduleBatch

## 5. getEnvVar / dependency cycles

### Problem
Problem: proposeDiamondCut and encodeDiamondCutCalldata were initially placed in utils.ts, which already imports from deploy/shared/*. The new functions needed to dynamically import propose-to-safe-tron, which itself imports getEnvVar from utils.ts — were creating circular dependency.                                                                      

### Solution

Moved both functions to deploy/shared/propose-diamond-cut.ts. That file is downstream of utils.ts and can freely import from both utils.ts (for getFacetSelectors) and the proposer scripts without creating any cycles.

## Changes Introduced

New

- deploy-and-register-near-intents-facet.ts. Deploys NEARIntentsFacet on Tron and proposes registration via Safe proposeDiamondCut & encodeDiamondCutCalldata (in utils.ts)
- Chain-agnostic helpers for diamond upgrades: DIAMOND_CUT_ABI (in constants.ts) and IProposeToSafeOptions (in types.ts)

⸻

Refactor
	•	propose-to-safe.ts
→ Extracted reusable function:
runPropose(options: IProposeToSafeOptions)
→ Enables programmatic usage across scripts

⸻

Updated
	•	deploy-and-register-{allbridge, eco, symbiosis}-facet.ts
→ Migrated from direct registerFacetToDiamond
→ Now uses proposeDiamondCut (Safe-based flow)


# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
