### PR TITLE
sc-design-review: add Phase 1.5 research + integrate creating-user-stories

### DIFF
--- a/.claude/skills/sc-design-review/SKILL.md
+++ b/.claude/skills/sc-design-review/SKILL.md
@@ -21,34 +21,55 @@ Do **not** use this skill for:
 - Generic spec review unrelated to smart contracts.
 - One-line questions answerable without a structured panel.
 
+## Relationship with `creating-user-stories`
+
+This skill consumes a PRD and produces a hardened smart contract design. The sibling [`creating-user-stories`](../creating-user-stories/SKILL.md) skill consumes the same PRD and produces a structured user-stories + open-questions catalogue as an intermediate artifact.
+
+**When both are run** (recommended for any non-trivial PRD): `creating-user-stories` runs first against the PRD; this skill ingests **both** the PRD and the resulting catalogue. The catalogue's open-questions feed the ambiguity gate (many gaps are already enumerated), and the stories pin capability scope so the Tech Lead doesn't have to re-extract it from PRD prose.
+
+**When only this skill runs**: the design pass still works against a raw PRD. The ambiguity gate has more work to do. For small features (≤ 5 stories) this is fine; for anything larger, running `creating-user-stories` first is strongly recommended — and the orchestrator will prompt for it (see Phase 0).
+
 ## Workflow overview
 
-The skill runs a 5-phase orchestration. **Read this section in full before starting** — the order and the gates matter.
+The skill runs a 6-phase orchestration. **Read this section in full before starting** — the order and the gates matter.
 
 ```
-[Phase 0] Ingest PRD ──► [Phase 1] Ambiguity gate ──► [Phase 2] Draft v1
-                              │
-                              └─► HALT + ask human (if material gaps)
-
-[Phase 2] Draft v1 ──► [Phase 3] Round 1 (full panel) ──► synthesise → v2
-                                                              │
-                                                              └─► early-exit possible
-                                       Round 2 (full panel) ──► synthesise → v3
-                                       Round 3 (security + QA only) ──► synthesise → v_final
-
-[Phase 4] Output ──► always write markdown locally
-                ──► ASK the executor: also create a Notion page?
+[Phase 0] Ingest PRD (+ optional stories catalogue)
+              │
+              ├─► [Phase 1]   Ambiguity gate ──► HALT + ask human (material gaps)
+              │
+              └─► [Phase 1.5] Research phase (parallel with ambiguity gate)
+                                  │
+                                  ▼
+          [Phase 2] Draft v1 (Tech Lead receives PRD + ambiguity report
+                              + research output + optional stories catalogue)
+                                  │
+                                  ▼
+          [Phase 3] Round 1 (full panel) ──► synthesise → v2
+                                              │
+                                              └─► early-exit possible
+                    Round 2 (full panel) ──► synthesise → v3
+                    Round 3 (security + QA only) ──► synthesise → v_final
+                                  │
+                                  ▼
+          [Phase 4] Output ──► always write markdown locally
+                          ──► ASK the executor: also create a Notion page?
 ```
 
-## Phase 0 — Ingest the PRD
+## Phase 0 — Ingest the PRD (and optional stories catalogue)
 
-**Input forms accepted:** Notion URL, Notion page ID, local markdown path.
+**Input forms accepted:** Notion URL, Notion page ID, local markdown path. The executor may pass a second argument pointing at a stories + open-questions catalogue (from `creating-user-stories`).
 
-1. If Notion: use `notion-fetch` (or the Notion MCP equivalent) on the page. Then recursively follow links to child pages **up to depth 2**. Stop at depth 2 to avoid runaway. Capture the full content as a single concatenated source string.
-2. If local file: read it directly.
+1. **PRD ingestion**:
+   - If Notion: use `notion-fetch` (or the Notion MCP equivalent) on the page. Then recursively follow links to child pages **up to depth 2**. Stop at depth 2 to avoid runaway. Capture the full content as a single concatenated source string.
+   - If local file: read it directly.
+2. **Stories-catalogue ingestion (optional)**:
+   - If the executor supplied a catalogue link / path: fetch both the Stories page and the companion Open Questions page (sibling pages produced by `creating-user-stories`). Concatenate into `stories_source`.
+   - If not supplied **and** the PRD describes a non-trivial feature (>5 distinct capabilities visible): ask the executor once: *"This looks substantial. Has `creating-user-stories` been run against this PRD? If yes, paste the catalogue link; if no, consider running it first — it will sharpen the ambiguity gate and the Phase 2 draft."* Wait for an answer. Either proceed without the catalogue or pause for it.
 3. Record:
-   - Source URL or path (will be cited in the final doc).
+   - PRD source URL or path (cited in the final doc).
    - PRD title.
+   - Stories-catalogue source URL or path (cited in the final doc when present).
    - Date of ingestion (today's date).
 4. If the PRD is empty, behind auth, or fetch fails: stop and tell the user.
 
@@ -56,7 +77,7 @@ The skill runs a 5-phase orchestration. **Read this section in full before start
 
 **Why this exists:** smart contract specs that proceed on assumed intent are how exploits are born. Spending six personas across three rounds debating an under-specified spec is wasteful; it is also dangerous because the personas will paper over the gaps with plausible-sounding assumptions that nobody validated.
 
-Invoke the **Tech Lead persona** (`personas/tech-lead.md`) with a single instruction: produce an *ambiguity report* against the PRD.
+Invoke the **Tech Lead persona** (`personas/tech-lead.md`) with a single instruction: produce an *ambiguity report* against the PRD. If a stories catalogue is in scope, pass it too — the Open Questions page often pre-enumerates ambiguities the Tech Lead would otherwise re-derive, and items already resolved by stories are not gaps.
 
 The ambiguity report must classify findings as:
 
@@ -70,11 +91,43 @@ The ambiguity report must classify findings as:
 
 When halting, the questionnaire is a numbered list of crisp questions. Do not write paragraphs; the executor needs to scan and answer.
 
+## Phase 1.5 — Comparable-product research
+
+Runs **in parallel with Phase 1** (ambiguity gate) — both feed Phase 2. Skip only when the ambiguity gate has already HALTed, or when the PRD describes a feature for which the existing codebase already contains a near-canonical pattern (e.g. another LiFi facet with the same shape).
+
+**Why this phase exists:** smart contract designs that proceed without comparable-product research routinely miss failure modes that are public knowledge in the comparables' source / post-mortems / governance archives. ~20–30% of the load-bearing findings in a hardened design (first-depositor inflation, harvest-sandwich MEV, beacon-key landmines, JIT-deposit reward gaming, etc.) come from reading what prior art got wrong. Without research, those findings only surface during external audit — at maximum cost.
+
+**The comparable set — pick 3–5 prior-art systems by role**, not by name:
+
+- **Explicit blueprint** — the system the PRD itself references as "we want one of these."
+- **Marquee-customer reality** — what a named target customer actually uses on-chain today (often diverges from what the PRD assumes).
+- **Dominant competitor / win-back target** — the system being displaced.
+- **Field-wide comparison** — table across 5–10 adjacent systems, shallow per cell but wide; surfaces convergent patterns.
+- **Adjacent-but-distinct** — a different problem with related architecture; clarifies what your scope is *not*.
+
+Below 3 you lose triangulation; above 5 the synthesis becomes unmanageable.
+
+**Recipe**:
+
+1. **Dispatch one subagent per comparable, in parallel** (single message, multiple `Agent` tool calls). Each writes a single-topic deep-dive to `<workdir>/research/raw/NN-<comparable>.md`. Standard subagent prompt + full recipe in `references/research-phase.md` — load before dispatching.
+2. **Synthesise into `<workdir>/research/research-analysis.md`** — one section per comparable, each closing with a **COPY / IMPROVE / AVOID** three-line summary.
+3. **Cross-cutting findings** section at the end of `research-analysis.md` — patterns visible across multiple comparables (convergent architecture, recurring anti-patterns, shared blind spots). This is where the value compounds — independent agents converging on a pattern is a high-confidence signal.
+
+**The COPY / IMPROVE / AVOID frame** is non-negotiable. Without it, research becomes a wiki — interesting but undecidable. With it, every research-derived design choice in Phase 2 can be traced back to a specific prior-art lesson.
+
+**Pass the synthesised `research-analysis.md`** (not the raw subagent outputs) into Phase 2. The Tech Lead's job is design, not research aggregation.
+
+**Anti-patterns**:
+- One subagent doing all comparables — loses parallel-independence value.
+- Agents reading each other's outputs mid-flight — convergence looks like consensus but is correlation.
+- Secondary sources only (blog-about-product instead of product docs / source / governance / post-mortems).
+- Skipping COPY/IMPROVE/AVOID — research becomes reference material, not design input.
+
 ## Phase 2 — Draft v1
 
-Invoke the **Tech Lead persona** with the PRD + ingestion metadata + the ambiguity report (so it knows which minor gaps it must explicitly note). It must produce design doc v1 conforming to `templates/design-doc.md`.
+Invoke the **Tech Lead persona** with the PRD + ingestion metadata + the ambiguity report + the research synthesis + the stories catalogue (if present). It must produce design doc v1 conforming to `templates/design-doc.md`.
 
-**Mandatory in v1:** all section headers from the template, even if a section reads "TBD — to be challenged in round 1". The challengers will fill in via critique. Section 13 (Custody of funds) must take an explicit position — silence is not acceptable.
+**Mandatory in v1:** all section headers from the template, even if a section reads "TBD — to be challenged in round 1". The challengers will fill in via critique. Section 13 (Custody of funds) must take an explicit position — silence is not acceptable. Design choices that came from comparable-product research should cite the COPY / IMPROVE / AVOID source inline (e.g. *"per `research-analysis.md` §A: AVOID Kiln's global beacon — use per-deploy immutable args."*).
 
 ## Phase 3 — Challenge rounds
 
@@ -180,6 +233,7 @@ Agent(
 - `personas/security-auditor.md` — adversarial lens
 - `personas/qa-verification.md` — testability lens
 - `personas/product-lead.md` — requirements completeness lens
+- `references/research-phase.md` — Phase 1.5 recipe: subagent prompt template, synthesis template, worked example. **Load before dispatching research subagents.**
 - `templates/design-doc.md` — final deliverable structure
 - `templates/finding.schema.json` — challenger output contract
 - `scripts/orchestrate.md` — turn-by-turn runbook (read this before executing)

--- a/.claude/skills/sc-design-review/personas/tech-lead.md
+++ b/.claude/skills/sc-design-review/personas/tech-lead.md
@@ -10,7 +10,7 @@ You will be invoked in one of three modes. The invocation prompt will tell you w
 
 ### Mode A — Ambiguity gate
 
-Input: a PRD.
+Input: a PRD. Optionally a stories + open-questions catalogue produced by `creating-user-stories`.
 
 Output: an ambiguity report classifying findings as:
 - `material` — design cannot proceed without resolution
@@ -18,6 +18,8 @@ Output: an ambiguity report classifying findings as:
 - `conflict` — two parts of the PRD disagree
 
 For each item give: location in PRD (quote or section), the gap, and the question that resolves it.
+
+**If a stories catalogue is in scope**: items the catalogue's stories pin (e.g. "withdrawals are always available — U20") are **not gaps**; cite the story ID and move on. Items the catalogue's Open Questions already enumerate are inherited as-is (don't re-derive them) — copy their lane tag (`⚠️ PRODUCT` / `[TECH]` / `[META]`) into your classification: `⚠️ PRODUCT` ⇒ `material`, `[TECH]` ⇒ `minor`, `[META]` ⇒ `minor` unless it blocks design.
 
 End with a single line: `material_gaps: <true|false>`.
 
@@ -27,9 +29,13 @@ If `true`, do not produce design content. Stop.
 
 ### Mode B — Drafting
 
-Input: PRD + ambiguity report (with `material_gaps: false`).
+Input: PRD + ambiguity report (with `material_gaps: false`) + comparable-product research synthesis. Optionally: stories + open-questions catalogue from `creating-user-stories`.
 
 Output: design doc v1 conforming exactly to `templates/design-doc.md`. Every section header present. Section 13 (Custody of funds) MUST take an explicit position — either "this contract does not custody funds, because <reason>" or full custodial-design treatment with risk assessment and security strategy. Silence on custody is a critical failure of this draft.
+
+**Use the research synthesis actively, not as background reading.** Design choices derived from research must cite the source inline: *"per `research-analysis.md` §B — AVOID Coinbase's off-chain trust on Merkl as default; ship on-chain `notifyRewardAmount` as primary."* Anything you COPY, IMPROVE, or AVOID relative to a comparable should be named. If you are designing a primitive that has no comparable lesson behind it, say so explicitly — that's a flag for the security auditor in Phase 3.
+
+**Use the stories catalogue (if present) as the capability spec.** Stories pin capability scope; you don't have to re-derive it from PRD prose. If you find yourself wanting to design a capability not in the stories, flag it in §12 (Open questions) — that's either a missing story or out-of-scope.
 
 If you find yourself wanting to assume away an ambiguity that the gate marked minor, instead write the assumption explicitly into section 12 (Open questions) so it is visible to challengers.
 

--- a/.claude/skills/sc-design-review/references/research-phase.md
+++ b/.claude/skills/sc-design-review/references/research-phase.md
@@ -1,0 +1,168 @@
+# Phase 1.5 — Comparable-product research
+
+Load before dispatching research subagents. Carries the subagent prompt template, the synthesis output template, a worked example, and anti-patterns. The Phase 1.5 body in `SKILL.md` is the abstract recipe; this file is the operational detail.
+
+## Why this phase is worth the cost
+
+A hardened SC design routinely depends on findings that are public knowledge in comparable-product source / governance archives / post-mortems, but absent from the PRD. Examples seen in past designs:
+
+- First-depositor inflation attack on ERC-4626 — mitigation comes from reading OpenZeppelin / Yearn / Morpho source.
+- Beacon-key landmines — one global upgrade key compromises every clone (Kiln's pattern; documented anti-pattern).
+- JIT-deposit reward gaming — invisible until you read Synthetix `MultiRewards` and the streaming-vs-lump-sum literature.
+- Withdraw-pause anti-pattern — Kiln explicitly does NOT pause withdrawals; pattern requires reading their access-control config.
+
+These are not exotic. They are dominant-failure-mode patterns in the comparable systems. Skip the research phase and the security auditor in Phase 3 will surface them — at maximum cost, with the design already drafted around assumptions that now have to be unwound.
+
+Run the research in parallel with the ambiguity gate. Cost: ~5–10 minutes of wall-clock, 3–5 subagent dispatches. Value: 20–30% of the load-bearing findings in v1, surfaced before drafting starts.
+
+## The comparable set — pick by role, not name
+
+| Role | What it gives you |
+|---|---|
+| **Explicit blueprint** | The system the PRD itself references ("we want one of these"). Highest signal-to-noise; this is where COPY/IMPROVE come from. |
+| **Marquee-customer reality** | What a named target customer actually uses on-chain today. Often diverges from what the PRD assumes about them. Surfaces "the PRD designs for X, but the customer's existing stack does Y" tensions. |
+| **Dominant competitor / win-back** | The system being displaced. Tells you what the catalogue must beat, not just match. |
+| **Field-wide comparison** | Table across 5–10 adjacent systems, shallow per cell. Surfaces convergent architecture patterns — when 6 of 8 comparables do the same thing, that's a high-confidence default. |
+| **Adjacent-but-distinct** | A different problem with related architecture. Clarifies what your scope is *not* (e.g. "Aave is a pool, not a wrapper — we're not designing a pool"). |
+
+Below 3 comparables: no triangulation; convergent findings could be coincidence. Above 5: the operator can't hold the synthesis in head. The sweet spot is 3–4 with the field-wide as a wide-shallow companion.
+
+## Subagent prompt template
+
+Each comparable gets one subagent dispatched in parallel. Standard brief:
+
+```
+You are researching <COMPARABLE_NAME> as a comparable for the
+<PROJECT_NAME> smart contract design. Your role in the comparable
+set is <ROLE: blueprint | marquee-customer-reality | competitor
+| field-wide | adjacent-but-distinct>.
+
+CONTEXT (1–2 paragraphs):
+- What we're designing (1 sentence).
+- Why this specific comparable is in the set (1 sentence).
+- Downstream consumer: the Tech Lead drafting v1 of an SC design doc;
+  hardening rounds by a 6-persona panel follow.
+
+REQUIRED READING (primary sources only):
+- Project docs URL
+- Verified contract source on Etherscan / Basescan / etc.
+- Public GitHub repo if open
+- Governance archives (Snapshot / on-chain governor / forum threads)
+- Public incident post-mortems / bug-bounty disclosures
+- Dashboard data (Dune, DefiLlama) where TVL / usage is relevant
+Do NOT cite secondary sources (Medium posts, listicles). If a primary
+source isn't available, mark the claim "unverified."
+
+SCOPE — answer 4–7 of these, picking the load-bearing ones:
+- Architecture & topology (factory? proxy pattern? upgrade model?)
+- Fee / monetization mechanism (rates, caps, accrual model, sweep authority)
+- Permissioning / access control (whitelist / blacklist / KYB / sanctions)
+- Failure-mode handling (pause topology, recovery, key-loss, migration)
+- Public incident history
+- Governance / change-control / timelock model
+- Reward injection / external-incentive surface
+- Observability / event schema
+- Known weaknesses / community-flagged anti-patterns
+- Composition story (who builds on top; integration interfaces)
+
+OUTPUT:
+- Structured markdown, ~300–500 lines, primary-source citations inline.
+- Final section: "Unverified items" — list every claim you couldn't
+  verify against a primary source. Don't fabricate.
+- Closing frame (MANDATORY, exactly 3 lines):
+    COPY: <what to mirror in our design>
+    IMPROVE: <what to do a stronger version of>
+    AVOID: <what to invert / not repeat>
+
+CONSTRAINTS:
+- You are one of N parallel subagents. You can't see other agents'
+  outputs. Don't speculate about what they found.
+- Cap output at <WORD_BUDGET> words. Be dense.
+- Don't propose design choices for <PROJECT_NAME>. Your job is the
+  comparable. The Tech Lead synthesises.
+```
+
+Tune `<WORD_BUDGET>`: 800 for blueprint, 500 for competitor/field-wide, 300 for adjacent-but-distinct.
+
+## Synthesis output template — `research/research-analysis.md`
+
+```markdown
+# Research Analysis — Comparable Products
+
+Background for the <PROJECT_NAME> SC design. Compiled <DATE> from
+primary sources. Raw per-comparable research in [`raw/`](raw/).
+
+## A. <Comparable 1 name> — the explicit blueprint
+[~300–400 words: architecture, primary mechanism we care about, fee /
+auth / pricing, governance, known weaknesses. Lift from raw/01.]
+
+**COPY**: <what to mirror>
+**IMPROVE**: <what to ship a stronger version of>
+**AVOID**: <what to invert>
+
+## B. <Comparable 2 name> — marquee-customer reality
+[Same shape.]
+
+...
+
+## Cross-cutting findings
+
+1. [Convergent pattern across ≥2 comparables: e.g. "all converged on
+   factory + immutable-per-instance + timelocked-mutable-params."]
+2. [Repeated anti-pattern: e.g. "every product with a single global
+   upgrade key has had at least one near-miss / incident."]
+3. [Convergent constraint: e.g. "every product in this space ships
+   without an X capability — confirms X is V2/V3 territory."]
+```
+
+The cross-cutting section is where the value compounds. Convergence across independently-dispatched subagents is a high-confidence signal. Flag every cross-cutting finding inline.
+
+## Worked example — Programmable Vault Wrapper
+
+**Project**: LI.FI Programmable Vault Wrapper (ERC-4626 wrapper factory + clone topology, per-integrator instances around well-behaved underlying vaults).
+
+**Comparable set picked**:
+
+| Role | Comparable | Why |
+|---|---|---|
+| Explicit blueprint | Kiln Omnivault | PRD names it: "clone of the Kiln pattern" |
+| Marquee-customer reality | Coinbase USDC Earn (Morpho/Steakhouse + Merkl stack) | Coinbase is a named target integrator; their actual on-chain stack matters more than what the PRD assumes about them |
+| Field-wide | Morpho MetaMorpho / Yearn V3 / Veda / Lagoon / Mellow / Superform / Sommelier / Idle | 8-row table across the EVM 4626/7540 wrapper landscape |
+
+Three subagents, dispatched in parallel. Output landed in `raw/01-kiln-omnivault.md`, `raw/02-coinbase-reward-injection.md`, `raw/03-similar-products.md`. Synthesised into `research-analysis.md`.
+
+**COPY/IMPROVE/AVOID excerpts that drove the design**:
+
+- *Kiln COPY*: beacon-proxy factory, OZ-`ERC4626Upgradeable` base, `AccessControlDefaultAdminRules` 2-step admin, `FeeRecipient[]` split with permissionless dispatch, `pendingFee` two-phase update, `minTotalSupply` + `offset_` (inflation-attack mitigations), OFAC `SanctionsList` + `BlockList`.
+- *Kiln IMPROVE*: first-class streamed reward primitive (Synthetix `MultiRewards.notifyRewardAmount`) — fixes JIT-attackability of Kiln's "Reinvest" mode; permissionless harvest with keeper-bond — inverts Kiln's `CLAIM_MANAGER_ROLE` operational dependency.
+- *Kiln AVOID*: global beacon controlling all integrators (the single biggest landmine — one key compromises everyone); Kiln-operated weekly keeper (single point of liveness failure); strategy hardcoded at init (no migration without redeploy).
+- *Coinbase COPY*: nothing on-chain (Coinbase ships no reward contract; the 10.8% APY is ~6% organic + ~5% Morpho-funded marketing boost via Merkl).
+- *Coinbase IMPROVE*: ship an on-chain `notifyRewardAmount` primitive — gives integrators a more direct primitive than Coinbase has today via the Morpho stack.
+- *Coinbase AVOID*: don't make Merkl the default — it's off-chain-trust-anchored.
+
+**Cross-cutting findings**:
+
+1. Converged architecture skeleton across MetaMorpho, Yearn V3, Lagoon: factory + immutable-per-vault + timelocked-mutable-params + guardian-veto. Adopt the same.
+2. Perf-fee cap encoded in implementation is the integrator-trust primitive — Morpho caps at 50%, Kiln has no cap. Without an immutable cap the wrapper is socially indistinguishable from "trust the deployer."
+3. Two viable reward-injection shapes: (a) harvest-and-reinvest into NAV (Idle, Yearn, Sommelier); (b) external distributor decoupled from share accounting (Morpho URD/Merkl, Mellow `RewardsDistributor`). Support (b) as primary so the wrapper stays 4626-clean; (a) optional for compound mode.
+
+The full realised output of this exact recipe is committed in `earn-monetization-v2-vault-wrapper/raw/` + `research-analysis.md` in the LiFi business-projects folder — load that if you need a reference shape.
+
+## Anti-patterns
+
+- **One subagent doing all comparables.** Loses parallel-independence value; introduces correlated bias. Output reads as a wiki, not as triangulated findings.
+- **Reading other agents' outputs mid-flight.** Convergent answers look like consensus but are correlation. Read after all return.
+- **Citing secondary sources.** A Medium post about Morpho isn't a source — Morpho's docs, contract source, governance forum, or audit reports are.
+- **Skipping COPY / IMPROVE / AVOID.** Research becomes reference material; the Tech Lead can't trace design choices back to it.
+- **Research after the draft is locked.** Re-opens v1 and erodes the audit trail. Run in parallel with the ambiguity gate.
+- **Padding the comparable set.** Below 3 = no triangulation; above 5 = unmanageable synthesis. Resist "and we should also look at …" past 5.
+- **Letting the blueprint dominate.** Every other comparable should pull weight. If the blueprint accounts for >60% of the research-derived design content, the comparable set was mis-picked.
+- **Spending the research budget on what the PRD already cites.** If the PRD already says "we copy Kiln's fee model," the research subagent on Kiln should focus on what's NOT in the PRD (Kiln's failure modes, governance landmines, weaknesses) — not re-derive what's already settled.
+
+## When to skip Phase 1.5 entirely
+
+- The PRD describes a feature for which the existing LiFi codebase already contains a near-canonical pattern (e.g. another facet with the same shape). The pattern *is* the research.
+- The ambiguity gate HALTed in Phase 1 with material gaps. Save the dispatched research for the next run after the executor returns answers.
+- The design is a minor extension to an already-audited contract. Run targeted research scoped to the extension surface only, not the full system.
+
+In all other cases, run Phase 1.5. Cost is low; the cost of skipping is high and back-loaded.

--- a/.claude/skills/sc-design-review/scripts/orchestrate.md
+++ b/.claude/skills/sc-design-review/scripts/orchestrate.md
@@ -4,19 +4,27 @@ This is the executable runbook for the orchestrator (i.e. the Claude session run
 
 ---
 
-## Step 1 — Resolve input
+## Step 1 — Resolve input (PRD + optional stories catalogue)
 
-Inputs accepted: Notion URL, Notion page ID, local markdown path.
+Inputs accepted: Notion URL, Notion page ID, local markdown path. Optional second input: stories-catalogue link / path produced by `creating-user-stories`.
 
+**PRD ingestion**:
 - If Notion: call `notion-fetch` on the page. For each child page link discovered, fetch it too. Stop at depth 2. Concatenate all page contents into `prd_source` with section headers per page.
 - If local: read the file. `prd_source` is the file content.
 - Capture `prd_title`, `prd_link` (URL or absolute path), `ingested_at` (today).
 
+**Stories-catalogue ingestion (optional)**:
+- If a catalogue link / path was supplied: fetch the Stories page **and** the companion Open Questions page (`creating-user-stories` produces both as siblings). Concatenate into `stories_source`. Capture `stories_link`.
+- If not supplied and the PRD has >5 distinct capabilities (rough heuristic: >5 third-level headings or >5 numbered "the system shall" / "users can" assertions): ask the executor once: *"This PRD looks substantial. Has `creating-user-stories` been run against it? Paste the catalogue link if yes; otherwise consider running it first."* Wait for the answer. Proceed without if declined; otherwise ingest as above.
+- If catalogue ingestion fails for any reason: continue without it, do not block on this.
+
 If `prd_source` is empty or fetch failed, stop and tell the user. Do not silently proceed.
 
-## Step 2 — Round 0: Ambiguity gate
+## Step 2 — Phases 1 + 1.5 (in parallel): Ambiguity gate + Research phase
 
-Spawn one Tech Lead subagent in Mode A:
+Spawn **both** subagent sets in **a single message**:
+
+1. **One Tech Lead subagent in Mode A** (ambiguity gate):
 
 ```
 Agent(
@@ -25,13 +33,18 @@ Agent(
   prompt: <personas/tech-lead.md>
         + "\n\n## Mode\nA — Ambiguity gate"
         + "\n\n## PRD\n" + prd_source
+        + (stories_source ? "\n\n## Stories catalogue (treat resolved items as NOT gaps)\n" + stories_source : "")
         + "\n\n## Output\nProduce the ambiguity report per the persona prompt. End with material_gaps: <true|false>."
 )
 ```
 
-If `material_gaps: true`: print the questionnaire to the executor. Stop. Do not draft.
+2. **N research subagents** (3–5; one per comparable). Load `references/research-phase.md` first; pick the comparable set per its "roles, not products" recipe; dispatch each with the standard prompt template from that reference. Each writes to `<workdir>/research/raw/NN-<comparable>.md`.
 
-If `material_gaps: false`: keep the ambiguity report in scope (you'll pass minor gaps into Mode B).
+Both blocks run in parallel — they don't depend on each other. Don't wait for the ambiguity gate before starting research.
+
+**Decision after both return**:
+- If `material_gaps: true`: print the questionnaire to the executor. Stop. The research output is still useful when the executor returns with answers — save the `raw/` files for the next run.
+- If `material_gaps: false`: synthesise the research into `<workdir>/research/research-analysis.md` per the recipe in `references/research-phase.md` (one section per comparable, COPY/IMPROVE/AVOID per comparable, cross-cutting findings section at end). Keep both the ambiguity report and the synthesised analysis in scope for Step 3.
 
 ## Step 3 — Phase 2: Draft v1
 
@@ -46,9 +59,12 @@ Agent(
         + "\n\n## PRD provenance\nTitle: " + prd_title
         + "\nSource: " + prd_link
         + "\nIngested: " + ingested_at
+        + (stories_link ? "\nStories catalogue: " + stories_link : "")
         + "\n\n## PRD\n" + prd_source
+        + (stories_source ? "\n\n## Stories catalogue\n" + stories_source : "")
         + "\n\n## Ambiguity report (minor gaps to flag in §12)\n" + ambiguity_report
-        + "\n\n## Output\nProduce design doc v1 per templates/design-doc.md. Fill Section 0 (Source PRD) using the provenance fields above. Section 13 (Custody of funds) MUST take an explicit position."
+        + "\n\n## Comparable-product research synthesis\n" + research_analysis
+        + "\n\n## Output\nProduce design doc v1 per templates/design-doc.md. Fill Section 0 (Source PRD) using the provenance fields above. Section 13 (Custody of funds) MUST take an explicit position. Design choices derived from comparable-product research should cite the COPY/IMPROVE/AVOID source inline."
 )
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #1753 — two related additions, both surfaced by the evaluation pass that ran the sibling \`creating-user-stories\` skill ([#1776](https://github.com/lifinance/contracts/pull/1776)) cold against the [Programmable Vault Wrapper PRD](https://www.notion.so/lifi/LI-FI-Programmable-Vault-Wrapper-PRD-352f0ff14ac780e9b426c99364cfe814).

**Targets** \`chore/add-sc-design-review-skill\` so #1753 stays the single landing point.

### Change 1 — integrate \`creating-user-stories\` as optional upstream input

The two skills are siblings: \`creating-user-stories\` consumes a PRD and produces a stories + open-questions catalogue; \`sc-design-review\` consumes a PRD and produces a hardened design doc. They share an input but their outputs feed different downstream work. The catalogue is a useful intermediate artifact for the design pass — pins capability scope, pre-enumerates ambiguities.

- New \"Relationship with \`creating-user-stories\`\" section at the top of \`SKILL.md\`.
- Phase 0 ingestion accepts an optional stories-catalogue link / path, prompts the executor once if the PRD looks substantial but no catalogue was supplied.
- Phase 1 ambiguity gate treats catalogue-pinned items as not-gaps and inherits Open Question lane tags into its classification (\`⚠️ PRODUCT\` → \`material\`, \`[TECH]\` → \`minor\`).
- Phase 2 drafting uses the stories catalogue as the capability spec — Tech Lead doesn't re-derive scope from PRD prose.
- Orchestrator runbook + Tech Lead persona Mode A / Mode B prompts updated for the new inputs.

### Change 2 — add Phase 1.5 (Comparable-product research) as a first-class phase

The single largest gap surfaced by the evaluation: ~20–30% of the load-bearing findings in a hardened design come from comparable-product research (Synthetix MultiRewards patterns, Coinbase/Morpho boost mechanism, Kiln beacon-key landmine, ERC-4626 inflation attack literature). Without a first-class phase, this work is back-loaded to Round 3 / external audit at maximum cost.

- New **Phase 1.5** in \`SKILL.md\` (~40 lines): trigger, comparable-set roles (blueprint / marquee-customer-reality / competitor / field-wide / adjacent-but-distinct), recipe, **COPY / IMPROVE / AVOID** frame, anti-patterns.
- New \`references/research-phase.md\` (~200 lines): subagent prompt template, synthesis output template, a full worked example (the Vault Wrapper research that produced the published catalogue's research-derived stories), anti-patterns, skip conditions.
- Orchestrator dispatches the ambiguity-gate Tech Lead **and** the N research subagents in a single message — they don't depend on each other; both feed Phase 2.
- Phase 2 drafting prompt now passes the synthesised research into the Tech Lead. Design choices derived from research must cite the COPY / IMPROVE / AVOID source inline (e.g. *\"per \`research-analysis.md\` §A: AVOID Kiln's global beacon\"*).
- Workflow diagram updated.

## Why Phase 1.5 lives in this skill, not in \`creating-user-stories\`

Both skills consume a PRD, but only this skill consumes research output for hardening decisions. The user-stories skill stays focused on user-story work; the design skill owns the research/hardening loop. A previous draft of this change ([#1777](https://github.com/lifinance/contracts/pull/1777), now closed) put the research phase in \`creating-user-stories\` — that was the wrong home. Catalogue authors *might* benefit from the research, but design authors *require* it.

## What this is NOT

- Not a research-as-its-own-skill extraction. Kept inline here for now. If \`comparable-product-research\` becomes useful in other contexts (PRD authoring, design-doc reviews, retrospectives), extract later.
- Not a change to the persona schema, finding-schema, or template.
- Not a change to the 3-round challenge loop in Phase 3.

## Test plan

Skills aren't compile-checked. Worth verifying:

- [ ] Run \`/sc-design-review\` against the Vault Wrapper PRD ([Notion](https://www.notion.so/lifi/LI-FI-Programmable-Vault-Wrapper-PRD-352f0ff14ac780e9b426c99364cfe814)) + catalogue link ([Stories](https://www.notion.so/lifi/Earn-PRD-Review-35af0ff14ac7805b98ece561ec483cde)) and confirm Phase 0 ingests both.
- [ ] Confirm Phase 1 + Phase 1.5 dispatch in parallel (single message with N+1 \`Agent\` calls).
- [ ] Confirm the research subagents return \`raw/NN-*.md\` files with the COPY/IMPROVE/AVOID closing frame.
- [ ] Confirm v1 of the design doc cites at least one research finding inline.
- [ ] Run against a small PRD (no catalogue) and confirm the executor is prompted once but not blocked.
- [ ] Confirm Phase 1.5 skip conditions trigger when the design is a minor extension to an audited contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)