### PR TITLE
chore(skills): add sprint-planning skill (WIP)

### DIFF
--- a/.claude/skills/sprint-planning/SKILL.md
+++ b/.claude/skills/sprint-planning/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: sprint-planning
+description: Sprint capacity planning for LI.FI squads. Pulls next sprint dates from Linear, checks team availability from HiBob, calculates historical velocity per role group (QA / Backend Dev / Smart Contract Dev), and outputs adjusted story point targets. Use when someone says "plan next sprint", "sprint planning", "what's our sprint capacity", "how many story points for next sprint", "sprint capacity for [squad]".
+---
+
+# Sprint Planning
+
+Run a full sprint capacity analysis for a squad: sprint window from Linear, team roster + availability from HiBob, historical velocity from past cycles, and adjusted story point targets per role group.
+
+## When to run
+
+- "Plan next sprint for API Expansion"
+- "What's our sprint capacity?"
+- "How many story points can we take on?"
+- "Sprint planning for [squad name]"
+
+## Inputs to collect
+
+Before starting, confirm with the user (use defaults if they agree):
+
+| Input | Default |
+|-------|---------|
+| Squad name | API Expansion |
+| Historical sprints to average | 3 |
+
+If the user's message already includes these (e.g., "plan next sprint for Protocol using 5 sprints"), use those values directly without asking.
+
+---
+
+## Procedure
+
+### Step 0 — Load squad config
+
+Before doing anything else, read the config file for the squad:
+
+```
+skills/sprint-planning/config/<squad-slug>.md
+```
+
+Where `<squad-slug>` is the squad name lowercased with spaces replaced by hyphens (e.g., "API Expansion" → `api-expansion.md`).
+
+If the file exists, extract and store:
+- **Capacity overrides** — per-person coding capacity % (overrides HiBob and 100% default in Step 5)
+- **Squad member mapping notes** — corrections to HiBob/Linear data
+- **Velocity notes** — guidance for when estimates are missing
+
+If no config file exists for this squad, proceed with defaults (no overrides).
+
+Tell the user: "Config loaded for [squad]." and list any active overrides:
+> Config loaded. Active overrides: Marcin (0% — on another team), Michał (0% — on another team), Daniel (20% coding capacity — Engineering Lead).
+
+### Step 1 — Find the Linear team
+
+Call `list_teams()` from the Linear MCP.
+
+Find the team whose name contains the squad name (case-insensitive). For "API Expansion", match teams like "API Expansion", "API Expansion EVM", etc. — if there are multiple, pick the most specific match or ask the user.
+
+Store: `teamId`, `teamName`
+
+### Step 2 — Find the next sprint cycle
+
+Call `list_cycles(teamId)`.
+
+Find the next **upcoming** cycle (state = "future" or closest future `startDate`). If no upcoming cycle exists, tell the user: "No upcoming cycle found in Linear for [team]. Sprint planning cannot proceed until a cycle is created."
+
+Store: `cycleId`, `cycleName`, `startDate`, `endDate`
+
+Present to user:
+> Next sprint: **[cycleName]** — [startDate] to [endDate]
+
+### Step 3 — Get squad members from HiBob
+
+Invoke `/hibob:squad-members` with the squad name.
+
+Group the returned members by `department` into role buckets:
+- **QA** — department contains "QA" or "Quality" (case-insensitive)
+- **Smart Contract** — department contains "Smart Contract" or "Solidity" (case-insensitive)
+- **Backend Dev** — all other squad members
+
+Store member list with `{name, email, department, roleGroup}`.
+
+If fewer than 2 members are returned, warn: "Only [N] member(s) found in HiBob for '[squad]'. Check the department name matches HiBob exactly."
+
+### Step 4 — Close the previous sprint, then read velocity from history
+
+Velocity is tracked as **SP per effective FTE-day** in `history/<squad-slug>.md`.
+That file is the single source of truth — the skill never recomputes FTE-days from APIs for past sprints,
+because HiBob leave data is incomplete (missing public holidays, ad-hoc absences, etc.).
+
+#### 4a — Close the previous sprint (if not yet recorded)
+
+Identify the most recently *completed* cycle (the one that ended just before the upcoming sprint).
+Check whether it already has an entry in `history/<squad-slug>.md`.
+
+**If already recorded:** skip to 4b.
+
+**If NOT recorded:** draft an entry now.
+
+1. Fetch completed SP from Linear: `list_issues(teamId, cycleId)` → sum estimates for Done issues per group
+2. Draft FTE-days from config: `Σ (working_days(cycle) × capacity_pct(person, cycle))` per group
+3. Present the draft to the user in one compact block:
+
+```
+Closing Expansion Cycle 5 (Apr 14–28) before planning Cycle 7.
+
+  Group           SP (from Linear)   FTE-days (from config)   Rate
+  Backend Dev          20                    40                0.50
+  Smart Contract        3                    30                0.10
+  QA                    0                    10                 —
+
+Were there any public holidays, unplanned absences, or other
+availability changes during Apr 14–28 I should adjust?
+(e.g. "Good Friday Apr 18 hit everyone" → -4 backend days, -3 SC days, -1 QA day)
+Or: "Looks right, save it."
+```
+
+4. Apply any adjustments the user gives, recompute rates, then **save the entry** to `history/<squad-slug>.md` (prepend at the top, most-recent-first). Propose a PR message for the shared repo.
+
+5. If the user says "skip for now" or "I'll do it later", proceed without saving — but note that velocity data for that sprint is missing from history.
+
+#### 4b — Read velocity from history
+
+Load `history/<squad-slug>.md`. Take the last N entries (most recent first).
+
+For each entry:
+- Read `Completed SP` and `FTE-Days` directly from the file — do not recompute
+- `velocity_rate[group][s] = Completed SP / FTE-Days`
+- Skip entries where Rate = `—` (estimates missing — not a zero, just absent data)
+
+Average across qualifying entries:
+- `velocity_rate[group] = mean(velocity_rate[group][s])`
+- Flag if < 2 qualifying entries: "⚠️ Limited history"
+- Flag if 0 qualifying entries: ask user for a manual rate
+
+See [references/capacity-calculation.md](references/capacity-calculation.md) for the full formula.
+
+### Step 5 — Determine availability for the upcoming sprint
+
+**5a — Resolve effective FTE-days per member** using the config dated overrides for the upcoming sprint window:
+- `effective_days(person) = sprint_working_days × capacity_pct(person, startDate, endDate)`
+- Members resolving to 0% contribute 0 days and are shown as `--` in the table
+
+**5b — Try HiBob for time-off:** Invoke `/hibob:availability` with `from=startDate`, `to=endDate`.
+- If HiBob returns leave data, subtract those absent days from each affected member's effective days
+- If HiBob returns empty (API permissions not yet configured), skip
+
+**5c — Ask for manual adjustments:**
+> "I'm using [config overrides + HiBob data / config overrides + 100% default] for capacity. Does anyone have planned leave, public holidays, or further changes during this sprint?"
+
+Accept natural language: "Daniel is out 3 days", "Public holiday May 1 affects everyone", "Everyone is fully available". Subtract from the relevant member's effective days.
+
+**5d — Group capacity %:**
+```
+current_effective_FTE_days[group] = Σ effective_days(person) for all members in group
+capacity_pct[group] = current_effective_FTE_days[group] / (member_count[group] × sprint_working_days) × 100
+```
+
+### Step 6 — Calculate available story points
+
+For each role group:
+```
+available_SP[group] = round(velocity_rate[group] × current_effective_FTE_days[group])
+```
+
+This automatically accounts for team size changes: if a new person joins, their FTE-days add to the multiplier; if someone leaves, their days drop out — without distorting the historical rate.
+
+### Step 7 — Present results
+
+Output in four blocks in this order:
+
+**Block 1 — Member list**
+One line per member: name, email, role group, and any active config override.
+
+**Block 2 — Availability table (members as rows, working days as columns)**
+
+Members are rows, grouped by role. One column per working day (Mon–Fri), plus a right-hand "Days" and "Eff." column. A sum row closes each group.
+
+Alignment rules (follow exactly to keep columns flush):
+- Name column: left-padded to 18 chars (including 2-space indent for members)
+- Each day cell: exactly 4 chars wide — use `" ok "` for available, `" -- "` for 0%-capacity, `" hb "` for HiBob leave
+- Days / Eff. columns: right-aligned in a 4-char field
+- Group header row spans full width with no day cells filled
+
+```
+## Availability: [cycleName] · [startDate] → [endDate] · [N] working days
+                    13/5 14/5 15/5 18/5 19/5 20/5 21/5 22/5 25/5 26/5   Eff.
+──────────────────────────────────────────────────────────────────────────────
+BACKEND DEV
+  Daniela           ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Joao              ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Nathan            ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Victor            ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Marcin            --   --   --   --   --   --   --   --   --   --        0  (other team)
+  GROUP TOTAL                                                              40
+──────────────────────────────────────────────────────────────────────────────
+SMART CONTRACT
+  Goran             ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Michal            ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Daniel            ok   ok   ok   ok   ok   ok   ok   ok   ok   ok        2  (20% coding)
+  GROUP TOTAL                                                              22
+──────────────────────────────────────────────────────────────────────────────
+QA
+  Yordan            ok   ok   ok   ok   ok   ok   ok   ok   ok   ok       10
+  Mayode            --   --   --   --   --   --   --   --   --   --        0  (other team)
+  GROUP TOTAL                                                              10
+──────────────────────────────────────────────────────────────────────────────
+TOTAL                                                                      72
+──────────────────────────────────────────────────────────────────────────────
+```
+
+Cell legend: `ok` = available · `--` = not on team / 0% config · `hb` = HiBob leave
+
+No capacity % column — it is always implicit. The Eff. column is the only number that matters.
+If there are temporary deviations (holidays, leave), note them below the table as a delta:
+```
+  ⚠️  May 1 Labour Day — if observed: −4 Backend, −2 Smart Contract, −1 QA effective days
+  ⚠️  HiBob time-off data unavailable (API permissions pending)
+```
+
+After deviations, print one line per config override so users know what's permanent:
+```
+Config overrides (edit config/api-expansion.md to change permanently):
+  Marcin — not on team (other squad since Feb 15)
+  Daniel — 20% coding capacity (Engineering Lead)
+  Mayode — not on team (other squad since Apr 10)
+```
+
+**Block 3 — Historical velocity table**
+
+```
+## Historical Velocity (last [N] sprints)
+
+Role Group       Sprint [name]   Sprint [name]   Sprint [name]   Average
+────────────────────────────────────────────────────────────────────────
+Backend Dev           38 pts          44 pts          40 pts      41 pts
+Smart Contract         3 pts           1 pts           1 pts       2 pts
+QA                     0 pts            —               —         ⚠️ n/a
+```
+
+Flag per group if: < 2 data points, all estimates missing, or if config velocity notes apply.
+
+**Block 4 — Summary and available SP**
+
+```
+## Sprint Capacity: [cycleName]
+
+Role Group       Eff. FTE-days   Avg Rate (SP/day)   Available SP
+────────────────────────────────────────────────────────────────────
+Backend Dev           40              0.55               22 pts
+Smart Contract        22              0.13                3 pts
+QA                    10             ⚠️ n/a               ? pts
+────────────────────────────────────────────────────────────────────
+TOTAL                 72                                ~25 pts
+
+Velocity rate based on last [N] sprints: [cycle names]
+```
+
+Then offer two prompts on separate lines:
+1. "Want me to recalculate with different numbers, or does this look right?"
+2. "Any of these capacity settings need a permanent update? I can edit `config/api-expansion.md` for you — changes will apply to all future sprint runs."
+
+---
+
+## Guardrails
+
+- **Read-only** — never create or modify Linear issues or HiBob records from this skill
+- If Linear has no story point estimates on past issues, do **not** report 0 as the available SP. Instead warn: "⚠️ [Group]: No estimates found on completed issues — velocity can't be calculated from history. What's a realistic sprint target based on your experience?" Then use whatever number the user provides.
+- If a role group has no members (e.g., no Smart Contract devs in the squad), skip that row
+- Do not extrapolate beyond the data — if only 1 historical cycle has data, say so clearly
+- Members with 0% coding capacity (from config) contribute 0 effective FTE-days and are shown as `--` in the availability table with a short reason. Never show a capacity % — just the Eff. FTE-days number.
+- Never show a "capacity %" column in any table. The only metric is effective FTE-days.

