### PR TITLE
fix(ci): mask RPCs, pin actions, and fix husky scan

### DIFF
--- a/.github/workflows/createPRsAsDraft.yml
+++ b/.github/workflows/createPRsAsDraft.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark as draft
-        uses: voiceflow/draft-pr@v1.1
+        uses: voiceflow/draft-pr@53c61b5093ebf96d8d7afb384128a2c4bbd018f7 # v1.1
         with:
           token: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }}

--- a/.github/workflows/diamondEmergencyPause.yml
+++ b/.github/workflows/diamondEmergencyPause.yml
@@ -58,9 +58,15 @@ jobs:
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable
           bun fetch-rpcs
-          # Only inject RPC endpoint variables into the GitHub Actions environment
+          # Only inject RPC endpoint variables into the GitHub Actions environment.
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
+              value="${line#*=}"
+              if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
+              if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "$line" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/diamondEmergencyPause.yml
+++ b/.github/workflows/diamondEmergencyPause.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       
       - name: Install dev dependencies
         run: bun install
@@ -32,7 +32,7 @@ jobs:
       - name: Authenticate git user (check membership in 'DiamondPauser' group)
         if: ${{ inputs.warning == 'UNDERSTOOD' }}
         id: authenticate-user
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3
         with:
           username: ${{ github.actor }}
           organization: lifinance
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       - name: Fetch RPC endpoints from MongoDB
         run: |
@@ -80,7 +80,7 @@ jobs:
           PRIVATE_KEY_PAUSER_WALLET: ${{ secrets.PRIV_KEY_PAUSER_WALLET }}
 
       - name: Send Reminder to Slack SC-general Channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/diamondEmergencyPauseStaging.yml
+++ b/.github/workflows/diamondEmergencyPauseStaging.yml
@@ -59,9 +59,15 @@ jobs:
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable
           bun fetch-rpcs
-          # Only inject RPC endpoint variables into the GitHub Actions environment
+          # Only inject RPC endpoint variables into the GitHub Actions environment.
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
+              value="${line#*=}"
+              if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
+              if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "$line" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -62,14 +62,6 @@ jobs:
             echo "solidity_changed=false" >> "$GITHUB_ENV"
           fi
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        if: env.solidity_changed == 'true'
-
-      - name: Install dev dependencies
-        run: bun install
-        if: env.solidity_changed == 'true'
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
         if: env.solidity_changed == 'true'

--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -21,12 +21,12 @@ jobs:
     env:
       MIN_TEST_COVERAGE: ${{ secrets.MIN_TEST_COVERAGE }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       
       - name: Install dev dependencies
         run: bun install
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         if: env.solidity_changed == 'true'
 
       - name: Install dev dependencies
@@ -71,7 +71,7 @@ jobs:
         if: env.solidity_changed == 'true'
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.3.1
+        uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
         if: env.solidity_changed == 'true'
 
       - name: Install forge Dependencies
@@ -170,7 +170,7 @@ jobs:
 
       - name: Comment with Coverage Summary in PR
         if: env.solidity_changed == 'true'
-        uses: mshick/add-pr-comment@v2.8.2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
           repo-token: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }}
           message: |

--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -36,9 +36,15 @@ jobs:
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable
           bun fetch-rpcs
-          # Only inject RPC endpoint variables into the GitHub Actions environment
+          # Only inject RPC endpoint variables into the GitHub Actions environment.
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
+              value="${line#*=}"
+              if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
+              if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "$line" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/ensureSCCoreDevApproval.yml
+++ b/.github/workflows/ensureSCCoreDevApproval.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Check if PR is approved by at least one SC core dev
         id: check-core-dev-approval
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request.number }}
         with:

--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -21,18 +21,18 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: recursive
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dev dependencies
         run: bun install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1.3.1
+        uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
 
       - name: Install forge Dependencies
         run: forge install
@@ -59,7 +59,7 @@ jobs:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
           
       - name: Run forge tests (with auto-repeat in case of error)
-        uses: Wandalen/wretry.action@v3.8.0
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
           command: forge test
           attempt_limit: 10

--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -42,9 +42,16 @@ jobs:
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable
           bun fetch-rpcs
-          # Only inject RPC endpoint variables into the GitHub Actions environment
+          # Only inject RPC endpoint variables into the GitHub Actions environment.
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
+              value="${line#*=}"
+              # Strip optional surrounding quotes so the masked token matches what tools print.
+              if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
+              if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "$line" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/healthCheckForNewNetworkDeployment.yml
+++ b/.github/workflows/healthCheckForNewNetworkDeployment.yml
@@ -110,13 +110,16 @@ jobs:
         run: |
           # Fetch prioritized RPCs (with auth where required) so health check uses same URLs as local
           bun run fetch-rpcs
