### PR TITLE
ci(setup-foundry): add forge build + solc cache to composite action

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -24,14 +24,11 @@ runs:
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
-      with:
-        version: ${{ steps.pin.outputs.version }}
-
     - name: Cache Foundry toolchain state (svm + foundryup)
-      # Version is folded into the cache key so a foundry bump invalidates the cache
-      # automatically and we never mix solc binaries across foundry versions.
+      # Restored before the install step so foundry-toolchain can detect an existing
+      # matching install and skip the download on a cache hit. Version is folded into
+      # the cache key so a foundry bump invalidates the cache automatically and we
+      # never mix solc binaries across foundry versions.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
@@ -40,6 +37,11 @@ runs:
         key: foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml') }}
         restore-keys: |
           foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-
+
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+      with:
+        version: ${{ steps.pin.outputs.version }}
 
     - name: Cache forge build artifacts (cache/, out/)
       # Key on every input that influences compilation. A cache miss falls back to

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -1,11 +1,13 @@
-# Composite action: install pinned foundry + verify
+# Composite action: install pinned foundry + verify (with caching)
 # - Reads .foundry-version from the checked-out repo
 # - Installs foundry at that version via foundry-rs/foundry-toolchain
+# - Restores ~/.foundry / ~/.svm (solc downloads) and cache/ + out/ (forge build artifacts)
+#   between runs to skip redundant downloads and recompilation.
 # - Verifies the installed binary matches the pin (catches action regressions or input typos)
 # Used by every workflow that needs forge/cast/anvil so a single pin source
 # (.foundry-version) flows everywhere.
 name: Setup Foundry
-description: Install pinned foundry from .foundry-version and verify the installed binary matches.
+description: Install pinned foundry from .foundry-version, restore solc + forge build caches, and verify the installed binary matches.
 
 runs:
   using: composite
@@ -26,6 +28,30 @@ runs:
       uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       with:
         version: ${{ steps.pin.outputs.version }}
+
+    - name: Cache Foundry toolchain state (svm + foundryup)
+      # Version is folded into the cache key so a foundry bump invalidates the cache
+      # automatically and we never mix solc binaries across foundry versions.
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: |
+          ~/.foundry
+          ~/.svm
+        key: foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml') }}
+        restore-keys: |
+          foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-
+
+    - name: Cache forge build artifacts (cache/, out/)
+      # Key on every input that influences compilation. A cache miss falls back to
+      # a clean build with no behavior change.
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: |
+          cache
+          out
+        key: forge-build-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
+        restore-keys: |
+          forge-build-${{ runner.os }}-${{ steps.pin.outputs.version }}-
 
     - name: Verify foundry version
       shell: bash


### PR DESCRIPTION
## Summary
- Stacked on top of [#1769](https://github.com/lifinance/contracts/pull/1769).
- Adds two `actions/cache` layers inside the existing `./.github/actions/setup-foundry` composite, so **every** workflow that calls it gets caching for free:
  - `~/.foundry` + `~/.svm` (solc downloads + foundryup state) — keyed on the pinned foundry version + `foundry.toml`.
  - `cache/` + `out/` (forge build artifacts) — keyed on the pinned version + `foundry.toml` + `remappings.txt` + `src/**` + `test/**` + `lib/**`.
- Cache keys fold in the pinned foundry version, so bumping `.foundry-version` invalidates the cache automatically — no risk of mixing solc/build artifacts across versions.
- Cache miss falls back to a clean install + build with no behavior change.

## Why
After #1769 lands, every CI workflow that needs foundry goes through one composite. That makes it the right place to add caching once instead of duplicating cache steps across seven workflows.

`forge build` / `forge test` / `forge coverage` are the wall-clock dominant steps on most CI runs. With caching, an unchanged `src/` skips solc recompilation entirely; only changed PRs pay the build cost.

## Test plan
- [ ] Merge into `pin-foundry`, observe first run = cold (saves cache).
- [ ] Run a second time on the same commit → confirm `Cache hit` for both cache steps.
- [ ] Bump `.foundry-version` on a throwaway commit → confirm cache key changes and the old cache is not reused.
- [ ] Touch a single `.sol` file → toolchain cache hits, build cache key changes (expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)