### PR TITLE
Added deploy logs for NEARIntentsFacet for tron and fixed update diamond logs scripts

### DIFF
--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -1,18 +1,6 @@
 {
   "LiFiDiamond": {
     "Facets": {
-      "TLqbL8MKosbLxrJ9iTDTpZTzcXRWq8bFJ3": {
-        "Name": "AccessManagerFacet",
-        "Version": "1.0.0"
-      },
-      "TFJLkNo9rHYTkp6w5G5ETnTBzzybRTqwQf": {
-        "Name": "CalldataVerificationFacet",
-        "Version": "1.3.1"
-      },
-      "TPDdY4Qqy9gU8eD3bJ63pUFhHr4WWnabks": {
-        "Name": "DexManagerFacet",
-        "Version": "1.0.2"
-      },
       "TNGUuj9GYbeUDn4GbTH2711kNyE4WcMbb4": {
         "Name": "DiamondCutFacet",
         "Version": "1.0.0"
@@ -21,9 +9,25 @@
         "Name": "DiamondLoupeFacet",
         "Version": "1.0.0"
       },
-      "TGyX2ysGYjKG8PLWiW7exXv3gesV8DJEA4": {
-        "Name": "EmergencyPauseFacet",
-        "Version": "1.0.1"
+      "TVofq5iFiwsDf4M3xcucpV7HCX5M6XpcHW": {
+        "Name": "OwnershipFacet",
+        "Version": "1.0.0"
+      },
+      "TZ35GFtD5rw1YGBbqaeWUW4dgPGpphUrAw": {
+        "Name": "WithdrawFacet",
+        "Version": "1.0.0"
+      },
+      "TPDdY4Qqy9gU8eD3bJ63pUFhHr4WWnabks": {
+        "Name": "DexManagerFacet",
+        "Version": "1.0.2"
+      },
+      "TLqbL8MKosbLxrJ9iTDTpZTzcXRWq8bFJ3": {
+        "Name": "AccessManagerFacet",
+        "Version": "1.0.0"
+      },
+      "TA9z2Lmg6g4tAwn31CK57ekjpmVXCr8kum": {
+        "Name": "PeripheryRegistryFacet",
+        "Version": "1.0.0"
       },
       "TPccg9MTwWVxcSrMA3dYRxzpAGaiLeZmxS": {
         "Name": "GenericSwapFacet",
@@ -33,17 +37,13 @@
         "Name": "GenericSwapFacetV3",
         "Version": "1.0.2"
       },
-      "TVofq5iFiwsDf4M3xcucpV7HCX5M6XpcHW": {
-        "Name": "OwnershipFacet",
-        "Version": "1.0.0"
+      "TFJLkNo9rHYTkp6w5G5ETnTBzzybRTqwQf": {
+        "Name": "CalldataVerificationFacet",
+        "Version": "1.3.1"
       },
-      "TA9z2Lmg6g4tAwn31CK57ekjpmVXCr8kum": {
-        "Name": "PeripheryRegistryFacet",
-        "Version": "1.0.0"
-      },
-      "TZ35GFtD5rw1YGBbqaeWUW4dgPGpphUrAw": {
-        "Name": "WithdrawFacet",
-        "Version": "1.0.0"
+      "TGyX2ysGYjKG8PLWiW7exXv3gesV8DJEA4": {
+        "Name": "EmergencyPauseFacet",
+        "Version": "1.0.1"
       },
       "TAXonvq4chZufsFS1NdTLaK4zq8ruPct8f": {
         "Name": "SymbiosisFacet",
@@ -51,23 +51,41 @@
       },
       "TCyAJzpLJjGyUqPoQ9Kvm1Zjw9zDmXLUfU": {
         "Name": "AllBridgeFacet",
-        "Version": "2.1.1"
+        "Version": ""
+      },
+      "TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8": {
+        "Name": "",
+        "Version": ""
       },
       "TYrocWGwdK6o4EBgTANEae9B18MMuhxgjM": {
         "Name": "EcoFacet",
-        "Version": "1.1.0"
+        "Version": ""
       },
       "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn": {
         "Name": "WhitelistManagerFacet",
+        "Version": ""
+      },
+      "TFFvFi3j5YBMrSBev6bm6ueEaq1XWJ1QJZ": {
+        "Name": "NEARIntentsFacet",
         "Version": "1.0.0"
       }
     },
     "Periphery": {
       "ERC20Proxy": "TUYvdo8bEjPidfSXhRMn9uRvSifesApPTC",
       "Executor": "TCwvHz3CqPtVor5eqTrnfj1fwmxUNBMKKf",
-      "TokenWrapper": "TBfUqkmaBBMFA87ZCCu9aibjo2EZLTSJv2",
+      "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q",
       "FeeForwarder": "TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ",
-      "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q"
+      "GasZipPeriphery": "",
+      "LiFiDEXAggregator": "",
+      "LidoWrapper": "",
+      "Patcher": "",
+      "Permit2Proxy": "",
+      "ReceiverAcrossV3": "",
+      "ReceiverAcrossV4": "",
+      "ReceiverChainflip": "",
+      "ReceiverOIF": "",
+      "ReceiverStargateV2": "",
+      "TokenWrapper": "TBfUqkmaBBMFA87ZCCu9aibjo2EZLTSJv2"
     }
   }
 }

--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -51,19 +51,19 @@
       },
       "TCyAJzpLJjGyUqPoQ9Kvm1Zjw9zDmXLUfU": {
         "Name": "AllBridgeFacet",
-        "Version": ""
+        "Version": "2.1.2"
       },
       "TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8": {
-        "Name": "",
-        "Version": ""
+        "Name": "EcoFacet",
+        "Version": "1.0.0"
       },
       "TYrocWGwdK6o4EBgTANEae9B18MMuhxgjM": {
         "Name": "EcoFacet",
-        "Version": ""
+        "Version": "1.1.0"
       },
       "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn": {
         "Name": "WhitelistManagerFacet",
-        "Version": ""
+        "Version": "1.1.0"
       },
       "TFFvFi3j5YBMrSBev6bm6ueEaq1XWJ1QJZ": {
         "Name": "NEARIntentsFacet",

--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -51,7 +51,7 @@
       },
       "TCyAJzpLJjGyUqPoQ9Kvm1Zjw9zDmXLUfU": {
         "Name": "AllBridgeFacet",
-        "Version": "2.1.2"
+        "Version": "2.1.1"
       },
       "TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8": {
         "Name": "EcoFacet",

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -20,5 +20,6 @@
   "FeeForwarder": "TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ",
   "WhitelistManagerFacet": "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn",
   "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q",
-  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu"
+  "LiFiTimelockController": "TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu",
+  "NEARIntentsFacet": "TFFvFi3j5YBMrSBev6bm6ueEaq1XWJ1QJZ"
 }

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -17,6 +17,7 @@ GLOBAL_FILE_PATH="config/global.json"
 source script/universalCast.sh
 
 ZERO_ADDRESS=0x0000000000000000000000000000000000000000
+TRON_ZERO_ADDRESS_BASE58=T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb
 RED='\033[0;31m'   # Red color
 GREEN='\033[0;32m' # Green color
 GRAY='\033[0;37m'  # Light gray color
@@ -974,18 +975,21 @@ function saveDiamondPeriphery() {
 
   # resolve each periphery address in parallel and write to temp files
   for CONTRACT in ${PERIPHERY_CONTRACTS}; do
-    # throttle background jobs
+    # throttle background jobs; for Tron wait 2s between dispatches to respect RPC rate limits
     while [[ $(jobs | wc -l | tr -d ' ') -ge $CONCURRENCY ]]; do
-      sleep 0.1
+      if isTronNetwork "$NETWORK"; then sleep 2; else sleep 0.1; fi
     done
 
     (
       ADDRESS=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "getPeripheryContract(string) returns (address)" "$CONTRACT" 2>/dev/null)
-      if [[ "$ADDRESS" == "$ZERO_ADDRESS" || -z "$ADDRESS" ]]; then
+      # Skip unregistered contracts (zero address in EVM hex or Tron base58 format, or empty)
+      if [[ -z "$ADDRESS" || "$ADDRESS" == "$ZERO_ADDRESS" || "$ADDRESS" == "$TRON_ZERO_ADDRESS_BASE58" ]]; then
         ADDRESS=""
       fi
       echo "{\"$CONTRACT\": \"$ADDRESS\"}" >"$PERIPHERY_DIR/${CONTRACT}.json"
     ) &
+
+    if isTronNetwork "$NETWORK"; then sleep 2; fi
   done
 
   # wait for all background jobs

--- a/script/universalCast.sh
+++ b/script/universalCast.sh
@@ -36,10 +36,11 @@ function universalCall() {
     local TRON_ENV
     TRON_ENV=$(getTronEnv "$NETWORK")
     if [[ ${#ARGS[@]} -gt 0 ]]; then
-      bun troncast call "$TARGET" "$SIGNATURE" "${ARGS[@]}" --env "$TRON_ENV" 2>&1
+      CONSOLA_LEVEL=3 bun troncast call "$TARGET" "$SIGNATURE" "${ARGS[@]}" --env "$TRON_ENV"
     else
-      bun troncast call "$TARGET" "$SIGNATURE" --env "$TRON_ENV" 2>&1
+      CONSOLA_LEVEL=3 bun troncast call "$TARGET" "$SIGNATURE" --env "$TRON_ENV"
     fi
+    return $?
   else
     local RPC_URL
     RPC_URL=$(getRPCUrl "$NETWORK") || {


### PR DESCRIPTION
# Which Linear task belongs to this PR?
https://linear.app/lifi-linear/issue/EXSC-227/sc-tron-deploy-nearintents-facet

# Why did I implement it this way?

Running option 11 in scriptMaster.sh – Update diamond logs on the Tron network corrupted
deployments/tron.diamond.json in multiple ways:

1. Zero-address periphery entries

saveDiamondPeriphery queries each periphery contract against the live diamond.

For contracts not deployed on Tron (e.g. GasZipPeriphery, LiFiDEXAggregator, ReceiverAcrossV3), the diamond returns the Tron zero address in base58 format: `T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb` (which is zero address for tron)
The existing validation only checked the EVM zero address (0x000...000), so this base58 zero address was incorrectly treated as valid and written into periphery slots.

2. troncast debug output polluting results

universalCall used: `bun troncast call ... 2>&1`
This redirected Bun’s internal script echo (stderr) into stdout.

As a result, callers received mixed output which, when parsed, produced garbage tokens (e.g. $, bun, run, contract address, function name, etc.). These tokens were mistakenly written as facet keys in the diamond JSON.

3. 429 rate-limit errors on TronGrid

Periphery contract queries were dispatched in parallel with only a 0.1s throttle.

This exceeded TronGrid rate limits, resulting in HTTP 429 errors and incomplete query results, further contributing to inconsistent diamond state.

Fix

script/helperFunctions.sh
	•	Added TRON_ZERO_ADDRESS_BASE58 constant
	•	Extended zero-address validation in saveDiamondPeriphery to also reject the Tron base58 zero address
	•	Unregistered periphery contracts are now correctly skipped

script/universalCast.sh
	•	Added CONSOLA_LEVEL=3 to all bun troncast call invocations
	•	Suppresses debug logs at the source (Consola debug = level 4)
	•	Removed 2>&1
	•	Prevents stderr (script echo, errors) from contaminating stdout
	•	Callers already handle stderr via 2>/dev/null where needed


Rate limiting adjustments
	•	Reduced parallelism / increased delay between TronGrid rpc calls to avoid 429 errors
	
Also updated tron.diamond.logs to correctly reflect diamond state
	



# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