-          # Inject RPC endpoint variables into the job environment (strip surrounding quotes so URL is valid)
+          # Inject RPC endpoint variables into the job environment (strip surrounding quotes so URL is valid).
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
               key="${line%%=*}"
               value="${line#*=}"
               if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
               if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "${key}=${value}" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/healthCheckForNewNetworkDeployment.yml
+++ b/.github/workflows/healthCheckForNewNetworkDeployment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -87,13 +87,13 @@ jobs:
 
       - name: Install Bun
         if: env.CONTINUE == 'true' && env.SKIP_CHECK != 'true'
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: latest
 
       - name: Install Foundry (provides cast)
         if: env.CONTINUE == 'true' && env.SKIP_CHECK != 'true'
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: v1.0.0
 

--- a/.github/workflows/jsonChecker.yml
+++ b/.github/workflows/jsonChecker.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       # Step 1: Checkout code
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Step 2: Set up Node.js
       - name: Set up Node.js
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
 

--- a/.github/workflows/jsonChecker.yml
+++ b/.github/workflows/jsonChecker.yml
@@ -1,3 +1,9 @@
+# JSON Checker
+# - validates JSON syntax of files in config/ and deployments/, plus a fixed set of well-known JSON files
+# - enforces a 5 MB per-file size limit
+# - rejects symlinks so a symlinked file cannot bypass validation
+# - known limitations: only the directories and files listed in the workflow are checked; JSON under other paths is not validated here
+
 name: JSON Checker
 on:
   pull_request:

--- a/.github/workflows/networkRpcsChecker.yml
+++ b/.github/workflows/networkRpcsChecker.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dev dependencies
         run: bun install
@@ -88,7 +88,7 @@ jobs:
 
       - name: Send Reminder to Slack SC-general Channel
         if: env.MISSING_RPCS != ''
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/networkRpcsChecker.yml
+++ b/.github/workflows/networkRpcsChecker.yml
@@ -32,9 +32,15 @@ jobs:
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable
           bun fetch-rpcs
-          # Only inject RPC endpoint variables into the GitHub Actions environment
+          # Only inject RPC endpoint variables into the GitHub Actions environment.
+          # Mask the URL (which may carry an API key) before forwarding so it is
+          # redacted from all subsequent log output for the rest of the run.
           while IFS= read -r line || [[ -n "$line" ]]; do
             if [[ "$line" =~ ^ETH_NODE_URI_ ]]; then
+              value="${line#*=}"
+              if [[ "$value" == \"*\" ]]; then value="${value:1:-1}"; fi
+              if [[ "$value" == \'*\' ]]; then value="${value:1:-1}"; fi
+              echo "::add-mask::$value"
               echo "$line" >> "$GITHUB_ENV"
             fi
           done < ".env"

--- a/.github/workflows/notifyDataTeamOnDeployment.yml
+++ b/.github/workflows/notifyDataTeamOnDeployment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 2 # Need previous commit to compare changes
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Send Slack Notification
         if: steps.get-changes.outputs.has_changes == 'true' && steps.parse-changes.outputs.contracts_found == 'true'
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DATA_TEAM }}
           webhook-type: incoming-webhook

--- a/.github/workflows/notifyDataTeamOnDeployment.yml
+++ b/.github/workflows/notifyDataTeamOnDeployment.yml
@@ -1,3 +1,9 @@
+# Notify Data Team on Contract Deployments
+# - posts a Slack message to the data team when a production deployment JSON file changes on main
+# - diffs the changed deployments/<network>.json files against the previous commit to extract contract names and addresses
+# - ignores diamond, staging, and the aggregated deployments log to avoid noise
+# - known limitations: requires fetch-depth: 2 to access the previous commit; does not validate deployment JSON schema
+
 name: Notify Data Team on Contract Deployments
 
 on:
@@ -11,7 +17,7 @@ on:
       - '!deployments/_deployments_log_file.json'
 
 permissions:
-  contents: read
+  contents: read # required to read deployment JSON files and diff against the previous commit
 
 jobs:
   notify-deployments:

--- a/.github/workflows/protectAuditLabels.yml
+++ b/.github/workflows/protectAuditLabels.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check if event requires audit label protection
         id: check_event

--- a/.github/workflows/protectSecurityRelevantCode.yml
+++ b/.github/workflows/protectSecurityRelevantCode.yml
@@ -21,7 +21,7 @@ jobs:
       CONTINUE: false # makes sure that variable is correctly initialized in all cases
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0 ##### Fetch all history for all branches
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Check approval of Information Security Manager
         id: check-sec-mgr-approval
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: env.CONTINUE == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.review.pull_request.number }}

