### PR TITLE
fix(safe): apply gas multiplier and fallback in EVM chain caller

### DIFF
--- a/script/deploy/safe/executors/evm-caller.ts
+++ b/script/deploy/safe/executors/evm-caller.ts
@@ -19,6 +19,8 @@ import type {
   IChainSimulateResult,
 } from '../../../common/types'
 
+import { getGasWithFallback } from './gas-with-fallback'
+
 export class EvmChainCaller implements IChainCaller {
   public readonly senderAddress: Address
 
@@ -33,23 +35,40 @@ export class EvmChainCaller implements IChainCaller {
   public async simulate(
     params: IChainCallParams
   ): Promise<IChainSimulateResult> {
-    const estimatedGas = await this.publicClient.estimateGas({
-      account: this.senderAddress,
-      to: params.to,
-      data: params.data,
-      value: params.value ?? 0n,
-    })
+    // Mirror the multiplier+fallback logic used in `call()` so the dry-run
+    // value reflects the gas limit that would actually be applied on-chain.
+    const estimatedGas = await getGasWithFallback(() =>
+      this.publicClient.estimateGas({
+        account: this.senderAddress,
+        to: params.to,
+        data: params.data,
+        value: params.value ?? 0n,
+      })
+    )
 
     return { estimatedResource: estimatedGas, resourceLabel: 'gas' }
   }
 
   public async call(params: IChainCallParams): Promise<IChainCallResult> {
+    // eth_estimateGas can revert outright on some chains (e.g. Jovay) even when
+    // the call succeeds, and viem's default ~20% buffer can under-count post-
+    // call overhead — apply GAS_ESTIMATE_MULTIPLIER with fallback.
+    const gas = await getGasWithFallback(() =>
+      this.publicClient.estimateGas({
+        account: this.senderAddress,
+        to: params.to,
+        data: params.data,
+        value: params.value ?? 0n,
+      })
+    )
+
     const txHash = await this.walletClient.sendTransaction({
       account: this.account,
       chain: this.walletClient.chain as Chain | null,
       to: params.to,
       data: params.data,
       value: params.value ?? 0n,
+      gas,
     })
 
     consola.info(`Blockchain Transaction Hash: \u001b[33m${txHash}\u001b[0m`)

--- a/script/deploy/safe/executors/evm-executor.ts
+++ b/script/deploy/safe/executors/evm-executor.ts
@@ -18,6 +18,8 @@ import type {
 } from '../../../common/types'
 import { SAFE_SINGLETON_ABI } from '../config'
 
+import { getGasWithFallback } from './gas-with-fallback'
+
 export class EvmChainExecutor implements IChainExecutor {
   public constructor(
     private readonly walletClient: WalletClient,
@@ -41,39 +43,21 @@ export class EvmChainExecutor implements IChainExecutor {
       params.signatures,
     ] as const
 
-    // Estimate gas and apply GAS_ESTIMATE_MULTIPLIER (percentage, default 130).
     // eth_estimateGas can under-count the Safe post-call overhead (ExecutionSuccess
     // event, refund logic), causing OOG reverts on chains with tight simulation vs.
     // execution deltas (e.g. Jovay). On some chains eth_estimateGas also fails
-    // outright even when the call would succeed on-chain — fall back to a fixed
-    // gas limit in that case.
-    const DEFAULT_MULTIPLIER = 130n
-    const rawMultiplier = process.env.GAS_ESTIMATE_MULTIPLIER?.trim()
-    let multiplier: bigint
-    try {
-      multiplier = rawMultiplier ? BigInt(rawMultiplier) : DEFAULT_MULTIPLIER
-      if (multiplier <= 0n) multiplier = DEFAULT_MULTIPLIER
-    } catch {
-      multiplier = DEFAULT_MULTIPLIER
-    }
-    // 500 000 is large enough for any realistic Safe execTransaction payload
-    const fallbackGas = 500_000n
-    let gas: bigint
-    try {
-      const estimatedGas = await this.publicClient.estimateContractGas({
+    // outright even when the call would succeed on-chain — getGasWithFallback
+    // applies GAS_ESTIMATE_MULTIPLIER and falls back to a fixed gas limit in
+    // that case.
+    const gas = await getGasWithFallback(() =>
+      this.publicClient.estimateContractGas({
         account: this.account,
         address: params.safeAddress,
         abi: SAFE_SINGLETON_ABI,
         functionName: 'execTransaction',
         args: execArgs,
       })
-      gas = (estimatedGas * multiplier) / 100n
-    } catch {
-      consola.warn(
-        `Gas estimation failed; using fallback gas limit: ${fallbackGas}`
-      )
-      gas = fallbackGas
-    }
+    )
 
     const txHash = await this.walletClient.writeContract({
       account: this.account,

--- a/script/deploy/safe/executors/gas-with-fallback.test.ts
+++ b/script/deploy/safe/executors/gas-with-fallback.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for `getGasWithFallback`: multiplier resolution from env and
+ * fallback-on-throw behaviour. Each test isolates `GAS_ESTIMATE_MULTIPLIER` so
+ * suite ordering is irrelevant.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { getGasWithFallback } from './gas-with-fallback'
+
+describe('getGasWithFallback', () => {
+  let originalEnv: string | undefined
+
+  beforeEach(() => {
+    originalEnv = process.env.GAS_ESTIMATE_MULTIPLIER
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.GAS_ESTIMATE_MULTIPLIER
+    else process.env.GAS_ESTIMATE_MULTIPLIER = originalEnv
+  })
+
+  it('applies the default 130% multiplier when env var is unset', async () => {
+    delete process.env.GAS_ESTIMATE_MULTIPLIER
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('uses GAS_ESTIMATE_MULTIPLIER from env when valid', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '200'
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(200_000n)
+  })
+
+  it('trims whitespace in env var', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '  150  '
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(150_000n)
+  })
+
+  it('falls back to 130% when env var is empty', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = ''
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('falls back to 130% when env var is whitespace-only', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '   '
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('falls back to 130% when env var is non-numeric (e.g. 1.3)', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '1.3'
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('falls back to 130% when env var contains non-digit chars', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '130%'
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('falls back to 130% when env var is zero', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '0'
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('falls back to 130% when env var is negative', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '-10'
+    const gas = await getGasWithFallback(async () => 100_000n)
+    expect(gas).toBe(130_000n)
+  })
+
+  it('returns default fallback (500_000) when estimation throws', async () => {
+    delete process.env.GAS_ESTIMATE_MULTIPLIER
+    const gas = await getGasWithFallback(async () => {
+      throw new Error('estimateGas reverted')
+    })
+    expect(gas).toBe(500_000n)
+  })
+
+  it('returns custom fallback when estimation throws', async () => {
+    delete process.env.GAS_ESTIMATE_MULTIPLIER
+    const gas = await getGasWithFallback(async () => {
+      throw new Error('estimateGas reverted')
+    }, 750_000n)
+    expect(gas).toBe(750_000n)
+  })
+
+  it('still applies multiplier on a small estimate (rounds via integer div)', async () => {
+    process.env.GAS_ESTIMATE_MULTIPLIER = '130'
+    const gas = await getGasWithFallback(async () => 7n)
+    // (7 * 130) / 100 = 910 / 100 = 9 (integer division)
+    expect(gas).toBe(9n)
+  })
+})

--- a/script/deploy/safe/executors/gas-with-fallback.ts
+++ b/script/deploy/safe/executors/gas-with-fallback.ts
@@ -1,0 +1,58 @@
+/**
+ * Gas estimation with chain-specific resilience for Safe/timelock execution.
+ *
+ * Wraps a viem gas estimation with: (1) a configurable safety multiplier via
+ * `GAS_ESTIMATE_MULTIPLIER` env var (default 130%, matching Foundry), and
+ * (2) a fixed fallback when estimation throws. Required for chains like Jovay
+ * where `eth_estimateGas` can revert even when `eth_call` with unlimited gas
+ * succeeds, and where viem's default ~20% buffer is too small to cover Safe /
+ * timelock post-call overhead. See PR #1762.
+ */
+
+import { consola } from 'consola'
+
+import {
+  DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT,
+  DEFAULT_GAS_FALLBACK,
+} from '../../shared/constants'
+
+/**
+ * Resolve `GAS_ESTIMATE_MULTIPLIER` from env, defaulting to
+ * {@link DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT}. Empty / whitespace /
+ * non-numeric / non-positive values fall back to default.
+ */
+function resolveMultiplier(): bigint {
+  const raw = process.env.GAS_ESTIMATE_MULTIPLIER?.trim()
+  if (!raw) return DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT
+  try {
+    const parsed = BigInt(raw)
+    return parsed > 0n ? parsed : DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT
+  } catch {
+    return DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT
+  }
+}
+
+/**
+ * Run a viem gas estimator and return either `(estimate * multiplier / 100)` or
+ * a fallback gas limit if estimation throws. Logs a warning on fallback so the
+ * caller knows a fixed limit was used.
+ *
+ * @param estimate - async fn returning a viem gas estimate (bigint)
+ * @param fallbackGas - gas limit used when estimation throws (default {@link DEFAULT_GAS_FALLBACK})
+ * @returns gas limit to apply to the subsequent transaction
+ */
+export async function getGasWithFallback(
+  estimate: () => Promise<bigint>,
+  fallbackGas: bigint = DEFAULT_GAS_FALLBACK
+): Promise<bigint> {
+  const multiplier = resolveMultiplier()
+  try {
+    const estimated = await estimate()
+    return (estimated * multiplier) / 100n
+  } catch {
+    consola.warn(
+      `Gas estimation failed; using fallback gas limit: ${fallbackGas}`
+    )
+    return fallbackGas
+  }
+}

--- a/script/deploy/shared/constants.ts
+++ b/script/deploy/shared/constants.ts
@@ -23,6 +23,23 @@ export const MAX_RETRIES = 3
 export const POLL_INTERVAL = 3000 // 3 seconds
 
 /**
+ * Gas estimate safety multiplier as a percentage. Matches Foundry's default
+ * `--gas-estimate-multiplier=130` (30% buffer on top of the raw estimate).
+ * Used by TS Safe/timelock executors as the canonical fallback when the
+ * `GAS_ESTIMATE_MULTIPLIER` env var is unset/invalid; bash deploy/update
+ * scripts apply the same `130` default inline (see .env.example).
+ */
+export const DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT = 130n
+
+/**
+ * Fixed gas limit applied when `eth_estimateGas` throws (e.g. Jovay, where
+ * the binary-search simulation reverts even when `eth_call` with unlimited gas
+ * succeeds). Sized ~4× the largest observed Safe/timelock execution
+ * (~120k for `scheduleBatch` on Jovay) to absorb post-call overhead.
+ */
+export const DEFAULT_GAS_FALLBACK = 500_000n
+
+/**
  * Centralized delay constants for consistent timing across the codebase
  *
  * Policy:


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — follow-up hotfix to #1762 for Jovay timelock execution failures.

# Why did I implement it this way?

## Problem

[PR #1762](https://github.com/lifinance/contracts/pull/1762) hardened gas estimation for `Safe.execTransaction` on Jovay (OOG after successful inner call + `eth_estimateGas` reverts), but the fix landed **only in `EvmChainExecutor`** — the path used by `confirm-safe-tx` to broadcast the Safe tx itself.

We missed the **execution part**: `EvmChainCaller.call()` (used by `execute-pending-timelock-tx` to call `executeBatch` / `cancel` on the timelock controller) still relied on viem's default ~20% gas buffer with no fallback. Re-running `bun run execute-timelock` on Jovay reproduced the exact same symptom — tx submits, then reverts on-chain with `Transaction failed with status: reverted` (e.g. `0x2075ab48241fc4160901ed9224e4f43416350e0e5853b15decaa32f1c5641a3d`, `0xea5c65bd9933c134aa142c89b7f52ef3481cff42f45c0b30fd42b6aad4f14347`):

```
[jovay] 📤 Submitting transaction...
ℹ Blockchain Transaction Hash: 0xea5c65bd…
 ERROR  [jovay] Failed to execute operation 0xcbb78cf5…: Transaction failed with status: reverted
    at EvmChainCaller.call (script/deploy/safe/executors/evm-caller.ts:76:18)
```

## Fix

- Extract the multiplier+fallback logic from `evm-executor.ts` into a shared helper `script/deploy/safe/executors/gas-with-fallback.ts` so both EVM executors share one implementation (and one place to patch in the future).
- Apply the helper to `EvmChainCaller.call()` (now passes `gas` to `sendTransaction`) and `EvmChainCaller.simulate()` (so dry-run output reflects the gas limit that would actually be used on-chain).
- Hoist the policy constants — `DEFAULT_GAS_ESTIMATE_MULTIPLIER_PERCENT = 130n` (matching Foundry's `--gas-estimate-multiplier` default, already used inline in 5 bash deploy scripts) and `DEFAULT_GAS_FALLBACK = 500_000n` — into `script/deploy/shared/constants.ts` alongside other project-wide defaults (`SAFE_THRESHOLD`, `CONFIRMATION_TIMEOUT`, `MAX_RETRIES`, …) so future TS callers don't redefine them.
- 12 unit tests for `getGasWithFallback` covering env-var parsing edge cases (unset / empty / whitespace / non-numeric / `1.3` / `130%` / zero / negative / valid) and the fallback-on-throw paths (default and custom fallback).

`tron-caller.ts` is intentionally untouched — it uses TronWeb's `fee_limit` (energy) model, a different code path with its own constants.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)