### PR TITLE
fix(security): apply Aikido security autofixes (handlebars + template injection)

### DIFF
--- a/.github/workflows/protectAuditLabels.yml
+++ b/.github/workflows/protectAuditLabels.yml
@@ -58,13 +58,14 @@ jobs:
         if: env.CONTINUE == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }}
+          TARGET_LABEL: ${{ github.event.label.name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
         run: |
 
           ##### Define the labels to protect
           PROTECTED_LABELS=("AuditCompleted" "AuditRequired" "AuditNotRequired")
-          TARGET_LABEL="${{ github.event.label.name }}"
-          EVENT_ACTION="${{ github.event.action }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
 
           ##### Fetch the current labels before action (to restore if needed)
           CURRENT_LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name' | tr '\n' ' ')
@@ -73,7 +74,7 @@ jobs:
 
           ##### Check if the event involves a protected label
           if [[ " ${PROTECTED_LABELS[*]} " =~ " $TARGET_LABEL " ]]; then
-            echo -e "\033[31mUnauthorized modification of a protected label by ${{ github.actor }}. Reverting changes...\033[0m"
+            echo -e "\033[31mUnauthorized modification of a protected label by $ACTOR. Reverting changes...\033[0m"
             ##### Revert to the previous state of labels
             if [[ "$EVENT_ACTION" == "unlabeled" ]]; then
               gh pr edit $PR_NUMBER --add-label "$TARGET_LABEL"

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Verify version updates on modified contracts
         id: verify_version_changes
         if: env.CONTINUE == 'true'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
 
           ##### Read tmp file into variable
@@ -132,7 +134,7 @@ jobs:
               echo -e "\033[32mFile contains a custom:version tag\033[0m"
 
               ##### Filter relevant code changes (exclude comments, pragma, license, empty lines)
-              DIFF_OUTPUT=$(git diff "origin/${{ github.event.pull_request.base.ref }}" HEAD -- "$FILE_PATH")
+              DIFF_OUTPUT=$(git diff "origin/$BASE_REF" HEAD -- "$FILE_PATH")
               RELEVANT_CHANGES=$(echo "$DIFF_OUTPUT" | grep -E '^[\+\-]' \
                 | grep -vE "^[\+\-][[:space:]]*(//|/\*|pragma)" \
                 | grep -vE '^(\+\+\+|---)' \
@@ -147,7 +149,7 @@ jobs:
                   echo "--------------------"
                   echo "Checking if version was updated..."
 
-                  OLD_FILE_CONTENT=$(git show "origin/${{ github.event.pull_request.base.ref }}:${FILE_PATH}" 2>/dev/null || echo "")
+                  OLD_FILE_CONTENT=$(git show "origin/$BASE_REF:${FILE_PATH}" 2>/dev/null || echo "")
                   OLD_VERSION=$(echo "$OLD_FILE_CONTENT" | grep -E '^/// @custom:version' | sed -E 's/^\/\/\/ @custom:version ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
 
                   # If there was no old version line in the diff, it's a new file.

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Get list of modified files by this PR
         id: modified_files
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
 
           ##### initialize empty file so that artifact upload step cannot fail
           echo "" > contracts_for_audit.txt

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "consola": "^3.2.3",
         "defender-relay-client": "^1.26.0",
         "enquirer": "^2.4.1",
+        "handlebars": "4.7.9",
         "light-spinner": "^1.0.4",
         "merkletreejs": "^0.3.11",
         "mongodb": "^6.13.0",
@@ -2690,6 +2691,8 @@
 
     "node-plop/globby": ["globby@13.2.2", "", { "dependencies": { "dir-glob": "^3.0.1", "fast-glob": "^3.3.0", "ignore": "^5.2.4", "merge2": "^1.4.1", "slash": "^4.0.0" } }, "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w=="],
 
+    "node-plop/handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+
     "node-plop/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
@@ -2755,6 +2758,8 @@
     "sc-istanbul/abbrev": ["abbrev@1.0.9", "", {}, "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q=="],
 
     "sc-istanbul/glob": ["glob@5.0.15", "", { "dependencies": { "inflight": "^1.0.4", "inherits": "2", "minimatch": "2 || 3", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA=="],
+
+    "sc-istanbul/handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
 
     "sc-istanbul/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
@@ -69,6 +70,7 @@
     },
   },
   "overrides": {
+    "handlebars": "4.7.9",
     "web3": "4.16.0",
   },
   "packages": {
@@ -1174,7 +1176,7 @@
 
     "hamt-sharding": ["hamt-sharding@2.0.1", "", { "dependencies": { "sparse-array": "^1.3.1", "uint8arrays": "^3.0.0" } }, "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA=="],
 
-    "handlebars": ["handlebars@4.7.8", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ=="],
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "zksync-web3": "^0.14.3"
   },
   "overrides": {
-    "web3": "4.16.0"
+    "web3": "4.16.0",
+    "handlebars": "4.7.9"
   },
   "scripts": {
     "abi:generate": "forge clean && forge build --skip script --skip test --skip Base --skip Test --skip '*.t.sol' && bun tasks/generateDiamondABI.ts",


### PR DESCRIPTION
## Summary

- Bump handlebars from 4.7.8 to 4.7.9 (`package.json`, `bun.lock`)
- Fix template injection in `protectAuditLabels.yml` — move GitHub context expressions to `env:` block
- Fix template injection in `versionControlAndAuditCheck.yml` — move `${{ github.event.pull_request.base.ref }}` to `env:` block

These were auto-applied to the `contracts-tron` fork by Aikido but never landed on upstream. Bringing them here so the fork can stay in sync via rebase rather than requiring merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)