--- a/.github/workflows/securityAlertsReview.yml
+++ b/.github/workflows/securityAlertsReview.yml
@@ -55,9 +55,9 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: jwalton/gh-find-current-pr@master
+      - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: findPr
 
       - name: Validate and set PR Number

--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -16,13 +16,13 @@ jobs:
     steps:
       # Step 1: Checkout the contracts repository
       - name: Checkout Contracts Repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ env.BRANCH_NAME }}
 
       # Step 2: Install Foundry
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
 
       # Step 3: Install Solidity Libraries
       - name: Install Solidity Libraries
@@ -30,7 +30,7 @@ jobs:
 
       # Step 4: Setup Bun
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       # Step 5: Install dev dependencies
       - name: Install dev dependencies
@@ -46,7 +46,7 @@ jobs:
 
       # Step 8: Checkout the lifi-contract-types repository
       - name: Checkout lifi-contract-types Repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: lifinance/lifi-contract-types
           path: lifi-contract-types

--- a/.github/workflows/updateScriptConfigReminder.yml
+++ b/.github/workflows/updateScriptConfigReminder.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Reminder to Slack SC-general Channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/updateScriptConfigReminder.yml
+++ b/.github/workflows/updateScriptConfigReminder.yml
@@ -1,3 +1,8 @@
+# Notify SmartContract channel when .env.example changes
+# - posts a Slack reminder to sc-general so developers refresh their local .env after a config addition/rename
+# - triggers on push to main when .env.example is modified
+# - known limitations: only fires on main (not on PR review); the workflow does not verify that developers actually updated their .env
+
 name: Notify SmartContract channel when .env.example changes
 
 on:

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -45,7 +45,7 @@ jobs:
       CONTINUE: false # makes sure that variable is correctly initialized in all cases
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -311,7 +311,7 @@ jobs:
           fi
 
       - name: Save updated contracts for downstream jobs
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: contracts_for_audit
           path: contracts_for_audit.txt
@@ -328,18 +328,18 @@ jobs:
       AUDIT_REQUIRED: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Download list of audit-relevant contracts from previous version control step
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: contracts_for_audit
 
       # makes sure that the "AuditCompleted" label is always removed in the beginning to make sure that this label is never assigned in (case of) error
       - name: Remove label "AuditCompleted", if currently assigned
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
         continue-on-error: true
         with:
           github_token: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }} # we use the token of the lifi-action-bot so the label protection check will pass
@@ -364,7 +364,7 @@ jobs:
           fi
 
       - name: Assign, update, and verify labels based on check outcome
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           AUDIT_REQUIRED: ${{ env.AUDIT_REQUIRED }}
         with:
