### PR TITLE
chore: whitelist Nordstern mainnet router

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4528,7 +4528,7 @@
       "contracts": {
         "mainnet": [
           {
-            "address": "0xc87de04e2ec1f4282dff2933a2d58199f688fc3d",
+            "address": "0xa929c559e5e6537359680f39cb4e3708e1a14dd1",
             "functions": {
               "0x3f0bde25": "IceCreamSwap()"
             }


### PR DESCRIPTION
## Summary
- Updates the Nordstern Ethereum mainnet router in `config/whitelist.json` to the new address reported by https://api.nordstern.finance/chains
- Old: `0xc87de04e2ec1f4282dff2933a2d58199f688fc3d`
- New: `0xa929c559e5e6537359680f39cb4e3708e1a14dd1`
- Selector `0x3f0bde25` (`IceCreamSwap()`) is unchanged

## Context
Nordstern is getting Ethereum mainnet enabled in the backend (see corresponding lifi-backend PR). The backend allowlist and signature generator now point at the new router, so the SC calldata validation whitelist needs to reflect the same address.

## Test plan
- [ ] SC team reviews the address change
- [ ] Verified the new router accepts calldata from Nordstern's `/aggregator/1` endpoint (see lifi-backend PR tx table once live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)