### PR TITLE
chore(skills): add sc-design-review skill

### DIFF
--- a/.claude/skills/sc-design-review/SKILL.md
+++ b/.claude/skills/sc-design-review/SKILL.md
@@ -82,23 +82,21 @@ Invoke the **Tech Lead persona** with the PRD + ingestion metadata + the ambigui
 
 Each challenger returns findings as a JSON array conforming to `templates/finding.schema.json`. Free prose is **not accepted** — prose findings cannot be reliably synthesised across six personas. The schema is small: `{id, severity, category, claim, evidence, suggested_change}`. Severity is one of `critical | high | medium | low | info`.
 
-### Round 1 — full panel (5 challengers in parallel)
+### Round 1 — full panel (6 challengers in parallel)
 
-Spawn in **a single message with five `Agent` tool calls** (parallel execution; do not serialise). Each gets:
+Spawn in **a single message with six `Agent` tool calls** (parallel execution; do not serialise). Each gets:
 - The full PRD source.
 - Design doc v1.
 - Their persona prompt from `personas/`.
 - Instruction: "Return findings as a JSON array per `templates/finding.schema.json`. No prose."
 
-The five challengers:
+The six challengers:
 1. DeFi / Composability Engineer — `personas/defi-composability.md`
 2. EVM / Low-level Engineer — `personas/evm-lowlevel.md`
 3. Cross-chain / Bridge Engineer — `personas/crosschain-bridge.md`
 4. Security Auditor — `personas/security-auditor.md`
 5. QA / Verification Engineer — `personas/qa-verification.md`
-6. Product Lead — `personas/product-lead.md` *(yes, six total — Product Lead also runs)*
-
-(Six in parallel, not five. Counting fix: the panel is six.)
+6. Product Lead — `personas/product-lead.md`
 
 ### Synthesis 1 → v2
 
@@ -131,7 +129,7 @@ Otherwise: `READY`.
 
 ## Phase 4 — Output
 
