### PR TITLE
chore: disable daily unreviewed-PR Slack reminder

### DIFF
--- a/.github/workflows/unreviewedPRReminder.yml
+++ b/.github/workflows/unreviewedPRReminder.yml
@@ -1,9 +1,7 @@
 name: 'Check old PRs'
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # run once a day
-  workflow_dispatch: # enables manual trigger
+  workflow_dispatch: # manually triggered only (daily schedule disabled)
 
 permissions:
   contents: read # required to fetch repository contents


### PR DESCRIPTION
## Summary

- Removes the daily `cron: '0 0 * * *'` trigger from `unreviewedPRReminder.yml`
- Keeps `workflow_dispatch` so the check can still be run manually on demand
- The daily Slack message was flagging PRs that are intentionally parked (e.g. waiting for audit, backend, or deprioritised), causing noise in the SC review channel

## Test plan

- [ ] Verify no automated Slack reminder fires the next day after merge
- [ ] Confirm `workflow_dispatch` still works by triggering manually from the Actions tab

🤖 Generated with [Claude Code](https://claude.ai/claude-code)