### PR TITLE
ci: path-gate forge unit tests + deploy smoke test + min test coverage

### DIFF
--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -3,7 +3,9 @@
 # - Triggers on PRs targeting main and on manual dispatch
 # - Validates the deploy script end-to-end so regressions in deploy bash,
 #   Solidity scripts, target state, or whitelist sync surface before merge
-# - Not a required status check initially; promote via repo settings once stable
+# - Path-gated: heavy job runs only when files that can affect the smoke outcome
+#   change. A `required-check` aggregator job always reports a final status so
+#   this workflow can be a required check on `main` branch protection.
 name: Deploy Smoke Test
 
 on:
@@ -14,21 +16,55 @@ on:
 
 permissions:
   contents: read # required to fetch repository contents
+  pull-requests: read # required by dorny/paths-filter to read changed files on PRs
 
 concurrency:
   group: deploy-smoke-test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    # Determines whether files that can influence the smoke pipeline were touched.
+    # Always runs (cheap) so the downstream required-check can report status.
+    runs-on: ubuntu-latest
+    outputs:
+      smoke: ${{ steps.filter.outputs.smoke }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            smoke:
+              - 'foundry.toml'
+              - 'remappings.txt'
+              - 'src/**'
+              - 'lib/**'
+              - '.gitmodules'
+              - 'config/**'
+              - 'deployments/**'
+              - 'script/deploy/**'
+              - 'script/utils/**'
+              - 'script/tasks/**'
+              - 'script/resources/**'
+              - '.env.example'
+              - 'package.json'
+              - 'bun.lockb'
+              - '.github/workflows/deploy-smoke-test.yml'
+
   deploy-smoke-test:
-    # Always run on manual dispatch; for PRs, skip drafts and require main as the base.
+    # Always run on manual dispatch; for PRs, skip drafts, require main as the base,
+    # and only run when files that influence the smoke pipeline have changed.
     # github.event.pull_request is unset on workflow_dispatch, so the explicit
     # event_name branch is required to keep the manual trigger path working.
+    needs: detect-changes
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' &&
            github.event.pull_request.draft == false &&
-           github.event.pull_request.base.ref == 'main') }}
+           github.event.pull_request.base.ref == 'main' &&
+           needs.detect-changes.outputs.smoke == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -132,3 +168,22 @@ jobs:
             deployments/localanvil*.json
           if-no-files-found: ignore
           retention-days: 7
