### PR TITLE
chore: add creating-user-stories skill

### DIFF
--- a/.claude/skills/creating-user-stories/SKILL.md
+++ b/.claude/skills/creating-user-stories/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: creating-user-stories
+description: Use when drafting, maintaining, refining, or auditing a structured user-stories catalogue from a product spec + design-review notes + open-questions list. Outputs persona-grouped stories with explicit linkage to unresolved open questions, in a readable format suited for product, engineering, and audit review alike. Trigger on "write user stories for", "draft stories from this spec", "expand the user stories", "add a story for X", "audit the catalogue", "clean up the open questions", "refine the stories", or any request to produce or maintain a stories catalogue. Use this skill whenever the user is working on a structured stories catalogue or its companion open-questions page, even if they don't say "user story" explicitly. Skip for casual feature lists or one-off ticket descriptions.
+---
+
+# Creating User Stories
+
+## When to use
+
+A **structured, auditable user-stories catalogue** — the kind that feeds a design doc, audit scope, or estimate. Not for one-off tickets or casual feature lists.
+
+**Inputs**: product spec / PRD, design-review or meeting notes, open-questions list (or create one in parallel), optional comparable-product research.
+
+**Output**: two pages — a **Stories** page and a companion **Open Questions** page. One readable format per page.
+
+## Core principles
+
+1. **One story = one discrete capability.** No "AND" in titles or action clauses. See "One-action-one-benefit grammar".
+2. **Surface unknowns, don't hide them.** A story shape that depends on an unresolved decision → mark with `❓Q-id`. Never invent an answer.
+3. **Research-derived stories** are flagged `*(research-derived)*` in the title to distinguish from spec-derived stories.
+4. **Stable IDs.** Once assigned, never renumber. Append new stories at the end of their theme group with the next free number.
+5. **Cross-doc alignment is non-negotiable.** Every `❓Q-id` must resolve to a real Q. Phantom Q references erode trust. See "Keeping pages in sync".
+6. **Spec is owned by product.** The catalogue surfaces tensions as questions; it never proposes spec edits. See "Spec ownership rule".
+7. **Human-readable framing wins.** Every story and every open Q must read like a sentence a smart colleague would write to another smart colleague — not a wall of jargon. See "Readability format" below.
+
+## Readability format
+
+The catalogue is read by product managers, engineers, auditors, and ops. None of them tolerate dense jargon. Apply these rules to **every story body and every open-question body**:
+
+### Phrasing
+
+- **Titles are the actual question or capability**, not category labels. ✓ *"What's the maximum allowed concurrent stream count?"* — ✗ *"Stream count cap"*.
+- **One plain sentence per idea.** If a sentence has 3 clauses joined by commas/semicolons, split it.
+- **Lead with the decision, not the mechanism.** Reader-facing body asks "what should the system do?", not "how does the implementation work?". Implementation belongs in the technical lane, not the story body.
+- **Drop filler.** Phrases like "It should be noted that…", "In order to…", "Different trade-offs exist…" — strip. Say the thing.
+
+### Labeling multiple options
+
+**Hard rule**: whenever a body presents 2+ discrete options (alternative behaviors, alternative mechanisms, alternative scopes), label them **(a)**, **(b)**, **(c)**, … and have the *Recommendation* explicitly reference the chosen letter.
+
+```
+*What*: **(a)** open to all, **(b)** invite-only, or **(c)** approval-gated.
+*Recommendation*: **(a)** — lowest friction for first-time users.
+```
+
+Reasons:
+1. The reader can scan options in one pass.
+2. The recommendation is unambiguous — no "the second one" or "invite-only"-style indirection that forces re-reading.
+3. Sub-questions can reference the letter: "If (b) is chosen, who issues invites?"
+
+When sub-options nest under one parent, use roman numerals to disambiguate:
+```
+*Sub-questions if (b)*: (i) who issues invites? (ii) how do invitees redeem? (iii) expiry policy?
+```
+
+**When NOT to label**: single-recommendation bodies, TBD entries with no enumerated choices, one-liners. If you find yourself writing "(a)" alone without a sibling, drop the label.
+
+### Pros / Cons
+
+Add a *Pros* / *Cons* block **only when the trade-off is real and a product owner needs to weigh it**. If you find yourself listing only one Pro or one Con, the trade-off isn't real — delete the section and just recommend.
+
+## Structure
+
+### Persona grouping (H2)
+
+Group stories by who wants the capability. Typical persona shapes for an internal-platform team:
+
+- `## As an [Org] admin, I want to...` — IDs start with `A`
+- `## As an integrator, I want to...` — IDs start with `I`
+- `## As an end user, I want to...` — IDs start with `U`
+
+Adapt to your domain (operator / viewer / partner / regulator / curator) but keep persona separation. One story does not span multiple personas — if you find one that does, split it.
+
+### Theme sub-grouping (H3)
+
+Within each persona, group stories by theme. Themes vary by product. Common shapes: lifecycle (deploy → configure → operate → decommission), permissioning, pricing or economics, safety and pause, observability, integrations, compliance. 6 themes per persona is typical; more than 10 usually means you should split a theme.
+
+### Per-story format
+
+```
+- **A1.** [verb-lowercase] [object], so that [why]. ❓[Q4.5](link), [Q9.1](link)
+```
+
+The persona phrase ("As a ...") is in the H2 heading, not repeated per story. One sentence each. No acceptance hints, no implementation detail — those belong in the design doc that consumes this catalogue, not in the story.
+
+Variants:
+- **Sub-points** (A2.1, A2.2 …) when a story is an umbrella that fans out to several concrete sub-actions. List each sub-action.
+- **Cross-references**: `(see A16)`, `(mirrors I18)` for adjacent-lifecycle stories — see below.
+
+## One-action-one-benefit grammar
+
+A user story has exactly two semantic slots: `[verb] [object], so that [benefit]`. Strict rule: **one action, one benefit, no compound verbs in the action clause.**
+
+### Fix patterns
+
+| Smell | Fix |
+|---|---|
+| `update price AND emit event, so that…` | Drop the mechanism: `update price within bounds, so that I can react to market.` Events are implementation. |
+| `pause writes AND reads, so that…` | Either split into two stories OR one composite: `pause the instance, so that…` |
+| `do X so that things keep working` | Sharpen the benefit: name the persona-specific stake, not generic "system works". |
+
+### Acceptable "and"
+
+`run end-of-day close, so that the day's transactions are crystallized AND the next-day balance is initialized.` — "and" connects two *outcomes* of one action. Fine. Compare to `crystallize AND initialize` in the action clause = two buttons, both must be pressed.
+
+### Quality check per sentence
+
+1. One verb in the action clause? (`trigger X` / `configure Y` = single verb-object, OK.)
+2. The "so that" names a persona-specific stake, not generic "system works"?
+3. If "and" appears, is it joining outcomes (downstream of one action), not parallel actions?
+4. Reader at risk of conflating with an adjacent-lifecycle story? Add a `(see IX)`.
+
+## Cross-referencing adjacent-lifecycle stories
+
+Two stories on the same concept at different lifecycle stages can be confused by a reader. Always cross-link with `(see IX)`.
+
+Examples of pairings worth cross-linking:
+- Configure-time vs runtime (set up an admin role vs use the role).
+- Inject vs schedule vs distribute vs cancel (for any flow with multiple temporal states).
+- Different pause variants — emergency, scheduled, partial.
+
+**Bidirectional** — if A→B is worth linking, B→A usually is. Verify on every edit.
+
+## Spec ownership rule
+
+The product spec is owned by the product team, NOT by the catalogue author. The catalogue's job:
+
+1. **Surface tensions** when stories drift from the spec or need to add capabilities the spec doesn't authorize.
+2. **Flag tensions as questions for product**, tagged `⚠️ PRODUCT DECISION NEEDED`.
+3. **Never edit the spec.** That's a product-team action.
+
+Anti-pattern: writing "Recommend spec-amend §X.Y to authorize …". The catalogue's role is to *surface the question*, not to *prescribe the answer*.
+
+### Phrasing template for product-decision Qs
+
+Follow the readability format (title is the actual question; options labeled; recommendation references a letter). Two flavors depending on whether there's a real trade-off:
+
+**Standard (most Qs)**:
+```
+**QX.Y — [The actual decision question]**
+*What*: [one-sentence context]. **(a)** ..., **(b)** ..., **(c)** ...
+*Recommendation*: **(b)** — [rationale in plain English].
+```
+
+**With trade-off (only when a product owner must weigh options)**:
+```
+**QX.Y — [The actual decision question]**
+*What*: [one-sentence context describing the capability and why it's debatable].
+*Pros*:
+- [specific upside]
+- [specific upside]
+*Cons*:
+- [specific downside]
+- [specific downside]
+*Recommendation*: **[defer / accept / specific option]** — [rationale].
+```
+
+Note: the lane tag (⚠️ PRODUCT DECISION NEEDED / [TECH] / [META]) sits on the **section header**, not in every question title — see "Open-question linkage".
+
+**Anti-patterns**:
+- Title as a category label (`Pricing mechanism`) instead of a question (`How should pricing be tiered?`).
+- Options listed in prose without (a)/(b) labels.
+- Recommendation that doesn't reference one of the labeled options.
+- Pros/Cons with only one bullet on each side — the trade-off isn't real, just recommend.
+
+## Surfacing implicit properties
+
+Some user-visible properties fall out "for free" from the architecture and have no explicit story. Readers ask about them first because they're invisible.
+
+**Litmus test**: when reviewing the catalogue, ask "what questions would a first-time reader have here that the catalogue doesn't answer because the answer is architectural?" If the answer is yes, write the implicit-property story and cross-reference where the property comes from.
+
+## The "naming a story" red flag
+
+If a story title contains a noun that could mean many things (`"manage the allowlist"`, `"handle errors"`), it's too vague. Either:
+- (a) Split into multiple concrete stories, or
+- (b) Keep the umbrella but enumerate sub-actions A2.1, A2.2, …
+
+Rule of thumb: if a reader can ask "which actions exactly?", you must list them. Most common failure mode in spec-derived stories — the spec says "the system is configurable" and the story inherits the vagueness.
+
+## Keeping pages in sync
+
+The catalogue lives across 2 pages: a Stories page and an Open Questions page. **A story edit touches every page the change affects, in the same session.** Stale cross-references erode the entire catalogue.
+
+### Edit-propagation matrix
+
+| Change | Stories page | Open Questions page |
+|---|---|---|
+| New story added | ✓ one-line entry | ✓ add any new Qs the story references |
+| Story re-titled / "so that" reframed | ✓ | — |
+| Open Q resolved | ✓ remove ❓ marker | ✓ move to "Resolved" section |
+| New open Q surfaced | ✓ add `❓[QX.Y](link)` | ✓ add Q with candidate |
+| Story deleted | ✓ remove | ✓ resolve orphaned Qs |
+| Story renumbered | NEVER | — |
+
+### Mandatory verification after every edit
+
+- Every `❓Q*.*` in Stories resolves to a real Q on Open Questions (no phantom references).
+- Every Q on Open Questions is referenced by ≥1 story OR explicitly tagged `[META]` (see below).
+- Every `(see IX)` cross-reference resolves to a real story.
+- Open Questions counts footer reflects current state.
+
+How to verify practically: fetch both pages, extract `Q*.*` markers from Stories, extract real Q-ids from Open Questions, diff both directions. Same for `(see *)` against story IDs.
+
+**Phantom Qs are the quickest path to "nobody trusts this doc anymore". Treat verification as ship-blocking.**
+
+### Meta / cross-cutting Qs (excluded from orphan check)
+
+Some Qs legitimately don't map to a single story:
+- Catalogue-level deliverables ("produce an access-control matrix").
+- Spec-level confirmations ("confirm V1 has no external dependencies").
+- Out-of-scope concerns (legal, compliance, ownership questions).
+- Refinements of other Qs.
+
+Tag these `[META]` in the title:
+```
+**Q4.6 [META] — Access-control matrix**
+```
+
+Sync check ignores `[META]`-tagged Qs. **When in doubt, link to a story** — `[META]` is a last resort.
+
+### Notion editing mechanics
+
+For block-anchor links, parallel-session drift, batched edits — see `references/notion-mcp.md`. Loading that doc is mandatory before any non-trivial Notion edit.
+
+### Anti-pattern: "I'll fix the other page next"
+
+Don't. Half-synced edits accumulate; eventually nothing is trusted. If you can't update all affected pages in one session, don't ship the change.
+
+## Open-question linkage
+
+Open questions live on their own dedicated page, never inline in stories. Stories reference Qs by ID only.
+
+**Open Questions page structure**:
+- **Top-level sections** (priority axis): `# BLOCKS [design-name]` / `# Nice-to-resolve` / `# Cosmetic` / `# Deferred` / `# Resolved`.
+- **Lane sub-sections** within BLOCKS (audience axis): `## ⚠️ Product decisions needed` / `## [TECH] technical questions` / `## [META] cross-cutting`. Within each lane, group by theme.
+- **Each Q**: `**QX.Y — Title**` + prose description + optional `*Recommendation*: ...`. The lane tag sits on the section header — no need to repeat the tag in every title.
+- **Counts footer**: tally per top-level section. Update on every add/resolve. Also acts as the audit trail when questions move dispositions (merged, removed, elevated to a story) — see `references/question-maintenance.md`.
+- **Q-ID numbering**: stable per theme (Q1.x = one theme, Q2.x = another). Don't renumber.
+
+### Mandatory lane tagging — every Q must signal its audience
+
+**Hard rule**: every open question must sit in exactly one lane — `⚠️ PRODUCT DECISION NEEDED`, `[TECH]`, or `[META]`. Untagged Qs (or questions in the wrong lane) are sync failures.
+
+Lane assignment — **strict criterion**:
+
+- **⚠️ PRODUCT DECISION NEEDED** — the *requirement itself* is not yet fixed. Product needs to clarify what behavior they want. Includes: capability scope (V1 vs V2), policy choices, trade-offs that affect user-visible behavior, partner-driven decisions.
+- **[TECH]** — the *requirement is clear* and there are multiple valid implementations of the same behavior. Tech team picks during implementation. **Test: "if you accept the requirement, is the user-visible outcome the same regardless of which option tech picks?" If yes → [TECH]. If no → ⚠️ PRODUCT.**
+- **[META]** — cross-cutting deliverable, spec confirmation, or out-of-scope.
+
+**Common mis-tagging**: anything that affects what users see, what integrators can configure, or what's in V1 scope is **product**, even if it looks technical. The product/tech distinction is about *what's already decided*, not *who will work on it*.
+
+**For Qs with both aspects**: default to ⚠️ PRODUCT (the technical implementation follows once product locks the requirement). Use both tags only when the two aspects are genuinely independent.
+
+**Why this matters**: without consistent lane tagging, the Open Questions page reads as one undifferentiated list. The operator can't quickly see "what does product need to answer this week" vs "what does tech team handle during implementation". Tag drift turns the catalogue into a wishlist.
+
+**Linking from stories**: `❓[Q4.9](url)` — hyperlinked to the Open Questions page URL.
+
+**Lifecycle**:
+- New Q while drafting a story → add to Open Questions in the same edit; link from the story.
+- Q resolved → move to "Resolved" with rationale (Rx-numbered); strip story markers; update counts.
+- Q's candidate shifts → edit Q in place; story bodies usually don't need touching.
+
+**Anti-pattern: inline Q text in a story** — `Depends on open Q: should this be set globally?` (no Q-id, untrackable). Promote to a real Q with an ID; link by ID.
+
+## Numbering & insertion discipline
+
+- IDs are sticky once assigned. Treat like database primary keys.
+- Inserting in the middle: append at end of theme group with next free number. Don't renumber.
+- Splitting one story: keep original ID for the most-canonical result; new stories get fresh appended IDs.
+- Deletion: prefer `(superseded by AX)` over removing — preserves the ID and audit trail. Only delete when a feature drops pre-implementation.
+- Flag your numbering choice inline ("Placed at end of theme group, no renumbering").
+
+## Question maintenance (audit / refine phase)
+
+When the catalogue is past initial extraction and you're refining or auditing it, four patterns recur often enough to need a shared vocabulary: dispositions for questions that shift state (merge / reframe / elevate-to-story / remove / resolve), reframing a question whose context changed because of an upstream decision, layered-concern decomposition for cross-cutting topics, and recognizing questions that should be removed rather than answered. See `references/question-maintenance.md` for the full patterns + worked examples. Read it before doing a refinement pass on an existing catalogue.
+
+**The one rule to remember without opening the reference**: never silently delete a question. Every removal must show up in the counts footer (`Q1.7 elevated to user story I26`, `Q6.2 removed as structurally answered by A5`, etc.). A year later, someone will ask why Q3.3 is missing — the footer must answer them in one line.
+
+## Anti-patterns
+
+- **Category-label titles instead of question titles.** `Pricing` → `How should tier boundaries be calculated?`. Apply to both stories and open Qs.
+- **Unlabeled options in prose.** Any body with 2+ alternatives must label them (a)/(b)/(c) and have the recommendation reference the letter.
+- **Pros/Cons block with only one bullet on each side.** The trade-off isn't real — drop the block and just recommend.
+- **"Non-user stories" describing what isn't built.** Stories phrased as "feature X is intentionally absent" / "interface Y is not implemented" are scope-documentation, not user stories. Capture out-of-scope items in the Deferred section of Open Questions.
+- **Vague-umbrella titles without sub-points.** "Upgrade the system" — list the concrete actions A2.1, A2.2, …
+- **Implementation detail in the story body.** Specific function names, code patterns, exact event payloads — these belong in the design doc that consumes the catalogue, not the user story.
+- **Mixing personas in one story.** "Admin and integrator can both pause" → split.
+- **Burying ambiguity in prose.** "Probably this is done at flush time" → make it an open Q with an ID.
+- **Treating the catalogue as static.** When a design review answers an open Q, edit affected stories the same day.
+
+## Workflow — drafting fresh from a spec
+
+1. Read the spec end-to-end first. Don't draft as you read.
+2. Extract every "the system shall" / "users can" / "the admin must" into a flat list.
+3. Cluster by persona, then by theme. 6 themes per persona typical, 12 is too many.
+4. Number within each persona in lifecycle order (deploy → configure → operate → emergency).
+5. For each item, draft the one-line story.
+6. Pass over: what's missing? Standard categories specs forget — key rotation, observability, emergency response, edge cases. Add them.
+7. Comparable-product sweep: what do analogous products in the space do? Add as `*(research-derived)*`.
+8. Open-questions extraction: every ambiguity, every "decide later" → a Q.
+
+## Workflow — adding stories to an existing catalogue
+
+1. Re-fetch the canonical pages (Stories + Open Questions). Never draft from memory.
+2. Read open questions in the same pass — many "new" stories are already-flagged ambiguities.
+3. Identify persona + theme; find the right H3 section.
+4. Pick next free ID in that persona.
+5. Draft per the per-story format.
+6. Cross-reference related stories.
+7. New open Q → add to Open Questions in the same edit.
+8. Update counts footer.
+9. Verify sync (phantom + orphan + cross-ref + counts).
+
+## Final review pass — the lightweight default
+
+When the catalogue feels "done" and you want to verify before locking it for downstream design work, run the **three-lane filter**. Default review, 30–60 min solo.
+
+### Three lanes
+
+Every finding from any review is routed into exactly one of three lanes:
+
+| Lane | Source of finding | Where it goes | Who decides |
+|---|---|---|---|
+| **1. Spec coverage** | Capability **in spec** missing/mis-stated in catalogue | Add/fix story directly | You (catalogue operator) |
+| **2. Product decision** | Capability **NOT in spec** — proposed by research / reviewer / design | Open Q tagged `⚠️ PRODUCT DECISION NEEDED` | Product team |
+| **3. Tech implementation** | Implementation detail spec doesn't speak to | Plain open Q tagged `[TECH]` | Tech team / reviewer (during design) |
+
+If a finding doesn't fit any lane → noise → drop it.
+
+### Procedure
+
+1. **Walk spec section by section.** For each requirement: covered by a story? If not → Lane 1 (add). If wrong → Lane 1 (fix). 15–30 min.
+2. **Walk catalogue story by story.** Does spec authorize this? If unclear → Lane 2 (open `⚠️ PRODUCT DECISION NEEDED` with candidate, default V2 unless flagged). 15 min.
+3. **Scan open Qs.** Each candidate good enough for tech team to design against, or needs product? Move `⚠️` tags as needed. 10 min.
+4. **Consistency check** (phantom / orphan / cross-ref / counts). 5 min.
+
+**Output**: a tight `⚠️ PRODUCT DECISION NEEDED` list for product + a clean catalogue ready for design.
+
+### What you do NOT do
+
+- ❌ Generate "proposed changes" lists with 30+ items. Not in a lane → drop.
+- ❌ Propose spec edits.
+- ❌ Add stories for capabilities the spec doesn't authorize. Open a `⚠️` Q instead.
+- ❌ Catalogue-craft polish during review. That's editing, do it separately.
+
+### Persistent artifact — spec coverage matrix
+
+Lane-1 walkthrough naturally produces a spec-section → story-IDs mapping. Maintain as a sibling page. Update every review. On the next review, the matrix is your starting point, not a blank slate.
+
+### Deep review — escalation only
+
+A multi-agent persona review (with named senior reviewer personas) is escalation-only, NOT default. Trigger only when going into high-stakes review, the product has truly bimodal users, or an incident exposed a class of finding lightweight review missed. Expect ~50 findings of which ~25 are noise. See `references/deep-review-persona-pass.md` for the procedure — note that the reference's specific persona set is calibrated for smart-contract review and should be re-cast for your domain if different.
+
+### Anti-patterns
+
+- **Treating "30 findings" as success.** Output of a good review is a short list of decisions, not a long list of things to think about.
+- **Adding stories before product green-lights.** Catalogue claims authority it doesn't have.
+- **Letting the catalogue become a wishlist.** Stories are commitments to build; wishlist items are open Qs until product approves.
+- **Running deep review as default.** Optimizes for finding things, not for finding decisions.

