### PR TITLE
creating-user-stories: promote research phase to first-class workflow step

### DIFF
--- a/.claude/skills/creating-user-stories/SKILL.md
+++ b/.claude/skills/creating-user-stories/SKILL.md
@@ -296,8 +296,57 @@ When the catalogue is past initial extraction and you're refining or auditing it
 4. Number within each persona in lifecycle order (deploy → configure → operate → emergency).
 5. For each item, draft the one-line story.
 6. Pass over: what's missing? Standard categories specs forget — key rotation, observability, emergency response, edge cases. Add them.
-7. Comparable-product sweep: what do analogous products in the space do? Add as `*(research-derived)*`.
+7. Comparable-product sweep — load the **Research phase** below if the catalogue feeds high-stakes downstream work. Research-derived items end up tagged `*(research-derived)*` with a `*Source*: [link]` pointer.
 8. Open-questions extraction: every ambiguity, every "decide later" → a Q.
+
+## Research phase — when the catalogue feeds high-stakes downstream work
+
+**Trigger** — the catalogue feeds an audit, an estimate, a third-party review, a budget decision, or any artifact someone signs off on. Skip for internal-only catalogues used for a single team's quick alignment.
+
+Without this phase, a catalogue typically underproduces by ~20–30% on coverage of failure modes, edge cases, prior-art-anti-patterns, and "things to invert from what the obvious blueprint did." That gap doesn't show up at draft time — it shows up at audit / review when reviewers ask "what about X?" and X was visible in any comparable product the operator didn't read.
+
+The phase runs **in parallel with — or just before — initial drafting**, not after. After-drafting research re-opens the catalogue; parallel research feeds it cleanly.
+
+### The comparable set — roles, not products
+
+Pick 3–5 prior-art systems. A useful default mix, expressed as **roles** (the domain instantiates the role):
+
+- **Explicit blueprint** — the system the spec/PRD itself references as "we want one of these."
+- **Marquee-customer reality** — what the named target customer / user actually uses today (often diverges from what the spec assumes about them).
+- **Dominant competitor / win-back target** — the system you're displacing in deals.
+- **Field-wide comparison** — table across 5–10 adjacent systems, shallow per cell but wide; surfaces convergent patterns.
+- **Adjacent-but-distinct** — a system that solves a related but different problem; clarifies what your scope is *not*.
+
+You don't always need all 5. Below ~3 you lose triangulation; above ~5 the operator can't hold the synthesis in head.
+
+### Recipe
+
+1. **Dispatch one subagent per comparable, in parallel.** Each writes a single-topic deep-dive to `raw/NN-<comparable>.md`. Standard prompt template + multi-domain worked examples in `references/research-phase.md` — load before dispatching.
+2. **Synthesize into `research-analysis.md`** — one section per comparable, each closing with a **COPY / IMPROVE / AVOID** three-line summary.
+3. **Cross-cutting findings section** at the end of `research-analysis.md` — patterns visible across multiple comparables (convergent architecture, recurring anti-patterns, shared blind spots).
+4. **During drafting**, every research-derived story / open Q carries `*(research-derived)*` + `*Source*: [link into raw/ or research-analysis.md]`. Provenance is non-negotiable — see verification step.
+
+### The COPY / IMPROVE / AVOID frame
+
+The single load-bearing output discipline. For each comparable, the subagent closes with three explicit lines:
+
+- **COPY** — what this system gets right that we should mirror.
+- **IMPROVE** — what this system gets approximately right; we should ship a stronger version.
+- **AVOID** — what this system gets wrong (known anti-pattern, public incident, community-flagged); we should invert it.
+
+Research without this frame becomes a wiki — interesting but undecidable. With the frame, every research-derived story or open Q has an answer to "why does this exist in the catalogue?"
+
+### Output contract
+
+`raw/` directory exists with 3–5 single-topic files, each citing primary sources. `research-analysis.md` exists, references every `raw/` file, has the COPY / IMPROVE / AVOID frame per comparable, has a cross-cutting findings section. Stories and open Qs derived from it are tagged + sourced.
+
+### Anti-patterns
+
+- **One subagent doing all comparables.** Loses parallel-independence value; consolidates bias.
+- **Agents reading each other's outputs mid-flight.** Convergent answers look like consensus but are correlation.
+- **Secondary sources only.** Blog-post-about-a-product instead of the product's docs / source / governance / post-mortem.
+- **Skipping COPY/IMPROVE/AVOID.** Research becomes reference material, not catalogue input.
+- **Research after drafting is locked.** Re-opens the catalogue and erodes the audit trail. Run in parallel or up front.
 
 ## Workflow — adding stories to an existing catalogue
 