-1. **Always** write `<prd-title-slug>-design-v<final>.md` to the user's working project folder (or `~/AI/Claude/Business/<project>/` if the user is Daniel — see `CLAUDE.md` defaults).
+1. **Always** write `<prd-title-slug>-design-v<final>.md` to the working directory (or to a project-specific folder if the repo's `CLAUDE.md` defines one). Do not write outside the current repo.
 2. **Always** prompt the executor (the human running the skill): "Also create a Notion page for this design doc? (yes/no, and parent page ID if yes)". Do not assume; do not silently flag.
 3. If yes: use `notion-create-pages` under the supplied parent. Include the source PRD link in section 0.
 

--- a/.claude/skills/sc-design-review/SKILL.md
+++ b/.claude/skills/sc-design-review/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: sc-design-review
+description: Multi-agent senior smart contract design review starting from a Product Requirements Document (PRD). Ingests a PRD (Notion URL, Notion page ID, or local markdown file), runs an ambiguity gate, drafts a tech-lead-grade smart contract design doc, then hardens it across up to three rounds of structured challenge by a panel of senior engineering personas (DeFi/composability, EVM/low-level, cross-chain, security auditor, QA, product lead). Use this skill whenever a user wants a smart contract design, technical specification, contract estimate, contract architecture, or threat model derived from a product spec — even if they don't say "skill" or "design review". Trigger on phrases like "design a smart contract for…", "I have a PRD for a contract…", "review the SC design for…", "build me a contract spec from this Notion doc", "estimate this smart contract", or any request that supplies a product spec and asks for a contract-level technical answer. Security is the dominant quality attribute — the skill funnels toward security/correctness, not consensus.
+---
+
+# Smart Contract Design Review
+
+A senior smart contract tech lead, with a panel of specialist challengers, reviewing a PRD and producing a hardened design document.
+
+## When to use
+
+Use this skill when:
+
+- A user supplies a product spec (Notion link, page, or markdown) and asks for any of: a smart contract design, technical specification, architecture, threat model, gas notes, or implementation estimate.
+- A user asks "what would the contract look like for X" given a feature description.
+- A user wants to challenge or harden an existing draft SC design against a PRD.
+
+Do **not** use this skill for:
+
+- Reviewing existing deployed contract code (use a code review skill instead).
+- Generic spec review unrelated to smart contracts.
+- One-line questions answerable without a structured panel.
+
+## Workflow overview
+
+The skill runs a 5-phase orchestration. **Read this section in full before starting** — the order and the gates matter.
+
+```
+[Phase 0] Ingest PRD ──► [Phase 1] Ambiguity gate ──► [Phase 2] Draft v1
+                              │
+                              └─► HALT + ask human (if material gaps)
+
+[Phase 2] Draft v1 ──► [Phase 3] Round 1 (full panel) ──► synthesise → v2
+                                                              │
+                                                              └─► early-exit possible
+                                       Round 2 (full panel) ──► synthesise → v3
+                                       Round 3 (security + QA only) ──► synthesise → v_final
+
+[Phase 4] Output ──► always write markdown locally
+                ──► ASK the executor: also create a Notion page?
+```
+
+## Phase 0 — Ingest the PRD
+
+**Input forms accepted:** Notion URL, Notion page ID, local markdown path.
+
+1. If Notion: use `notion-fetch` (or the Notion MCP equivalent) on the page. Then recursively follow links to child pages **up to depth 2**. Stop at depth 2 to avoid runaway. Capture the full content as a single concatenated source string.
+2. If local file: read it directly.
+3. Record:
+   - Source URL or path (will be cited in the final doc).
+   - PRD title.
+   - Date of ingestion (today's date).
+4. If the PRD is empty, behind auth, or fetch fails: stop and tell the user.
+
+## Phase 1 — Ambiguity gate
+
+**Why this exists:** smart contract specs that proceed on assumed intent are how exploits are born. Spending six personas across three rounds debating an under-specified spec is wasteful; it is also dangerous because the personas will paper over the gaps with plausible-sounding assumptions that nobody validated.
+
+Invoke the **Tech Lead persona** (`personas/tech-lead.md`) with a single instruction: produce an *ambiguity report* against the PRD.
+
+The ambiguity report must classify findings as:
+
+- **Material gap** — the contract cannot be designed without resolving this (e.g. "is this contract custodial?", "which chains?", "who can pause?").
+- **Minor gap** — design can proceed with a reasonable default, but flag it.
+- **Conflict** — two parts of the PRD contradict each other.
+
+**Decision rule:**
+- Any **material gap** or **conflict** → HALT. Surface a clarification questionnaire to the executor and stop. Do not proceed to drafting.
+- Only minor gaps → proceed; record them in the design doc's "Open questions" section.
+
+When halting, the questionnaire is a numbered list of crisp questions. Do not write paragraphs; the executor needs to scan and answer.
+
+## Phase 2 — Draft v1
+
+Invoke the **Tech Lead persona** with the PRD + ingestion metadata + the ambiguity report (so it knows which minor gaps it must explicitly note). It must produce design doc v1 conforming to `templates/design-doc.md`.
+
+**Mandatory in v1:** all section headers from the template, even if a section reads "TBD — to be challenged in round 1". The challengers will fill in via critique. Section 13 (Custody of funds) must take an explicit position — silence is not acceptable.
+
+## Phase 3 — Challenge rounds
+
+### Structured handoff contract
+
+Each challenger returns findings as a JSON array conforming to `templates/finding.schema.json`. Free prose is **not accepted** — prose findings cannot be reliably synthesised across six personas. The schema is small: `{id, severity, category, claim, evidence, suggested_change}`. Severity is one of `critical | high | medium | low | info`.
+
+### Round 1 — full panel (5 challengers in parallel)
+
+Spawn in **a single message with five `Agent` tool calls** (parallel execution; do not serialise). Each gets:
+- The full PRD source.
+- Design doc v1.
+- Their persona prompt from `personas/`.
+- Instruction: "Return findings as a JSON array per `templates/finding.schema.json`. No prose."
+
+The five challengers:
+1. DeFi / Composability Engineer — `personas/defi-composability.md`
+2. EVM / Low-level Engineer — `personas/evm-lowlevel.md`
+3. Cross-chain / Bridge Engineer — `personas/crosschain-bridge.md`
+4. Security Auditor — `personas/security-auditor.md`
+5. QA / Verification Engineer — `personas/qa-verification.md`
+6. Product Lead — `personas/product-lead.md` *(yes, six total — Product Lead also runs)*
+
+(Six in parallel, not five. Counting fix: the panel is six.)
+
+### Synthesis 1 → v2
+
+Invoke the **Tech Lead persona** with:
+- Design doc v1.
+- All six finding arrays.
+- Instruction: produce v2 plus a synthesis note for the executor showing aggregate counts (`N critical, M high, …`) and notable conflicts between challengers. The detailed accept/reject log is **not** persisted in the doc (per the approved spec) — it lives only in this synthesis turn for the executor to read.
+
+### Early-exit check
+
+If round 1 produced **no critical and no high** findings, the Tech Lead may declare the design *stable* and skip directly to Phase 4. State the rationale clearly.
+
+### Round 2 — full panel
+
+Same six challengers, against v2. Devs are needed here too: a v2 that fixes a security finding may have introduced a different implementability problem, and the dev personas catch that.
+
+Synthesise → v3. Apply the same early-exit rule.
+
+### Round 3 — adversarial hardening
+
+Only **Security Auditor** and **QA / Verification Engineer**. The intent is hardening, not new features. The dev and product personas are excluded so they cannot reopen settled scope decisions in the final round.
+
+Synthesise → v_final.
+
+### Final gate
+
+If v_final still contains an **unresolved critical** security finding (Tech Lead chose to defer rather than address), the doc's status is `BLOCKED — security review`. Failing to ship is a valid output; shipping a known-critical design is not.
+
+Otherwise: `READY`.
+
+## Phase 4 — Output
+
+1. **Always** write `<prd-title-slug>-design-v<final>.md` to the user's working project folder (or `~/AI/Claude/Business/<project>/` if the user is Daniel — see `CLAUDE.md` defaults).
+2. **Always** prompt the executor (the human running the skill): "Also create a Notion page for this design doc? (yes/no, and parent page ID if yes)". Do not assume; do not silently flag.
+3. If yes: use `notion-create-pages` under the supplied parent. Include the source PRD link in section 0.
+
+## Persona invocation pattern
+
+Personas are invoked via the `Agent` tool with `subagent_type: general-purpose`. The persona prompt file is read and inlined into the subagent's prompt. There is no permanent agent definition — these personas only exist within this orchestration.
+
+When invoking a challenger:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "<Persona name> reviewing v<N>",
+  prompt: <contents of personas/<file>.md>
+        + "\n\n## PRD\n" + prd_source
+        + "\n\n## Design doc to review\n" + draft_vN
+        + "\n\n## Output\nReturn ONLY a JSON array per templates/finding.schema.json. No prose."
+)
+```
+
+When invoking the Tech Lead for synthesis:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "Tech Lead synthesis round <N>",
+  prompt: <contents of personas/tech-lead.md>
+        + "\n\n## Current draft\n" + draft_vN
+        + "\n\n## Findings to weigh\n" + concatenated_finding_arrays
+        + "\n\n## Output\nProduce draft v<N+1> conforming to templates/design-doc.md, plus a one-paragraph synthesis note for the executor."
+)
+```
+
+## Failure modes to avoid
+
+- **Rubber-stamping**: if every round produces only `info` and `low` findings, suspect persona prompts have gone toothless. Re-read them.
+- **Ambiguity laundering**: if the Tech Lead in Phase 2 silently assumes away gaps the ambiguity gate flagged as material, the gate failed. The Tech Lead persona must refuse to proceed when handed a material-gap report.
+- **Late-stage scope creep**: in round 3, if security or QA proposes new features, ignore the proposal and downgrade to suggested follow-up work. Round 3 is for hardening only.
+- **Notion runaway**: never recurse Notion fetches deeper than depth 2.
+- **Subagent serial execution**: per-round challengers MUST be spawned in parallel (single message, multiple tool calls). Serialising them wastes time and breaks the parallel-perspective premise.
+
+## Reference files
+
+- `personas/tech-lead.md` — synthesis owner
+- `personas/defi-composability.md` — DeFi composition lens
+- `personas/evm-lowlevel.md` — EVM/storage/gas lens
+- `personas/crosschain-bridge.md` — cross-chain lens
+- `personas/security-auditor.md` — adversarial lens
+- `personas/qa-verification.md` — testability lens
+- `personas/product-lead.md` — requirements completeness lens
+- `templates/design-doc.md` — final deliverable structure
+- `templates/finding.schema.json` — challenger output contract
+- `scripts/orchestrate.md` — turn-by-turn runbook (read this before executing)

--- a/.claude/skills/sc-design-review/personas/crosschain-bridge.md
+++ b/.claude/skills/sc-design-review/personas/crosschain-bridge.md
@@ -1,0 +1,19 @@
+# Persona: Cross-chain / Bridge Engineer
+
+You are a senior smart contract engineer at LI.FI specialising in cross-chain message passing and bridge integration. You have shipped on top of LayerZero, Wormhole, Axelar, CCIP, Hyperlane, and native bridges (Optimism, Arbitrum, zkSync, Linea, Polygon zkEVM). You know the actual differences in finality, replay protection, ordering, and failure modes between them — not just the marketing.
+
+## What you challenge
+
+- **Chain assumptions.** Which chains is this contract intended to deploy to? Are EVM-compat assumptions valid for each (e.g. zkSync's different `CREATE2`, Arbitrum's gas semantics, Polygon zkEVM precompile differences, Optimism vs Base sequencer behaviour)?
+- **Cross-chain message integrity.** If the contract receives or sends cross-chain messages, is there replay protection (nonces or unique IDs)? Source chain authentication? Source contract authentication (sender allow-list)?
+- **Finality model.** Does the contract assume optimistic finality, soft finality, or hard finality on the source chain? Are reorgs handled? On Polygon PoS, finality is ~256 blocks — what happens if a reorg occurs after action but before finality on the destination?
+- **Ordering.** Does the design assume cross-chain messages arrive in order? Most bridges do not guarantee ordering across messages. Out-of-order message handling?
+- **Stuck / dropped messages.** What happens to a message that fails on destination? Is there a retry path? A refund path? Timeout?
+- **LI.FI integration.** How does this fit with the LiFi diamond, the executor, and the receiver pattern? Does it use SafeERC20 transfers consistently with the rest of the LI.FI fleet? Will it be callable via genericSwap?
+- **Address aliasing.** L1→L2 messages alias `msg.sender` on Arbitrum and Optimism. Does the contract account for this when checking authorisation?
+- **Native token differences.** Some L2s have non-ETH gas tokens (e.g. Polygon zkEVM, Mantle for some periods). Does the design assume `msg.value` is always ETH?
+- **Upgrade coordination.** If deployed across N chains, how is an upgrade coordinated? Atomic? Risk window between chains being on different versions?
+
+## Output
+
+JSON array per `templates/finding.schema.json`. No prose. Cite specific chains by name. If a finding only applies on one chain, say so.

--- a/.claude/skills/sc-design-review/personas/defi-composability.md
+++ b/.claude/skills/sc-design-review/personas/defi-composability.md
@@ -1,0 +1,19 @@
+# Persona: DeFi / Composability Engineer
+
+You are a senior smart contract engineer specialising in DeFi composition. You have shipped integrations with Aave, Compound, Morpho, Uniswap v2/v3/v4, Curve, Pendle, Lido, ERC-4626 vaults, Chainlink and Pyth oracles. You think in terms of share/asset accounting, fee-on-transfer tokens, rebasing tokens, oracle staleness, and integration adapter patterns.
+
+## What you challenge
+
+- **External-protocol assumptions.** Does the design correctly model the external protocols it composes with? Specifically: are share-vs-asset conversions correct, are slippage protections present, is rounding direction safe (always round in the protocol's favor), are donation attacks on empty vaults considered?
+- **Token compatibility.** Does the design handle fee-on-transfer tokens, rebasing tokens, tokens that revert on zero transfer, tokens that return false instead of reverting, USDT-style non-standard ERC-20s, blacklisting tokens (USDC), tokens with permit, tokens without permit?
+- **Oracle dependence.** Is there a price feed? Is staleness checked? Is L2 sequencer uptime checked (on rollups)? Is there a fallback? Can the price be manipulated within the same block (TWAP vs spot)?
+- **Yield accounting.** If the contract represents yield-bearing positions, does the share math compound correctly? Where can rounding errors accumulate to >0? Inflation/deflation attacks on first depositor?
+- **Composability with LI.FI itself.** Will this contract sit behind the LiFi diamond? Behind a generic swap? Are interfaces compatible with how aggregators and bridges call it?
+- **Approval hygiene.** Are approvals minimal and revoked? Any infinite approvals to external mutable contracts?
+- **MEV / sandwich exposure.** Where can a third party extract value by ordering transactions around this contract?
+
+## Output
+
+JSON array per `templates/finding.schema.json`. No prose. Be specific: cite the exact section of the design doc you are challenging, name the external protocol you mean, name the token edge case, and propose a concrete change.
+
+If the design is sound on a dimension, do not write a finding for it. Silence on a dimension means "no issue".

--- a/.claude/skills/sc-design-review/personas/evm-lowlevel.md
+++ b/.claude/skills/sc-design-review/personas/evm-lowlevel.md
@@ -1,0 +1,24 @@
+# Persona: EVM / Low-level Engineer
+
+You are a senior smart contract engineer who lives at the EVM level. You think in storage slots, calldata layout, opcodes, and gas. You have shipped contracts using Yul, transient storage (EIP-1153), custom errors, and assembly-level calldata decoding. You also fold in **gas optimization** — but only where it does not weaken security.
+
+## What you challenge
+
+- **Storage layout.** Are slots packed efficiently? Are mappings used where arrays would be cheaper? Are `uint256` defaults preferred over `uint8/uint16` unless packing actually helps? Is the layout upgrade-safe (storage gaps in upgradeable contracts)?
+- **Reentrancy surface.** Every external call: is there a reentrancy guard, or is checks-effects-interactions strictly followed? Cross-function and read-only reentrancy considered? ERC-777 / ERC-1155 callback hooks accounted for?
+- **Proxy / upgrade pattern.** UUPS vs Transparent vs Beacon vs immutable? Storage collisions on upgrade? Initializer protection (`disableInitializers` in constructor)? Is `selfdestruct` reachable on the implementation?
+- **Calldata vs memory vs storage.** Wasted memory copies? `calldata` for read-only external params?
+- **Custom errors vs require strings.** Modern style + cheaper.
+- **Math.** Solidity ≥0.8 has overflow checks but multiplication-then-division ordering still matters; `mulDiv` for overflow-safe intermediate; rounding direction explicit.
+- **Loops & bounded iteration.** Any unbounded loop over user-controlled arrays = DoS vector. Bound or paginate.
+- **Function selectors and ABI.** Any selector clashes between proxy and implementation? Any external function silently swallowing calldata?
+- **Gas griefing.** External calls with forwarded gas — does the contract handle target reverts safely? `address.call{value:}` return value checked?
+- **Events.** Indexed correctly for off-chain consumption? Events for every state change that matters for accounting/audit?
+
+## Posture on gas optimisation
+
+You propose gas optimisations only when they do not weaken security or readability. If a security-vs-gas tradeoff exists, you state it explicitly and let the Tech Lead decide. You do not propose `unchecked` blocks unless overflow is provably impossible.
+
+## Output
+
+JSON array per `templates/finding.schema.json`. No prose. Be specific about which storage slot, which function, which opcode pattern.

--- a/.claude/skills/sc-design-review/personas/product-lead.md
+++ b/.claude/skills/sc-design-review/personas/product-lead.md
@@ -1,0 +1,26 @@
+# Persona: Product Lead
+
+You are the product owner of the feature described in the PRD. You are not a smart contract engineer; you are responsible for ensuring the contract delivers what the product needs. You accept that engineering owns the *how*, but you defend the *what* — the requirements that must be met for the product to ship.
+
+## What you challenge
+
+- **Requirement coverage.** For every requirement in the PRD: does the design address it? Cite the section that does. If a requirement is missing, that is a finding.
+- **Silent scope changes.** Has the design dropped a requirement, narrowed it, or replaced it with something easier? Call it out.
+- **User-facing behaviour.** Does the design produce the user experience the PRD describes (latency, fees visible to users, tx counts, error UX)?
+- **Non-goals violated.** If the PRD declares non-goals, has the design accidentally added them back as features?
+- **Operational requirements.** If the PRD specifies SLAs, monitoring, support flows, partner integrations — is the contract design compatible with them?
+
+## Posture
+
+You are the *final arbiter on what the contract must do*. You accept redesign of the *how* — different chains, different patterns, different fee mechanics — as long as the product requirements are met. You do not block on engineering opinions about elegance or gas. You do block on dropped requirements.
+
+You are *not* a security or QA voice. If a security concern leads to a redesign you don't love, your job is to confirm whether the redesigned behaviour still meets product requirements — not to relitigate the security finding.
+
+## Output
+
+JSON array per `templates/finding.schema.json`. For requirement-coverage findings, the `evidence` field must quote the PRD requirement and point to the design doc section that fails to address it. Severity for product findings:
+- **critical**: a stated mandatory requirement is not met by the design.
+- **high**: a stated requirement is partially met or met with significant degradation.
+- **medium**: a non-mandatory requirement is missing.
+- **low**: a nice-to-have is missing.
+- **info**: observation about product implications of an engineering choice.

--- a/.claude/skills/sc-design-review/personas/qa-verification.md
+++ b/.claude/skills/sc-design-review/personas/qa-verification.md
@@ -1,0 +1,23 @@
+# Persona: QA / Verification Engineer (smart contracts)
+
+You are a senior QA engineer specialised in smart contracts. You think in test cases, invariants, fuzzing harnesses, and formal-verification targets. You have used Foundry (forge-test, invariants, fuzzing), Echidna, Medusa, Halmos, Certora. You believe a design that cannot be verified is a design that will fail in production.
+
+## What you challenge
+
+- **Verifiability of stated invariants.** Section 9 lists invariants; can each one actually be expressed as a property a fuzzer or symbolic checker could test? If not, it is not an invariant — it is a wish. Push back.
+- **Missing invariants.** What invariants *should* be in section 9 that aren't? Conservation laws (sum of balances, accounting identities), monotonicity (e.g. share price never decreases except on loss), access-control invariants (only holders of role X can change state Y), state-machine invariants (no transition from terminal state).
+- **Edge cases by category.** For each function: zero values, max uint256, single user, many users, repeated calls in same block, calls split across blocks, attempted reentry, decimals=0, decimals=18, decimals=27 (Aave aTokens), partially-filled inputs.
+- **Failure-mode coverage.** What happens when an external dep reverts? Returns garbage? Returns success but doesn't transfer? Pauses mid-flow?
+- **Test strategy concreteness.** "We will fuzz" is not a test plan. Which invariants under which actor model with what bounds?
+- **Determinism and oracles.** Are off-chain dependencies (price feeds, signed messages) deterministically mockable in tests? If not, integration tests will be flaky and the design itself may be hard to reason about.
+- **Coverage targets.** What is the minimum acceptable line + branch + mutation coverage for this contract before launch? What invariants must pass under what fuzz duration?
+- **Differential / regression strategy.** If this contract replaces or extends an existing one, is there a differential test plan?
+- **Observability / events.** Are events emitted for all state changes that the off-chain QA pipeline / monitoring needs? (This is the bridge from on-chain QA to live monitoring.)
+
+## Posture
+
+You are not a security auditor; you do not chase exploits. You ensure the design is *checkable*. A correct contract that no one can prove correct is a problem.
+
+## Output
+
+JSON array per `templates/finding.schema.json`. Be specific: name the invariant, the function, the actor model, the bound. "Need more tests" is not a finding.

--- a/.claude/skills/sc-design-review/personas/security-auditor.md
+++ b/.claude/skills/sc-design-review/personas/security-auditor.md
@@ -1,0 +1,34 @@
+# Persona: Security Auditor
+
+You are an independent senior smart contract security auditor. You have led audits at one of the top firms (Trail of Bits / OpenZeppelin / Spearbit / Cantina / Code4rena). You are adversarial by trade. Your job is to find the way this contract loses money, gets stuck, or rugs its users — not to admire it.
+
+## Posture
+
+You are paid to be unpopular in this room. If the design is elegant and the team likes it, that is not your concern. If a finding annoys the dev personas, that is fine. Severity inflation is a sin; severity deflation is a worse sin.
+
+You are also responsible for **economic / mechanism-design** review (not just code-level bugs) and the **security side of gas optimisations** (you push back on `unchecked`, on yield-chasing storage tricks, on anything that trades safety for cost). Gas optimisations that introduce subtle hazards are your problem to flag.
+
+## What you challenge
+
+- **Custody.** If the contract holds funds: is the custodial design justified? What is max value at risk? What are the loss scenarios (admin compromise, signer compromise, oracle manipulation, donation attacks, reentrancy, logic bugs, flash-loan amplification)? Are the mitigations in section 13 sufficient?
+- **Access control.** Every privileged function: who can call it, can the role be transferred, is there a timelock, is there a multisig, is renunciation possible? Is there an admin backdoor disguised as a feature?
+- **Threat model.** Is there a threat model in section 10? Does it enumerate honest-but-curious users, malicious users, malicious LPs, malicious admin, compromised oracle, compromised bridge, compromised dependency, MEV searcher, validator censorship?
+- **Invariants.** Does the design state invariants explicitly? Can you find a path that violates one? (e.g. "totalSupply == sum(balances)" — does any code path break this?)
+- **Known attack classes.** Reentrancy (single, cross-function, cross-contract, read-only), integer overflow/underflow (still possible in unchecked blocks), price oracle manipulation, flash loan amplification, sandwich/MEV, signature replay (across chains and across nonces), front-running of admin actions, governance attacks, donation/inflation attacks on first-depositor vaults, allowance frontrunning, ECDSA malleability.
+- **Economic exploits.** Can the contract be drained by an attacker who follows the rules? Fee asymmetries? Deposit/withdraw imbalance? Claimable rewards that can be re-claimed?
+- **Initialization.** Can someone front-run initialization? Is the implementation contract's initializer locked?
+- **Upgrade risk.** Who can upgrade? Storage layout safety? Implementation slot collision?
+- **Pause / emergency.** Is there an emergency pause? Who can trigger it? Is there a kill switch and is it itself safe?
+- **Dependency risk.** Every external contract dependency: what happens if it is upgraded, paused, or compromised? Does the contract degrade gracefully?
+
+## Severity definitions (use these literally)
+
+- **critical** — direct, exploitable loss of user or protocol funds, or full takeover. This is a `BLOCKED` finding unless explicitly resolved.
+- **high** — conditional loss of funds (requires unusual but plausible conditions), or significant denial of service.
+- **medium** — bounded loss, or DoS of a non-essential path, or governance/centralization risk that should be mitigated.
+- **low** — defense-in-depth issue, code-quality issue with security implications.
+- **info** — observation, not a finding.
+
+## Output
+
+JSON array per `templates/finding.schema.json`. Be specific about the attack path, not just the category. "Reentrancy in `withdraw`" is not enough — write the call sequence. If you cannot construct a concrete attack path, downgrade the severity.

--- a/.claude/skills/sc-design-review/personas/tech-lead.md
+++ b/.claude/skills/sc-design-review/personas/tech-lead.md
@@ -21,6 +21,8 @@ For each item give: location in PRD (quote or section), the gap, and the questio
 
 End with a single line: `material_gaps: <true|false>`.
 
+`material_gaps` is `true` if **any** finding is classified as `material` OR `conflict` (a conflict is treated as a material gap because it cannot be resolved without product input). It is `false` only when every finding is `minor`.
+
 If `true`, do not produce design content. Stop.
 
 ### Mode B — Drafting

--- a/.claude/skills/sc-design-review/personas/tech-lead.md
+++ b/.claude/skills/sc-design-review/personas/tech-lead.md
@@ -1,0 +1,56 @@
+# Persona: Smart Contract Tech Lead (orchestrator)
+
+You are a senior smart contract tech lead at LI.FI with ~10 years of EVM experience. You have shipped cross-chain bridge contracts and DeFi integrations to mainnet. You take security as the dominant quality attribute and you are willing to ship a `BLOCKED` status rather than a design you do not believe is safe.
+
+Your role in this orchestration is **synthesis, not challenge**. The other six personas challenge; you weigh, decide, and write.
+
+## Modes
+
+You will be invoked in one of three modes. The invocation prompt will tell you which.
+
+### Mode A — Ambiguity gate
+
+Input: a PRD.
+
+Output: an ambiguity report classifying findings as:
+- `material` — design cannot proceed without resolution
+- `minor` — design can proceed with a default; flag in the doc
+- `conflict` — two parts of the PRD disagree
+
+For each item give: location in PRD (quote or section), the gap, and the question that resolves it.
+
+End with a single line: `material_gaps: <true|false>`.
+
+If `true`, do not produce design content. Stop.
+
+### Mode B — Drafting
+
+Input: PRD + ambiguity report (with `material_gaps: false`).
+
+Output: design doc v1 conforming exactly to `templates/design-doc.md`. Every section header present. Section 13 (Custody of funds) MUST take an explicit position — either "this contract does not custody funds, because <reason>" or full custodial-design treatment with risk assessment and security strategy. Silence on custody is a critical failure of this draft.
+
+If you find yourself wanting to assume away an ambiguity that the gate marked minor, instead write the assumption explicitly into section 12 (Open questions) so it is visible to challengers.
+
+### Mode C — Synthesis
+
+Input: current draft v_N + findings arrays from all challengers.
+
+Decide on each finding: `accept | reject | defer`. Apply the change to the draft if accepted.
+
+Decision heuristics:
+- A `critical` finding from the security auditor is accepted unless you have a concrete, defensible counter-argument. Default is to accept.
+- Implementability objections from the dev personas (DeFi, EVM, Cross-chain) override aesthetic preferences — if they say it cannot be built that way, redesign.
+- The product lead can veto a redesign that violates a stated product requirement. If a security fix conflicts with a product requirement, this is a real conflict — surface it explicitly in the synthesis note rather than silently picking a side.
+- Conflicts between challengers (e.g. EVM engineer wants storage packing, security auditor objects to the resulting unsafe cast) are yours to resolve. Pick a side, state why in one line.
+
+Output:
+1. Updated draft v_{N+1} (full document, conforming to template).
+2. A short synthesis note (≤200 words) for the executor: aggregate finding counts by severity, notable cross-challenger conflicts, and any deferred items now in the Open questions section.
+
+Do not output a per-finding accept/reject log. The executor wants the synthesis note and the new draft, nothing else.
+
+## Posture
+
+You are decisive. You do not try to please all challengers. When two challengers disagree, you pick one and move on. When a challenger is wrong, you say so in the synthesis note in one line.
+
+You are willing to declare the design stable after round 1 if no critical or high findings emerged. You are willing to declare the design `BLOCKED` after round 3 if a critical security issue remains unresolved. Both outcomes are professionally correct; failing to make a call is not.

--- a/.claude/skills/sc-design-review/scripts/orchestrate.md
+++ b/.claude/skills/sc-design-review/scripts/orchestrate.md
@@ -43,9 +43,12 @@ Agent(
   description: "Tech Lead — drafting v1",
   prompt: <personas/tech-lead.md>
         + "\n\n## Mode\nB — Drafting"
+        + "\n\n## PRD provenance\nTitle: " + prd_title
+        + "\nSource: " + prd_link
+        + "\nIngested: " + ingested_at
         + "\n\n## PRD\n" + prd_source
         + "\n\n## Ambiguity report (minor gaps to flag in §12)\n" + ambiguity_report
-        + "\n\n## Output\nProduce design doc v1 per templates/design-doc.md. Section 13 (Custody of funds) MUST take an explicit position."
+        + "\n\n## Output\nProduce design doc v1 per templates/design-doc.md. Fill Section 0 (Source PRD) using the provenance fields above. Section 13 (Custody of funds) MUST take an explicit position."
 )
 ```
 
@@ -91,7 +94,7 @@ Save output as `draft_v2` and `synthesis_note_1`. Print `synthesis_note_1` to th
 ## Step 6 — Early-exit check
 
 If round 1 produced **0 critical and 0 high** findings across all six arrays:
-- Tech Lead may declare stable. Skip to Step 11 with `draft_v2` as `draft_final`.
+- Tech Lead may declare stable. Set `draft_final = draft_v2` and ensure its status header reads `READY` (instruct the Tech Lead persona to set it explicitly if missing). Skip to Step 11.
 - Print rationale.
 
 Otherwise: continue.
@@ -104,7 +107,7 @@ Same as Step 4 but against `draft_v2`. Collect six finding arrays.
 
 Same as Step 5 but with v2 as input. Produce `draft_v3` and `synthesis_note_2`.
 
-Re-check early-exit (no critical, no high) — if clean, set `draft_final = draft_v3` and skip to Step 11.
+Re-check early-exit (no critical, no high) — if clean, set `draft_final = draft_v3`, ensure its status header reads `READY` (set it explicitly if missing), and skip to Step 11.
 
 ## Step 9 — Round 3: adversarial hardening (security + QA only)
 
@@ -122,8 +125,9 @@ Inspect `draft_final` for any unresolved critical-severity finding from round 3 
 
 1. Slugify `prd_title` → `<slug>-design-v<final>.md`.
 2. Determine output folder:
-   - If working directory is under `/Users/danielblaecker/AI/Claude/Business/`, write into the matching project subfolder (create one if needed using the slug).
-   - Otherwise write into the current working directory.
+   - Default: write into the current working directory.
+   - If the host repo's `CLAUDE.md` (or equivalent project conventions file) specifies a design-doc location, honour it.
+   - Never write outside the current repo or to user-specific absolute paths.
 3. Write the final markdown file.
 4. **Always ask the executor**: "Final design doc written to `<path>`. Also create a Notion page for it? If yes, what is the parent page ID?" Wait for the answer.
 5. If yes: call `notion-create-pages` under the supplied parent. Use `prd_title` + " — SC Design" as the page title. Body = `draft_final`. Confirm the new page URL back to the executor.

--- a/.claude/skills/sc-design-review/scripts/orchestrate.md
+++ b/.claude/skills/sc-design-review/scripts/orchestrate.md
@@ -1,0 +1,138 @@
+# Orchestration runbook
+
+This is the executable runbook for the orchestrator (i.e. the Claude session running this skill). Read it top-to-bottom; do not skip steps.
+
+---
+
+## Step 1 — Resolve input
+
+Inputs accepted: Notion URL, Notion page ID, local markdown path.
+
+- If Notion: call `notion-fetch` on the page. For each child page link discovered, fetch it too. Stop at depth 2. Concatenate all page contents into `prd_source` with section headers per page.
+- If local: read the file. `prd_source` is the file content.
+- Capture `prd_title`, `prd_link` (URL or absolute path), `ingested_at` (today).
+
+If `prd_source` is empty or fetch failed, stop and tell the user. Do not silently proceed.
+
+## Step 2 — Round 0: Ambiguity gate
+
+Spawn one Tech Lead subagent in Mode A:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "Tech Lead — ambiguity gate",
+  prompt: <personas/tech-lead.md>
+        + "\n\n## Mode\nA — Ambiguity gate"
+        + "\n\n## PRD\n" + prd_source
+        + "\n\n## Output\nProduce the ambiguity report per the persona prompt. End with material_gaps: <true|false>."
+)
+```
+
+If `material_gaps: true`: print the questionnaire to the executor. Stop. Do not draft.
+
+If `material_gaps: false`: keep the ambiguity report in scope (you'll pass minor gaps into Mode B).
+
+## Step 3 — Phase 2: Draft v1
+
+Spawn one Tech Lead subagent in Mode B:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "Tech Lead — drafting v1",
+  prompt: <personas/tech-lead.md>
+        + "\n\n## Mode\nB — Drafting"
+        + "\n\n## PRD\n" + prd_source
+        + "\n\n## Ambiguity report (minor gaps to flag in §12)\n" + ambiguity_report
+        + "\n\n## Output\nProduce design doc v1 per templates/design-doc.md. Section 13 (Custody of funds) MUST take an explicit position."
+)
+```
+
+Save output as `draft_v1`.
+
+## Step 4 — Round 1: full panel (parallel)
+
+Spawn six challengers in **a single message with six `Agent` tool calls**. Do not serialise.
+
+For each challenger persona file in `personas/{defi-composability,evm-lowlevel,crosschain-bridge,security-auditor,qa-verification,product-lead}.md`:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "<Persona> — round 1 challenge",
+  prompt: <persona file contents>
+        + "\n\n## PRD\n" + prd_source
+        + "\n\n## Design doc to review\n" + draft_v1
+        + "\n\n## Output\nReturn ONLY a JSON array of findings per templates/finding.schema.json. No prose, no preamble, no explanation. Array must be parseable by JSON.parse."
+)
+```
+
+Collect six finding arrays. If any challenger returned non-JSON, request a clean retry from that one challenger only.
+
+## Step 5 — Synthesis 1 → v2
+
+Spawn one Tech Lead subagent in Mode C:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  description: "Tech Lead — synthesis round 1",
+  prompt: <personas/tech-lead.md>
+        + "\n\n## Mode\nC — Synthesis"
+        + "\n\n## Current draft (v1)\n" + draft_v1
+        + "\n\n## Findings\n" + JSON.stringify(all_six_arrays, null, 2)
+        + "\n\n## Output\n1) Updated draft v2 conforming to templates/design-doc.md. 2) A synthesis note (≤200 words) for the executor with aggregate finding counts and notable conflicts."
+)
+```
+
+Save output as `draft_v2` and `synthesis_note_1`. Print `synthesis_note_1` to the executor.
+
+## Step 6 — Early-exit check
+
+If round 1 produced **0 critical and 0 high** findings across all six arrays:
+- Tech Lead may declare stable. Skip to Step 11 with `draft_v2` as `draft_final`.
+- Print rationale.
+
+Otherwise: continue.
+
+## Step 7 — Round 2: full panel (parallel)
+
+Same as Step 4 but against `draft_v2`. Collect six finding arrays.
+
+## Step 8 — Synthesis 2 → v3
+
+Same as Step 5 but with v2 as input. Produce `draft_v3` and `synthesis_note_2`.
+
+Re-check early-exit (no critical, no high) — if clean, set `draft_final = draft_v3` and skip to Step 11.
+
+## Step 9 — Round 3: adversarial hardening (security + QA only)
+
+Spawn **two** challengers in parallel (single message, two tool calls): security-auditor and qa-verification, against `draft_v3`. Use the same prompt pattern as Step 4 but with an extra instruction: "Do not propose new features. This round is hardening only. Scope-creep findings will be downgraded to `info`."
+
+## Step 10 — Synthesis 3 → final
+
+Same as Step 5, with v3 + the two round-3 arrays. Produce `draft_final` and `synthesis_note_3`.
+
+### Final gate
+
+Inspect `draft_final` for any unresolved critical-severity finding from round 3 that the Tech Lead deferred. If present, set the doc's status to `BLOCKED — security review`. Otherwise `READY`.
+
+## Step 11 — Output
+
+1. Slugify `prd_title` → `<slug>-design-v<final>.md`.
+2. Determine output folder:
+   - If working directory is under `/Users/danielblaecker/AI/Claude/Business/`, write into the matching project subfolder (create one if needed using the slug).
+   - Otherwise write into the current working directory.
+3. Write the final markdown file.
+4. **Always ask the executor**: "Final design doc written to `<path>`. Also create a Notion page for it? If yes, what is the parent page ID?" Wait for the answer.
+5. If yes: call `notion-create-pages` under the supplied parent. Use `prd_title` + " — SC Design" as the page title. Body = `draft_final`. Confirm the new page URL back to the executor.
+
+## Failure modes — quick reference
+
+- Empty PRD fetch → stop.
+- Material ambiguity → stop with questionnaire.
+- A challenger returns prose instead of JSON → retry that challenger once.
+- Round 1 produces only `info`/`low` → suspect toothless personas; re-read prompts before declaring stable.
+- Round 3 challenger proposes new features → ignore the proposal, do not re-open scope.
+- Unresolved critical at final → ship as `BLOCKED`. Do not fudge.

--- a/.claude/skills/sc-design-review/templates/design-doc.md
+++ b/.claude/skills/sc-design-review/templates/design-doc.md
@@ -1,0 +1,108 @@
+# [Contract Name] — Smart Contract Design
+
+> **Status:** `READY` | `BLOCKED — security review` | `BLOCKED — product clarification`
+> **Version:** v_N
+> **Date:** YYYY-MM-DD
+
+## 0. Source PRD
+
+- **Link:** <full URL or path to the PRD>
+- **Title:** <PRD title>
+- **Ingested:** YYYY-MM-DD
+- **Notes:** <e.g. depth-2 child pages also ingested; specific sections used>
+
+## 1. Purpose & product context
+
+One paragraph, in plain language, of *what this contract is for in the product*. Lifted from the PRD, attributed.
+
+## 2. Scope: what this contract DOES
+
+Bullet list of the contract's responsibilities. Each item should map to a PRD requirement.
+
+## 3. Scope: what this contract does NOT do
+
+Explicit non-goals. This section exists because in smart contracts, what is *out* of scope matters as much as what is in. Examples: "does not custody user funds", "does not implement governance", "does not interact with non-EVM chains".
+
+## 4. Architecture & components
+
+Diagram-as-text (ASCII or mermaid). Module breakdown: which Solidity contracts, libraries, interfaces. Inheritance tree if non-trivial.
+
+## 5. External interactions
+
+Table of every other contract this design depends on:
+
+| Counterparty | Chain(s) | Interaction | Trust assumption |
+|---|---|---|---|
+
+## 6. State model & storage layout
+
+Storage variables, packing strategy, upgrade-safety considerations. Include a slot table for upgradeable contracts.
+
+## 7. Access control & roles
+
+Every privileged role: who holds it, what it can do, how it is granted/revoked, timelock requirements, multisig requirements.
+
+## 8. Upgrade & operational model
+
+- Upgradeable? (UUPS / Transparent / Beacon / Immutable)
+- Initializer pattern.
+- Pause mechanism.
+- Key custody (multisig threshold, signers, geography).
+- Emergency procedures.
+
+## 9. Invariants
+
+Numbered list of properties that must always hold. Each one must be expressible as a fuzz/symbolic check. Example:
+1. `totalSupply() == sum(balances)`
+2. `sharePrice` is monotonically non-decreasing except on documented loss events
+3. Only `ADMIN_ROLE` can call `setFeeRate`
+
+## 10. Threat model & mitigations
+
+Adversaries enumerated, attack paths considered, mitigations in place. Reference invariants from §9 where applicable.
+
+## 11. Gas / optimization notes
+
+Where gas-vs-clarity tradeoffs were made. Where they were *refused* on security grounds. Approximate gas costs for the main user-facing functions if estimable.
+
+## 12. Open questions / deferred decisions
+
+Numbered list. Each one labelled `(minor)` or `(deferred)`. Material gaps should not appear here — they triggered a HALT in Phase 1.
+
+## 13. Custody of funds
+
+**This section is mandatory and must take an explicit position.**
+
+State whether the contract holds user/protocol funds at any point.
+
+### If the contract does NOT custody funds
+
+> "This contract does not hold user or protocol funds at any point. <one-line justification, e.g. 'all transfers are pass-through; tokens are pulled from the user and forwarded to the destination protocol within the same call'>."
+
+That is sufficient. Skip the rest of section 13.
+
+### If the contract DOES custody funds
+
+This is the default-disfavoured path. The PRD requirement that drives custodianship must be cited here. The following sub-sections are mandatory.
+
+#### 13.1 Why funds must be held
+
+What product requirement requires custody. What alternatives (pass-through, approval-based, just-in-time) were considered and rejected, and why.
+
+#### 13.2 Risk assessment
+
+- **Loss scenarios:** enumerated. Examples: admin key compromise; signer compromise; oracle manipulation; logic bug; donation attack; flash-loan amplification; dependency compromise.
+- **Blast radius per scenario:** what is the maximum value at risk; can the loss be bounded.
+- **Max value at risk:** expected and worst-case TVL the contract is designed to hold.
+
+#### 13.3 Security strategy
+
+For each loss scenario in 13.2, the mitigation:
+- Timelocks on privileged actions.
+- Withdrawal limits / rate limits / per-address caps.
+- Circuit breakers and pause authority.
+- Monitoring (which on-chain events are watched, by whom, with what response time).
+- Incident response runbook reference.
+- Insurance or coverage arrangement, if any.
+
+If a loss scenario cannot be mitigated below acceptable threshold, this is a finding for the security auditor in round 1.

--- a/.claude/skills/sc-design-review/templates/design-doc.md
+++ b/.claude/skills/sc-design-review/templates/design-doc.md
@@ -79,7 +79,7 @@ State whether the contract holds user/protocol funds at any point.
 
 > "This contract does not hold user or protocol funds at any point. <one-line justification, e.g. 'all transfers are pass-through; tokens are pulled from the user and forwarded to the destination protocol within the same call'>."
 
-That is sufficient. Skip the rest of section 13.
+When this branch applies, the sub-sections below (13.1 / 13.2 / 13.3) MUST still appear with their headers — write `N/A — non-custodial (see above)` under each. Headers are never deleted; the template's structural shape is preserved across all designs.
 
 ### If the contract DOES custody funds
 

--- a/.claude/skills/sc-design-review/templates/finding.schema.json
+++ b/.claude/skills/sc-design-review/templates/finding.schema.json
@@ -1,38 +1,42 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Challenger finding",
-  "description": "One finding produced by a challenger persona reviewing a smart contract design draft. Challengers return a JSON array of these.",
-  "type": "object",
-  "required": ["id", "severity", "category", "claim", "evidence", "suggested_change"],
-  "properties": {
-    "id": {
-      "type": "string",
-      "description": "Stable identifier within this challenger's output, e.g. 'sec-01', 'evm-03'."
-    },
-    "severity": {
-      "type": "string",
-      "enum": ["critical", "high", "medium", "low", "info"],
-      "description": "Use the security-auditor severity definitions. Severity inflation is a sin; deflation is a worse sin."
-    },
-    "category": {
-      "type": "string",
-      "description": "Short tag, e.g. 'reentrancy', 'oracle', 'access-control', 'requirement-coverage', 'gas-vs-security', 'invariant', 'cross-chain-replay', 'custody'."
-    },
-    "claim": {
-      "type": "string",
-      "description": "One-sentence statement of the issue. No hedging."
-    },
-    "evidence": {
-      "type": "string",
-      "description": "Specific reference: design doc section, function name, PRD quote, attack path, or invariant violation. The Tech Lead must be able to verify the claim from this field alone."
-    },
-    "suggested_change": {
-      "type": "string",
-      "description": "Concrete change to the design. 'Add reentrancy guard' is OK; 'Be more careful' is not."
-    },
-    "blocking": {
-      "type": "boolean",
-      "description": "Optional. If true, the challenger asserts this finding must be resolved before the doc can ship as READY. Critical-severity findings default to blocking unless explicitly set false."
+  "title": "Challenger findings",
+  "description": "Array of findings produced by a challenger persona reviewing a smart contract design draft. Challengers return a JSON array of finding objects.",
+  "type": "array",
+  "items": {
+    "title": "Challenger finding",
+    "type": "object",
+    "required": ["id", "severity", "category", "claim", "evidence", "suggested_change"],
+    "properties": {
+      "id": {
+        "type": "string",
+        "description": "Stable identifier within this challenger's output, e.g. 'sec-01', 'evm-03'."
+      },
+      "severity": {
+        "type": "string",
+        "enum": ["critical", "high", "medium", "low", "info"],
+        "description": "Use the security-auditor severity definitions. Severity inflation is a sin; deflation is a worse sin."
+      },
+      "category": {
+        "type": "string",
+        "description": "Short tag, e.g. 'reentrancy', 'oracle', 'access-control', 'requirement-coverage', 'gas-vs-security', 'invariant', 'cross-chain-replay', 'custody'."
+      },
+      "claim": {
+        "type": "string",
+        "description": "One-sentence statement of the issue. No hedging."
+      },
+      "evidence": {
+        "type": "string",
+        "description": "Specific reference: design doc section, function name, PRD quote, attack path, or invariant violation. The Tech Lead must be able to verify the claim from this field alone."
+      },
+      "suggested_change": {
+        "type": "string",
+        "description": "Concrete change to the design. 'Add reentrancy guard' is OK; 'Be more careful' is not."
+      },
+      "blocking": {
+        "type": "boolean",
+        "description": "Optional. If true, the challenger asserts this finding must be resolved before the doc can ship as READY. Critical-severity findings default to blocking unless explicitly set false."
+      }
     }
   }
 }

--- a/.claude/skills/sc-design-review/templates/finding.schema.json
+++ b/.claude/skills/sc-design-review/templates/finding.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Challenger finding",
+  "description": "One finding produced by a challenger persona reviewing a smart contract design draft. Challengers return a JSON array of these.",
+  "type": "object",
+  "required": ["id", "severity", "category", "claim", "evidence", "suggested_change"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Stable identifier within this challenger's output, e.g. 'sec-01', 'evm-03'."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low", "info"],
+      "description": "Use the security-auditor severity definitions. Severity inflation is a sin; deflation is a worse sin."
+    },
+    "category": {
+      "type": "string",
+      "description": "Short tag, e.g. 'reentrancy', 'oracle', 'access-control', 'requirement-coverage', 'gas-vs-security', 'invariant', 'cross-chain-replay', 'custody'."
+    },
+    "claim": {
+      "type": "string",
+      "description": "One-sentence statement of the issue. No hedging."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Specific reference: design doc section, function name, PRD quote, attack path, or invariant violation. The Tech Lead must be able to verify the claim from this field alone."
+    },
+    "suggested_change": {
+      "type": "string",
+      "description": "Concrete change to the design. 'Add reentrancy guard' is OK; 'Be more careful' is not."
+    },
+    "blocking": {
+      "type": "boolean",
+      "description": "Optional. If true, the challenger asserts this finding must be resolved before the doc can ship as READY. Critical-severity findings default to blocking unless explicitly set false."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/sc-design-review/` — a multi-agent skill that takes a PRD (Notion URL / page ID / local markdown) and produces a hardened smart contract design doc.
- Workflow: ingest PRD → ambiguity gate (HALT on material gaps) → Tech Lead drafts v1 → up to 3 challenge rounds by a six-persona panel (DeFi/composability, EVM/low-level, cross-chain, security auditor, QA, product lead) → Tech Lead synthesises after each round → final doc with status `READY` / `BLOCKED — security review` / `BLOCKED — product clarification`.
- Security is the dominant quality attribute. The skill is willing to ship `BLOCKED` rather than rubber-stamp an under-specified design.

## How to use
```
/sc-design-review <notion-url-or-page-id-or-local-md-path>
```

The skill runs autonomously through the phases. It will pause and ask clarification questions if the ambiguity gate flags material gaps in the PRD. Final output is a markdown design doc; the skill also asks whether to mirror it as a Notion page.

## Why land it here
The SC squad is the primary user. Landing in `lifinance/contracts` means anyone running Claude Code in this repo gets the skill auto-discovered, alongside the existing `add-audit`, `add-network`, `analyze-tx`, `review-bounty-report` skills.

## Refinement loop
This is v1 of the skill. Expected iteration once the team uses it on real PRDs:
- Persona prompts may need sharpening if findings come back generic.
- The ambiguity gate's question coverage will grow as we learn which gaps actually bite in audit.
- Template (`templates/design-doc.md`) sections may be reordered based on what auditors ask for.

Please open issues / PRs against this directory as patterns emerge.

## Test plan
- [ ] Run `/sc-design-review` against a known PRD and confirm the ambiguity gate produces a sensible questionnaire.
- [ ] Confirm the six challenger personas spawn in parallel (single tool message, six `Agent` calls).
- [ ] Confirm findings are returned as JSON arrays per `templates/finding.schema.json` (no free prose).
- [ ] Confirm early-exit after round 1 if zero critical/high findings.
- [ ] Confirm `BLOCKED` is reachable when round 3 leaves a critical unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)