### PR TITLE
chore: add creating-user-stories skill

### DIFF
--- a/.claude/skills/creating-user-stories/SKILL.md
+++ b/.claude/skills/creating-user-stories/SKILL.md
@@ -1,0 +1,449 @@
+---
+name: creating-user-stories
+description: Use when drafting, maintaining, refining, or auditing a structured, audit-ready user-stories catalogue from a PRD + design-review notes + open-questions list. Outputs persona-grouped stories with concrete acceptance hints, source citations, and explicit linkage to unresolved open questions across a simplified + verbose two-phase workflow. Trigger on "write user stories for", "draft stories from this PRD", "expand the user stories", "add a story for X", "audit the catalogue", "clean up the open questions", "refine the stories", or any request to produce or maintain a stories catalogue feeding SC design or audit scoping. Use this skill whenever the user is working on a structured stories catalogue or its companion open-questions page, even if they don't say "user story" explicitly. Skip for casual feature lists or one-off ticket descriptions.
+---
+
+# Creating User Stories
+
+## When to use
+
+A **structured, auditable user-stories catalogue** — the kind that feeds an SC design doc, audit scope, or estimate. Not for one-off Jira tickets or casual feature lists.
+
+**Inputs**: PRD, design-review/meeting notes, open-questions list (or create one in parallel), optional comparable-product research.
+
+**Output**: a catalogue across 3 pages, 2 phases.
+
+| Phase | Active pages | What's happening |
+|---|---|---|
+| **Phase 1 — Finalisation (default)** | Simplified + Open Questions | Catalogue in flux. The Verbose page does NOT exist. |
+| **Phase 2 — Verbose generation** | Simplified + Open Questions + Verbose | Triggered ONCE the catalogue stabilises. See `references/phase-2-regeneration.md`. |
+
+**Default to Phase 1.** Maintaining two pages during a moving target is high cost / low benefit. Generate Verbose once when stable. If you find a Verbose page started prematurely, archive it (banner + title prefix `📦 [ARCHIVED]`) rather than maintaining both.
+
+## Core principles
+
+1. **One story = one discrete capability.** No "AND" in titles or action clauses. See "One-action-one-benefit grammar".
+2. **Acceptance hints are concrete contract behavior** — function names, events, reverts, role checks. Not generic "should work correctly". *(Phase 2 only.)*
+3. **Always cite source** in the Verbose page. Phantom citations ("PRD" without §) get challenged. *(Phase 2 only.)*
+4. **Surface unknowns, don't hide them.** Story shape that depends on an unresolved decision → mark with `❓Q-id` (Simplified) or `**Depends on open Q**` (Verbose). Never invent an answer.
+5. **Research-derived stories** are flagged `*(research-derived)*` in the title.
+6. **Stable IDs.** Once assigned, never renumber. Append new at end of theme group with next free number.
+7. **Cross-doc alignment is non-negotiable.** Every `❓Q-id` must resolve to a real Q. Phantom Q references erode trust. See "Keeping pages in sync".
+8. **PRD is owned by product.** The catalogue surfaces tensions as questions; it never proposes PRD edits. See "PRD ownership rule".
+9. **Human-readable framing wins.** Every story and every open Q must read like a sentence a smart PM/engineer would write to a colleague — not a wall of technical jargon. See "Readability format" below.
+
+## Readability format
+
+The catalogue is read by product managers, smart-contract engineers, auditors, and BD. None of them tolerate dense jargon. Apply these rules to **every story body, every open-Q body, every acceptance hint**:
+
+### Phrasing
+
+- **Titles are the actual question / capability**, not category labels. ✓ `What's the hard ceiling on the performance fee an integrator can set?` — ✗ `Maximum performance-fee cap`.
+- **One plain sentence per idea.** If a sentence has 3 clauses joined by commas/semicolons, split it.
+- **Lead with the decision, not the mechanism.** PM-facing body asks "what should the system do?", not "how does the implementation work?" Implementation goes in acceptance hints, not the story body.
+- **Drop filler.** Phrases like "It should be noted that…", "In order to…", "Different UX trade-offs exist…" — strip. Say the thing.
+
+### Labeling multiple options
+
+**Hard rule**: whenever a body presents 2+ discrete options (alternative behaviors, alternative mechanisms, alternative scopes), label them **(a)**, **(b)**, **(c)**, … and have the *Recommendation* / *Candidate* / acceptance hints explicitly reference the chosen letter.
+
+```
+*What*: **(a)** integrator-only, **(b)** LI.FI-only, **(c)** permissionless, or **(d)** per-instance allowlist.
+*Recommendation*: **(a)** — the integrator owns the wrapper's commercial economics.
+```
+
+Reasons:
+1. The reader can scan the options in one pass without re-parsing prose.
+2. The recommendation is unambiguous — no "the second one" / "permissionless"-style indirection.
+3. Sub-questions can reference the letter: "If (b) is chosen, who can update the list?"
+
+When sub-options nest under one parent option, use roman numerals to disambiguate:
+```
+*Sub-questions if (b)*: (i) who can trigger? (ii) where do proceeds go? (iii) auto-trigger on whitelist removal?
+```
+
+**When NOT to label**: single-recommendation bodies (no alternative being considered), TBD entries with no enumerated choices, or one-liners. If you find yourself writing "(a)" alone without a sibling, drop the label.
+
+### Pros / Cons
+
+Add a *Pros* / *Cons* block **only when the trade-off is real and a PM needs to weigh it**. Examples:
+- ✓ Q2.12 (V1-vs-V2 scope decision with named partner implications).
+- ✗ "Should we use CREATE2?" — has a clear right answer; just label options and recommend.
+
+If you find yourself listing only one Pro or one Con, the trade-off isn't real — delete the section and just recommend.
+
+### Source attribution
+
+- **Open Questions catalogue**: source attribution is optional and lives at the end (`*Source*: ...`). For human-readable versions intended for product review, drop it entirely — the source is recoverable from the page history.
+- **Stories (Verbose)**: source is still mandatory per Core Principle 3. The audit trail requires it.
+
+## Structure
+
+### Persona grouping (H2)
+
+- `## As a [Org] admin, I want to...` — IDs start with `A`
+- `## As an integrator, I want to...` — IDs start with `I`
+- `## As a user (EOA or smart wallet), I want to...` — IDs start with `U`
+
+Adapt for non-SC products (operator / viewer), but keep persona separation.
+
+### Theme sub-grouping (H3)
+
+Within each persona, group by theme. Typical themes for an SC wrapper: Factory & implementation lifecycle / Onboarding & allowlist / Fee economics / Pause & safety / Compliance / Operations & observability / Rewards / Deposit-withdrawal flows / Shares & MEV protection.
+
+### Per-story format
+
+**Simplified** (Phase 1 + Phase 2):
+```
+- **A1.** [verb-lowercase] [object], so that [why]. ❓[Q4.5](link), [Q9.1](link)
+```
+Persona phrase is in the H2 heading, not repeated per story. One sentence each, no acceptance hints, no source.
+
+**Verbose** (Phase 2 only):
+```
+### A1. Short imperative title (or the actual capability phrased as a sentence)
+- **Story**: As a [persona], I want to [capability], so that [why].
+- **Acceptance hints**: concrete contract behavior — function signatures, events, reverts, role checks. Plain English, one fact per bullet.
+- **Source**: PRD §X.Y / Earn PRD Review / Inferred / Research.
+- **Depends on open Q**: QX.Y (one-line description). [optional]
+```
+
+Variants:
+- **Sub-points** (A2.1, A2.2 …) when a story title is an umbrella ("gate every slow-path action") — list every concrete sub-action.
+- **Alternative acceptance hints** when an open Q has 2+ plausible answers — show all, label them **(a)** / **(b)** / **(c)** per "Readability format → Labeling multiple options", don't pick prematurely. The candidate (if any) references the chosen letter.
+- **Cross-references**: `(see A16)`, `(mirrors I18)` — see "Cross-referencing adjacent-lifecycle stories".
+
+Example of labeled alternative hints:
+```
+- **Acceptance hints (depends on Q1.3)**:
+  - **(a) Virtual-shares dilution** — mint fee-shares to treasury on `harvest()`; PPS reflects post-fee value continuously; emits `FeeAccrued(amount, sharesMinted)`.
+  - **(b) Event-based extraction** — transfer fee as ERC-20 on harvest/withdraw; emits `FeeExtracted(recipient, amount)`.
+  - **(c) Accumulate-and-sweep** — fee accumulates in wrapper; admin-callable `sweepFees()` transfers to treasury; emits `FeesSwept(recipient, amount)`.
+- **Depends on open Q**: Q1.3 — candidate (a). Acceptance hint locks once Q1.3 resolves.
+```
+
+## One-action-one-benefit grammar
+
+A user story has exactly two semantic slots: `[verb] [object], so that [benefit]`. Strict rule: **one action, one benefit, no compound verbs in the action clause.**
+
+### Fix patterns
+
+| Smell | Fix |
+|---|---|
+| `crystallize yield AND split into buckets, so that accounting stays current` | Move AND into the consequence: `trigger harvest, so that accrued yield is crystallized and fees become claimable.` (Both flow from ONE action — acceptable.) |
+| `update fee AND emit event, so that...` | Drop the mechanism: `update fee within bounds, so that I can react to market.` Events are implementation. |
+| `pause withdrawals AND deposits, so that...` | Two stories OR one composite: `pause the instance, so that...` |
+| `do X so that fee accounting stays current` | Sharpen the benefit: `do X so that my accrued balance reflects current yield and I can sweep it.` |
+
+### Acceptable "and"
+
+`trigger harvest(), so that accrued yield gets crystallized AND fees become claimable.` — "and" connects two *outcomes* of ONE action. Fine. Compare to `crystallize AND split` in the action clause = two buttons, both must be pressed.
+
+### Quality check per sentence
+
+1. One verb in the action clause? (`trigger X` / `configure Y` = single verb-object, OK.)
+2. The "so that" names a persona-specific stake, not generic "system works"?
+3. If "and" appears, is it joining outcomes (downstream of one action), not parallel actions?
+4. Reader at risk of conflating with an adjacent-lifecycle story? Add a `(see IX)`.
+
+## Cross-referencing adjacent-lifecycle stories
+
+Two stories on the same concept (fees, rewards, shares, whitelist) at different lifecycle stages can be confused by a reader. Always cross-link with `(see IX)`.
+
+**Common pairings**:
+- Crystallize (`harvest()`, I17) vs claim (`claimIntegratorFees()`, I5).
+- Configure (`setIntegratorReceivers`, I25) vs apply (claim, I5).
+- Inject vs schedule vs distribute vs cancel (I10–I14).
+- Allowlist (A5) vs deploy (A8).
+- Pause variants — emergency (A13) vs global (A14) vs non-emergency (A15) vs withdrawal (I19).
+
+**Bidirectional** — if A→B is worth linking, B→A usually is. Verify on every edit.
+
+## PRD ownership rule
+
+The PRD is owned by the product team, NOT by the SC team. The catalogue's job:
+
+1. **Surface tensions** when stories drift from PRD or need to add capabilities the PRD doesn't authorize.
+2. **Flag tensions as questions for product** with the `⚠️ PRODUCT DECISION NEEDED` tag.
+3. **NEVER edit the PRD.** That's a product-team action.
+
+Anti-pattern: writing "Recommend PRD-amend §X.Y to authorize ...". Catalogue role is to *surface the question*, not to *prescribe the answer*.
+
+### Phrasing template for product-decision Qs
+
+Follow the readability format (title is the actual question; options labeled; recommendation references a letter). Two flavors depending on complexity:
+
+**Standard (most Qs)**:
+```
+**QX.Y — [The actual decision question] — ⚠️ PRODUCT DECISION NEEDED**
+*What*: [one-sentence context]. **(a)** ..., **(b)** ..., **(c)** ...
+*Recommendation*: **(b)** — [rationale in plain English].
+```
+
+**With trade-off (only when a PM must weigh options)**:
+```
+**QX.Y — [The actual decision question] — ⚠️ PRODUCT DECISION NEEDED**
+*What*: [one-sentence context describing the capability and why it's debatable].
+*Pros*:
+- [specific upside]
+- [specific upside]
+*Cons*:
+- [specific downside]
+- [specific downside]
+*Recommendation*: **[defer / accept / specific option]** — [rationale].
+```
+
+**Anti-patterns**:
+- Title as a category label (`Fee mechanism`) instead of a question (`How should the fee mechanism work?`).
+- Options listed in prose without (a)/(b) labels.
+- Recommendation that doesn't reference one of the labeled options.
+- Pros/Cons block with only one bullet on each side — the trade-off isn't real, just recommend.
+
+## Surfacing implicit architectural properties
+
+Some user-visible properties fall out "for free" from architecture and have no explicit story. Readers ask about them first because they're invisible.
+
+**Example**: underlying yield auto-compounds because the wrapper holds underlying-vault shares (it was never withdrawn). Reader sees `harvest()` and asks "where do the funds go?". Architecture provides the property, no story names it → write one:
+
+> **U19.** see my underlying-vault yield auto-compound into my wrapper share price (see I17), so that no claim or reinvest action is needed.
+
+The `(see I17)` traces the property to its mechanical source.
+
+**Litmus test**: when reviewing the catalogue, ask "what questions would a first-time reader have here that the catalogue doesn't answer because the answer is architectural?" If the answer is yes, write the implicit-property story.
+
+## The "naming a story" red flag
+
+If a story title contains a noun that could mean many things (`"upgrade the factory"`, `"manage the allowlist"`), it's too vague. Either:
+- (a) Split into multiple concrete stories, or
+- (b) Keep the umbrella but enumerate sub-actions A2.1, A2.2, …
+
+Rule of thumb: if a reader can ask "which actions exactly?", you must list them. Most common failure mode in PRD-derived stories — the PRD says "factory is upgradeable" and the story inherits the vagueness.
+
+## Acceptance-hint quality bar
+
+*(Phase 2 only.)*
+
+Bad: "User can deposit and earn yield."
+Good: "ERC-4626 conformant; `previewDeposit` / `previewMint` match actual outcome under non-pathological conditions; emits `Deposit`; flash-deposit guard (A16) enforced; reverts if `whitelist` active and `msg.sender ∉ allowlist`."
+
+A hint passes when it answers ≥3 of: function(s) called / state-changes & events / revert conditions / authorization checks / invariants held / what's intentionally out of scope.
+
+**Multiple valid behaviors**: if a hint depends on an unresolved open Q with 2+ plausible answers, list all variants labeled **(a)** / **(b)** / **(c)** per "Readability format → Labeling multiple options". The candidate references the chosen letter; the hint locks when the Q resolves. Don't pick prematurely; don't bury the alternatives in prose.
+
+## Source-tag conventions
+
+*(Phase 2 only — Phase 1 simplified carries no source; source-check happens at regeneration.)*
+
+| Tag | Confidence | Meaning |
+|---|---|---|
+| `PRD §X.Y` | **Authoritative** | Direct lift from PRD body with section reference. Always cite section number. |
+| `⚠️ Suggested by SC team, decision required` | **Tentative** | Surfaced in meeting notes / design discussions. MUST pair with an open Q. |
+| `Inferred` | **Guess** | Standard requirement you added not in any input doc. Flag explicitly. |
+| `Research` | **External pattern** | Pattern from comparable products. Pair with `*(research-derived)*` in title. |
+| `Architectural decision — [topic]` | **Resolved-in-design** | Decision from design discussion that supersedes ambiguity. |
+
+**The PRD-vs-notes trap**: a meeting-notes claim ("we said PartnerPortal would do X") gets transcribed as `Source: PRD — "..."`. The PRD body never said it. By audit time nobody remembers and the assumption is load-bearing. Before writing `Source: PRD §X.Y`, you must point to that section. If you can only point to notes → `⚠️ Suggested by SC team, decision required`. When in doubt, downgrade.
+
+**Downgrading an existing story's source**:
+1. Re-tag with `⚠️ Suggested by SC team, decision required` and state in one line what was suggested.
+2. Reference an existing open Q if one exists; add one if not.
+3. Don't delete the story — capability is probably still wanted under different terms.
+
+## Keeping pages in sync
+
+The catalogue lives across 2–3 Notion pages: Open Questions (always), Simplified (always), Verbose (Phase 2 only). **A story edit touches every page the change affects, in the same session.** Stale cross-references erode the entire catalogue.
+
+### Edit-propagation matrix
+
+| Change | Verbose (Phase 2) | Simplified | Open Questions |
+|---|---|---|---|
+| New story added | ✓ full entry | ✓ one-line entry, same ID | ✓ add new Qs referenced |
+| Story re-titled / "so that" reframed | ✓ | ✓ (line must match new "so that") | — |
+| Open Q resolved | ✓ remove "Depends on open Q", update story body | ✓ remove ❓ marker | ✓ move to "Resolved" |
+| New open Q surfaced | ✓ add "Depends on open Q: QX.Y" | ✓ add `❓[QX.Y](link)` | ✓ add Q with candidate, source |
+| Story deleted | ✓ remove (or mark superseded) | ✓ remove | ✓ resolve orphaned Qs |
+| Story renumbered | NEVER | NEVER | — |
+| Theme regrouped | ✓ | ✓ identical regrouping | — |
+
+### Mandatory verification after every edit
+
+- Every `❓Q*.*` in Simplified resolves to a real Q on Open Questions (no phantom references).
+- Every Q on Open Questions is referenced by ≥1 story OR explicitly tagged `[META]` (see below).
+- Every ID in Simplified appears in Verbose and vice versa (Phase 2).
+- Every `Depends on open Q: QX.Y` in Verbose matches a `❓QX.Y` in Simplified (Phase 2).
+- Every `(see IX)` cross-reference resolves to a real story.
+- Open Questions counts footer reflects current state.
+
+How to verify practically: fetch both pages, extract `Q*.*` markers from Simplified, extract real Q-ids from Open Questions, diff both directions. Same for `(see *)` against story IDs.
+
+**Phantom Qs are the quickest path to "nobody trusts this doc anymore". Treat verification as ship-blocking.**
+
+### Meta / cross-cutting Qs (excluded from orphan check)
+
+Some Qs legitimately don't map to a single story:
+- Catalogue-level deliverables ("produce an admin-capability matrix").
+- Spec-level confirmations ("confirm V1 has zero oracle dependencies").
+- Out-of-contract scope (audit budget, legal/compliance, KYB-routing ownership).
+- Refinements of other Qs.
+
+Tag these `[META]` in the title:
+```
+**Q4.6 [META] — Admin-capability matrix**
+```
+
+Sync check ignores `[META]`-tagged Qs. **When in doubt, link to a story** — `[META]` is a last resort.
+
+### Notion editing mechanics
+
+For block-anchor links, parallel-session drift, timeout-is-deceptive pattern, batched edits — see `references/notion-mcp.md`. Loading that doc is mandatory before any non-trivial Notion edit.
+
+### Anti-pattern: "I'll fix the other page next"
+
+Don't. Half-synced edits accumulate; eventually nothing is trusted. If you can't update all affected pages in one session, don't ship the change.
+
+## Open-question linkage
+
+Open questions live on their own dedicated page, never inline in stories. Stories reference Qs by ID only.
+
+**Open Questions page structure**:
+- **Top-level sections** (priority axis): `# BLOCKS SC design` / `# Nice-to-resolve` / `# Cosmetic` / `# V2 / Deferred` / `# Resolved`.
+- **Lane sub-sections** within BLOCKS (audience axis): `## ⚠️ Product decisions needed` / `## [SC-DESIGN] technical questions` / `## [META] / cross-cutting`. Within each lane, group by theme.
+- **Each Q**: `**QX.Y — Title — ⚠️ PRODUCT DECISION NEEDED**` / `**QX.Y — Title — [SC-DESIGN]**` / `**QX.Y [META] — Title**` + prose description + optional `*Candidate*: ...` + `*Source*: ...`.
+- **Counts footer**: tally per top-level section. Update on every add/resolve.
+- **Q-ID numbering**: stable per theme (Q1.x = fees, Q2.x = rewards). Don't renumber.
+
+### Mandatory lane tagging — every Q must signal its audience
+
+**Hard rule**: every open question must carry exactly one lane tag in its title — `⚠️ PRODUCT DECISION NEEDED` (Lane 2), `[SC-DESIGN]` (Lane 3), or `[META]` (cross-cutting / out-of-contract). Untagged Qs are sync failures.
+
+Lane assignment — **strict criterion**:
+
+- **⚠️ PRODUCT DECISION NEEDED** — the *requirement itself* is not yet fixed. Product needs to clarify what behavior they want. Includes: capability scope (V1 vs V2), policy choices (cooldowns, caps, thresholds), trade-offs that affect user-visible behavior, partner-driven decisions.
+- **[SC-DESIGN]** — the *requirement is clear* and there are multiple valid implementations of the same behavior. SC team picks during contract design. **Test: "if you accept the requirement, is the user-visible outcome the same regardless of which option SC picks?" If yes → [SC-DESIGN]. If no → ⚠️ PRODUCT.**
+- **[META]** — cross-cutting deliverable, spec confirmation, or out-of-contract scope.
+
+**Common mis-tagging**: anything that affects what users see, what integrators can configure, or what's in V1 scope is **product**, even if it looks technical. Examples that LOOK like SC-design but are actually product:
+- "Per-user vs pooled fee accounting" — different user-visible behaviors → ⚠️ PRODUCT
+- "Max concurrent reward streams = N=?" — policy ceiling → ⚠️ PRODUCT
+- "Whitelist mode: Merkle / mapping / both" — capability decision → ⚠️ PRODUCT
+- "preview() net-of-fee vs gross" — downstream integration contract → ⚠️ PRODUCT
+
+Genuine [SC-DESIGN] examples: rounding direction in convertToAssets, which functions get `nonReentrant`, CREATE2 vs CREATE for clone deployment, event schema field naming, reentrancy guard scope — all cases where the user-visible outcome is identical regardless of choice.
+
+**For Qs with both aspects**: default to ⚠️ PRODUCT (the SC implementation follows once product locks the requirement). Use both tags only when the two aspects are genuinely independent.
+
+**Why this matters**: without consistent lane tagging, the Open Questions page reads as one undifferentiated list. The operator can't quickly see "what does product need to answer this week" vs "what does SC team handle during design". Tag drift turns the catalogue into a wishlist.
+
+**Linking from stories**:
+- Verbose: `**Depends on open Q**: Q4.9 (one-line description).`
+- Simplified: `❓[Q4.9](url)` — hyperlinked to the Open Questions page URL (block-level anchors typically not available; see `references/notion-mcp.md`).
+
+**Lifecycle**:
+- New Q while drafting a story → add to Open Questions in the same edit; link from the story.
+- Q resolved → move to "Resolved" with rationale (Rx-numbered); strip story markers; update counts.
+- Q's candidate shifts → edit Q in place; story bodies usually don't need touching.
+
+**Anti-pattern: inline Q text in a story** — `Depends on open Q: should this be set globally?` (no Q-id, untrackable). Promote to a real Q with an ID; link by ID.
+
+## Numbering & insertion discipline
+
+- IDs are sticky once assigned. Treat like database primary keys.
+- Inserting in the middle: append at end of theme group with next free number. Don't renumber.
+- Splitting one story: keep original ID for the most-canonical result; new stories get fresh appended IDs.
+- Deletion: prefer `(superseded by AX)` over removing — preserves the ID and audit trail. Only delete when a feature drops pre-implementation.
+- Flag your numbering choice inline ("Placed at end of theme group, no renumbering").
+
+## Question maintenance (audit / refine phase)
+
+When the catalogue is past initial extraction and you're refining or auditing it, four patterns recur often enough to need a shared vocabulary: dispositions for questions that shift state (merge / reframe / elevate-to-story / remove / resolve), reframing a question whose threat surface changed because of an upstream decision, layered-concern decomposition for cross-cutting topics, and recognizing questions that should be removed rather than answered. See `references/question-maintenance.md` for the full patterns + worked examples. Read it before doing a refinement pass on an existing catalogue.
+
+**The one rule to remember without opening the reference**: never silently delete a question. Every removal must show up in the coverage-check footer (`Q1.7 elevated to user story I26`, `Q6.2 removed as structurally answered by A5`, etc.). A year later, someone will ask why Q3.3 is missing — the footer must answer them in one line.
+
+## Anti-patterns
+
+- **Category-label titles instead of question titles.** `Fee mechanism` → `How should the performance fee crystallize?`. Apply to both stories ("Pause" → "Pause the wrapper in a partner-side incident") and open Qs.
+- **Unlabeled options in prose.** Any body with 2+ alternatives must label them (a)/(b)/(c) and have the recommendation reference the letter. See "Readability format → Labeling multiple options".
+- **Pros/Cons block with only one bullet on each side.** The trade-off isn't real — drop the block and just recommend.
+- **"Non-user stories" describing what isn't built.** Stories phrased as "feature X is intentionally absent" / "interface Y is not implemented" are scope-documentation, not user stories. Capture out-of-scope items in `# V2 / Deferred` section of Open Questions. Litmus test: if the acceptance hint is "no selector exists for X" with nothing actively built, delete it.
+- **Source-laundering.** Tagging notes-derived assumptions as `PRD`. If you can't cite a section number, it's not `PRD`.
+- **Vague-umbrella titles without sub-points.** "Upgrade the factory" — list the concrete actions A2.1, A2.2, …
+- **"Immutable" / "fixed" claims without enumerated exceptions.** If a contract is "immutable post-deploy", enumerate what *can* change (pause state, integrator params within bounds) and what *cannot* (bytecode, underlying, role topology).
+- **Implementation in the story body.** `_burn(amount)` is a design detail, not a capability.
+- **Mixing personas in one story.** "Admin and integrator can both pause" → split.
+- **Burying ambiguity in prose.** "Probably this is done at harvest time" → make it an open Q with an ID.
+- **Acceptance hints that re-state the story.** Delete and write a real hint.
+- **Treating the catalogue as static.** When a design review answers an open Q, edit affected stories the same day.
+
+## Workflow — drafting fresh from a PRD
+
+1. Read PRD end-to-end first. Don't draft as you read.
+2. Extract every "the system shall" / "users can" / "the admin must" into a flat list.
+3. Cluster by persona, then by theme. 6 themes per persona typical, 12 is too many.
+4. Number within each persona in lifecycle order (deploy → configure → operate → emergency).
+5. For each item, draft Story + acceptance hints + Source. Citations non-negotiable on a first pass.
+6. Pass over: what's missing? Standard categories PRDs forget — key rotation, observability, emergency response, edge cases. Add as `Source: Inferred`.
+7. Comparable-product sweep: what do Morpho / Yearn / Compound / Aave / Synthetix do? Add as `*(research-derived)*`.
+8. Open-questions extraction: every ambiguity, every "decide later" → a Q.
+
+## Workflow — adding stories to an existing catalogue
+
+1. Re-fetch the canonical pages (Simplified + Open Questions). Never draft from memory.
+2. Read open questions in the same pass — many "new" stories are already-flagged ambiguities.
+3. Identify persona + theme; find the right H3 section.
+4. Pick next free ID in that persona.
+5. Draft per the per-story format.
+6. Cross-reference related stories.
+7. New open Q → add to Open Questions in the same edit.
+8. Update counts footer.
+9. Verify sync (phantom + orphan + cross-ref + counts).
+
+## Final review pass — the lightweight default
+
+When the catalogue feels "done" and you want to verify before SC design lock, run the **three-lane filter**. Default review, 30–60 min solo.
+
+### Three lanes
+
+Every finding from any review is routed into exactly one of three lanes:
+
+| Lane | Source of finding | Where it goes | Who decides |
+|---|---|---|---|
+| **1. PRD coverage** | Capability **in PRD** missing/mis-stated in catalogue | Add/fix story directly | You (catalogue operator) |
+| **2. Product decision** | Capability **NOT in PRD** — proposed by research / reviewer / design | Open Q tagged `⚠️ PRODUCT DECISION NEEDED` | Product team |
+| **3. SC technical** | Implementation detail PRD doesn't speak to (ERC-4626 edge cases, accounting, MEV, gas, reentrancy) | Plain open Q | SC team / auditor (during design) |
+
+If a finding doesn't fit any lane → noise → drop it.
+
+### Procedure
+
+1. **Walk PRD section by section.** For each requirement: covered by a story? If not → Lane 1 (add). If wrong → Lane 1 (fix). 15–30 min.
+2. **Walk catalogue story by story.** Does PRD authorize this? If unclear → Lane 2 (open `⚠️ PRODUCT DECISION NEEDED` with candidate, default V2 unless flagged). 15 min.
+3. **Scan open Qs.** Each candidate good enough for SC team to design against, or needs product? Move `⚠️` tags as needed. 10 min.
+4. **Consistency check** (phantom / orphan / cross-ref / counts). 5 min.
+
+**Output**: a tight `⚠️ PRODUCT DECISION NEEDED` list for product + a clean catalogue ready for SC design.
+
+### What you do NOT do
+
+- ❌ Generate "proposed changes" lists with 30+ items. Not in a lane → drop.
+- ❌ Propose PRD edits.
+- ❌ Add stories for capabilities the PRD doesn't authorize. Open a `⚠️` Q instead.
+- ❌ Catalogue-craft polish during review. That's editing, do it separately.
+
+### Persistent artifact — PRD coverage matrix
+
+Lane-1 walkthrough naturally produces a PRD-section → story-IDs mapping. Maintain as a sibling page (or Verbose section in Phase 2). Update every review. On the next review, the matrix is your starting point, not blank slate.
+
+### Deep review — escalation only
+
+The multi-agent persona review (5 personas with named characters) is escalation-only, NOT default. Trigger only when going into high-stakes audit, the product has truly bimodal users, or an incident exposed a class of finding lightweight review missed. Expect ~50 findings of which ~25 are noise. See `references/deep-review-persona-pass.md` for the full procedure.
+
+### Anti-patterns
+
+- **Treating "30 findings" as success.** Output of a good review is a short list of decisions, not a long list of things to think about.
+- **Adding stories before product green-lights.** Catalogue claims authority it doesn't have.
+- **Letting the catalogue become a wishlist.** Stories are commitments to build; wishlist items are open Qs until product approves.
+- **Running deep review as default.** Optimizes for finding things, not for finding decisions.
+
+## Reference example
+
+The LI.FI Programmable Vault Wrapper user stories at https://www.notion.so/35df0ff14ac78180b8f1ca564c424c1a — canonical worked example: 3 personas, ~65 stories, dual-path authority model with sub-points (A2), research-derived stories flagged, every dependency linked to an open Q.