--- a/.claude/skills/creating-user-stories/references/research-phase.md
+++ b/.claude/skills/creating-user-stories/references/research-phase.md
@@ -1,0 +1,205 @@
+# Research phase — recipe, subagent template, worked examples
+
+Load when running the research phase from `SKILL.md`. Carries the subagent prompt template + three worked examples (one SC, one DevOps tool, one API/dev-product) so the genericity claim is concrete, not asserted.
+
+## Subagent prompt template (domain-agnostic)
+
+Each comparable gets one subagent dispatched in parallel. Standard agent brief:
+
+```
+You are researching <COMPARABLE_NAME> as a comparable for the
+<PROJECT_NAME> design. Your role in the comparable set is
+<ROLE: blueprint | marquee-customer-reality | competitor | field-wide
+       | adjacent-but-distinct>.
+
+CONTEXT (1–2 paragraphs):
+- What we're building (1 sentence).
+- Why this specific comparable is in the set (1 sentence).
+- What downstream work this research feeds (audit / estimate / review).
+
+REQUIRED READING (primary sources only):
+- <docs URL>
+- <source repo / verified contract / public spec>
+- <governance archive / incident post-mortem / RFC>
+- <data dashboard / dune / public usage stats if relevant>
+Do NOT pad with secondary sources (blog posts about the product, listicles).
+If a primary source isn't available for a claim, mark it "unverified."
+
+SCOPE — answer 4–7 of these, picking the ones load-bearing for our design:
+- Architecture & topology
+- Pricing / monetization mechanism
+- Permissioning / access control
+- Failure-mode handling (degraded state, recovery, key-loss, migration)
+- Public incident history
+- Governance / change-control / upgrade model
+- Observability / event model / API surface for integrators
+- Composition story (who builds on top; integration interfaces)
+- Known weaknesses / community-flagged anti-patterns
+
+OUTPUT:
+- Structured markdown, ~300–500 lines, primary-source citations inline.
+- Final section: "Unverified items" — list every claim you couldn't verify
+  against a primary source. Don't fabricate. Better to leave a gap than
+  to invent.
+- Closing frame (MANDATORY, exactly 3 lines):
+    COPY: <what to mirror>
+    IMPROVE: <what to do a stronger version of>
+    AVOID: <what to invert / not repeat>
+
+CONSTRAINTS:
+- You are one of N parallel subagents. Don't reference other agents'
+  findings; you can't see them.
+- Cap your output at <WORD_BUDGET> words. Be dense.
+- Don't propose stories for <PROJECT_NAME>. Your job is the comparable.
+  The operator does the synthesis.
+```
+
+Tune `<WORD_BUDGET>` to the comparable's depth (800 for blueprint, 400 for adjacent-but-distinct).
+
+## Synthesis output template — `research-analysis.md`
+
+```markdown
+# Research Analysis — Comparable Products
+
+Background for <PROJECT_NAME> design. Compiled <DATE> from primary sources.
+Raw per-comparable research in [`raw/`](raw/).
+
+## A. <Comparable 1 name> — the explicit blueprint
+[~300 words: architecture, primary mechanism we care about, fee/auth/pricing,
+governance, known weaknesses. Lift from raw/01.]
+
+**COPY**: ...
+**IMPROVE**: ...
+**AVOID**: ...
+
+## B. <Comparable 2 name> — marquee-customer reality
+[Same shape.]
+
+...
+
+## Cross-cutting findings
+1. [Pattern visible across ≥2 comparables: e.g. "all converged on
+   factory + immutable-per-instance + timelocked-mutable-params."]
+2. [Repeated anti-pattern: e.g. "every competitor with a single global
+   upgrade key has had at least one near-miss."]
+3. [Convergent constraint: e.g. "every product in this space ships
+   without an X capability — confirms X is V2/V3 territory."]
+```
+
+The cross-cutting section is where the value compounds — convergence across independent subagents is a high-confidence signal.
+
+---
+
+## Worked Example A — Smart-contract design (SC)
+
+**Project**: LI.FI Programmable Vault Wrapper (an ERC-4626 wrapper factory + clone topology).
+
+**Comparable set**:
+
+| Role | Comparable | Why |
+|---|---|---|
+| Explicit blueprint | Kiln Omnivault | PRD names it: "clone of the Kiln pattern" |
+| Marquee-customer reality | Coinbase USDC Earn (Morpho/Steakhouse + Merkl stack) | Coinbase is named in the PRD; their actual on-chain stack matters more than what they say they want |
+| Field-wide | Morpho MetaMorpho / Yearn V3 / Veda / Lagoon / Mellow / Superform / Sommelier / Idle | 8-row table across the EVM 4626/7540 wrapper landscape |
+| Competitor (deferred — no dedicated agent) | Yield.xyz | Folded into field-wide; primary sources thin |
+| Adjacent-but-distinct (deferred) | Aave Pool / Compound Comet | Not wrappers; the underlying primitive |
+
+Realised output: see `earn-monetization-v2-vault-wrapper/raw/{01,02,03}-*.md` + `research-analysis.md` in the same folder. Three subagents (Kiln deep-dive, Coinbase reward-injection deep-dive, similar-products comparison) plus two follow-on synthesis agents (research-derived stories, ambiguities). The two synthesis-agent outputs (`04-user-stories.md`, `05-open-questions.md`) demonstrate the next step — research feeds drafting directly.
+
+**Cross-cutting findings that drove the actual catalogue**:
+1. Converged architecture skeleton: factory + immutable-per-instance + timelocked-mutable-params + guardian-veto (Morpho, Yearn V3, Lagoon). Drove A1–A3 of the final catalogue.
+2. Perf-fee cap encoded in implementation is the integrator-trust primitive — Morpho caps at 50%, Kiln has no cap. Drove A11 (immutable bytecode cap) + Q1.10 (distinct from factory-tunable cap).
+3. Two viable reward-injection shapes: harvest-and-reinvest into NAV vs external distributor decoupled from share accounting. Drove I10, I11, I15 + the entire reward-injection Q-section.
+
+---
+
+## Worked Example B — DevOps / internal tooling
+
+**Project**: an internal on-call scheduling + paging tool (replacing a "we use a Slack channel and pray" status quo for a 50-engineer org).
+
+**Comparable set**:
+
+| Role | Comparable | Why in the set |
+|---|---|---|
+| Explicit blueprint | PagerDuty | The category-defining product; the spec references it |
+| Marquee-customer reality | The engineering team's current state (Slack + a shared Google Sheet rotation) | What they actually do today, not what they think they do |
+| Dominant competitor | Opsgenie (Atlassian) | The "if not PagerDuty, then this" |
+| Field-wide | PagerDuty / Opsgenie / VictorOps / Squadcast / Better Stack / Rootly / Incident.io | 7-row table |
+| Adjacent-but-distinct | Slack-native incident bots (e.g. Slack Huddles + Workflow Builder) | Solves the "page someone" half but not the "schedule rotations" half |
+
+**What the comparables differ on (the design's load-bearing axes)**:
+- Rotation expression language (custom DSL vs override-on-top-of-recurring-rule vs ICS calendars).
+- Escalation policy semantics (timed escalations vs explicit acknowledge vs hybrid).
+- "Who's on-call right now?" API surface (REST vs Slack-slash vs both).
+- Integration model (webhooks / push connectors / iPaaS).
+- Audit / compliance posture (SOC2-relevant action log).
+
+**COPY/IMPROVE/AVOID examples** (per comparable, illustrative):
+- *PagerDuty COPY*: timed-escalation with explicit acknowledge semantics; this is the load-bearing primitive.
+- *PagerDuty IMPROVE*: the rotation-expression DSL is too powerful for our scope — ship a smaller declarative surface.
+- *PagerDuty AVOID*: pricing model is per-user-per-month; for internal we ignore.
+- *Current-state AVOID*: nobody knows who's on-call without a Slack scroll — primary capability the design must solve.
+
+**Cross-cutting findings the operator would actually carry forward**:
+1. Every product converges on "rotation × escalation × notification channel" as the core data model.
+2. Every public incident review of an on-call tool failure traces to "notification channel was misconfigured" (SMS down, phone-on-DND, the notified person was already on PTO). Drives an "active-watcher health check" capability into V1.
+3. Adjacent-but-distinct (Slack-only) makes the case for *not* shipping a paging primitive in V1 if Slack alerting + a single shared escalation policy is enough.
+
+Same skill, same recipe, different domain. The COPY/IMPROVE/AVOID frame ports unchanged.
+
+---
+
+## Worked Example C — Developer-product API design
+
+**Project**: an internal-platform feature-flag service for a 30-product company (replacing a homegrown env-var dance + a half-built admin tool).
+
+**Comparable set**:
+
+| Role | Comparable | Why |
+|---|---|---|
+| Explicit blueprint | LaunchDarkly | The category leader; the spec references it |
+| Marquee-customer reality | The web platform team's current state (env vars + a wiki of flag definitions) | The team most painful to migrate; their workflow drives the requirements |
+| Dominant competitor | Statsig | The "if not LaunchDarkly, then this"; bundles experimentation |
+| Field-wide | LaunchDarkly / Statsig / Unleash / GrowthBook / ConfigCat / Flagsmith / PostHog Feature Flags | 7-row table |
+| Adjacent-but-distinct | OpenFeature (spec, not a product) | Forces the question: do we adopt the open standard's interface, or invent our own? |
+
+**Load-bearing design axes the comparables differ on**:
+- SDK model (server-side fetch vs streaming vs local-evaluation with rule sync).
+- Targeting-rule expression (DSL vs JSON vs visual builder).
+- Evaluation latency (cached-locally vs round-trip per flag).
+- Multi-environment model (env-as-property vs env-as-namespace).
+- Audit-log shape (per-flag history vs global event stream).
+- Kill-switch semantics (per-flag vs global vs none).
+
+**COPY/IMPROVE/AVOID examples**:
+- *LaunchDarkly COPY*: local-evaluation SDK with background rule sync — the latency profile is non-negotiable for hot paths.
+- *LaunchDarkly IMPROVE*: targeting-rule DSL is rich but undocumented; ship a smaller surface with a public grammar.
+- *LaunchDarkly AVOID*: per-MAU pricing distorts product usage (teams stop putting low-traffic features behind flags).
+- *OpenFeature COPY*: provider interface — even if we don't adopt it as our public API, our internal SDK should conform so we can swap providers later.
+- *Statsig AVOID*: bundling experimentation with feature flags couples two unrelated lifecycles.
+
+**Cross-cutting findings**:
+1. Every product offers local-evaluation; round-trip-per-flag is dead. Confirms V1 architecture.
+2. Every product publishes an audit log; only some publish it as a stream consumable by SIEM tools. Drives a "stream the audit log" V1 requirement for the platform team's security review.
+3. OpenFeature's existence means inventing a non-conforming public API has a known future-cost; conforming has near-zero present-cost. Easy V1 decision.
+
+---
+
+## Anti-patterns (cross-domain)
+
+- **One subagent doing all comparables.** Loses parallel-independence value; introduces correlated bias.
+- **Reading other agents' outputs mid-flight.** Convergent answers look like consensus but are correlation. Read after all return.
+- **Citing secondary sources.** "A Medium post says LaunchDarkly does X" is not a source — LaunchDarkly's docs or a public RFC is.
+- **Skipping COPY / IMPROVE / AVOID.** Research becomes a wiki; you can't trace catalogue items back to a decision input.
+- **Research after drafting is locked.** Re-opens the catalogue and erodes the audit trail. Run in parallel with — or just before — initial drafting.
+- **Padding the comparable set.** Below 3 = no triangulation; above 5 = the operator can't hold the synthesis. Resist "and we should also look at …" when the set is already at 5.
+- **Letting the blueprint dominate the synthesis.** Every other comparable should pull weight; if the blueprint accounts for >60% of the catalogue's research-derived content, the comparable set was mis-picked.
+
+## When to skip the phase entirely
+
+The trigger is "feeds high-stakes downstream work." Some catalogues genuinely don't:
+- Internal team-alignment doc that nobody outside the team will read.
+- Quick spec-extraction for a small feature with no third-party dependencies.
+- A catalogue refresh after the original research is still fresh (<6 months).
+
+In these cases, run the workflow without the research phase. The catalogue will be 20–30% thinner on edge cases but that's the right trade-off when no downstream reviewer demands the coverage.


### PR DESCRIPTION
## Summary

Follow-up to #1776 — based on an evaluation pass that ran the skill cold against the [Programmable Vault Wrapper PRD](https://www.notion.so/lifi/LI-FI-Programmable-Vault-Wrapper-PRD-352f0ff14ac780e9b426c99364cfe814) and compared the output to the published [Earn PRD Review](https://www.notion.so/lifi/Earn-PRD-Review-35af0ff14ac7805b98ece561ec483cde) catalogue.

**Finding it addresses**: ~20–30% of the published catalogue's value lives in research-derived stories and open Qs (Synthetix MultiRewards, Coinbase/Morpho boost, Kiln upgrade-key inversion, ERC-4626 inflation attack). The current skill mentions this as a single prose line in workflow step 7. A cold operator reads that and skips it.

**Targets** \`chore/add-creating-user-stories-skill\` so #1776 stays the single landing point.

## What changed

- **\`SKILL.md\`** — forward-pointer in workflow step 7; new \"Research phase\" section between the two workflow blocks (~50 lines). Carries trigger condition, comparable-set roles (blueprint / marquee-customer-reality / competitor / field-wide / adjacent-but-distinct), recipe, COPY/IMPROVE/AVOID frame, output contract, anti-patterns.
- **\`references/research-phase.md\`** — net-new (~250 lines). Subagent prompt template, synthesis template, and three worked examples spanning SC (vault wrapper, real \`raw/\` realised output cited), DevOps (on-call paging tool), and API (feature-flag service). The multi-domain examples make the domain-agnosticism claim concrete rather than asserted.

## Genericity strategy

Three moves that compound — discussed in detail in the evaluation that produced this diff:

1. **Trigger framed by *consequence*** (\"feeds high-stakes downstream work\"), not domain.
2. **Comparable set defined by *roles*, not products** — the domain instantiates the role.
3. **Multi-domain worked examples in the reference file**, not the skill body — \`SKILL.md\` stays abstract; the reference carries one realised example per domain.

**Load-bearing through-line**: COPY / IMPROVE / AVOID. Ports unchanged across domains.

## Out of scope (separate follow-ups from the same evaluation)

- Expand the mandatory verification checklist (Q-link target page resolution, bidirectional cross-link check, sub-point existence, ID-gap audit trail). \`evaluation/improvements.md\` #I2.
- Codify the provenance-tag set (\`*(new — surfaces a PRD contradiction)*\`, \`*(provisional)*\`, \`*(blocked by QX.Y)*\`). #I3.
- Re-cast the worked examples in SKILL.md body toward truly neutral domains. #I4.

## Test plan

Skills aren't compile-checked. Worth verifying:

- [ ] Read the new \"Research phase\" section cold — does it feel actionable to a non-SC team?
- [ ] Walk through Example B (DevOps on-call) and Example C (feature-flag API) — do they read as \"real\" or as stubs?
- [ ] Confirm the trigger condition (\"feeds high-stakes downstream work\") is tight enough that it doesn't fire on every quick spec.
- [ ] Confirm the COPY/IMPROVE/AVOID frame is the same in skill body and all three worked examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)