+
+  required-check:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `deploy-smoke-test`) as the required status check on `main`.
+    needs: [detect-changes, deploy-smoke-test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        run: |
+          set -euo pipefail
+          result="${{ needs.deploy-smoke-test.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo -e "\033[32mrequired-check OK (deploy-smoke-test=$result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mrequired-check FAILED (deploy-smoke-test=$result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -125,6 +125,7 @@ jobs:
           # shellcheck disable=SC2016 # the $PRIVATE_KEY_ANVIL literal is expanded later when .env is sourced, not now
           {
             echo 'PRIVATE_KEY=$PRIVATE_KEY_ANVIL'
+            # pre-commit-checker: not a secret
             echo 'ETH_NODE_URI_LOCALANVIL=http://localhost:8545'
             echo 'MONGODB_URI=mongodb://localhost:27017/contract-deployments'
           } >> .env
@@ -137,6 +138,7 @@ jobs:
           anvil --mnemonic "${MNEMONIC}" --silent &
           # Bounded readiness probe — fail fast if anvil never comes up.
           for _ in $(seq 1 30); do
+            # pre-commit-checker: not a secret
             if [[ "$(cast chain-id --rpc-url http://localhost:8545 2>/dev/null || true)" == "31337" ]]; then
               echo -e "\033[32manvil ready\033[0m"
               exit 0
@@ -178,12 +180,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `deploy-smoke-test`
+        # would be `skipped` due to the dependency failure — and treating that
+        # `skipped` as success would mask the infra failure from branch protection.
         run: |
           set -euo pipefail
-          result="${{ needs.deploy-smoke-test.result }}"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo -e "\033[32msmoke-test-required OK (deploy-smoke-test=$result)\033[0m"
+          detect_result="${{ needs.detect-changes.result }}"
+          smoke_result="${{ needs.deploy-smoke-test.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31msmoke-test-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$smoke_result" == "success" || "$smoke_result" == "skipped" ]]; then
+            echo -e "\033[32msmoke-test-required OK (deploy-smoke-test=$smoke_result)\033[0m"
             exit 0
           fi
-          echo -e "\033[31msmoke-test-required FAILED (deploy-smoke-test=$result)\033[0m" >&2
+          echo -e "\033[31msmoke-test-required FAILED (deploy-smoke-test=$smoke_result)\033[0m" >&2
           exit 1

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -4,7 +4,7 @@
 # - Validates the deploy script end-to-end so regressions in deploy bash,
 #   Solidity scripts, target state, or whitelist sync surface before merge
 # - Path-gated: heavy job runs only when files that can affect the smoke outcome
-#   change. A `required-check` aggregator job always reports a final status so
+#   change. A `smoke-test-required` aggregator job always reports a final status so
 #   this workflow can be a required check on `main` branch protection.
 name: Deploy Smoke Test
 
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   detect-changes:
     # Determines whether files that can influence the smoke pipeline were touched.
-    # Always runs (cheap) so the downstream required-check can report status.
+    # Always runs (cheap) so the downstream smoke-test-required can report status.
     runs-on: ubuntu-latest
     outputs:
       smoke: ${{ steps.filter.outputs.smoke }}
@@ -169,7 +169,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  required-check:
+  smoke-test-required:
     # Aggregator job for branch protection. Reports green when the heavy job
     # either succeeded or was skipped because no relevant files changed.
     # Register THIS job (not `deploy-smoke-test`) as the required status check on `main`.
@@ -182,8 +182,8 @@ jobs:
           set -euo pipefail
           result="${{ needs.deploy-smoke-test.result }}"
           if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo -e "\033[32mrequired-check OK (deploy-smoke-test=$result)\033[0m"
+            echo -e "\033[32msmoke-test-required OK (deploy-smoke-test=$result)\033[0m"
             exit 0
           fi
-          echo -e "\033[31mrequired-check FAILED (deploy-smoke-test=$result)\033[0m" >&2
+          echo -e "\033[31msmoke-test-required FAILED (deploy-smoke-test=$result)\033[0m" >&2
           exit 1

--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -3,6 +3,10 @@ name: Enforce Min Test Coverage
 # - will make sure that (Foundry) unit test coverage is above min threshold
 # - we start with 74% (status today), planning to increase to 100% until EOY 2024
 # - Only the 'lines' coverage counts as 'branch' coverage is not reliable
+# - Path-gated: heavy job runs only when files that can affect coverage outcome
+#   change. A `coverage-required` aggregator job always reports a final status so
+#   this workflow can remain a required check on `main` branch protection even
+#   when the heavy job is skipped.
 
 on:
   pull_request:
@@ -13,10 +17,39 @@ permissions:
   pull-requests: write # required to post the coverage summary as a PR comment
 
 jobs:
-  enforce-min-test-coverage:
+  detect-changes:
+    # Determines whether files that can influence `forge coverage` outcomes were touched.
+    # Always runs (cheap) so the downstream coverage-required can report status.
     runs-on: ubuntu-latest
-    # will only run once the PR is in "Ready for Review" state
-    if: ${{ github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+    outputs:
+      coverage: ${{ steps.filter.outputs.coverage }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            coverage:
+              - 'foundry.toml'
+              - 'remappings.txt'
+              - 'src/**'
+              - 'test/**'
+              - 'lib/**'
+              - '.gitmodules'
+              - '.github/workflows/enforceTestCoverage.yml'
+
+  enforce-min-test-coverage:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    # will only run once the PR is in "Ready for Review" state AND files that
+    # influence coverage have changed
+    if: >-
+      ${{ github.event.pull_request.draft == false &&
+          needs.detect-changes.outputs.coverage == 'true' }}
 
     env:
       MIN_TEST_COVERAGE: ${{ secrets.MIN_TEST_COVERAGE }}
@@ -27,7 +60,7 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      
+
       - name: Install dev dependencies
         run: bun install
 
@@ -51,27 +84,13 @@ jobs:
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
 
-      - name: Check for Solidity file changes
-        id: check_files
-        run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^src/.*\.sol|^test/.*\.sol' || true)
-          if [[ -n "$CHANGED_FILES" ]]; then
-            echo "solidity_changed=true" >> "$GITHUB_ENV"
-          else
-            echo "solidity_changed=false" >> "$GITHUB_ENV"
-          fi
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
-        if: env.solidity_changed == 'true'
 
       - name: Install forge Dependencies
         run: forge install
-        if: env.solidity_changed == 'true'
 
       - name: Generate Coverage Report
-        if: env.solidity_changed == 'true'
         run: |
           forge coverage --report lcov --force --ir-minimum
 
@@ -82,7 +101,6 @@ jobs:
           echo "Coverage report successfully filtered"
 
       - name: Generate Coverage Summary
-        if: env.solidity_changed == 'true'
         run: |
 
 
@@ -161,7 +179,6 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Comment with Coverage Summary in PR
-        if: env.solidity_changed == 'true'
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
           repo-token: ${{ secrets.GIT_ACTIONS_BOT_PAT_CLASSIC }}
@@ -172,6 +189,29 @@ jobs:
             ${{ env.BRANCH_COVERAGE_REPORT }}
             ${{ env.RESULT_COVERAGE_REPORT }}
 
-      - name: Skip Tests (No Solidity Changes)
-        if: env.solidity_changed == 'false'
-        run: echo "No Solidity files changed. Skipping test coverage check."
+  coverage-required:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `enforce-min-test-coverage`) as the required status check on `main`.
+    needs: [detect-changes, enforce-min-test-coverage]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `enforce-min-test-coverage`
+        # would be `skipped` due to the dependency failure — and treating that
+        # `skipped` as success would mask the infra failure from branch protection.
+        run: |
+          set -euo pipefail
+          detect_result="${{ needs.detect-changes.result }}"
+          coverage_result="${{ needs.enforce-min-test-coverage.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31mcoverage-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$coverage_result" == "success" || "$coverage_result" == "skipped" ]]; then
+            echo -e "\033[32mcoverage-required OK (enforce-min-test-coverage=$coverage_result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mcoverage-required FAILED (enforce-min-test-coverage=$coverage_result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -44,9 +44,17 @@ jobs:
               - '.github/workflows/forge-unit-tests.yml'
 
   run-unit-tests:
-    # will only run once the PR is in "Ready for Review" state AND relevant files changed
+    # Runs on PRs (once out of draft) and on push/workflow_dispatch.
+    # For non-PR events `github.event.pull_request` is null, so the draft check
+    # is gated behind an event-name guard to avoid `null == false` evaluating to
+    # false and silently skipping the job after a merge to main.
     needs: detect-changes
-    if: ${{ github.event.pull_request.draft == false && needs.detect-changes.outputs.forge == 'true' }}
+    if: >-
+      ${{
+        needs.detect-changes.outputs.forge == 'true' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.draft == false)
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -102,12 +110,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `run-unit-tests`
+        # would be `skipped` due to the dependency failure — and treating that
+        # `skipped` as success would mask the infra failure from branch protection.
         run: |
           set -euo pipefail
-          result="${{ needs.run-unit-tests.result }}"
-          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo -e "\033[32munit-tests-required OK (run-unit-tests=$result)\033[0m"
+          detect_result="${{ needs.detect-changes.result }}"
+          test_result="${{ needs.run-unit-tests.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31munit-tests-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$test_result" == "success" || "$test_result" == "skipped" ]]; then
+            echo -e "\033[32munit-tests-required OK (run-unit-tests=$test_result)\033[0m"
             exit 0
           fi
-          echo -e "\033[31munit-tests-required FAILED (run-unit-tests=$result)\033[0m" >&2
+          echo -e "\033[31munit-tests-required FAILED (run-unit-tests=$test_result)\033[0m" >&2
           exit 1

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -1,5 +1,9 @@
 # - Run (Foundry) Unit Test Suite
 # - will make sure that all tests pass
+# - Path-gated: heavy job runs only when files that can affect test outcome change.
+#   A `required-check` aggregator job always reports a final status so this
+#   workflow can remain a required check on `main` branch protection even when
+#   the heavy job is skipped (see `.agents/rules/500-github-actions.md`).
 
 name: Run Unit Tests
 on:
@@ -14,11 +18,35 @@ on:
 
 permissions:
   contents: read # required to fetch repository contents
+  pull-requests: read # required by dorny/paths-filter to read changed files on PRs
 
 jobs:
+  detect-changes:
+    # Determines whether files that can influence `forge test` outcomes were touched.
+    # Always runs (cheap) so the downstream required-check can report status.
+    runs-on: ubuntu-latest
+    outputs:
+      forge: ${{ steps.filter.outputs.forge }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            forge:
+              - 'foundry.toml'
+              - 'remappings.txt'
+              - 'src/**'
+              - 'test/**'
+              - 'lib/**'
+              - '.gitmodules'
+              - '.github/workflows/forge-unit-tests.yml'
+
   run-unit-tests:
-    # will only run once the PR is in "Ready for Review" state
-    if: ${{ github.event.pull_request.draft == false }}
+    # will only run once the PR is in "Ready for Review" state AND relevant files changed
+    needs: detect-changes
+    if: ${{ github.event.pull_request.draft == false && needs.detect-changes.outputs.forge == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -57,10 +85,29 @@ jobs:
           done < ".env"
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          
+
       - name: Run forge tests (with auto-repeat in case of error)
         uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
         with:
           command: forge test
           attempt_limit: 10
           attempt_delay: 15000
+
+  required-check:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `run-unit-tests`) as the required status check on `main`.
+    needs: [detect-changes, run-unit-tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        run: |
+          set -euo pipefail
+          result="${{ needs.run-unit-tests.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo -e "\033[32mrequired-check OK (run-unit-tests=$result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mrequired-check FAILED (run-unit-tests=$result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -1,7 +1,7 @@
 # - Run (Foundry) Unit Test Suite
 # - will make sure that all tests pass
 # - Path-gated: heavy job runs only when files that can affect test outcome change.
-#   A `required-check` aggregator job always reports a final status so this
+#   A `unit-tests-required` aggregator job always reports a final status so this
 #   workflow can remain a required check on `main` branch protection even when
 #   the heavy job is skipped (see `.agents/rules/500-github-actions.md`).
 
@@ -23,7 +23,7 @@ permissions:
 jobs:
   detect-changes:
     # Determines whether files that can influence `forge test` outcomes were touched.
-    # Always runs (cheap) so the downstream required-check can report status.
+    # Always runs (cheap) so the downstream unit-tests-required can report status.
     runs-on: ubuntu-latest
     outputs:
       forge: ${{ steps.filter.outputs.forge }}
@@ -93,7 +93,7 @@ jobs:
           attempt_limit: 10
           attempt_delay: 15000
 
-  required-check:
+  unit-tests-required:
     # Aggregator job for branch protection. Reports green when the heavy job
     # either succeeded or was skipped because no relevant files changed.
     # Register THIS job (not `run-unit-tests`) as the required status check on `main`.
@@ -106,8 +106,8 @@ jobs:
           set -euo pipefail
           result="${{ needs.run-unit-tests.result }}"
           if [[ "$result" == "success" || "$result" == "skipped" ]]; then
-            echo -e "\033[32mrequired-check OK (run-unit-tests=$result)\033[0m"
+            echo -e "\033[32munit-tests-required OK (run-unit-tests=$result)\033[0m"
             exit 0
           fi
-          echo -e "\033[31mrequired-check FAILED (run-unit-tests=$result)\033[0m" >&2
+          echo -e "\033[31munit-tests-required FAILED (run-unit-tests=$result)\033[0m" >&2
           exit 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Forge](https://github.com/lifinance/contracts/actions/workflows/forge.yml/badge.svg)](https://github.com/lifinance/contracts/actions/workflows/forge.yml)
+[![Forge](https://github.com/lifinance/contracts/actions/workflows/forge-unit-tests.yml/badge.svg)](https://github.com/lifinance/contracts/actions/workflows/forge-unit-tests.yml)
 
 # LI.FI Smart Contracts
 


### PR DESCRIPTION
## Summary
`Run Unit Tests`, `Deploy Smoke Test`, and `Enforce Min Test Coverage` are all required-for-merge but run unconditionally today, so a docs-only PR still waits minutes for a full rebuild + anvil pipeline + coverage run. This PR adds path-gating to all three, without breaking branch protection.

**Pattern (per workflow):**
1. `detect-changes:` runs first — uses `dorny/paths-filter` to compute whether files that can actually influence outcome were touched (conservative include list).
2. Heavy job gates on the output. Skipped if nothing relevant changed.
3. `required-check:` runs last with `if: always()` and reports green when the heavy job either succeeded or was skipped. **This is the job that branch protection should require** — it sidesteps the GitHub footgun where top-level `on.paths` filters make required checks hang forever in *"Expected — Waiting for status to be reported"*.

Also renames `.github/workflows/forge.yml` → `forge-unit-tests.yml` to match the smoke workflow's naming style.

## Path scope (conservative)

**Forge unit tests:**
`foundry.toml`, `remappings.txt`, `src/**`, `test/**`, `lib/**`, `.gitmodules`, the workflow file itself.

**Smoke test:**
`foundry.toml`, `remappings.txt`, `src/**`, `lib/**`, `.gitmodules`, `config/**`, `deployments/**`, `script/deploy/**`, `script/utils/**`, `script/tasks/**`, `script/resources/**`, `.env.example`, `package.json`, `bun.lockb`, the workflow file itself.

`test/**` is intentionally NOT in the smoke scope. Docs/markdown/audit/templates/tasks are not in either.

**Min test coverage:**
`foundry.toml`, `remappings.txt`, `src/**`, `test/**`, `lib/**`, `.gitmodules`, the workflow file itself. Same scope as forge unit tests since `forge coverage` runs the same compilation + test surface. Broader than the previous in-job `.sol`-only filter — `foundry.toml`/`lib/**`/`remappings.txt` changes can shift coverage and were previously skipped silently. The redundant in-job `git diff` step is removed in favour of the outer gate.

## Scope of this PR
Only path-gating + the rename. Foundry-toolchain unification + caching is being handled separately in [#1769](https://github.com/lifinance/contracts/pull/1769) (pin foundry version) and [#1790](https://github.com/lifinance/contracts/pull/1790) (add caching to that composite). Whichever of those merges first, this PR will need a trivial rebase to swap its `foundry-rs/foundry-toolchain@…` step for `./.github/actions/setup-foundry`.

## Follow-up (admin action required)
On `main` branch protection, **swap the required status checks**:
- `run-unit-tests` → `required-check` (from `Run Unit Tests` workflow)
- `deploy-smoke-test` → `required-check` (from `Deploy Smoke Test` workflow)
- `enforce-min-test-coverage` → `coverage-required` (from `Enforce Min Test Coverage` workflow)

If protection isn't updated, currently-open PRs will keep waiting on the old job names. Do this in the same change window as the merge of this PR.

## Test plan
- [ ] PR touching only a `*.md` → all three heavy jobs skip, all three `required-check` / `coverage-required` jobs report green within ~10s.
- [ ] PR touching `src/Facets/*.sol` → forge runs; smoke runs; coverage runs (and posts PR comment).
- [ ] PR touching only `test/**` → forge runs; coverage runs; smoke skips.
- [ ] PR touching only `foundry.toml` → forge, smoke, and coverage all run (validates broader coverage scope vs. previous `.sol`-only inner filter).
- [ ] PR bumping a submodule under `lib/` → all three run.
- [ ] PR editing `.github/workflows/forge-unit-tests.yml` → forge runs (self-test). Same for the other two workflow files.
- [ ] After admin updates branch protection: confirm a docs-only PR is mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)