--- a/.claude/skills/creating-user-stories/references/deep-review-persona-pass.md
+++ b/.claude/skills/creating-user-stories/references/deep-review-persona-pass.md
@@ -1,0 +1,72 @@
+# Deep review — multi-agent persona pass (escalation only)
+
+Load this only when escalating beyond the SKILL.md "lightweight three-lane review". The deep review surfaces ~50 findings of which ~10 are real product decisions and ~15 are SC technical questions — the remaining ~25 are noise. Account for the noise tax before running.
+
+## When to escalate
+
+Trigger the deep review only when:
+- The catalogue is going into a high-stakes audit (third-party with substantial engagement).
+- The product has truly bimodal users (e.g. compliance-heavy AND DeFi-native integrators with very different needs).
+- An incident or near-miss revealed a class of finding the lightweight review missed.
+
+Default to the lightweight three-lane review. Most catalogues (~50–80 stories) don't need this.
+
+## Standard persona set (5 agents, run in parallel)
+
+Use named personas (named produces sharper findings than generic "Reviewer #1"). Adapt names to the product domain, keep role coverage:
+
+1. **Integrator** (e.g. "Maya Chen, Head of DeFi Partnerships at a DeFi-native fintech") — runs a product team, ships white-labeled yield products. Reviews integrator + cross-cutting stories.
+2. **Internal admin / product operator** (e.g. "Alex Lee, Earn Product Lead") — runs the protocol day-to-day, holds emergency keys, manages BD pipeline. Reviews admin + scale/crisis/compliance.
+3. **Sophisticated end user** (e.g. "Jordan Park, $500k DeFi power user with Safe wallet") — reads contract source before depositing, skeptical, MEV-aware. Reviews user + trust/exit/MEV.
+4. **Senior SC dev / DeFi expert** (e.g. "Vlad Petrov, ex-Trail-of-Bits") — reads PRD + research notes + comparable-product audits. Reviews technical + audit-readiness.
+5. **PM owning the PRD** (e.g. "Priya Shah, Senior PM") — strict gatekeeper, owns PRD-traceability, fights scope creep. Reviews PRD-coverage matrix + scope departures.
+
+**On agent count**: 5 is the default. Add a 6th adversarial reviewer (hostile auditor, regulator, MEV attacker) only for high-stakes pre-audit. Add a 2nd integrator (compliance-focused) only if the product has truly bimodal integrator types.
+
+## Required agent-prompt structure
+
+Every agent prompt must include:
+- **Persona briefing**: name, role, background, what they care about, what they've been burned by (1–2 paragraphs).
+- **Required reading**: exact URLs / file paths. Don't assume the agent can guess.
+- **Task** with 4–6 explicit categories of finding to look for.
+- **Output format**: numbered list, capped at 10–15 findings, with severity (S1 blocker / S2 high / S3 medium / S4 polish) and cost-to-fix (XS/S/M/L) tags per finding.
+- **Word cap**: 500–900 words depending on agent scope.
+- **High-signal only**: do NOT pad with "this looks good" notes.
+- **Propose, don't apply**: agent recommends actions; does NOT edit the catalogue.
+
+Findings format per agent:
+```
+**Finding-N**: [Category] [SeverityTag] [Cost-tag] — one-sentence description — suggested action
+```
+
+## Consolidation procedure (operator's job)
+
+After all agents return:
+
+1. **Route each finding into the three lanes** (PRD coverage / product decision / SC technical) — same lanes as the lightweight review. Findings that don't fit a lane are noise — drop them.
+2. **Tag consensus signals.** Findings flagged by 2+ agents get a `[consensus]` tag — highest confidence, raise to top.
+3. **Scope-tension report.** Findings that add capability conflicting with findings that remove capability get flagged. Force explicit user decision.
+4. **All findings are proposals**, not auto-applied. Human-in-the-loop accept/dismiss.
+
+## Mandatory consistency check
+
+Run SKILL.md's standard verification (phantom Qs, orphan Qs except `[META]`, cross-reference resolution, ID gaps, counts footer). Clean-or-violations report.
+
+## Meta-review (mandatory final step)
+
+After consolidation, before next review:
+
+1. **Did each agent's findings actually differ?** If two agents found the same things, persona briefings weren't differentiated enough.
+2. **Did the persona set cover all relevant lenses?** Did consolidation reveal a class no agent caught?
+3. **Were the word/finding caps right?** Too low = misses; too high = noise.
+4. **Were consensus signals reliable?** If a triple-consensus finding turned out wrong, prompts may bias toward false agreement.
+5. **What scope-tensions surfaced?** Many conflicts → PRD may be ambiguous, feed back to PM.
+
+Output: short note in operator's review log, NOT inline in the catalogue.
+
+## Anti-patterns
+
+- **Treating deep-review findings count as success.** ~25 of ~50 will be noise. The output of a good review is a short list of decisions you need, not a long list of things to think about.
+- **Letting agents see each other's reports.** Independence is the value. Sequence only if you have a specific consolidation step between (and even then, don't show prior findings).
+- **Skipping the meta-review.** The meta-review is what makes the next review better. Without it, the same blind spots recur.
+- **Running deep review as the default** instead of the lightweight three-lane review. Optimizes for finding things, not for finding decisions.