@@ -664,7 +664,7 @@ jobs:
 
       - name: Assign label "AuditCompleted" if all checks passed
         if: ${{ env.AUDIT_REQUIRED == 'true' }}
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         id: assign_label
         with:
           github_token: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }} # we use the token of the lifi-action-bot so the label protection check will pass

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -48,8 +48,10 @@ KNOWN_FALSE_POSITIVES=(
   "foundry.toml"
   "50000000000"
   # Well-known Anvil/Foundry development defaults documented in .env.example.
+  # pre-commit-checker: not a secret
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
   "test test test test test test test test test test test junk"
+  # pre-commit-checker: not a secret
   "0xc726deb4bf42c6ef5d0b4e3080ace43aed9b270938861f7cacf900eba890fa66"
 )
 EXCLUDED_PATHS=(

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -47,6 +47,10 @@ KNOWN_FALSE_POSITIVES=(
   "verifyContract"
   "foundry.toml"
   "50000000000"
+  # Well-known Anvil/Foundry development defaults documented in .env.example.
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+  "test test test test test test test test test test test junk"
+  "0xc726deb4bf42c6ef5d0b4e3080ace43aed9b270938861f7cacf900eba890fa66"
 )
 EXCLUDED_PATHS=(
   "deployments/_deployments_log_file.json"
@@ -325,10 +329,19 @@ prepare_env_secrets() {
       continue
     fi
 
+    local KEY_UPPER
+    KEY_UPPER=$(printf '%s' "$KEY" | tr '[:lower:]' '[:upper:]')
+
+    # Keys that hold filesystem paths or directories legitimately appear in
+    # source/workflows; their values are not credentials.
+    case "$KEY_UPPER" in
+      *_PATH|*_DIRECTORY|*_DIR)
+        continue
+        ;;
+    esac
+
     # Skip short values only for clearly non-secret keys to avoid blind spots
     if [ ${#VALUE} -lt 8 ]; then
-      local KEY_UPPER
-      KEY_UPPER=$(printf '%s' "$KEY" | tr '[:lower:]' '[:upper:]')
       case "$KEY_UPPER" in
         *SECRET*|*TOKEN*|*PASSWORD*|*PRIVATE*|*API_KEY*|*ACCESS_KEY*)
           ;; # still track potentially sensitive short values


### PR DESCRIPTION
# Which Linear task belongs to this PR?

- [EXSC-308 — Workflows leak RPCs](https://linear.app/lifi-linear/issue/EXSC-308/workflows-leak-rpcs)
- [EXSC-307 — Pin GitHub Actions in all workflows to SHAs](https://linear.app/lifi-linear/issue/EXSC-307/pin-github-actions-in-all-workflows-to-shas)

# Why did I implement it this way?

Workflow-hardening changes bundled because they touch the same area.

## EXSC-308 — mask RPC URLs before writing to `$GITHUB_ENV`

Six workflows fetch RPC endpoints from MongoDB into `.env` and forward every `ETH_NODE_URI_*` line into `$GITHUB_ENV`: `forge.yml`, `enforceTestCoverage.yml`, `diamondEmergencyPause.yml`, `diamondEmergencyPauseStaging.yml`, `networkRpcsChecker.yml`, `healthCheckForNewNetworkDeployment.yml`.

The forwarded URLs embed provider API keys (e.g. drpc `dkey=…`). Because `lifinance/contracts` is public, downstream tools that surface these values on error — `forge test` fork errors, `cast … --rpc-url "$RPC_URL" 2>&1` in the emergency-pause scripts, anything that prints env — leak the credentials in public CI logs.

Each loop now strips optional surrounding quotes, emits `::add-mask::$value`, then writes to `$GITHUB_ENV`. Once masked, GitHub redacts the value from all subsequent log output for the rest of the run.

Rotating the exposed dRPC `dkey` and auditing MongoDB's `RpcEndpoints` collection for other URL-embedded credentials must be done out-of-band.

## EXSC-307 — pin actions to full commit SHAs

Per `[CONV:ACTIONS-IMMUTABLE]`, every `uses:` reference must pin to a 40-char commit SHA so a compromised tag (cf. `tj-actions/changed-files`) cannot retroactively change what runs in CI. All active workflows now use SHA pins with a trailing `# <version>` comment for traceability. `jwalton/gh-find-current-pr` moved from `@master` to `v1.3.5` so the reference is reproducible.

Deactivated workflows (`.github/workflows_deactivated/`, `.github/workflows/disabled/`) are out of scope — they do not run, and should be pinned when reactivated.

## Husky `.env` secret-scan false positives

PR #1771 fixed `${`#VALUE`}` (malformed bash expansion that had been silently disabling the `.env` scan via "bad substitution"). With the scan now running, every value from `.env` is brute-force grepped against staged files — including path-shaped config like `TARGET_STATE_PATH=script/deploy/_targetState.json` that legitimately appears in source.

1. Skip values for `*_PATH` / `*_DIRECTORY` / `*_DIR` keys in `prepare_env_secrets()` — they hold paths, not credentials.
2. Add the documented Anvil/Foundry development defaults (Anvil private key, test mnemonic, default deploy salt) to `KNOWN_FALSE_POSITIVES` and mark the hex constants with `# pre-commit-checker: not a secret` so the parallel private-key regex check skips them too.

## Drive-by cleanup (CodeRabbit findings)

- Added the required header comment block to `jsonChecker.yml`, `notifyDataTeamOnDeployment.yml`, `updateScriptConfigReminder.yml` per `[CONV] .agents/rules/500-github-actions.md`. Also documented `contents: read` inline in the data-team workflow.
- Removed the redundant `Set up Bun` + `Install dev dependencies` pair in `enforceTestCoverage.yml` — Bun is already installed unconditionally earlier in the job.

11 other active workflows still lack header blocks per the same rule. Tracked as follow-up; sweeping them is out of scope here.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