--- a/.claude/skills/sprint-planning/config/example-squad.md
+++ b/.claude/skills/sprint-planning/config/example-squad.md
@@ -1,0 +1,53 @@
+# Sprint Planning Config — Example Squad
+
+This file is read automatically by the `/sprint-planning` skill at the start of every run.
+Edit it to update capacity overrides — changes apply to the next sprint planning run immediately.
+
+The filename must match the squad slug: lowercase, spaces replaced with hyphens
+(e.g. squad "API Expansion" → `config/api-expansion.md`).
+
+---
+
+## Capacity Overrides
+
+Entries here define each person's coding capacity for a date range.
+The skill uses these to reconstruct team composition for **both past and future sprints**,
+enabling normalized velocity (SP per FTE-day) that stays valid as the team grows or shrinks.
+
+Rules:
+- `Until` = `—` means the override is still active today
+- A person with no entry is assumed 100% for all time
+- Multiple rows for the same person are allowed (e.g. 0% → then back to 100%)
+- Dates are YYYY-MM-DD
+
+| Person | Email | Capacity | From | Until | Reason |
+|--------|-------|:--------:|------|-------|--------|
+| Example Lead | example.lead@li.finance | 20% | 2026-01-01 | — | Engineering Lead — 80% is management, reviews, coordination |
+
+**When someone returns:** set their `Until` date and add a new 100% row from the return date.
+
+**When someone joins:** add a 100% row from their start date (so past sprints without them aren't inflated).
+
+---
+
+## Squad Member Mapping Notes
+
+Corrections to HiBob or Linear data the skill should know about. Example:
+
+- **someAssignee** — appears in Linear issues but NOT in HiBob squad. Do not map to any role group.
+- **QA:ExampleSquad** Linear team was created recently. Insufficient historical data — flag velocity as insufficient rather than using 0.
+
+---
+
+## Velocity Notes
+
+- Story point estimates may be **sparsely set** across Linear teams.
+- When calculated velocity rate = 0 due to missing estimates, do NOT report 0 as the sprint capacity. Instead, warn the user and ask for a manual SP-per-FTE-day rate or a total target.
+
+---
+
+## How to Update This File
+
+For **permanent changes**: edit this file (PR into the shared skills repo).
+For **one-off sprint adjustments** (e.g. "Person X is out 2 days next sprint", "public holiday May 1"):
+provide them interactively when the skill asks — don't add them here.

--- a/.claude/skills/sprint-planning/history/example-squad.md
+++ b/.claude/skills/sprint-planning/history/example-squad.md
@@ -1,0 +1,30 @@
+# Sprint History — Example Squad
+
+> Filename pattern: `history/<squad-slug>.md` (e.g. `history/api-expansion.md`).
+
+Source of truth for past sprint velocity calculations.
+Each entry is recorded at the start of the *next* sprint planning run.
+
+- **Completed SP** — summed from Linear completed issues with estimates
+- **FTE-Days** — working days × effective team size, adjusted for actual absences (holidays, sickness, etc.)
+- **Rate** — computed as `Completed SP / FTE-Days` (do not edit manually)
+- **Notes** — any deviations from config defaults (public holidays, unplanned leave, etc.)
+
+When estimates were missing from Linear issues, the SP count will be 0 and Rate will be `—`.
+These sprints are excluded from the velocity rate average.
+
+---
+
+<!-- Add new entries at the TOP (most recent first) -->
+
+<!-- TEMPLATE — copy and fill in when recording a new sprint:
+
+## [Cycle Name] · [YYYY-MM-DD] → [YYYY-MM-DD]
+
+| Group         | Completed SP | FTE-Days | Rate | Notes |
+|---------------|:---:|:---:|:---:|---|
+| Backend Dev   |  0  |  0  |  —  | |
+| Smart Contract|  0  |  0  |  —  | |
+| QA            |  0  |  0  |  —  | |
+
+-->

--- a/.claude/skills/sprint-planning/references/capacity-calculation.md
+++ b/.claude/skills/sprint-planning/references/capacity-calculation.md
@@ -1,0 +1,135 @@
+# Capacity Calculation Reference
+
+## Core Concept: SP per FTE-Day
+
+Raw sprint velocity (total story points) is not comparable across sprints when team size changes.
+Instead, track **SP per effective FTE-day** — a normalized rate that remains valid as people
+join, leave, or change capacity.
+
+```
+velocity_rate[group] = completed_SP[group][sprint] / effective_FTE_days[group][sprint]
+available_SP[group]  = avg(velocity_rate[group]) × current_effective_FTE_days[group]
+```
+
+---
+
+## Working Days
+
+Working days = Mon–Fri only. No public holiday awareness (conservative: treat all weekdays as working).
+
+To count working days between two dates (inclusive):
+1. Iterate each calendar day from `from` to `to`
+2. Count days where `dayOfWeek` is not Saturday (6) or Sunday (0)
+
+---
+
+## Step 1 — Resolve Capacity Per Person Per Sprint
+
+For each person in the squad and each historical/upcoming sprint, look up their coding capacity
+using the config file's dated override table:
+
+```
+capacity_pct(person, sprint_start, sprint_end):
+  Find all config rows for this person where:
+    row.From <= sprint_end  AND  (row.Until == '—' OR row.Until >= sprint_start)
+  If multiple rows overlap, use the one with the latest From date.
+  If no row matches, return 100%.
+```
+
+This means:
+- Marcin at 0% from 2026-02-15 → any sprint starting after Feb 15 treats him as 0%
+- A new hire joining 2026-06-01 → any sprint before June 1 treats them as absent (not in the team yet)
+
+---
+
+## Step 2 — Effective FTE-Days Per Group Per Sprint
+
+```
+sprint_working_days            = count Mon–Fri days in sprint window (inclusive)
+
+effective_FTE_days[group][s]   = Σ (sprint_working_days × capacity_pct(person, s))
+                                   for each person in group
+```
+
+Also compute the **baseline FTE-days** (what 100% capacity for all current members would be):
+```
+baseline_FTE_days[group]       = member_count[group] × sprint_working_days
+```
+
+The capacity % shown in the summary table is:
+```
+capacity_pct[group] = effective_FTE_days[group] / baseline_FTE_days[group] × 100
+```
+
+---
+
+## Step 3 — Velocity Rate Per Historical Sprint
+
+```
+completed_SP[group][s]  = Σ issue.estimate for completed issues assigned to group members in sprint s
+                          (exclude issues with no estimate from the sum, but note them)
+
+velocity_rate[group][s] = completed_SP[group][s] / effective_FTE_days[group][s]
+                          (skip sprint s for this group if effective_FTE_days == 0)
+```
+
+Exclude a sprint from the average if:
+- `effective_FTE_days[group][s] == 0` (no one in this group was active that sprint)
+- `completed_SP[group][s] == 0` AND no member in the group was assigned any issues that sprint
+  (i.e. they simply weren't tracked, not that they completed nothing)
+
+---
+
+## Step 4 — Average Velocity Rate
+
+```
+velocity_rate[group] = mean(velocity_rate[group][s])
+                       across qualifying sprints (see exclusion rules above)
+```
+
+If fewer than 2 qualifying sprints exist, flag as "⚠️ Limited history — estimate may be inaccurate".
+If all qualifying sprints have 0 completed SP (estimates missing), flag as "⚠️ No estimates — cannot calculate rate" and ask the user for a manual rate or target.
+
+---
+
+## Step 5 — Available Story Points
+
+```
+current_effective_FTE_days[group] = Σ (sprint_working_days × capacity_pct(person, upcoming_sprint))
+                                      for each person in group
+
+available_SP[group] = round(velocity_rate[group] × current_effective_FTE_days[group])
+```
+
+---
+
+## Step 6 — Total Row
+
+```
+total_effective_FTE_days = Σ current_effective_FTE_days[group]
+total_available_SP       = Σ available_SP[group]
+total_capacity_pct       = total_effective_FTE_days / (total_member_count × sprint_working_days) × 100
+```
+
+---
+
+## Example
+
+Two backend sprints, Marcin moved to another team from sprint 2 onward.
+
+**Sprint 1** (10 working days, 5 members all at 100%):
+- effective FTE-days = 5 × 10 = 50
+- completed SP = 30
+- velocity_rate = 30 / 50 = **0.60 SP/FTE-day**
+
+**Sprint 2** (10 working days, Marcin at 0%):
+- effective FTE-days = 4 × 10 = 40
+- completed SP = 24
+- velocity_rate = 24 / 40 = **0.60 SP/FTE-day**
+
+**Next sprint** (10 working days, Marcin still at 0%, new hire joins):
+- effective FTE-days = 5 × 10 = 50  (4 original + 1 new)
+- avg velocity_rate = (0.60 + 0.60) / 2 = 0.60
+- available_SP = round(0.60 × 50) = **30 pts**
+
+Without normalization the raw average would be (30 + 24) / 2 = 27 pts, and the new hire would be invisible to the calculation. With normalization the team gets full credit for their new capacity.


### PR DESCRIPTION
## Summary

Adds the `sprint-planning` skill — sprint capacity planning for LI.FI squads.

- Pulls next sprint dates from Linear
- Checks team availability from HiBob
- Calculates historical velocity per role group (QA / Backend Dev / Smart Contract Dev)
- Outputs adjusted story point targets

## Status

**Draft / WIP — do not merge yet.** Still iterating on:

- Generalizing the squad-specific examples (currently uses "API Expansion" as a running example throughout `SKILL.md`)
- Squad-detection UX (matching Linear team names vs HiBob squad names)
- Behavior when story point estimates are sparse in Linear history
- Removing any remaining personal/squad-specific assumptions

Personnel-specific config (capacity overrides with names, percentages, reasons) is **not** pushed — only a sanitized `example-squad.md` template lives in this PR. The real squad configs and sprint history remain in the maintainer's local `~/.claude/skills/sprint-planning/`.

## Test plan

- [ ] Walk through a real sprint planning run for a non-API-Expansion squad to find hardcoded assumptions
- [ ] Confirm `example-squad.md` template is enough for a new squad to bootstrap without seeing the original config
- [ ] Sanity-check Linear + HiBob MCP requirements documented in `SKILL.md`
- [ ] Generalize the running example or label it clearly as illustrative