--- a/.claude/skills/creating-user-stories/references/deep-review-persona-pass.md
+++ b/.claude/skills/creating-user-stories/references/deep-review-persona-pass.md
@@ -1,0 +1,72 @@
+# Deep review — multi-agent persona pass (escalation only)
+
+Load this only when escalating beyond the SKILL.md "lightweight three-lane review". The deep review surfaces ~50 findings of which ~10 are real product decisions and ~15 are SC technical questions — the remaining ~25 are noise. Account for the noise tax before running.
+
+## When to escalate
+
+Trigger the deep review only when:
+- The catalogue is going into a high-stakes audit (third-party with substantial engagement).
+- The product has truly bimodal users (e.g. compliance-heavy AND DeFi-native integrators with very different needs).
+- An incident or near-miss revealed a class of finding the lightweight review missed.
+
+Default to the lightweight three-lane review. Most catalogues (~50–80 stories) don't need this.
+
+## Standard persona set (5 agents, run in parallel)
+
+Use named personas (named produces sharper findings than generic "Reviewer #1"). Adapt names to the product domain, keep role coverage:
+
+1. **Integrator** (e.g. "Maya Chen, Head of DeFi Partnerships at a DeFi-native fintech") — runs a product team, ships white-labeled yield products. Reviews integrator + cross-cutting stories.
+2. **Internal admin / product operator** (e.g. "Alex Lee, Earn Product Lead") — runs the protocol day-to-day, holds emergency keys, manages BD pipeline. Reviews admin + scale/crisis/compliance.
+3. **Sophisticated end user** (e.g. "Jordan Park, $500k DeFi power user with Safe wallet") — reads contract source before depositing, skeptical, MEV-aware. Reviews user + trust/exit/MEV.
+4. **Senior SC dev / DeFi expert** (e.g. "Vlad Petrov, ex-Trail-of-Bits") — reads PRD + research notes + comparable-product audits. Reviews technical + audit-readiness.
+5. **PM owning the PRD** (e.g. "Priya Shah, Senior PM") — strict gatekeeper, owns PRD-traceability, fights scope creep. Reviews PRD-coverage matrix + scope departures.
+
+**On agent count**: 5 is the default. Add a 6th adversarial reviewer (hostile auditor, regulator, MEV attacker) only for high-stakes pre-audit. Add a 2nd integrator (compliance-focused) only if the product has truly bimodal integrator types.
+
+## Required agent-prompt structure
+
+Every agent prompt must include:
+- **Persona briefing**: name, role, background, what they care about, what they've been burned by (1–2 paragraphs).
+- **Required reading**: exact URLs / file paths. Don't assume the agent can guess.
+- **Task** with 4–6 explicit categories of finding to look for.
+- **Output format**: numbered list, capped at 10–15 findings, with severity (S1 blocker / S2 high / S3 medium / S4 polish) and cost-to-fix (XS/S/M/L) tags per finding.
+- **Word cap**: 500–900 words depending on agent scope.
+- **High-signal only**: do NOT pad with "this looks good" notes.
+- **Propose, don't apply**: agent recommends actions; does NOT edit the catalogue.
+
+Findings format per agent:
+```
+**Finding-N**: [Category] [SeverityTag] [Cost-tag] — one-sentence description — suggested action
+```
+
+## Consolidation procedure (operator's job)
+
+After all agents return:
+
+1. **Route each finding into the three lanes** (PRD coverage / product decision / SC technical) — same lanes as the lightweight review. Findings that don't fit a lane are noise — drop them.
+2. **Tag consensus signals.** Findings flagged by 2+ agents get a `[consensus]` tag — highest confidence, raise to top.
+3. **Scope-tension report.** Findings that add capability conflicting with findings that remove capability get flagged. Force explicit user decision.
+4. **All findings are proposals**, not auto-applied. Human-in-the-loop accept/dismiss.
+
+## Mandatory consistency check
+
+Run SKILL.md's standard verification (phantom Qs, orphan Qs except `[META]`, cross-reference resolution, ID gaps, counts footer). Clean-or-violations report.
+
+## Meta-review (mandatory final step)
+
+After consolidation, before next review:
+
+1. **Did each agent's findings actually differ?** If two agents found the same things, persona briefings weren't differentiated enough.
+2. **Did the persona set cover all relevant lenses?** Did consolidation reveal a class no agent caught?
+3. **Were the word/finding caps right?** Too low = misses; too high = noise.
+4. **Were consensus signals reliable?** If a triple-consensus finding turned out wrong, prompts may bias toward false agreement.
+5. **What scope-tensions surfaced?** Many conflicts → PRD may be ambiguous, feed back to PM.
+
+Output: short note in operator's review log, NOT inline in the catalogue.
+
+## Anti-patterns
+
+- **Treating deep-review findings count as success.** ~25 of ~50 will be noise. The output of a good review is a short list of decisions you need, not a long list of things to think about.
+- **Letting agents see each other's reports.** Independence is the value. Sequence only if you have a specific consolidation step between (and even then, don't show prior findings).
+- **Skipping the meta-review.** The meta-review is what makes the next review better. Without it, the same blind spots recur.
+- **Running deep review as the default** instead of the lightweight three-lane review. Optimizes for finding things, not for finding decisions.

