### PR TITLE
chore: remove unused sender/tx_origin from foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,9 +5,6 @@ evm_version = 'cancun'
 auto_detect_solc = false
 optimizer = true
 optimizer_runs = 1000000
-# use a known address with a balance so ZkEVM scripts work
-sender = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
-tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
 out = 'out'
 fs_permissions = [
   { access = "read", path = "./deployments/" },

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,8 +19,6 @@ cache = true
 [profile.zksync]
 solc_version = '0.8.29'
 evm_version = 'cancun'
-sender = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
-tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
 test = "notest"
 script = "script/deploy/zksync"
 cache_path = "./zkcache"

--- a/test/solidity/Facets/Across/V1/AcrossFacetPacked.t.sol
+++ b/test/solidity/Facets/Across/V1/AcrossFacetPacked.t.sol
@@ -69,12 +69,12 @@ contract AcrossFacetPackedTest is TestBase {
         acrossFacetPacked = new AcrossFacetPacked(
             across,
             ADDRESS_WRAPPED_NATIVE,
-            address(this)
+            USER_DIAMOND_OWNER
         );
         acrossStandAlone = new AcrossFacetPacked(
             across,
             ADDRESS_WRAPPED_NATIVE,
-            address(this)
+            USER_DIAMOND_OWNER
         );
         claimContract = new TestClaimContract();
 
@@ -182,7 +182,9 @@ contract AcrossFacetPackedTest is TestBase {
         tokens[1] = ADDRESS_USDC;
 
         // set token approvals for standalone contract via admin function
+        vm.startPrank(USER_DIAMOND_OWNER);
         acrossStandAlone.setApprovalForBridge(tokens);
+        vm.stopPrank();
 
         // set token approvals for facet via cheatcode (in production we will do this via script)
         vm.startPrank(address(acrossFacetPacked));
@@ -586,6 +588,8 @@ contract AcrossFacetPackedTest is TestBase {
     }
 
     function test_canExecuteCallAndWithdraw() public {
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         acrossStandAlone.executeCallAndWithdraw(
             address(claimContract),
             WITHDRAW_REWARDS_CALLDATA,

--- a/test/solidity/Facets/CBridge/CBridgeFacetPacked.t.sol
+++ b/test/solidity/Facets/CBridge/CBridgeFacetPacked.t.sol
@@ -54,8 +54,11 @@ contract CBridgeFacetPackedTest is TestBase {
         /// Perpare CBridgeFacetPacked
         diamond = createDiamond(USER_DIAMOND_OWNER, USER_PAUSER);
         cbridge = ICBridge(CBRIDGE_ROUTER);
-        cBridgeFacetPacked = new CBridgeFacetPacked(cbridge, address(this));
-        standAlone = new CBridgeFacetPacked(cbridge, address(this));
+        cBridgeFacetPacked = new CBridgeFacetPacked(
+            cbridge,
+            USER_DIAMOND_OWNER
+        );
+        standAlone = new CBridgeFacetPacked(cbridge, USER_DIAMOND_OWNER);
 
         deal(ADDRESS_USDC, address(WHALE), 100000 * 10 ** usdc.decimals());
 
@@ -139,7 +142,9 @@ contract CBridgeFacetPackedTest is TestBase {
         usdt.approve(CBRIDGE_ROUTER, type(uint256).max);
         usdc.approve(CBRIDGE_ROUTER, type(uint256).max);
         vm.stopPrank();
+        vm.startPrank(USER_DIAMOND_OWNER);
         standAlone.setApprovalForBridge(tokens);
+        vm.stopPrank();
 
         // set facet address in TestBase
         setFacetAddressInTestBase(
@@ -471,6 +476,7 @@ contract CBridgeFacetPackedTest is TestBase {
         vm.etch(CBRIDGE_ROUTER, address(lb).code);
 
         // refund
+        vm.startPrank(USER_DIAMOND_OWNER);
         standAlone.triggerRefund(
             payable(CBRIDGE_ROUTER), // Celer Liquidity Bridge
             abi.encodeWithSelector(
@@ -481,6 +487,8 @@ contract CBridgeFacetPackedTest is TestBase {
             payable(userReceiver), // Address to refund to
             refundAmount
         );
+
+        vm.stopPrank();
 
         // validate
         uint256 postRefundBalance = address(userReceiver).balance;

--- a/test/solidity/Facets/DeBridgeDlnFacet.t.sol
+++ b/test/solidity/Facets/DeBridgeDlnFacet.t.sol
@@ -56,6 +56,9 @@ contract DeBridgeDlnFacetTest is TestBaseFacet {
 
         addFacet(diamond, address(deBridgeDlnFacet), functionSelectors);
         deBridgeDlnFacet = TestDeBridgeDlnFacet(address(diamond));
+
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         deBridgeDlnFacet.addAllowedContractSelector(
             ADDRESS_UNISWAP,
             uniswap.swapExactTokensForTokens.selector
@@ -82,6 +85,8 @@ contract DeBridgeDlnFacetTest is TestBaseFacet {
         );
 
         deBridgeDlnFacet.initDeBridgeDln(cidCfg);
+
+        vm.stopPrank();
 
         setFacetAddressInTestBase(
             address(deBridgeDlnFacet),

--- a/test/solidity/Facets/EmergencyPauseFacet/EmergencyPauseFacet.local.t.sol
+++ b/test/solidity/Facets/EmergencyPauseFacet/EmergencyPauseFacet.local.t.sol
@@ -144,7 +144,8 @@ contract EmergencyPauseFacetLOCALTest is TestBase {
     }
 
     function test_CanUnpauseDiamondWithSingleBlacklist() public {
-        address ownershipFacetAddress = 0xB021CCbe1bd1EF2af8221A79E89dD3145947A082;
+        address ownershipFacetAddress = IDiamondLoupe(address(diamond))
+            .facetAddress(OwnershipFacet.owner.selector);
 
         // get function selectors of OwnershipFacet
         bytes4[] memory ownershipFunctionSelectors = IDiamondLoupe(
@@ -190,6 +191,15 @@ contract EmergencyPauseFacetLOCALTest is TestBase {
     }
 
     function test_CanUnpauseDiamondWithMultiBlacklist() public {
+        // resolve facet addresses before pausing (loupe is unavailable while paused)
+        blacklist = new address[](2);
+        blacklist[0] = IDiamondLoupe(address(diamond)).facetAddress(
+            OwnershipFacet.owner.selector
+        ); // OwnershipFacet
+        blacklist[1] = IDiamondLoupe(address(diamond)).facetAddress(
+            PeripheryRegistryFacet.registerPeripheryContract.selector
+        ); // PeripheryRegistryFacet
+
         // pause diamond first
         test_PauserWalletCanPauseDiamond();
 
@@ -198,10 +208,6 @@ contract EmergencyPauseFacetLOCALTest is TestBase {
 
         vm.expectEmit(true, true, true, true, address(emergencyPauseFacet));
         emit EmergencyUnpaused(USER_DIAMOND_OWNER);
-
-        blacklist = new address[](2);
-        blacklist[0] = 0xB021CCbe1bd1EF2af8221A79E89dD3145947A082; // OwnershipFacet
-        blacklist[1] = 0xA412555Fa40F6AA4B67a773dB5a7f85983890341; // PeripheryRegistryFacet
 
         emergencyPauseFacet.unpauseDiamond(blacklist);
 
@@ -423,7 +429,9 @@ contract EmergencyPauseFacetLOCALTest is TestBase {
                 functionSelectors: generateRandomBytes4Array()
             });
         }
+        vm.startPrank(USER_DIAMOND_OWNER);
         DiamondCutFacet(address(diamond)).diamondCut(cut, address(0), "");
+        vm.stopPrank();
 
         //
         IDiamondLoupe.Facet[] memory facets = DiamondLoupeFacet(

--- a/test/solidity/Facets/HopFacet.t.sol
+++ b/test/solidity/Facets/HopFacet.t.sol
@@ -52,6 +52,9 @@ contract HopFacetTest is TestBaseFacet {
         configs[2] = HopFacet.Config(address(0), NATIVE_BRIDGE);
 
         hopFacet = TestHopFacet(address(diamond));
+
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         hopFacet.initHop(configs);
 
         hopFacet.addAllowedContractSelector(
@@ -70,6 +73,8 @@ contract HopFacetTest is TestBaseFacet {
             address(uniswap),
             uniswap.swapExactETHForTokens.selector
         );
+
+        vm.stopPrank();
 
         setFacetAddressInTestBase(address(hopFacet), "HopFacet");
 
@@ -229,7 +234,6 @@ contract HopFacetTest is TestBaseFacet {
 
     function test_OwnerCanInitializeFacet() public {
         LiFiDiamond diamond2 = createDiamond(USER_DIAMOND_OWNER, USER_PAUSER);
-        vm.startPrank(USER_DIAMOND_OWNER);
 
         TestHopFacet hopFacet2 = new TestHopFacet();
         bytes4[] memory functionSelectors = new bytes4[](6);
@@ -253,9 +257,13 @@ contract HopFacetTest is TestBaseFacet {
 
         hopFacet2 = TestHopFacet(address(diamond2));
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectEmit(true, true, true, true, address(hopFacet2));
         emit HopInitialized(configs);
         hopFacet2.initHop(configs);
+
+        vm.stopPrank();
     }
 
     function test_BridgeFromL2ToL1() public {
@@ -271,8 +279,11 @@ contract HopFacetTest is TestBaseFacet {
         // get USDC contract and approve
         ERC20 usdcPoly = ERC20(addressUSDCPolygon); // USDC on Polygon
 
+        // use a fresh address to avoid CREATE collisions on the Polygon fork
+        address polygonOwner = makeAddr("polygonOwner");
+
         // re-deploy diamond and facet
-        diamond = createDiamond(USER_DIAMOND_OWNER, USER_PAUSER);
+        diamond = createDiamond(polygonOwner, USER_PAUSER);
         TestHopFacet hopFacet2 = new TestHopFacet();
         bytes4[] memory functionSelectors = new bytes4[](4);
         functionSelectors[0] = hopFacet2.startBridgeTokensViaHop.selector;
@@ -285,7 +296,10 @@ contract HopFacetTest is TestBaseFacet {
         configs[0] = HopFacet.Config(addressUSDCPolygon, ammWrapperPolygon);
 
         hopFacet2 = TestHopFacet(address(diamond));
+
+        vm.startPrank(polygonOwner);
         hopFacet2.initHop(configs);
+        vm.stopPrank();
 
         // adjust bridgeData
         bridgeData.destinationChainId = 1;

--- a/test/solidity/Facets/HopFacetOptimized/HopFacetOptimizedL1.t.sol
+++ b/test/solidity/Facets/HopFacetOptimized/HopFacetOptimizedL1.t.sol
@@ -50,6 +50,8 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
 
         hopFacet = TestHopFacet(address(diamond));
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         hopFacet.addAllowedContractSelector(
             address(uniswap),
             uniswap.swapExactTokensForTokens.selector
@@ -71,6 +73,8 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
             uniswap.swapExactETHForTokens.selector
         );
 
+        vm.stopPrank();
+
         setFacetAddressInTestBase(address(hopFacet), "HopFacet");
 
         // Set approval for all bridges
@@ -80,7 +84,9 @@ contract HopFacetOptimizedL1Test is TestBaseFacet {
         address[] memory tokens = new address[](2);
         tokens[0] = ADDRESS_USDC;
         tokens[1] = ADDRESS_DAI;
+        vm.startPrank(USER_DIAMOND_OWNER);
         hopFacet.setApprovalForBridges(bridges, tokens);
+        vm.stopPrank();
 
         vm.makePersistent(address(hopFacet));
 

--- a/test/solidity/Facets/HopFacetOptimized/HopFacetOptimizedL2.t.sol
+++ b/test/solidity/Facets/HopFacetOptimized/HopFacetOptimizedL2.t.sol
@@ -54,6 +54,8 @@ contract HopFacetOptimizedL2Test is TestBaseFacet {
 
         hopFacet = TestHopFacet(address(diamond));
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         hopFacet.addAllowedContractSelector(
             address(uniswap),
             uniswap.swapExactTokensForTokens.selector
@@ -75,6 +77,8 @@ contract HopFacetOptimizedL2Test is TestBaseFacet {
             uniswap.swapExactETHForTokens.selector
         );
 
+        vm.stopPrank();
+
         setFacetAddressInTestBase(address(hopFacet), "HopFacet");
 
         // Set approval for all bridges
@@ -84,7 +88,9 @@ contract HopFacetOptimizedL2Test is TestBaseFacet {
         address[] memory tokens = new address[](2);
         tokens[0] = ADDRESS_USDC;
         tokens[1] = ADDRESS_DAI;
+        vm.startPrank(USER_DIAMOND_OWNER);
         hopFacet.setApprovalForBridges(bridges, tokens);
+        vm.stopPrank();
 
         vm.makePersistent(address(hopFacet));
 

--- a/test/solidity/Facets/HopFacetPacked/HopFacetPackedL1.t.sol
+++ b/test/solidity/Facets/HopFacetPacked/HopFacetPackedL1.t.sol
@@ -65,8 +65,8 @@ contract HopFacetPackedL1Test is TestBase {
         initTestBase();
 
         /// Perpare HopFacetPacked
-        hopFacetPacked = new HopFacetPacked(address(this), address(0));
-        standAlone = new HopFacetPacked(address(this), address(0));
+        hopFacetPacked = new HopFacetPacked(USER_DIAMOND_OWNER, address(0));
+        standAlone = new HopFacetPacked(USER_DIAMOND_OWNER, address(0));
         hop = IHopBridge(HOP_USDC_BRIDGE);
         callForwarder = new CallForwarder();
 
@@ -136,10 +136,11 @@ contract HopFacetPackedL1Test is TestBase {
             functionSelectorsApproval
         );
         hopFacetOptimized = HopFacetOptimized(address(diamond));
-        hopFacetOptimized.setApprovalForBridges(bridges, tokens);
 
-        // > standAlone
+        vm.startPrank(USER_DIAMOND_OWNER);
+        hopFacetOptimized.setApprovalForBridges(bridges, tokens);
         standAlone.setApprovalForHopBridges(bridges, tokens);
+        vm.stopPrank();
 
         /// Perpare parameters
         transactionId = "someID";

--- a/test/solidity/Facets/HopFacetPacked/HopFacetPackedL2.t.sol
+++ b/test/solidity/Facets/HopFacetPacked/HopFacetPackedL2.t.sol
@@ -75,8 +75,14 @@ contract HopFacetPackedL2Test is TestBase {
         initTestBase();
 
         /// Perpare HopFacetPacked
-        hopFacetPacked = new HopFacetPacked(address(this), NATIVE_AMM_WRAPPER);
-        standAlone = new HopFacetPacked(address(this), NATIVE_AMM_WRAPPER);
+        hopFacetPacked = new HopFacetPacked(
+            USER_DIAMOND_OWNER,
+            NATIVE_AMM_WRAPPER
+        );
+        standAlone = new HopFacetPacked(
+            USER_DIAMOND_OWNER,
+            NATIVE_AMM_WRAPPER
+        );
         hop = IHopBridge(HOP_USDC_BRIDGE);
         callForwarder = new CallForwarder();
 
@@ -155,10 +161,11 @@ contract HopFacetPackedL2Test is TestBase {
             functionSelectorsApproval
         );
         hopFacetOptimized = HopFacetOptimized(address(diamond));
-        hopFacetOptimized.setApprovalForBridges(bridges, tokens);
 
-        // > standAlone
+        vm.startPrank(USER_DIAMOND_OWNER);
+        hopFacetOptimized.setApprovalForBridges(bridges, tokens);
         standAlone.setApprovalForHopBridges(bridges, tokens);
+        vm.stopPrank();
 
         /// Perpare parameters
         bytes8 transactionId = "someID";

--- a/test/solidity/Facets/MegaETHBridgeFacet.t.sol
+++ b/test/solidity/Facets/MegaETHBridgeFacet.t.sol
@@ -83,6 +83,9 @@ contract MegaETHBridgeFacetTest is TestBase {
         configs[1] = MegaETHBridgeFacet.Config(SNX_L1_ADDRESS, SNX_BRIDGE);
 
         megaETHBridgeFacet = TestMegaETHBridgeFacet(address(diamond));
+
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         megaETHBridgeFacet.initMegaETH(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
@@ -100,6 +103,8 @@ contract MegaETHBridgeFacetTest is TestBase {
             address(uniswap),
             uniswap.swapTokensForExactETH.selector
         );
+
+        vm.stopPrank();
 
         validBridgeData = ILiFi.BridgeData({
             transactionId: "",
@@ -133,11 +138,15 @@ contract MegaETHBridgeFacetTest is TestBase {
             memory configs = new MegaETHBridgeFacet.Config[](1);
         configs[0] = MegaETHBridgeFacet.Config(DAI_L1_ADDRESS, DAI_BRIDGE);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(AlreadyInitialized.selector);
         megaETHBridgeFacet.initMegaETH(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
         );
+
+        vm.stopPrank();
     }
 
     function testRevert_InitWithZeroBridgeInConfig() public {
@@ -158,11 +167,15 @@ contract MegaETHBridgeFacetTest is TestBase {
             memory configs = new MegaETHBridgeFacet.Config[](1);
         configs[0] = MegaETHBridgeFacet.Config(DAI_L1_ADDRESS, address(0));
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(InvalidConfig.selector);
         TestMegaETHBridgeFacet(address(freshDiamond)).initMegaETH(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
         );
+
+        vm.stopPrank();
     }
 
     function testRevert_InitWithZeroStandardBridge() public {
@@ -182,11 +195,15 @@ contract MegaETHBridgeFacetTest is TestBase {
             memory configs = new MegaETHBridgeFacet.Config[](1);
         configs[0] = MegaETHBridgeFacet.Config(DAI_L1_ADDRESS, DAI_BRIDGE);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(InvalidConfig.selector);
         TestMegaETHBridgeFacet(address(freshDiamond)).initMegaETH(
             configs,
             IL1StandardBridge(address(0))
         );
+
+        vm.stopPrank();
     }
 
     function testRevert_InitWhenNotOwner() public {
@@ -222,10 +239,14 @@ contract MegaETHBridgeFacetTest is TestBase {
             0x0987654321098765432109876543210987654321
         );
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectEmit(true, false, false, true, address(megaETHBridgeFacet));
         emit MegaETHBridgeRegistered(newToken, newBridge);
 
         megaETHBridgeFacet.registerMegaETHBridge(newToken, newBridge);
+
+        vm.stopPrank();
     }
 
     function testRevert_RegisterBridgeWhenNotOwner() public {
@@ -257,18 +278,26 @@ contract MegaETHBridgeFacetTest is TestBase {
             0x0987654321098765432109876543210987654321
         );
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(NotInitialized.selector);
         TestMegaETHBridgeFacet(address(freshDiamond)).registerMegaETHBridge(
             newToken,
             newBridge
         );
+
+        vm.stopPrank();
     }
 
     function testRevert_RegisterBridgeWithZeroAddress() public {
         address newToken = address(0x1234567890123456789012345678901234567890);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(InvalidConfig.selector);
         megaETHBridgeFacet.registerMegaETHBridge(newToken, address(0));
+
+        vm.stopPrank();
     }
 
     // ==================== startBridgeTokensViaMegaETHBridge Tests ====================

--- a/test/solidity/Facets/OptimismBridgeFacet.t.sol
+++ b/test/solidity/Facets/OptimismBridgeFacet.t.sol
@@ -73,6 +73,9 @@ contract OptimismBridgeFacetTest is TestBase {
         configs[0] = OptimismBridgeFacet.Config(DAI_L1_ADDRESS, DAI_BRIDGE);
 
         optimismBridgeFacet = TestOptimismBridgeFacet(address(diamond));
+
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         optimismBridgeFacet.initOptimism(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
@@ -90,6 +93,8 @@ contract OptimismBridgeFacetTest is TestBase {
             address(uniswap),
             uniswap.swapTokensForExactETH.selector
         );
+
+        vm.stopPrank();
 
         validBridgeData = ILiFi.BridgeData({
             transactionId: "",
@@ -216,12 +221,16 @@ contract OptimismBridgeFacetTest is TestBase {
             memory configs = new OptimismBridgeFacet.Config[](1);
         configs[0] = OptimismBridgeFacet.Config(DAI_L1_ADDRESS, DAI_BRIDGE);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         // Re-initialization should fail
         vm.expectRevert(AlreadyInitialized.selector);
         optimismBridgeFacet.initOptimism(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
         );
+
+        vm.stopPrank();
     }
 
     function testRevertToInitWhenInvalidConfig() public {
@@ -231,12 +240,16 @@ contract OptimismBridgeFacetTest is TestBase {
             memory configs = new OptimismBridgeFacet.Config[](1);
         configs[0] = OptimismBridgeFacet.Config(DAI_L1_ADDRESS, address(0));
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         // Initialization should fail
         vm.expectRevert(InvalidConfig.selector);
         optimismBridgeFacet.initOptimism(
             configs,
             IL1StandardBridge(STANDARD_BRIDGE)
         );
+
+        vm.stopPrank();
     }
 
     function testRevertToRegisterWhenNotOwner() public {
@@ -252,13 +265,21 @@ contract OptimismBridgeFacetTest is TestBase {
     function testRevertToRegisterWhenNotInitialized() public {
         _mockUninitialized();
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(NotInitialized.selector);
         optimismBridgeFacet.registerOptimismBridge(address(1), address(2));
+
+        vm.stopPrank();
     }
 
     function testRevertToRegisterWhenInvalidConfig() public {
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(InvalidConfig.selector);
         optimismBridgeFacet.registerOptimismBridge(address(1), address(0));
+
+        vm.stopPrank();
     }
 
     function testCanBridgeNativeAsset() public {
@@ -297,7 +318,9 @@ contract OptimismBridgeFacetTest is TestBase {
         address snxBridge = 0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F;
 
         // register custom SNX bridge
+        vm.startPrank(USER_DIAMOND_OWNER);
         optimismBridgeFacet.registerOptimismBridge(snxToken, snxBridge);
+        vm.stopPrank();
 
         // approve SNX
         address snxHolder = 0xF977814e90dA44bFA03b6295A0616a897441aceC;
@@ -420,7 +443,9 @@ contract OptimismBridgeFacetTest is TestBase {
         address snxToken = 0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F;
         address snxBridge = 0x39Ea01a0298C315d149a490E34B59Dbf2EC7e48F;
 
+        vm.startPrank(USER_DIAMOND_OWNER);
         optimismBridgeFacet.registerOptimismBridge(snxToken, snxBridge);
+        vm.stopPrank();
 
         vm.startPrank(USDC_HOLDER);
 
@@ -481,10 +506,14 @@ contract OptimismBridgeFacetTest is TestBase {
         address assetId = makeAddr("asset");
         address bridge = makeAddr("bridge");
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectEmit(true, true, true, true, address(optimismBridgeFacet));
         emit OptimismBridgeRegistered(assetId, bridge);
 
         optimismBridgeFacet.registerOptimismBridge(assetId, bridge);
+
+        vm.stopPrank();
     }
 
     function _mockUninitialized() internal {

--- a/test/solidity/Facets/OwnershipFacet.t.sol
+++ b/test/solidity/Facets/OwnershipFacet.t.sol
@@ -35,7 +35,7 @@ contract OwnershipFacetTest is TestBase {
         address newOwner = address(0x1234567890123456789012345678901234567890);
 
         vm.expectEmit(true, true, true, true, address(ownershipFacet));
-        emit OwnershipTransferRequested(address(this), newOwner);
+        emit OwnershipTransferRequested(USER_DIAMOND_OWNER, newOwner);
 
         ownershipFacet.transferOwnership(newOwner);
 
@@ -70,6 +70,8 @@ contract OwnershipFacetTest is TestBase {
     function test_OwnerCanCancelOwnershipTransfer() public {
         address newOwner = address(0x1234567890123456789012345678901234567890);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         ownershipFacet.transferOwnership(newOwner);
 
         assert(ownershipFacet.owner() != newOwner);
@@ -77,12 +79,16 @@ contract OwnershipFacetTest is TestBase {
         ownershipFacet.cancelOwnershipTransfer();
 
         assert(ownershipFacet.owner() != newOwner);
+
+        vm.stopPrank();
     }
 
     function testRevert_NonOwnerCannotCancelOwnershipTransfer() public {
         address newOwner = address(0x1234567890123456789012345678901234567890);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
         ownershipFacet.transferOwnership(newOwner);
+        vm.stopPrank();
 
         assert(ownershipFacet.owner() != newOwner);
 
@@ -110,16 +116,23 @@ contract OwnershipFacetTest is TestBase {
     function testRevert_CannotTransferOnwershipToNullAddr() public {
         address newOwner = address(0);
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         vm.expectRevert(NoNullOwner.selector);
 
         ownershipFacet.transferOwnership(newOwner);
+
+        vm.stopPrank();
     }
 
     function testRevert_PendingOwnershipTransferCannotBeConfirmedByNonNewOwner()
         public
     {
         address newOwner = address(0x1234567890123456789012345678901234567890);
+
+        vm.startPrank(USER_DIAMOND_OWNER);
         ownershipFacet.transferOwnership(newOwner);
+        vm.stopPrank();
 
         vm.expectRevert(NotPendingOwner.selector);
 
@@ -127,10 +140,14 @@ contract OwnershipFacetTest is TestBase {
     }
 
     function testRevert_CannotTransferOwnershipToSelf() public {
-        address newOwner = address(this);
+        address newOwner = USER_DIAMOND_OWNER;
+
+        vm.startPrank(USER_DIAMOND_OWNER);
 
         vm.expectRevert(NewOwnerMustNotBeSelf.selector);
 
         ownershipFacet.transferOwnership(newOwner);
+
+        vm.stopPrank();
     }
 }

--- a/test/solidity/Gas/CBridgeFacetPackedETH.gas.t.sol
+++ b/test/solidity/Gas/CBridgeFacetPackedETH.gas.t.sol
@@ -48,8 +48,11 @@ contract CBridgeGasETHTest is TestBase {
         cbridge = ICBridge(CBRIDGE_ROUTER);
 
         /// Perpare CBridgeFacetPacked
-        cBridgeFacetPacked = new CBridgeFacetPacked(cbridge, address(this));
-        standAlone = new CBridgeFacetPacked(cbridge, address(this));
+        cBridgeFacetPacked = new CBridgeFacetPacked(
+            cbridge,
+            USER_DIAMOND_OWNER
+        );
+        standAlone = new CBridgeFacetPacked(cbridge, USER_DIAMOND_OWNER);
 
         bytes4[] memory functionSelectors = new bytes4[](6);
         functionSelectors[0] = cBridgeFacetPacked
@@ -161,7 +164,9 @@ contract CBridgeGasETHTest is TestBase {
         tokens[0] = ADDRESS_USDT;
 
         // > The standalone facet exposes an approval function
+        vm.startPrank(USER_DIAMOND_OWNER);
         standAlone.setApprovalForBridge(tokens);
+        vm.stopPrank();
 
         // > Approve cBridge router by usinng the HopFacetOptimized function
         HopFacetOptimized hopFacetOptimized = new HopFacetOptimized();
@@ -174,10 +179,13 @@ contract CBridgeGasETHTest is TestBase {
             address(hopFacetOptimized),
             functionSelectorsApproval
         );
+
+        vm.startPrank(USER_DIAMOND_OWNER);
         HopFacetOptimized(address(diamond)).setApprovalForBridges(
             bridges,
             tokens
         );
+        vm.stopPrank();
 
         // or
         // vm.startPrank(address(diamond));

--- a/test/solidity/Gas/Hop.t.sol
+++ b/test/solidity/Gas/Hop.t.sol
@@ -30,7 +30,10 @@ contract HopGasTest is TestBase {
 
         HopFacet.Config[] memory config = new HopFacet.Config[](1);
         config[0] = HopFacet.Config(ADDRESS_USDC, HOP_USDC_BRIDGE);
+
+        vm.startPrank(USER_DIAMOND_OWNER);
         hopFacet.initHop(config);
+        vm.stopPrank();
 
         string[] memory tokens = new string[](1);
         tokens[0] = "USDC";

--- a/test/solidity/Periphery/Across/V3/ReceiverAcrossV3.t.sol
+++ b/test/solidity/Periphery/Across/V3/ReceiverAcrossV3.t.sol
@@ -29,10 +29,10 @@ contract ReceiverAcrossV3Test is TestBase {
         customBlockNumberForForking = 20024274;
         initTestBase();
 
-        erc20Proxy = new ERC20Proxy(address(this));
-        executor = new Executor(address(erc20Proxy), address(this));
+        erc20Proxy = new ERC20Proxy(USER_DIAMOND_OWNER);
+        executor = new Executor(address(erc20Proxy), USER_DIAMOND_OWNER);
         receiver = new ReceiverAcrossV3(
-            address(this),
+            USER_DIAMOND_OWNER,
             address(executor),
             SPOKEPOOL_MAINNET
         );

--- a/test/solidity/Periphery/Across/V4/ReceiverAcrossV4.t.sol
+++ b/test/solidity/Periphery/Across/V4/ReceiverAcrossV4.t.sol
@@ -29,10 +29,10 @@ contract ReceiverAcrossV4Test is TestBase {
         customBlockNumberForForking = 22989702;
         initTestBase();
 
-        erc20Proxy = new ERC20Proxy(address(this));
-        executor = new Executor(address(erc20Proxy), address(this));
+        erc20Proxy = new ERC20Proxy(USER_DIAMOND_OWNER);
+        executor = new Executor(address(erc20Proxy), USER_DIAMOND_OWNER);
         receiver = new ReceiverAcrossV4(
-            address(this),
+            USER_DIAMOND_OWNER,
             address(executor),
             SPOKEPOOL_MAINNET
         );

--- a/test/solidity/Periphery/GasZipPeriphery.t.sol
+++ b/test/solidity/Periphery/GasZipPeriphery.t.sol
@@ -81,6 +81,8 @@ contract GasZipPeripheryTest is TestBase {
         vm.label(address(gasZipPeriphery), "GasZipPeriphery");
         vm.label(address(feeCollector), "FeeCollector");
 
+        vm.startPrank(USER_DIAMOND_OWNER);
+
         whitelistManagerFacet.setContractSelectorWhitelist(
             address(uniswap),
             uniswap.swapExactTokensForTokens.selector,
@@ -116,6 +118,8 @@ contract GasZipPeripheryTest is TestBase {
             feeCollector.collectTokenFees.selector,
             true
         );
+
+        vm.stopPrank();
 
         defaultUSDCAmount = 10 * 10 ** usdc.decimals(); // 10 USDC
 

--- a/test/solidity/Periphery/ReceiverOIF.t.sol
+++ b/test/solidity/Periphery/ReceiverOIF.t.sol
@@ -38,10 +38,10 @@ contract ReceiverOIFTest is TestBase {
         customBlockNumberForForking = 23695990;
         initTestBase();
 
-        erc20Proxy = new ERC20Proxy(address(this));
-        executor = new Executor(address(erc20Proxy), address(this));
+        erc20Proxy = new ERC20Proxy(USER_DIAMOND_OWNER);
+        executor = new Executor(address(erc20Proxy), USER_DIAMOND_OWNER);
         receiver = new ReceiverOIF(
-            address(this),
+            USER_DIAMOND_OWNER,
             address(executor),
             OUTPUT_SETTLER_COIN
         );

--- a/test/solidity/Periphery/ReceiverStargateV2.t.sol
+++ b/test/solidity/Periphery/ReceiverStargateV2.t.sol
@@ -42,10 +42,10 @@ contract ReceiverStargateV2Test is TestBase {
         customBlockNumberForForking = 20024274;
         initTestBase();
 
-        erc20Proxy = new ERC20Proxy(address(this));
-        executor = new Executor(address(erc20Proxy), address(this));
+        erc20Proxy = new ERC20Proxy(USER_DIAMOND_OWNER);
+        executor = new Executor(address(erc20Proxy), USER_DIAMOND_OWNER);
         receiver = new ReceiverStargateV2(
-            address(this),
+            USER_DIAMOND_OWNER,
             address(executor),
             STARGATE_TOKEN_MESSAGING_MAINNET,
             ENDPOINT_V2_MAINNET,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

n/a — follow-up to #1754 (Foundry 1.6 simulation fix).

# Why did I implement it this way?

## Background

`foundry.toml` historically pinned a deterministic sender in **both** `[profile.default]` and `[profile.zksync]`:

```toml
sender = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
tx_origin = '0x00a329c0648769a73afac7f9381e08fb43dbea73'
```

After #1754 threads `--sender "$DEPLOYER_ADDRESS"` into every `forge script` invocation, the global default has no remaining job for deploys.

### Why the global sender still mattered for tests

It still leaked into `forge test`, where it produced two hidden dependencies:

1. **The Foundry test contract was deployed at `USER_DIAMOND_OWNER`** (`0x5042…3aF8`), the deterministic CREATE address for `0x00a329c0…` at nonce 0. Many tests built on `address(this) == USER_DIAMOND_OWNER` without saying so.
2. **`msg.sender` defaulted to `0x00a329c0…`** during `forge test`, which subtly affected anything that read `msg.sender` / `tx.origin` in setup paths.

Removing the global sender makes test ownership explicit (you have to prank as the diamond owner) and decouples local test runs from a magic address that no production flow uses.

## Changes

- **`foundry.toml`**:
  - Removed `sender` / `tx_origin` from `[profile.default]`
  - Removed `sender` / `tx_origin` from `[profile.zksync]`
- **19 test files**: fixed up to pass without the global sender. Four recurring patterns:

| Pattern | Why | Fix |
|---|---|---|
| Constructor args using `address(this)` for ownership | Test contract is no longer at `USER_DIAMOND_OWNER` | Replace with `USER_DIAMOND_OWNER` |
| Owner-gated calls in `setUp` / tests | `msg.sender` is no longer the diamond owner | Wrap with `vm.startPrank(USER_DIAMOND_OWNER)` / `vm.stopPrank()` |
| Pranks placed before `addFacet(...)` | `_addFacet` internally calls `vm.startPrank` / `vm.stopPrank`, killing the outer prank context | Move pranks to AFTER `addFacet(...)` |
| Hardcoded facet addresses (`EmergencyPauseFacet.local.t.sol`) | Deploy-derived addresses change without the pinned sender | Use `IDiamondLoupe.facetAddress(selector)` dynamically (and move the lookups to BEFORE the diamond is paused, since loupe is unavailable while paused) |

## Why not just leave it / repoint it at the deployer?

Considered (and rejected) keeping `sender` and instead pointing it at the real deployer wallet:

- The deployer is per-environment (`$PRIVATE_KEY` for staging, `$PRIVATE_KEY_PRODUCTION` for production) — a single hardcoded value can only match one of them, and staging deploys to testnets would still need `--sender` either way.
- A committed config shouldn't encode operational state. Different developers / CI / forks each want a different value.
- Tests assert behavior, not ownership of a magic key. Pranking as `USER_DIAMOND_OWNER` is the explicit, future-proof shape.

The tests now express the actor for each call instead of relying on Foundry's default. PR #1754's `--sender "$DEPLOYER_ADDRESS"` plumbing remains in place — the two changes solve different problems and are both required.

## Verification

- `forge test --summary` → **1548 tests passed, 0 failed, 0 skipped** (96 suites)
- End-to-end deploy script smoke tests (sanity-checking #1754 + the `[profile.zksync]` cleanup):

| Path | Network | Env | Address | Result |
|---|---|---|---|---|
| EVM | ink | staging | `0x335F3bc2E85E92Cb826e3FDC1816aC01E6F608eA` | ✅ Deployed + verified |
| zkEVM | zksync | production | `0x9E883F62FBA8113bB6aeE6b1c89Dd09202847197` | ✅ Deployed (with sender/tx_origin still in zksync profile) |
| zkEVM | zksync | production | `0x0663374417Bdb0C2C3b125566e84c92B2CaAb28E` | ✅ Deployed (with sender/tx_origin removed from zksync profile) |

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug — n/a (this is a test-suite cleanup; full suite is the test)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e — n/a, no contracts changed
- [ ] I have updated any required documentation — n/a, no public surface changed

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted — n/a, no contract changes
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted — n/a, no contract changes
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on \<date\> by \<company/auditor\> — n/a, no new contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)