### PR TITLE
fix(safe): detect stale proposals and improve nonce traceability

### DIFF
--- a/script/deploy/deployAndStoreCREATE3Factory.sh
+++ b/script/deploy/deployAndStoreCREATE3Factory.sh
@@ -47,10 +47,12 @@ deployAndStoreCREATE3Factory() {
     error "Failed to load PRIVATE_KEY for network $NETWORK (environment: $ENVIRONMENT)"
     return 1
   }
+  # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
+  DEPLOYER_ADDRESS=$(cast wallet address "$PRIVATE_KEY")
 
   # 1) Try forge script (works for chains in Foundry's alloy-chains list)
   if executeAndParse \
-    "PRIVATE_KEY=\"$PRIVATE_KEY\" forge script script/deploy/facets/DeployCREATE3Factory.s.sol --fork-url \"$NETWORK\" --json --broadcast --legacy --slow $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
+    "PRIVATE_KEY=\"$PRIVATE_KEY\" forge script script/deploy/facets/DeployCREATE3Factory.s.sol --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy --slow $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
     "true" \
     "" \
     "return"; then

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -256,16 +256,20 @@ deploySingleContract() {
       SKIP_SIMULATION_FLAG=""
     fi
 
+    # forge >=1.6 validates the simulation sender's balance against gas_estimate * gas_price;
+    # the foundry.toml default `sender` has 0 balance on real chains, so we override to the funded deployer.
+    DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
+
     # Execute, parse, and check return code
     if isZkEvmNetwork "$NETWORK"; then
       # Deploy zksync scripts using the zksync specific fork of forge
       executeAndParse \
-        "FOUNDRY_PROFILE=zksync DEPLOYSALT=$DEPLOYSALT NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" ./foundry-zksync/forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --broadcast --skip-simulation --slow --zksync --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" --gas-limit 50000000" \
+        "FOUNDRY_PROFILE=zksync DEPLOYSALT=$DEPLOYSALT NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" ./foundry-zksync/forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --skip-simulation --slow --zksync --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" --gas-limit 50000000" \
         "true"
     else
       # try to execute call
       executeAndParse \
-        "DEPLOYSALT=\"$DEPLOYSALT\" CREATE3_FACTORY_ADDRESS=\"$CREATE3_FACTORY_ADDRESS\" NETWORK=\"$NETWORK\" FILE_SUFFIX=\"$FILE_SUFFIX\" DEFAULT_DIAMOND_ADDRESS_DEPLOYSALT=\"$DEFAULT_DIAMOND_ADDRESS_DEPLOYSALT\" DEPLOY_TO_DEFAULT_DIAMOND_ADDRESS=\"$DEPLOY_TO_DEFAULT_DIAMOND_ADDRESS\" PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" DIAMOND_TYPE=\"$DIAMOND_TYPE\" forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --broadcast --legacy --slow $SKIP_SIMULATION_FLAG $ADDITIONAL_FLAGS --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
+        "DEPLOYSALT=\"$DEPLOYSALT\" CREATE3_FACTORY_ADDRESS=\"$CREATE3_FACTORY_ADDRESS\" NETWORK=\"$NETWORK\" FILE_SUFFIX=\"$FILE_SUFFIX\" DEFAULT_DIAMOND_ADDRESS_DEPLOYSALT=\"$DEFAULT_DIAMOND_ADDRESS_DEPLOYSALT\" DEPLOY_TO_DEFAULT_DIAMOND_ADDRESS=\"$DEPLOY_TO_DEFAULT_DIAMOND_ADDRESS\" PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" DIAMOND_TYPE=\"$DIAMOND_TYPE\" forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy --slow $SKIP_SIMULATION_FLAG $ADDITIONAL_FLAGS --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
         "true"
     fi
 

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -444,7 +444,7 @@ const processTxs = async (
         `  Likely cause: the RPC returned a stale nonce when the proposal was created.`
       )
       consola.error(
-        `  Fix: delete this proposal and re-run propose-to-safe to create a new one with nonce ${expectedNonce}.`
+        `  Fix: delete this proposal and re-run propose-to-safe — it will assign the next valid nonce automatically.`
       )
       consola.error('='.repeat(80))
       consola.error('')

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -294,7 +294,14 @@ const processTxs = async (
   })) {
     // Recompute nonce status dynamically — expectedNonce advances after each successful execution
     const txNonce = BigInt(tx.safeTx.data.nonce)
-    const nonceStatus = txNonce === expectedNonce ? 'current' : 'future'
+    // 'stale': nonce already used on-chain (proposal was created with a wrong/old nonce, e.g. due to stale RPC)
+    // 'future': nonce not yet reachable (a lower-nonce proposal must execute first)
+    const nonceStatus =
+      txNonce === expectedNonce
+        ? 'current'
+        : txNonce < expectedNonce
+        ? 'stale'
+        : 'future'
 
     consola.info('-'.repeat(80))
     consola.info('Transaction Details:')
@@ -320,10 +327,13 @@ const processTxs = async (
       tx.proposer
     )
 
-    const nonceColor = nonceStatus === 'current' ? '32' : '33'
+    const nonceColor =
+      nonceStatus === 'current' ? '32' : nonceStatus === 'stale' ? '31' : '33'
     // Only show nonce warning if the tx can be executed — irrelevant while still collecting signatures
     const nonceWarning =
-      nonceStatus === 'future' && tx.canExecute
+      nonceStatus === 'stale'
+        ? ` \u001b[31m✗ STALE — on-chain nonce is ${expectedNonce}, this proposal's nonce was already used\u001b[0m`
+        : nonceStatus === 'future' && tx.canExecute
         ? ` \u001b[33m⚠ on-chain nonce is ${expectedNonce} — cannot execute yet\u001b[0m`
         : ''
 
@@ -418,6 +428,29 @@ const processTxs = async (
       'Sign & Execute',
       'Sign and Execute With Deployer',
     ].includes(action)
+
+    if (isExecuteAction && nonceStatus === 'stale') {
+      consola.error('')
+      consola.error('='.repeat(80))
+      consola.error('✗  STALE PROPOSAL — THIS TRANSACTION WILL REVERT')
+      consola.error('='.repeat(80))
+      consola.error(
+        `  This proposal has nonce \u001b[31m${tx.safeTx.data.nonce}\u001b[0m but the Safe's on-chain nonce is already \u001b[31m${expectedNonce}\u001b[0m.`
+      )
+      consola.error(
+        `  Nonce ${tx.safeTx.data.nonce} was already used — this proposal is stale and cannot be executed.`
+      )
+      consola.error(
+        `  Likely cause: the RPC returned a stale nonce when the proposal was created.`
+      )
+      consola.error(
+        `  Fix: delete this proposal and re-run propose-to-safe to create a new one with nonce ${expectedNonce}.`
+      )
+      consola.error('='.repeat(80))
+      consola.error('')
+      consola.info('Execution aborted — proposal is stale')
+      continue
+    }
 
     if (isExecuteAction && nonceStatus === 'future') {
       // Check if there is actually a pending proposal for the blocking nonce in the DB

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -105,9 +105,7 @@ export async function runPropose(options: IProposeToSafeOptions) {
   if (options.calldataFile) {
     if (!fs.existsSync(options.calldataFile))
       throw new Error(`Calldata file not found: ${options.calldataFile}`)
-    finalCalldata = fs
-      .readFileSync(options.calldataFile, 'utf8')
-      .trim() as Hex
+    finalCalldata = fs.readFileSync(options.calldataFile, 'utf8').trim() as Hex
     consola.info(`Loaded calldata from file: ${options.calldataFile}`)
   } else if (options.calldata) {
     finalCalldata = options.calldata as Hex
@@ -180,6 +178,7 @@ export async function runPropose(options: IProposeToSafeOptions) {
   consola.info('Signer Address', senderAddress)
   consola.info('Safe Address', safeAddress)
   consola.info('Network', chain.name)
+  consola.info('Nonce', nextNonce.toString())
   consola.info('Proposing transaction to', finalTo)
   if (options.timelock) {
     consola.info('Original target was', options.to)

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1176,6 +1176,7 @@ export async function getSafeMongoCollection(): Promise<{
   }
 
   const client = new MongoClient(process.env.SC_MONGODB_URI)
+  await client.connect()
   const db = client.db('sc_private')
   const pendingTransactions = db.collection<ISafeTxDocument>(
     'pendingTransactions'
@@ -1217,8 +1218,16 @@ export async function getNextNonce(
   if (latestTx.length > 0) {
     const tx = latestTx[0]
     if (!tx) throw new Error('Latest transaction not found')
-    return BigInt(tx.safeTx?.data?.nonce || 0) + 1n
+    const pendingNonce = BigInt(tx.safeTx?.data?.nonce || 0)
+    const nextNonce = pendingNonce + 1n
+    consola.debug(
+      `[getNextNonce] found pending proposal with nonce ${pendingNonce} → assigning ${nextNonce} (on-chain nonce: ${currentNonce})`
+    )
+    return nextNonce
   }
+  consola.debug(
+    `[getNextNonce] no pending proposals found → using on-chain nonce ${currentNonce}`
+  )
   return currentNonce
 }
 

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1219,7 +1219,11 @@ export async function getNextNonce(
     const tx = latestTx[0]
     if (!tx) throw new Error('Latest transaction not found')
     const pendingNonce = BigInt(tx.safeTx?.data?.nonce || 0)
-    const nextNonce = pendingNonce + 1n
+    // Clamp to on-chain nonce: if the DB-derived nonce is behind the chain
+    // (stale pending rows), use the on-chain nonce so we don't mint another
+    // stale proposal.
+    const nextNonce =
+      pendingNonce + 1n > currentNonce ? pendingNonce + 1n : currentNonce
     consola.debug(
       `[getNextNonce] found pending proposal with nonce ${pendingNonce} → assigning ${nextNonce} (on-chain nonce: ${currentNonce})`
     )

--- a/script/tasks/diamondUpdateFacet.sh
+++ b/script/tasks/diamondUpdateFacet.sh
@@ -127,16 +127,18 @@ diamondUpdateFacet() {
       # PROD: suggest diamondCut transaction to SAFE
 
       PRIVATE_KEY=$(getPrivateKey "$NETWORK" "$ENVIRONMENT")
+      # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
+      DEPLOYER_ADDRESS=$(cast wallet address "$PRIVATE_KEY")
       echoDebug "Calculating facet cuts for $CONTRACT_NAME in path $SCRIPT_PATH..."
 
       # Execute, parse, and check return code
       local COMMAND
       if isZkEvmNetwork "$NETWORK"; then
         echo "zkEVM network detected"
-        COMMAND="FOUNDRY_PROFILE=zksync NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
+        COMMAND="FOUNDRY_PROFILE=zksync NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
       else
         # PROD (normal mode): suggest diamondCut transaction to SAFE
-        COMMAND="NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --json $SKIP_SIMULATION_FLAG --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
+        COMMAND="NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json $SKIP_SIMULATION_FLAG --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
       fi
       
       if ! executeAndParse \
@@ -250,12 +252,15 @@ diamondUpdateFacet() {
       # STAGING (or new network deployment): just deploy normally without further checks
       echo "Sending diamondCut transaction directly to diamond (staging or new network deployment)..."
 
+      # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
+      DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
+
       # Execute, parse, and check return code
       local COMMAND
       if isZkEvmNetwork "$NETWORK"; then
-        COMMAND="FOUNDRY_PROFILE=zksync NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --broadcast --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" --private-key $(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")"
+        COMMAND="FOUNDRY_PROFILE=zksync NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" --private-key $(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")"
       else
-        COMMAND="NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND NO_BROADCAST=false PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --broadcast --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" $SKIP_SIMULATION_FLAG"
+        COMMAND="NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND NO_BROADCAST=false PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" $SKIP_SIMULATION_FLAG"
       fi
       
       if ! executeAndParse \

--- a/script/tasks/updateFacetConfig.sh
+++ b/script/tasks/updateFacetConfig.sh
@@ -77,10 +77,13 @@ updateFacetConfig() {
 
       # Add skip simulation flag based on environment variable
       SKIP_SIMULATION_FLAG=$(getSkipSimulationFlag)
-      
+
+      # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
+      DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
+
       # Execute, parse, and check return code
       if ! executeAndParse \
-        "NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --json --broadcast --legacy $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
+        "NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
         "true" \
         "forge script failed for $SCRIPT on network $NETWORK" \
         "continue"; then


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — discovered during Jovay deployment investigation

# Why did I implement it this way?

A Jovay Safe proposal was created with a nonce higher than the current on-chain nonce, which made it show up as "not executable". We verified there were no pending proposals in MongoDB at the time and no proposals were created outside our scripts — so at this point it's unclear where the incorrect nonce originated from.

The issue was further obscured by `confirm-safe-tx` treating both cases — nonce already used on-chain (stale) and nonce not yet reachable (future) — the same way, showing an identical GS026 warning with wrong advice for the stale case.

Changes:
- **`confirm-safe-tx`**: introduce `'stale'` nonce status (`txNonce < onChainNonce`) distinct from `'future'` (`txNonce > onChainNonce`). Stale proposals now show a red `✗ STALE` label and abort with the correct fix instruction instead of the misleading GS026 flow.
- **`propose-to-safe`**: log the assigned nonce at creation time.
- **`getNextNonce`**: log whether a pending proposal was found in MongoDB, what nonce it had, and what was returned vs the on-chain nonce — so if this happens again we'll know immediately where the wrong nonce came from.
- **`getSafeMongoCollection`**: add explicit `await client.connect()` so connection failures throw immediately rather than being silently swallowed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [x] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>