--- a/.claude/skills/creating-user-stories/references/notion-mcp.md
+++ b/.claude/skills/creating-user-stories/references/notion-mcp.md
@@ -1,0 +1,68 @@
+# Notion MCP edit hygiene
+
+Mechanics for editing Notion pages via the MCP without losing data or generating duplicates. Load this when working with Notion pages; the SKILL.md body assumes you've read it.
+
+## Always re-fetch before non-trivial edits
+
+The Notion pages used by the catalogue are shared workspace artifacts. Humans and other AI sessions may edit them in parallel with your work. State you saw at the start of a session may have changed mid-session.
+
+**Mandatory discipline:**
+1. **Always `notion-fetch` the affected page immediately before any non-trivial edit.** Stale context older than ~5 minutes is risky on a shared doc.
+2. **For large batched edits**: fetch → construct `old_str` values from the just-fetched content → submit immediately. Don't interleave other tool calls between construction and submission.
+3. **After every edit, fetch again to verify.** Don't trust the `{page_id: ...}` response as confirmation.
+
+### Concrete failure modes if you skip the re-fetch
+
+- **Page edited mid-session**: your `old_str` no longer matches because someone reworded a paragraph. Edit fails with "No matches found" — or worse, fuzzy-matches the wrong block.
+- **New blocks added**: new Qs appear that you don't know about; your sync check from a stale fetch flags them as orphans incorrectly.
+- **Stories split or restructured**: e.g. I22 → I22a + I22b. Your `old_str` for the original I22 won't match anything.
+- **Marker chains grow**: a story that had `❓Q4.8` now has `❓Q4.8, Q4.10`. Your update replacing `❓Q4.8` no longer matches.
+
+## The timeout-is-deceptive pattern
+
+`notionhq_client_request_timeout` from `notion-update-page` does **NOT** mean the edit failed. Observed in practice: the request reaches the server, the server processes it (sometimes partially), the response doesn't arrive in time. The page IS modified.
+
+**Always verify with a fetch after a timeout, never blindly retry.** A blind retry can:
+- Succeed twice and create duplicate content (e.g. ❓Q markers appearing twice on each story).
+- Fail with `old_str not found` because the first attempt already changed the content.
+
+**Recovery procedure after timeout**: fetch → diff against intended state → submit corrective edit if needed, with `old_str` constructed from the actual current content.
+
+## Block-anchor deep linking
+
+In Notion, ANY block (paragraph, heading, bullet, callout, …) is anchorable via its block ID. Headings are NOT required. URL format: `https://www.notion.so/<page-id>#<block-id-without-dashes>`. Clicking scrolls to and highlights that block.
+
+### What the MCP can and cannot do (tested 2026-05-12)
+
+**Cannot do programmatically** (verified):
+- `notion-fetch` returns markdown content; block IDs are NOT in the output.
+- `notion-fetch` with `include_discussions: true` only surfaces block-anchored `discussion://` URLs when discussions already exist on the page.
+- `notion-update-page` and `notion-create-pages` return only the page ID, not per-block IDs.
+- `notion-search` with `page_url` returns page-level results, not per-block matches.
+
+**Can do, but with a catch** (verified):
+- Discussion URLs have the form `discussion://pageId/blockId/discussionId`. So `notion-create-comment` on a block + `notion-get-comments` reveals the block's ID via the URL.
+- **Catch**: the MCP has no `notion-delete-comment` or `notion-resolve-comment` tool. Comments persist permanently. Polluting a doc with 30+ visible comments is worse than not having deep links.
+
+### Workflow options for ❓Q-id hyperlinks
+
+Pick one:
+
+**(A) Default — page-level links, no hash.** All ❓ markers point at the Open Questions page URL (no `#<block-id>`). User uses Ctrl+F to jump to the Q. Zero cost. Good enough for most workflows.
+
+**(B) Manual one-time paste — for stable Q lists.** Ask the human owner to right-click each Q block → "Copy link to block" and paste them all once. Capture in a `QX.Y → block-URL` mapping and wire into the simplified page. New Qs require one paste each.
+
+**(C) Comment-harvest hack — only if you control the page and accept pollution.** `notion-create-comment` on each Q block, `notion-get-comments` with `include_all_blocks: true`, parse block IDs from `discussion://` URLs. **Comments persist** — re-evaluate before doing this on shared pages.
+
+### Don't do this
+
+- Don't restructure Open Questions to use H3 headings on the assumption that headings have predictable anchors. They don't — heading anchors are still UUID block IDs.
+- Don't claim the simplified page has deep links when URLs are page-level. Be explicit in the page preamble.
+
+## Editing tips
+
+- Use a single `update_content` call with multiple `content_updates` entries for batched edits — atomic and faster.
+- For inserting between existing blocks, `old_str` should anchor on the preceding block's last line AND the next block's start. `new_str` = same anchors + new content between.
+- Keep `old_str` short enough to be unique but long enough to be unambiguous. ~50–150 chars is usually right.
+- Headers: `###` for stories, `##` for personas. Code spans for function names. `*(italic)*` for research-derived flags.
+- Preserve `**Source**` formatting — downstream tooling greps on it.

