### PR TITLE
chore: remove LiFiDEXAggregator from corePeriphery

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -55,7 +55,6 @@
     "FeeCollector",
     "FeeForwarder",
     "GasZipPeriphery",
-    "LiFiDEXAggregator",
     "LiFiTimelockController",
     "Permit2Proxy",
     "TokenWrapper"


### PR DESCRIPTION
## Summary
- Removes `LiFiDEXAggregator` from the `corePeriphery` list in `config/global.json` so it is no longer deployed to new chains.
- Contract is **not** deprecated — existing deployments remain in place; the `whitelistPeripheryFunctions.LiFiDEXAggregator` entry is left untouched.

## Test plan
- [ ] CI passes
- [ ] Confirm deployment scripts skip `LiFiDEXAggregator` on new-chain runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)