--- a/.claude/skills/creating-user-stories/references/notion-mcp.md
+++ b/.claude/skills/creating-user-stories/references/notion-mcp.md
@@ -1,0 +1,68 @@
+# Notion MCP edit hygiene
+
+Mechanics for editing Notion pages via the MCP without losing data or generating duplicates. Load this when working with Notion pages; the SKILL.md body assumes you've read it.
+
+## Always re-fetch before non-trivial edits
+
+The Notion pages used by the catalogue are shared workspace artifacts. Humans and other AI sessions may edit them in parallel with your work. State you saw at the start of a session may have changed mid-session.
+
+**Mandatory discipline:**
+1. **Always `notion-fetch` the affected page immediately before any non-trivial edit.** Stale context older than ~5 minutes is risky on a shared doc.
+2. **For large batched edits**: fetch → construct `old_str` values from the just-fetched content → submit immediately. Don't interleave other tool calls between construction and submission.
+3. **After every edit, fetch again to verify.** Don't trust the `{page_id: ...}` response as confirmation.
+
+### Concrete failure modes if you skip the re-fetch
+
+- **Page edited mid-session**: your `old_str` no longer matches because someone reworded a paragraph. Edit fails with "No matches found" — or worse, fuzzy-matches the wrong block.
+- **New blocks added**: new Qs appear that you don't know about; your sync check from a stale fetch flags them as orphans incorrectly.
+- **Stories split or restructured**: e.g. I22 → I22a + I22b. Your `old_str` for the original I22 won't match anything.
+- **Marker chains grow**: a story that had `❓Q4.8` now has `❓Q4.8, Q4.10`. Your update replacing `❓Q4.8` no longer matches.
+
+## The timeout-is-deceptive pattern
+
+`notionhq_client_request_timeout` from `notion-update-page` does **NOT** mean the edit failed. Observed in practice: the request reaches the server, the server processes it (sometimes partially), the response doesn't arrive in time. The page IS modified.
+
+**Always verify with a fetch after a timeout, never blindly retry.** A blind retry can:
+- Succeed twice and create duplicate content (e.g. ❓Q markers appearing twice on each story).
+- Fail with `old_str not found` because the first attempt already changed the content.
+
+**Recovery procedure after timeout**: fetch → diff against intended state → submit corrective edit if needed, with `old_str` constructed from the actual current content.
+
+## Block-anchor deep linking
+
+In Notion, ANY block (paragraph, heading, bullet, callout, …) is anchorable via its block ID. Headings are NOT required. URL format: `https://www.notion.so/<page-id>#<block-id-without-dashes>`. Clicking scrolls to and highlights that block.
+
+### What the MCP can and cannot do (tested 2026-05-12)
+
+**Cannot do programmatically** (verified):
+- `notion-fetch` returns markdown content; block IDs are NOT in the output.
+- `notion-fetch` with `include_discussions: true` only surfaces block-anchored `discussion://` URLs when discussions already exist on the page.
+- `notion-update-page` and `notion-create-pages` return only the page ID, not per-block IDs.
+- `notion-search` with `page_url` returns page-level results, not per-block matches.
+
+**Can do, but with a catch** (verified):
+- Discussion URLs have the form `discussion://pageId/blockId/discussionId`. So `notion-create-comment` on a block + `notion-get-comments` reveals the block's ID via the URL.
+- **Catch**: the MCP has no `notion-delete-comment` or `notion-resolve-comment` tool. Comments persist permanently. Polluting a doc with 30+ visible comments is worse than not having deep links.
+
+### Workflow options for ❓Q-id hyperlinks
+
+Pick one:
+
+**(A) Default — page-level links, no hash.** All ❓ markers point at the Open Questions page URL (no `#<block-id>`). User uses Ctrl+F to jump to the Q. Zero cost. Good enough for most workflows.
+
+**(B) Manual one-time paste — for stable Q lists.** Ask the human owner to right-click each Q block → "Copy link to block" and paste them all once. Capture in a `QX.Y → block-URL` mapping and wire into the simplified page. New Qs require one paste each.
+
+**(C) Comment-harvest hack — only if you control the page and accept pollution.** `notion-create-comment` on each Q block, `notion-get-comments` with `include_all_blocks: true`, parse block IDs from `discussion://` URLs. **Comments persist** — re-evaluate before doing this on shared pages.
+
+### Don't do this
+
+- Don't restructure Open Questions to use H3 headings on the assumption that headings have predictable anchors. They don't — heading anchors are still UUID block IDs.
+- Don't claim the simplified page has deep links when URLs are page-level. Be explicit in the page preamble.
+
+## Editing tips
+
+- Use a single `update_content` call with multiple `content_updates` entries for batched edits — atomic and faster.
+- For inserting between existing blocks, `old_str` should anchor on the preceding block's last line AND the next block's start. `new_str` = same anchors + new content between.
+- Keep `old_str` short enough to be unique but long enough to be unambiguous. ~50–150 chars is usually right.
+- Headers: `###` for stories, `##` for personas. Code spans for function names. `*(italic)*` for research-derived flags.
+- Preserve `**Source**` formatting — downstream tooling greps on it.