--- a/.claude/skills/creating-user-stories/references/phase-2-regeneration.md
+++ b/.claude/skills/creating-user-stories/references/phase-2-regeneration.md
@@ -1,0 +1,77 @@
+# Phase 2 — Regenerating the verbose page from simplified
+
+Load this when the catalogue has stabilised (story IDs settled, "so that..." clauses settled, open Qs mostly resolved or candidate-locked) and you're generating the verbose page for the first time. This runs ONCE per catalogue. SKILL.md defaults to Phase 1; you're entering Phase 2 only when explicitly triggered.
+
+## When to enter Phase 2
+
+Triggers:
+- Catalogue feels stable (most reviewers agree on story shape).
+- Open Qs are mostly resolved or have locked candidate answers.
+- Ready to hand off to SC design / audit.
+
+Do NOT enter Phase 2 during ongoing finalisation. The cost of two-page maintenance during a moving target exceeds the benefit.
+
+## Inputs required
+
+- **Simplified user-stories page** — IDs, titles, "so that..." clauses, persona/theme grouping, ❓Q-id markers.
+- **Open Questions page** — full text of every Q referenced from a story.
+- **PRD** — original product spec, ideally with section numbers.
+- **Design review notes** — meeting notes, async discussion threads.
+- **Research notes** — comparable-product audits, prior-art surveys.
+- **Architectural-decision records** — design discussions that supersede ambiguity ("we decided dual-path authority on date X").
+
+## Step-by-step derivation
+
+For each simplified story `- **A13.** [verb-phrase], so that [why]. ❓[Q4.2](link), [Q4.8](link)`:
+
+1. **Title** — promote the verb-phrase into a title-cased H3 heading. Add `*(research-derived)*` if the story exists because of comparable-product research (not the PRD).
+
+2. **Story** — restate as full "As a [persona], I want to [verb-phrase], so that [why]." sentence. Persona comes from the simplified section header.
+
+3. **Acceptance hints** — generate by reasoning about contract behavior. Pass the "Acceptance-hint quality bar" three-of-six test from SKILL.md.
+   - What function(s) get called? Pick names matching the verb-phrase.
+   - What events emit?
+   - What role checks (`onlyOwner`, `onlyRole(X)`, `msg.sender == address(timelock)`)?
+   - What revert conditions and custom errors?
+   - What invariants hold afterwards?
+   - What's intentionally NOT in scope (and where it lives instead)?
+
+4. **Sub-points (if needed)** — if the story is a "vague umbrella" (gate every X, configure all Y), enumerate sub-items as `A2.1`, `A2.2`, …. Apply the naming-red-flag test.
+
+5. **Source** — cross-check against the PRD using SKILL.md's source-tag table:
+   - PRD body with section number → `**Source**: PRD §X.Y`.
+   - Design-review notes → `**Source**: ⚠️ Suggested by SC team, decision required`.
+   - Your own inference → `**Source**: Inferred`.
+   - Comparable-product audit → `**Source**: Research — [protocol comparison]`.
+   - Don't launder notes-derived stories as `PRD §X.Y`.
+
+6. **Depends on open Q** — copy from the simplified ❓ markers, expand to `**Depends on open Q**: QX.Y (one-line restatement of the Q's title)`. Pull the title from the Open Questions page.
+
+7. **Provisional flag** (if applicable) — if the simplified page marked the story `*(provisional)*`, transcribe as a full **⚠️ Provisional status** section in the verbose story.
+
+8. **Cross-references** — add `(see AX, IY)` pointers wherever the story interacts with another.
+
+## What requires generative judgment (be honest)
+
+- **Acceptance-hint specifics** (exact function names, event signatures, gas estimates, threshold values) — these are NEW design choices made during regeneration, not extractable from the simplified page. **MUST be reviewed by the SC team before the verbose page is treated as authoritative.**
+- **Threat-model framing** for layered controls — re-derive from the open Q's candidate answer.
+- **"Who actually benefits" reframings** — re-derive from the architecture (immutability story + slow-path action list).
+
+## Output review checklist before declaring done
+
+- [ ] Every simplified story has a corresponding verbose entry with the same ID.
+- [ ] Every "so that..." clause matches between simplified and verbose (no drift).
+- [ ] Every `Depends on open Q` references a real Q on Open Questions.
+- [ ] No story is sourced as `PRD §X.Y` without a section reference.
+- [ ] No story is missing acceptance hints.
+- [ ] Sub-points exist for every umbrella-titled story.
+- [ ] "Immutable" / "fixed" claims enumerate exceptions.
+- [ ] Cross-references resolve.
+- [ ] SC team sign-off captured: "acceptance hints reviewed by [name] on [date]".
+
+## Post-Phase-2 alignment
+
+After the verbose page exists, follow the edit-propagation matrix in SKILL.md "Keeping pages in sync":
+- New story or wording change → land on simplified first, then propagate to verbose in the same session.
+- Open Q resolved → strip ❓ from simplified, remove "Depends on open Q" from verbose, move Q to Resolved.
+- Story deleted → remove from both, mark orphaned Qs.

