### PR TITLE
feat(scripts): add explorer links to Safe and timelock tx output

### DIFF
--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -209,6 +209,8 @@ export interface IChainCallResult {
   receipt?: TransactionReceipt
   /** Gas used by the transaction (from receipt). */
   gasUsed?: bigint
+  /** Human-readable explorer URL for CLI display. */
+  explorerUrl?: string
 }
 
 /** Result of simulating a contract call (dry-run). */

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -13,6 +13,7 @@ import { type Collection } from 'mongodb'
 import type { Account, Address, Hex } from 'viem'
 
 import networksData from '../../../config/networks.json'
+import { buildExplorerAddressUrl } from '../../utils/viemScriptHelpers'
 import { formatAddressForNetworkCliDisplay } from '../tron/helpers/formatAddressForCliDisplay'
 
 import type { ILedgerAccountResult } from './ledger'
@@ -185,11 +186,12 @@ const processTxs = async (
 
       consola.info(`   - Safe Tx Hash:   \u001b[36m${safeTxHash}\u001b[0m`)
       const displayHash = exec.displayHash ?? executionHash
-      consola.info(`   - Execution Hash: \u001b[33m${displayHash}\u001b[0m`)
-      if (exec.explorerUrl)
-        consola.info(
-          `   - Explorer:       \u001b[36m${exec.explorerUrl}\u001b[0m`
-        )
+      const explorerSuffix = exec.explorerUrl
+        ? ` \u001b[36m(${exec.explorerUrl})\u001b[0m`
+        : ''
+      consola.info(
+        `   - Execution Hash: \u001b[33m${displayHash}\u001b[0m${explorerSuffix}`
+      )
       consola.log(' ')
 
       return !!exec.receipt
@@ -322,6 +324,11 @@ const processTxs = async (
     const toDisplay = targetName
       ? `${toAddrDisplay} \u001b[33m${targetName}\u001b[0m`
       : toAddrDisplay
+    const toExplorerUrl = buildExplorerAddressUrl(
+      network.toLowerCase(),
+      tx.safeTx.data.to
+    )
+    const toExplorerSuffix = toExplorerUrl ? ` [36m${toExplorerUrl}[0m` : ''
     const proposerDisplay = formatAddressForNetworkCliDisplay(
       network,
       tx.proposer
@@ -341,7 +348,7 @@ const processTxs = async (
     Nonce:           \u001b[${nonceColor}m${
       tx.safeTx.data.nonce
     }\u001b[0m${nonceWarning}
-    To:              \u001b[32m${toDisplay}\u001b[0m
+    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m
     Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m
     Operation:       \u001b[32m${
       tx.safeTx.data.operation === 0 ? 'Call' : 'DelegateCall'

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -1152,7 +1152,12 @@ async function executeOperation(
         data: callData,
       })
 
-      consola.info(`${networkPrefix}    Transaction hash: ${result.hash}`)
+      const txExplorerSuffix = result.explorerUrl
+        ? ` (${result.explorerUrl})`
+        : ''
+      consola.info(
+        `${networkPrefix}    Transaction hash: ${result.hash}${txExplorerSuffix}`
+      )
 
       if (result.receipt && result.receipt.status !== 'success') {
         consola.error(

--- a/script/deploy/safe/executors/create-chain-caller.ts
+++ b/script/deploy/safe/executors/create-chain-caller.ts
@@ -48,5 +48,10 @@ export async function createChainCaller(
     )
 
   const { EvmChainCaller } = await import('./evm-caller')
-  return new EvmChainCaller(params.walletClient, params.publicClient, account)
+  return new EvmChainCaller(
+    params.walletClient,
+    params.publicClient,
+    account,
+    params.networkName
+  )
 }

--- a/script/deploy/safe/executors/evm-caller.ts
+++ b/script/deploy/safe/executors/evm-caller.ts
@@ -18,6 +18,7 @@ import type {
   IChainCaller,
   IChainSimulateResult,
 } from '../../../common/types'
+import { buildExplorerTxUrl } from '../../../utils/viemScriptHelpers'
 
 import { getGasWithFallback } from './gas-with-fallback'
 
@@ -27,7 +28,8 @@ export class EvmChainCaller implements IChainCaller {
   public constructor(
     private readonly walletClient: WalletClient,
     private readonly publicClient: PublicClient,
-    private readonly account: Account
+    private readonly account: Account,
+    private readonly networkName?: string
   ) {
     this.senderAddress = account.address
   }
@@ -90,8 +92,12 @@ export class EvmChainCaller implements IChainCaller {
         timeoutPromise,
       ])) as TransactionReceipt
 
+      const explorerUrl = this.networkName
+        ? buildExplorerTxUrl(this.networkName, txHash)
+        : undefined
+
       if (receipt.status === 'success')
-        return { hash: txHash, receipt, gasUsed: receipt.gasUsed }
+        return { hash: txHash, receipt, gasUsed: receipt.gasUsed, explorerUrl }
       else throw new Error(`Transaction failed with status: ${receipt.status}`)
     } catch (timeoutError: unknown) {
       const errorMsg =
@@ -104,7 +110,10 @@ export class EvmChainCaller implements IChainCaller {
         )
         consola.warn(`   Transaction hash: ${txHash}`)
         consola.warn(`   Please manually verify transaction status later`)
-        return { hash: txHash }
+        const explorerUrl = this.networkName
+          ? buildExplorerTxUrl(this.networkName, txHash)
+          : undefined
+        return { hash: txHash, explorerUrl }
       }
       throw timeoutError
     }

--- a/script/deploy/safe/executors/evm-executor.ts
+++ b/script/deploy/safe/executors/evm-executor.ts
@@ -16,6 +16,7 @@ import type {
   IChainExecutionResult,
   IChainExecutor,
 } from '../../../common/types'
+import { buildExplorerTxUrl } from '../../../utils/viemScriptHelpers'
 import { SAFE_SINGLETON_ABI } from '../config'
 
 import { getGasWithFallback } from './gas-with-fallback'
@@ -24,7 +25,8 @@ export class EvmChainExecutor implements IChainExecutor {
   public constructor(
     private readonly walletClient: WalletClient,
     private readonly publicClient: PublicClient,
-    private readonly account: Account
+    private readonly account: Account,
+    private readonly networkName?: string
   ) {}
 
   public async executeTransaction(
@@ -88,7 +90,12 @@ export class EvmChainExecutor implements IChainExecutor {
         timeoutPromise,
       ])) as TransactionReceipt
 
-      if (receipt.status === 'success') return { hash: txHash, receipt }
+      const explorerUrl = this.networkName
+        ? buildExplorerTxUrl(this.networkName, txHash)
+        : undefined
+
+      if (receipt.status === 'success')
+        return { hash: txHash, receipt, explorerUrl }
       else throw new Error(`Transaction failed with status: ${receipt.status}`)
     } catch (timeoutError: unknown) {
       const errorMsg =
@@ -101,7 +108,10 @@ export class EvmChainExecutor implements IChainExecutor {
         )
         consola.warn(`   Transaction hash: ${txHash}`)
         consola.warn(`   Please manually verify transaction status later`)
-        return { hash: txHash }
+        const explorerUrl = this.networkName
+          ? buildExplorerTxUrl(this.networkName, txHash)
+          : undefined
+        return { hash: txHash, explorerUrl }
       }
       throw timeoutError
     }

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -184,6 +184,7 @@ export class SafeClient {
    * @param walletClient - Wallet client used for EVM execution
    * @param account - Account used for signing and broadcasting
    * @param tronWalletClient - Optional Tron signer required for TVM execution
+   * @param networkName - Network name used to construct explorer URLs in results
    * @returns Executor implementation matching the connected chain
    * @throws Error if a Tron executor is required but no Tron signer is available
    */
@@ -191,7 +192,8 @@ export class SafeClient {
     publicClient: PublicClient,
     walletClient: WalletClient,
     account: Account,
-    tronWalletClient?: TronWalletClient
+    tronWalletClient?: TronWalletClient,
+    networkName?: string
   ): Promise<IChainExecutor | undefined> {
     const chainId = await publicClient.getChainId()
 
@@ -210,7 +212,12 @@ export class SafeClient {
     }
 
     const { EvmChainExecutor } = await import('./executors/evm-executor')
-    return new EvmChainExecutor(walletClient, publicClient, account)
+    return new EvmChainExecutor(
+      walletClient,
+      publicClient,
+      account,
+      networkName
+    )
   }
 
   public static async init(options: {
@@ -224,6 +231,7 @@ export class SafeClient {
       accountIndex?: number
     }
     account?: Account
+    networkName?: string
   }): Promise<SafeClient> {
     const {
       privateKey,
@@ -232,6 +240,7 @@ export class SafeClient {
       useLedger,
       ledgerOptions,
       account: preCreatedAccount,
+      networkName,
     } = options
 
     // Create provider with Viem
@@ -300,7 +309,8 @@ export class SafeClient {
       publicClient,
       walletClient,
       account,
-      tronWalletClient
+      tronWalletClient,
+      networkName
     )
 
     return new SafeClient(
@@ -1322,6 +1332,7 @@ export async function initializeSafeClient(
       useLedger,
       ledgerOptions,
       account,
+      networkName: network.toLowerCase(),
     })
 
     return { safe, chain, safeAddress: finalSafeAddress }

--- a/script/utils/viemScriptHelpers.ts
+++ b/script/utils/viemScriptHelpers.ts
@@ -166,6 +166,27 @@ export const buildExplorerContractPageUrl = (
 }
 
 /**
+ * Builds a block explorer transaction URL for a given network and tx hash.
+ *
+ * Uses `/tx/<hash>` for most EVM explorers and `/#/transaction/<hash>` for TronScan.
+ * Returns `undefined` if the network has no `explorerUrl` configured.
+ */
+export const buildExplorerTxUrl = (
+  networkId: string,
+  txHash: string
+): string | undefined => {
+  const network = networks[networkId]
+  if (!network || !network.explorerUrl) return undefined
+
+  const base = network.explorerUrl.replace(/\/+$/, '')
+
+  if (network.verificationType === 'tronscan')
+    return `${base}/#/transaction/${txHash}`
+
+  return `${base}/tx/${txHash}`
+}
+
+/**
  * Builds a viem `Chain` object for the given network name using `config/networks.json`.
  * Appends `/jsonrpc` to TronGrid RPC URLs so viem's JSON-RPC transport works correctly.
  * Includes `multicall3` contract address when configured for the network.


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A

# Why did I implement it this way?

**Problem:** When executing Safe transactions via `confirm-safe-tx` or timelock operations via `execute-pending-timelock-tx`, the CLI output showed transaction hashes and Safe target addresses as plain hex strings with no clickable explorer links. This made it tedious to verify executions — you had to manually copy the hash and navigate to the explorer.

**Solution:** Added a `buildExplorerTxUrl` helper to `viemScriptHelpers.ts` (mirroring the existing `buildExplorerAddressUrl`/`buildExplorerContractPageUrl` pattern) and threaded the network name through the EVM executor and caller chain (`EvmChainExecutor`, `EvmChainCaller`, `SafeClient`, `createChainCaller`) so that `IChainExecutionResult` and `IChainCallResult` now carry a populated `explorerUrl` for all EVM networks. The display in both scripts was updated to show the link inline in brackets next to the relevant hash/address.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>