--- a/.claude/skills/creating-user-stories/references/question-maintenance.md
+++ b/.claude/skills/creating-user-stories/references/question-maintenance.md
@@ -1,0 +1,64 @@
+# Question maintenance — lifecycle, reframing, layering, removal
+
+Reference for the question-maintenance patterns that surface when the catalogue is being refined or audited (not when it's first drafted). Read this when the catalogue is past initial extraction and you're cleaning up dispositions, redrafting questions whose threat surface changed, or pruning questions that don't really exist.
+
+## Question lifecycle dispositions
+
+Open questions are not just "open" or "resolved." During catalogue maintenance, a question can shift to one of several dispositions. Each has a specific marker and a coverage-check entry so the trail is recoverable.
+
+| Disposition | Marker on the surviving entry | Coverage-check footnote |
+|---|---|---|
+| **Kept as-is** | (none) | listed in counts |
+| **Merged into another Q** | `*(absorbs former QX.Y)*` on the surviving Q's title | `QA.B *(absorbs QX.Y)*` in counts |
+| **Reframed downstream of another Q** | `*(reframed — downstream of QX.Y)*` on the title; body adds *Threat-model dependency on QX.Y* or *Interactions* paragraph | listed normally; no count change |
+| **Elevated to a user story** | Q removed from catalogue; corresponding story (new or updated) carries the assumption | footer notes: "QX.Y elevated to user story (IZ + updated IW)" |
+| **Removed as structurally answered** | Q removed entirely | footer notes: "QX.Y removed as structurally answered by AZ / QW" |
+| **Resolved** | Move to `# Resolved` section with an `RX` number; preserve the question text + the resolution | footer counts the Resolved section |
+
+**Hard rule**: never silently delete a question. Every removal must show up in the coverage-check footer. The catalogue's auditability depends on this — a year later, someone will ask "why isn't there a Q3.3?" and the footer answers them in one line.
+
+**Coverage-check footer is the audit trail.** It's not just a sanity counter. Keep historical change notes inline (`— Q1.7 and Q3.3 elevated to user stories (I26 + updated I7); Q6.2 removed as structurally answered by A5; Q11.3 merged into Q9.3`). When dispositions accumulate, prune the oldest ones only after the change has been internalized by the team (i.e. after the relevant SC design milestone).
+
+**Resolved section must exist if you reference it.** If any open Q body says "Q4.10 already resolved..." or "R10 locks...", the `# Resolved` section must contain a real entry with that ID. Phantom resolved-refs are the same trust failure as phantom open-Q refs. If a decision is locked via a user story (e.g. U20 "withdrawals always available"), reference the *story*, not a non-existent Resolved Q.
+
+## Reframing a question when upstream decisions change its threat surface
+
+When an earlier decision (often in the same review session) changes what a downstream question is actually asking, don't silently rewrite the question — reframe it explicitly:
+
+1. Add `*(reframed — downstream of QX.Y)*` to the title.
+2. Keep the question itself answerable (don't collapse to "moot"). Reframe the options to match the new threat surface.
+3. Add a *Threat-model dependency on QX.Y* paragraph that explains the dependency: what changed, what residual concerns remain, and what happens if the upstream decision reverts.
+4. The recommendation should note whether the question is still load-bearing or has become defense-in-depth.
+
+Worked example shape: when an upstream architectural decision is locked, a downstream protection question often goes from "load-bearing" to "defense-in-depth" because the canonical attack vector is mostly closed by the upstream decision. The downstream question stays open (residual concerns matter), but the body now opens with the dependency and the recommendation explicitly calls out that the question is "optional, not load-bearing." If the upstream decision later reverts, the downstream becomes load-bearing again — the explicit reframing makes that recoverable.
+
+The reason to reframe explicitly rather than rewrite silently: future readers need to understand why the question's framing changed. A silent rewrite looks like the question was always shaped that way; an explicit reframing shows the decision trail and lets the reader undo it if the upstream decision reverts.
+
+## Layered-concern decomposition
+
+For cross-cutting topics (compliance, observability, monitoring, rate limiting, access control), questions often confuse readers because the topic spans multiple layers of the stack. The fix:
+
+1. **In the *What* section, enumerate the layers** and who enforces at each. A small table helps. Generic example for a typical service stack:
+   - Identity provider (Auth0 / Okta / etc.) — enforces who you are.
+   - API gateway / WAF — enforces rate limits, geo restrictions, request shape.
+   - Application — enforces business rules and feature gates.
+   - Data layer — enforces final access control.
+2. **Scope the question to one layer.** The decision is *which layer we play at*, not whether the concern is handled at all.
+3. **Cross-reference adjacent layers** so the reader understands the question's scope without re-deriving it.
+
+Without layered decomposition, a single question collapses into something like "should we do compliance?" — un-answerable. With the layers explicit, the question becomes "at which layer do we play?" — a concrete decision.
+
+This pattern shows up most often for: compliance / blacklisting / sanctions, observability and event emission, rate limiting, access control distributed across layers. When you spot a topic spanning layers, decompose it before answering.
+
+## Common reasons to remove rather than answer a question
+
+A question may look open but actually be already-determined by an earlier decision. Signs:
+
+- The "options" all collapse to the same outcome under existing constraints.
+- The answer is implied by an `A`-story already in the catalogue (e.g. A5 already mandates an on-chain allowlist — a Q asking "where does the allowlist live?" is moot).
+- The decision is *operational* (which DEXes to support, which tools to use) rather than *architectural* — operational decisions belong in runbooks, not the SC design catalogue.
+- The question is asking about a mechanism, not a requirement, AND a clear requirement already exists — that's `[SC-DESIGN]`, not `⚠️ PRODUCT`.
+
+When you spot one of these, remove the question and add a footer note explaining the disposition. Don't leave a TBD-recommendation question lingering just because it was originally drafted.
+
+The opposite trap is also worth naming: don't *answer* a question that looks decided by writing a fake recommendation. If you find yourself writing "*Recommendation*: TBD" three times in a row, or if every option in your draft collapses to the same answer, the question itself is the problem — surface it, don't paper over it.


### PR DESCRIPTION
## Summary

- Adds the `creating-user-stories` Claude Code skill — companion to `sc-design-review` ([#1753](https://github.com/lifinance/contracts/pull/1753)). Where sc-design-review consumes a PRD and produces a contract design, this skill produces the intermediate persona-grouped stories + open-questions catalogue that feeds it.
- **Intentionally domain-agnostic** — the skill body avoids smart-contract-specific terminology so other teams can adopt it. Examples and patterns use neutral language (pricing, auth layers, etc.). The one SC-specific artifact (`references/deep-review-persona-pass.md` persona set) is flagged in the skill as needing re-casting when adopted by other domains.
- 4 files, 563 lines, no Solidity changes — skill files only under `.claude/skills/creating-user-stories/`.

## What's in the skill

Main `SKILL.md` (360 lines) covers:

- **One-action-one-benefit grammar** for stories: `[verb] [object], so that [why]` — strict, with a fix-pattern table for common smells.
- **Readability format** for every story body and every open-question body: question-as-title, plain sentences, labeled (a)/(b)/(c) options with the recommendation referencing the chosen letter, Pros/Cons only where the trade-off is real.
- **Two-page output** — a Stories page (one readable sentence per story, no acceptance hints or implementation detail in the story body) and a companion Open Questions page.
- **Mandatory lane tagging** on every open Q (⚠️ PRODUCT DECISION NEEDED / [TECH] / [META]) with a strict criterion: if the user-visible outcome is the same regardless of which option is picked → [TECH]; otherwise ⚠️ PRODUCT.
- **Cross-doc alignment is non-negotiable** — phantom ❓Q-refs erode the entire catalogue. Mandatory verification after every edit (phantom / orphan / cross-ref / counts).
- **Counts footer as audit trail** — never silently delete a question; every removal documented so a year later someone reading \"why no Q3.3?\" gets a one-line answer.
- **Three-lane lightweight final review** (spec coverage / product decision / tech implementation) as the default before locking the catalogue. Deep multi-persona review reserved for high-stakes audit prep.

Reference files (progressive disclosure — loaded on demand):

- `references/question-maintenance.md` (64 lines) — audit-phase patterns: lifecycle dispositions (merge / reframe / elevate-to-story / remove / resolve), reframing when an upstream decision changes a question's context, layered-concern decomposition for cross-cutting topics, and recognizing questions that should be removed rather than answered.
- `references/deep-review-persona-pass.md` — escalation-only deep review with named senior-reviewer personas. Currently calibrated for smart-contract review; the skill flags this and notes the personas will be re-cast when the skill is moved to a generic repo.
- `references/notion-mcp.md` — Notion editing mechanics (block anchors, batched edits, parallel-session drift).

## Origin

Patterns in the skill were developed and battle-tested during the Earn Monetization v2 Programmable Vault Wrapper review ([EXSC-282](https://linear.app/lifi-linear/issue/EXSC-282/earn-monetization-v2-custom-vault-wrapper-design-and-estimate)):

- Drafted ~65 stories across 3 personas with sub-points, research-derived stories flagged, every ambiguity tracked as an open Q.
- Drafted an Open Questions catalogue (60+ entries across BLOCKS / Nice-to-resolve / Cosmetic / Deferred / [TECH] sections).
- Iteratively refined both based on review feedback from product + engineering reviewers. Every pattern in the skill came from a specific concrete problem in that catalogue — none are speculative.

## Test plan

Skills aren't compile-checked, but worth verifying:

- [ ] Skill triggers when expected — try a prompt like \"draft user stories for [a PRD]\" or \"audit the open questions catalogue\" and confirm Claude invokes the skill.
- [ ] Skill does NOT trigger on casual feature lists / one-off Jira tickets.
- [ ] References load on demand — `question-maintenance.md` should be read when refining/auditing, not when drafting from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)