--- a/.claude/skills/creating-user-stories/references/question-maintenance.md
+++ b/.claude/skills/creating-user-stories/references/question-maintenance.md
@@ -1,0 +1,64 @@
+# Question maintenance — lifecycle, reframing, layering, removal
+
+Reference for the question-maintenance patterns that surface when the catalogue is being refined or audited (not when it's first drafted). Read this when the catalogue is past initial extraction and you're cleaning up dispositions, redrafting questions whose threat surface changed, or pruning questions that don't really exist.
+
+## Question lifecycle dispositions
+
+Open questions are not just "open" or "resolved." During catalogue maintenance, a question can shift to one of several dispositions. Each has a specific marker and a coverage-check entry so the trail is recoverable.
+
+| Disposition | Marker on the surviving entry | Coverage-check footnote |
+|---|---|---|
+| **Kept as-is** | (none) | listed in counts |
+| **Merged into another Q** | `*(absorbs former QX.Y)*` on the surviving Q's title | `QA.B *(absorbs QX.Y)*` in counts |
+| **Reframed downstream of another Q** | `*(reframed — downstream of QX.Y)*` on the title; body adds *Threat-model dependency on QX.Y* or *Interactions* paragraph | listed normally; no count change |
+| **Elevated to a user story** | Q removed from catalogue; corresponding story (new or updated) carries the assumption | footer notes: "QX.Y elevated to user story (IZ + updated IW)" |
+| **Removed as structurally answered** | Q removed entirely | footer notes: "QX.Y removed as structurally answered by AZ / QW" |
+| **Resolved** | Move to `# Resolved` section with an `RX` number; preserve the question text + the resolution | footer counts the Resolved section |
+
+**Hard rule**: never silently delete a question. Every removal must show up in the coverage-check footer. The catalogue's auditability depends on this — a year later, someone will ask "why isn't there a Q3.3?" and the footer answers them in one line.
+
+**Coverage-check footer is the audit trail.** It's not just a sanity counter. Keep historical change notes inline (`— Q1.7 and Q3.3 elevated to user stories (I26 + updated I7); Q6.2 removed as structurally answered by A5; Q11.3 merged into Q9.3`). When dispositions accumulate, prune the oldest ones only after the change has been internalized by the team (i.e. after the relevant SC design milestone).
+
+**Resolved section must exist if you reference it.** If any open Q body says "Q4.10 already resolved..." or "R10 locks...", the `# Resolved` section must contain a real entry with that ID. Phantom resolved-refs are the same trust failure as phantom open-Q refs. If a decision is locked via a user story (e.g. U20 "withdrawals always available"), reference the *story*, not a non-existent Resolved Q.
+
+## Reframing a question when upstream decisions change its threat surface
+
+When an earlier decision (often in the same review session) changes what a downstream question is actually asking, don't silently rewrite the question — reframe it explicitly:
+
+1. Add `*(reframed — downstream of QX.Y)*` to the title.
+2. Keep the question itself answerable (don't collapse to "moot"). Reframe the options to match the new threat surface.
+3. Add a *Threat-model dependency on QX.Y* paragraph that explains the dependency: what changed, what residual concerns remain, and what happens if the upstream decision reverts.
+4. The recommendation should note whether the question is still load-bearing or has become defense-in-depth.
+
+Worked example: when Q1.3 candidate (a) virtual-shares is adopted, Q7.5 ("lock period after deposit?") goes from "load-bearing MEV protection" to "defense-in-depth" because the harvest-sandwich vector is mostly closed by the upstream decision. Q7.5 stays open (because Q1.3 isn't locked yet, and there are residual concerns), but the body now opens with the dependency and the recommendation explicitly calls out that the question is "optional, not load-bearing."
+
+The reason to reframe explicitly rather than rewrite silently: future readers need to understand why the question's framing changed. A silent rewrite looks like the question was always shaped that way; an explicit reframing shows the decision trail and lets the reader undo it if the upstream decision reverts.
+
+## Layered-concern decomposition
+
+For cross-cutting topics (compliance, observability, monitoring, fee handling, sandwich protection), questions often confuse readers because the topic spans multiple layers. The fix:
+
+1. **In the *What* section, enumerate the layers** and who enforces at each. A small table helps. Example for sanctions compliance:
+   - Asset issuer (Circle, Tether) — ERC-20 transfer reverts.
+   - Protocol / wrapper — industry norm is to stay neutral.
+   - Aggregator / router — frontend screening.
+   - Integrator — per-instance whitelist.
+2. **Scope the question to one layer.** The decision is *which layer LI.FI plays at*, not whether the concern is handled at all.
+3. **Cross-reference adjacent layers** so the reader understands the question's scope without re-deriving it.
+
+Without layered decomposition, a single question collapses into "should we do compliance?" — un-answerable. With the layers explicit, the question becomes "at which layer do we play?" — a concrete decision.
+
+This pattern shows up most often for: sanctions / blacklisting / compliance, observability and event emission, reward forwarding across infrastructure boundaries, fee accounting at protocol vs asset-issuer level, MEV protection at wrapper vs aggregator vs UI level. When you spot a topic spanning layers, decompose it before answering.
+
+## Common reasons to remove rather than answer a question
+
+A question may look open but actually be already-determined by an earlier decision. Signs:
+
+- The "options" all collapse to the same outcome under existing constraints.
+- The answer is implied by an `A`-story already in the catalogue (e.g. A5 already mandates an on-chain allowlist — a Q asking "where does the allowlist live?" is moot).
+- The decision is *operational* (which DEXes to support, which tools to use) rather than *architectural* — operational decisions belong in runbooks, not the SC design catalogue.
+- The question is asking about a mechanism, not a requirement, AND a clear requirement already exists — that's `[SC-DESIGN]`, not `⚠️ PRODUCT`.
+
+When you spot one of these, remove the question and add a footer note explaining the disposition. Don't leave a TBD-recommendation question lingering just because it was originally drafted.
+
+The opposite trap is also worth naming: don't *answer* a question that looks decided by writing a fake recommendation. If you find yourself writing "*Recommendation*: TBD" three times in a row, or if every option in your draft collapses to the same answer, the question itself is the problem — surface it, don't paper over it.


### PR DESCRIPTION
## Summary

- Adds the `creating-user-stories` Claude Code skill — companion to `sc-design-review` ([#1753](https://github.com/lifinance/contracts/pull/1753)). Where sc-design-review consumes a PRD and produces a contract design, this skill produces the intermediate persona-grouped stories + open-questions catalogue that feeds it.
- Encodes patterns surfaced during the Earn Monetization v2 Programmable Vault Wrapper review ([EXSC-282](https://linear.app/lifi-linear/issue/EXSC-282/earn-monetization-v2-custom-vault-wrapper-design-and-estimate)).
- 5 files, 730 lines, no Solidity changes — skill files only under `.claude/skills/creating-user-stories/`.

## What's in the skill

Main `SKILL.md` (449 lines) covers:

- **Two-phase workflow** — Phase 1 Simplified + Open Questions only; Phase 2 generates Verbose once the catalogue stabilises. Avoids maintaining two pages during a moving target.
- **Goran-style readability format** — every story and every open Q reads like a sentence a smart PM/engineer would write to a colleague. Question-as-title, plain sentences, labeled (a)/(b)/(c) options with the recommendation referencing the chosen letter, Pros/Cons only where the trade-off is real.
- **One-action-one-benefit grammar** for stories.
- **Mandatory lane tagging** on every open Q (⚠️ PRODUCT DECISION NEEDED / [SC-DESIGN] / [META]) with a strict criterion: if the user-visible outcome is the same regardless of which option is picked → [SC-DESIGN]; otherwise ⚠️ PRODUCT.
- **Cross-doc alignment is non-negotiable** — phantom ❓Q-refs erode the entire catalogue. Mandatory verification after every edit (phantom / orphan / cross-ref / counts).
- **Coverage-check footer as audit trail** — never silently delete a question; every removal documented so a year later someone reading "why no Q3.3?" gets a one-line answer.
- **Three-lane lightweight final review** (PRD coverage / product decision / SC technical) as the default before SC design lock. Deep multi-persona review reserved for high-stakes audit prep.

Reference files (progressive disclosure):

- `references/question-maintenance.md` (64 lines) — audit-phase patterns: lifecycle dispositions (merge / reframe / elevate-to-story / remove / resolve), reframing when an upstream decision changes a question's threat surface, layered-concern decomposition for cross-cutting topics, and recognizing questions that should be removed rather than answered.
- `references/phase-2-regeneration.md` — when and how to regenerate the Verbose page.
- `references/deep-review-persona-pass.md` — escalation-only deep review.
- `references/notion-mcp.md` — Notion editing mechanics (block anchors, batched edits, parallel-session drift).

## Origin

Skill was developed and battle-tested during the Earn Monetization v2 Programmable Vault Wrapper review:

- Drafted [User Stories](https://www.notion.so/lifi/35ef0ff14ac781a5af61f5818df51142) (3 personas, ~65 stories, dual-path authority model with sub-points, research-derived stories flagged).
- Drafted [Open Questions](https://www.notion.so/lifi/35df0ff14ac7810cb53ed50d17db9d49) catalogue (61 entries across BLOCKS / Nice-to-resolve / Cosmetic / V2-Deferred / SC-DESIGN sections).
- Iteratively refined both based on review comments from Goran (readability), Michał (coverage), and Daniel (substantive review). Every pattern in the skill came from a specific concrete problem in that catalogue.

## Test plan

Skills aren't compile-checked, but worth verifying:

- [ ] Skill triggers when expected — try a prompt like "draft user stories for [a PRD]" or "audit the open questions catalogue" and confirm Claude invokes the skill.
- [ ] Skill does NOT trigger on casual feature lists / one-off Jira tickets.
- [ ] References load on demand — `question-maintenance.md` should be read when refining/auditing, not when drafting from scratch.
- [ ] Spot-check that the skill's recommendations (lane tagging, labeled options, coverage footer) match how the [Programmable Vault Wrapper User Stories](https://www.notion.so/lifi/35ef0ff14ac781a5af61f5818df51142) and [Open Questions](https://www.notion.so/lifi/35df0ff14ac7810cb53ed50d17db9d49) actually look in Notion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)