### PR TITLE
chore: whitelist fly pharos router

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4517,6 +4517,15 @@
               "0x25e651ed": "swapWithUserSignature(bytes)"
             }
           }
+        ],
+        "pharos": [
+          {
+            "address": "0x956df8424b556f0076e8abf5481605f5a791cc7f",
+            "functions": {
+              "0x73fc4457": "swapWithMagpieSignature(bytes)",
+              "0x25e651ed": "swapWithUserSignature(bytes)"
+            }
+          }
         ]
       }
     },


### PR DESCRIPTION
## Summary
- Add Pharos (chainId 1672) to the Fly (Magpie) calldata-validation whitelist.
- Router address: 0x956df8424b556f0076e8abf5481605f5a791cc7f (MagpieRouterV3_1, same as other newer Fly deployments).
- Selectors: swapWithMagpieSignature(bytes) (0x73fc4457) and swapWithUserSignature(bytes) (0x25e651ed).

## Context
Paired backend PR: to be opened on branch feat/add-pharos-chain in lifinance/lifi-backend.

Generated via pnpm script generateDexWhitelistsAndSignatures scoped to fly; selector names reconciled against existing fly entries in this whitelist.