### PR TITLE
chore(skills): sync post-pr-for-review from local

### DIFF
--- a/.claude/skills/post-pr-for-review/SKILL.md
+++ b/.claude/skills/post-pr-for-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-pr-for-review
-description: Post a pull request to the LI.FI `#dev-sc-review` Slack channel for smart-contract team review. Enables auto-merge (squash) on the PR by default, posts the PR URL + title as a top-level message (matching the existing channel format `<URL> << <title>`), then replies in-thread tagging the `@smartcontract_core` user group. Use when the user says "post PR for review", "send to sc review", "share PR with sc team", "post to dev-sc-review", or supplies a PR URL with intent to request review from the smart-contract core team. Requires the Slack MCP server to be connected.
+description: Post a LI.FI pull request to the right Slack review channel based on the source repo. Smart-contract PRs (`lifinance/contracts`) go to `#dev-sc-review` with an in-thread tag of `@smartcontract_core`; backend PRs (`lifinance/lifi-backend`, `lifinance/tenderly-sim`, and other backend-services repos) go to `#dev-backend-expansion-review` as a single top-level message with no thread and no tag. Enables auto-merge (squash) on the PR by default, posts in the channel's terse `<URL> << <title>` format. Use when the user says "post PR for review", "send for review", "share for review", "post to dev-sc-review", "post to dev-backend-expansion-review", or supplies a GitHub PR URL with intent to request review from the appropriate LI.FI team. Requires the Slack MCP server to be connected.
 ---
 
 # Post PR for Review
@@ -17,41 +17,82 @@ User says any of:
 
 - **PR URL** (optional). If omitted, resolve from current branch via `gh pr view --json url,title,body,number`. If no PR exists for the current branch, ask the user for the URL.
 
-## Channel + audience (fixed)
+## Routing — which channel based on the PR's repo
 
-- **Channel:** `#dev-sc-review` (resolve ID via `slack_search_channels`; known ID at time of writing: `C088UJWC8PR`)
-- **Tag in thread:** `@smartcontract_core` — Slack user group, subteam ID `S096X6MCB0C`
+The destination channel and post shape are **derived from the PR's repo**, not from the user's phrasing. Pick the route at the start of step 1 and carry it through.
+
+### Route A — Smart contracts (`lifinance/contracts`)
+
+- **Channel:** `#dev-sc-review` (known ID: `C088UJWC8PR`; resolve via `slack_search_channels` if unknown)
+- **Post shape:** top-level message **+** thread reply
+- **Thread tag:** `@smartcontract_core` — Slack user group, subteam ID `S096X6MCB0C`
 - **Mention syntax (REQUIRED):** `<!subteam^S096X6MCB0C>` — plain `@smartcontract_core` does NOT trigger notifications (verified 2026-05-13)
 
-## Format (match existing channel convention exactly)
+### Route B — Backend services
 
-Top-level message:
-```
+Repos that route to backend: `lifinance/lifi-backend`, `lifinance/tenderly-sim`, and other LI.FI backend-services repos (any repo under `lifinance/*` that is clearly a backend service rather than the smart-contract monorepo or a frontend).
+
+- **Channel:** `#dev-backend-expansion-review` (resolve via `slack_search_channels`)
+- **Post shape:** single top-level message only — **no thread reply, no tag**
+- **Why no tag:** the channel's existing convention (verified from history) is terse PR drops without notifications; reviewers self-serve from the channel.
+
+### Unknown repo
+
+If the PR is from a repo you can't confidently place in Route A or Route B (e.g., a frontend repo, a tooling repo, or a private repo you haven't seen), **ask the user** which channel to post to rather than guessing. Do not invent a route.
+
+## Format (match the channel's existing convention exactly)
+
+Top-level message (both routes use the same shape):
+```text
 <PR_URL> << <PR_TITLE>
 ```
 
-Example from the channel:
-```
+Example from `#dev-sc-review`:
+```text
 https://github.com/lifinance/contracts/pull/1776 << claude skill for creating user stories
 ```
 
-**Do not** add prefixes like "New PR:" or emoji to the top-level message. Match the channel's terse style.
-
-Thread reply (first reply, posted by the same skill run):
+Example from `#dev-backend-expansion-review`:
+```text
+https://github.com/lifinance/lifi-backend/pull/8345 << Add Polygon and BSC support LI.FI Intents
 ```
+
+**Do not** add prefixes like "New PR:" or decorative emoji to the top-level message. Both channels are high-signal/low-noise.
+
+Route A thread reply (first reply, posted by the same skill run):
+```text
 <!subteam^S096X6MCB0C> please review 🙏
 ```
 
-That's it. No long description, no checklist. The channel is high-signal/low-noise.
+Route B: **no thread reply.** Stop after the top-level message.
 
 ## Workflow
 
-1. **Resolve PR**
+1. **Resolve PR + pick route**
    - If URL given, parse `owner/repo/pull/N`.
    - Else: `gh pr view --json url,title,number,body,headRefName,isDraft` (in the current repo).
-   - Extract `title`, `url`, `number`, `isDraft`.
+   - Extract `title`, `url`, `number`, `isDraft`, plus `owner` and `repo` from the URL.
+   - **Pick route from `owner/repo`** (see "Routing" section above): Route A for `lifinance/contracts`, Route B for backend repos, ask the user if unsure. Carry the chosen route through every remaining step — channel ID, post shape, and the confirmation message all depend on it.
 
-2. **Pre-flight checks** — run all three before touching Slack. The goal is simple: don't waste the SC team's attention on a PR that obviously isn't ready. We surface problems to the executor and let them decide what to fix — this skill does NOT auto-create fix PRs (a sibling skill, planned as `address-pr-review-comments`, owns that separate concern).
+2. **Pre-flight checks** — what you check depends on the route. The goal is simple: don't waste reviewers' attention on a PR that obviously isn't ready, but don't impose more friction than the team actually wants.
+
+   - **Route A (SC):** run all three checks below — unresolved threads, CI status, draft status. SC reviews are expensive; we gate hard.
+   - **Route B (backend):** check **unresolved review threads** + **squad label**. Skip the CI and draft checks — the backend team is fine reviewing PRs with in-progress CI.
+
+   ### Route B — squad label requirement
+
+   `lifinance/lifi-backend` requires every PR to carry either an `Expansion` or `Core` label (enforced by the repo's `label` CI check). Because we're posting to `#dev-backend-expansion-review`, the right label is **`Expansion`** — the channel name itself confirms the squad.
+
+   Workflow:
+   1. Check current labels: `gh pr view <N> --repo lifinance/lifi-backend --json labels --jq '.labels[].name'`
+   2. If the PR already has `Expansion` or `Core` → continue.
+   3. If it has neither → **add `Expansion`** without asking (the channel determines the squad; this isn't a judgment call):
+      ```bash
+      gh pr edit <N> --repo lifinance/lifi-backend --add-label Expansion
+      ```
+   4. If the user explicitly says the PR is `Core` (e.g., "post #1234 to dev-backend-expansion-review, it's core" — note: would be unusual, since Core PRs wouldn't normally go to the expansion channel), surface the contradiction and ask.
+
+   Run pre-flight, then jump to step 3. We surface problems to the executor and let them decide what to fix — this skill does NOT auto-create fix PRs (a sibling skill, planned as `address-pr-review-comments`, owns that separate concern).
 
    **a) Unresolved review threads** — especially CodeRabbit, but any unresolved thread counts. REST doesn't expose `isResolved`, so use GraphQL:
    ```bash
@@ -80,7 +121,7 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
    ```
    Treat as blockers: non-success terminal states (`FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`) **except** for review-gated checks (see allowlist below). `IN_PROGRESS`/`QUEUED`/`PENDING`/`SKIPPED` is informational, not a blocker on its own.
 
-   **Review-triggered check allowlist** — workflows wired to GitHub's `pull_request_review` event only fire *after* a reviewer submits a review. Pre-review they sit in `SKIPPED`/`PENDING`/`ACTION_REQUIRED` by design — they haven't been triggered yet. GitHub renders these in the checks list with a `(pull_request_review)` suffix on the check name. Posting to `#dev-sc-review` is literally how we trigger them, so blocking on them would be circular.
+   **Review-triggered check allowlist** — workflows wired to GitHub's `pull_request_review` event only fire *after* a reviewer submits a review. Pre-review they sit in `SKIPPED`/`PENDING`/`ACTION_REQUIRED` by design — they haven't been triggered yet. GitHub renders these in the checks list with a `(pull_request_review)` suffix on the check name. Posting to the review channel is literally how we trigger them, so blocking on them would be circular.
 
    Rule: ignore (don't block, don't mention) any check whose name ends in `(pull_request_review)`. This is the only allowlist criterion — it's a workflow-trigger fact, not a name-match.
 
@@ -94,9 +135,9 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
 
 3. **Decide based on pre-flight**
 
-   - **Unresolved comments OR failing CI** → do NOT post. Summarize to the executor and stop:
-     ```
-     Not posting to #dev-sc-review yet — please resolve these first:
+   - **Unresolved comments OR failing CI** → do NOT post. Summarize to the executor and stop (substitute the route's channel name):
+     ```text
+     Not posting to <#channel> yet — please resolve these first:
 
      Unresolved review threads (N total):
        • coderabbitai (X): <url>, <url>, ...
@@ -119,10 +160,12 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
 
 4. **Confirm with user before posting** — but skip the confirmation if the user's invoking message already constitutes consent.
 
-   Skip confirmation when the request includes an explicit imperative to post, e.g. "post for review", "push for review", "send it", "ship it", "post to dev-sc-review", "move to ready and push", or similar. In that case, post immediately and report what was posted afterward — re-asking is friction the user has already cleared.
+   Skip confirmation when the request includes an explicit imperative to post, e.g. "post for review", "push for review", "send it", "ship it", "post to dev-sc-review", "post to dev-backend-expansion-review", "move to ready and push", or similar. In that case, post immediately and report what was posted afterward — re-asking is friction the user has already cleared.
 
-   Otherwise (the user only named the PR, asked to "prepare" a post, or the intent is ambiguous), confirm first. Slack posts are visible to others and reversible only by deletion, so when in doubt, ask:
-   ```
+   Otherwise (the user only named the PR, asked to "prepare" a post, or the intent is ambiguous), confirm first. Slack posts are visible to others and reversible only by deletion, so when in doubt, ask. Use the route's channel name and post shape:
+
+   Route A (smart contracts):
+   ```text
    About to post to #dev-sc-review:
 
      <url> << <title>
@@ -131,43 +174,63 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
 
    Proceed? (y/n)
    ```
+
+   Route B (backend):
+   ```text
+   About to post to #dev-backend-expansion-review:
+
+     <url> << <title>
+
+   (No thread reply, no tag — channel convention.)
+
+   Proceed? (y/n)
+   ```
    If user says yes/y/go/ship, proceed. Otherwise wait for edits.
 
    Note: the pre-flight gate in step 3 is the real safety net — it blocks accidental posts of broken PRs regardless of whether step 4 confirms. Step 4 is just about content/wording, which is fixed and predictable here.
 
-5. **Enable auto-merge** (default; do this *before* posting to Slack).
+5. **Enable auto-merge** — **Route A (SC) only.** Skip this step entirely on Route B; the backend team doesn't use auto-merge as a default (they prefer the author to merge after review).
 
-   Why: the SC team's review is the last gate. Once they approve and CI is green, the PR should merge itself — no second round-trip to the author. The reviewer's approval doubles as the merge signal.
+   Why for SC: the reviewers' approval is the last gate. Once they approve and CI is green, the PR should merge itself — no second round-trip to the author. The reviewer's approval doubles as the merge signal.
 
    Command:
    ```bash
    gh pr merge <N> --repo <owner>/<repo> --auto --squash
    ```
-   Squash is the LI.FI default merge method for `lifinance/contracts`. If a future repo uses a different default, mirror it (`--merge` or `--rebase`); when unsure, surface to the user.
+   Squash is the LI.FI default merge method for `lifinance/contracts` and our backend repos. If a future repo uses a different default, mirror it (`--merge` or `--rebase`); when unsure, surface to the user.
 
    Handle these outcomes silently (just log a one-line note, then continue):
    - **Already enabled** → no-op, move on.
-   - **"Pull request is already in clean status"** / mergeable now → it would merge immediately. Do NOT auto-merge before posting — disable and surface to user: "PR is already mergeable; not enabling auto-merge so the SC team can still review. Want me to merge now instead?"
+   - **"Pull request is already in clean status"** / mergeable now → it would merge immediately. Do NOT auto-merge before posting — disable and surface to user: "PR is already mergeable; not enabling auto-merge so the reviewers can still see it. Want me to merge now instead?"
    - **"Auto-merge is not enabled for this repository"** → skip with a note: "Auto-merge isn't enabled on this repo; posting without it." Don't ask.
    - **Any other gh error** → surface verbatim, ask whether to post anyway.
 
    **Opt-out**: if the user's invoking message includes "without auto-merge", "no auto-merge", "don't auto-merge", or "manual merge", skip this step entirely.
 
-6. **Resolve channel ID** via `slack_search_channels` (query: `dev-sc-review`). Pick the exact-name match.
+6. **Resolve channel ID** via `slack_search_channels`, using the route's channel name as the query:
+   - Route A → `dev-sc-review` (known ID `C088UJWC8PR`; the search is a safety net in case it ever moves)
+   - Route B → `dev-backend-expansion-review` (resolve via search; no hard-coded ID yet)
 
-7. **Post top-level** via `slack_send_message`:
+   Pick the exact-name match. If multiple results come back, prefer the non-archived public channel whose name matches exactly.
+
+7. **Post top-level** via `slack_send_message` (both routes):
    - `channel_id`: resolved ID
    - `text`: `<url> << <title>`
-   - Capture the returned `ts` (message timestamp) — needed for threading.
+   - Capture the returned `ts` (message timestamp) — only needed if the route has a thread reply.
 
-8. **Post thread reply** via `slack_send_message`:
+8. **Post thread reply** — **Route A only.** Skip this step entirely on Route B.
+   Via `slack_send_message`:
    - `channel_id`: same
    - `thread_ts`: the `ts` from step 7
    - `text`: `<!subteam^S096X6MCB0C> please review 🙏`
 
-9. **Confirm to user** — include both the Slack permalink (if returned) and the auto-merge state (enabled / skipped / already-mergeable), e.g.:
+9. **Confirm to user** — include the Slack permalink (if returned), the route used, and (Route A only) the auto-merge state, e.g.:
+   ```text
+   Posted to #dev-sc-review ✓ — auto-merge (squash) enabled
    ```
-   Posted ✓ — auto-merge (squash) enabled
+   or for Route B:
+   ```text
+   Posted to #dev-backend-expansion-review ✓ (no thread, no tag, no auto-merge — backend convention)
    ```
 
 ## Failure modes
@@ -179,12 +242,21 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
 
 ## Design notes (why this skill exists)
 
-- Posts via Slack MCP → message appears as the *human user*, preserving thread-reply notifications and author attribution. This is the right channel etiquette for `#dev-sc-review`.
+- Posts via Slack MCP → message appears as the *human user*, preserving thread-reply notifications and author attribution. This is the right channel etiquette for both `#dev-sc-review` and `#dev-backend-expansion-review`.
 - Webhook-based posting (used by `audit-request-slack-relay` in CI) is intentionally NOT used here — it would post as a bot and lose attribution.
 - No secrets stored anywhere; each teammate authenticates the Slack MCP once via their own Claude Code config.
+- Route is derived from the PR's `owner/repo`, not the user's phrasing — this avoids the failure mode where the user says "post for review" but the message lands in the wrong channel because the skill defaulted to SC.
 
 ## Variations the user may request
 
+Route A (SC) only:
 - "Also @ Daniela specifically" → add `@Daniela` after the group tag in the thread reply.
 - "Add context: <message>" → append the message as a second thread reply, NOT to the top-level post.
 - "Quiet ping" → drop the 🙏 emoji; keep just `@smartcontract_core please review`.
+
+Both routes:
+- "Without auto-merge" / "no auto-merge" → skip step 5 entirely.
+- Explicit channel override ("post to #some-other-channel") → use that channel instead of the route's default, but keep the route's post shape (thread + tag for SC-like requests, no-thread for backend-like requests) unless the user also overrides that.
+
+Route B (backend) only:
+- If the user asks to "ping someone in particular" on a backend PR, do it via a thread reply (not the top-level message) — this is a soft deviation from channel convention but acceptable when the user explicitly wants attention from a specific reviewer. Default backend behavior remains no-thread, no-tag.

--- a/.claude/skills/post-pr-for-review/SKILL.md
+++ b/.claude/skills/post-pr-for-review/SKILL.md
@@ -75,10 +75,10 @@ Group by author; CodeRabbit is `coderabbitai` / `coderabbitai[bot]`.
 **Squad label (Route B)**:
 
 ```bash
-gh pr view <N> --repo lifinance/lifi-backend --json labels --jq '.labels[].name'
+gh pr view <N> --repo <owner>/<repo> --json labels --jq '.labels[].name'
 ```
 
-If neither `Expansion` nor `Core` present → `gh pr edit <N> --repo lifinance/lifi-backend --add-label Expansion`. The channel determines the squad — not a judgment call. If user explicitly says it's `Core`, surface the contradiction.
+If neither `Expansion` nor `Core` present → `gh pr edit <N> --repo <owner>/<repo> --add-label Expansion`. The channel determines the squad — not a judgment call. If user explicitly says it's `Core`, surface the contradiction.
 
 ### 3. Gate on pre-flight
 

--- a/.claude/skills/post-pr-for-review/SKILL.md
+++ b/.claude/skills/post-pr-for-review/SKILL.md
@@ -1,262 +1,165 @@
 ---
 name: post-pr-for-review
-description: Post a LI.FI pull request to the right Slack review channel based on the source repo. Smart-contract PRs (`lifinance/contracts`) go to `#dev-sc-review` with an in-thread tag of `@smartcontract_core`; backend PRs (`lifinance/lifi-backend`, `lifinance/tenderly-sim`, and other backend-services repos) go to `#dev-backend-expansion-review` as a single top-level message with no thread and no tag. Enables auto-merge (squash) on the PR by default, posts in the channel's terse `<URL> << <title>` format. Use when the user says "post PR for review", "send for review", "share for review", "post to dev-sc-review", "post to dev-backend-expansion-review", or supplies a GitHub PR URL with intent to request review from the appropriate LI.FI team. Requires the Slack MCP server to be connected.
+description: Post a LI.FI pull request to the right Slack review channel based on the source repo. `lifinance/contracts` → `#dev-sc-review` (top-level + thread tag `@smartcontract_core`); `lifinance/lifi-backend`, `lifinance/tenderly-sim`, and other backend services → `#dev-backend-expansion-review` (top-level only, no tag). Enables auto-merge (squash, SC route only). Use when the user says "post PR for review", "send for review", "share for review", "post to dev-sc-review", "post to dev-backend-expansion-review", or supplies a GitHub PR URL with review intent. Requires the Slack MCP server.
 ---
 
 # Post PR for Review
 
-## When to trigger
-
-User says any of:
-- "post PR for review" / "send PR to sc review" / "share for review"
-- "post to dev-sc-review"
-- Provides a GitHub PR URL with review intent
-- `/post-pr-for-review [url]`
-
 ## Inputs
 
-- **PR URL** (optional). If omitted, resolve from current branch via `gh pr view --json url,title,body,number`. If no PR exists for the current branch, ask the user for the URL.
+PR URL (optional). If omitted, resolve from current branch via `gh pr view --json url,title,body,number,headRefName,isDraft`. If no PR exists, ask for the URL.
 
-## Routing — which channel based on the PR's repo
+## Routing
 
-The destination channel and post shape are **derived from the PR's repo**, not from the user's phrasing. Pick the route at the start of step 1 and carry it through.
+Derived from the PR's `owner/repo`, not from user phrasing. Pick at step 1, carry through.
 
-### Route A — Smart contracts (`lifinance/contracts`)
+| Route | Trigger repos | Channel | Channel ID | Post shape | Auto-merge |
+|---|---|---|---|---|---|
+| **A — SC** | `lifinance/contracts` | `#dev-sc-review` | `C088UJWC8PR` | top-level + thread reply tagging `<!subteam^S096X6MCB0C>` | yes (squash) |
+| **B — Backend** | `lifinance/lifi-backend`, `lifinance/tenderly-sim`, other backend services | `#dev-backend-expansion-review` | resolve via `slack_search_channels` | top-level only, no tag | no |
 
-- **Channel:** `#dev-sc-review` (known ID: `C088UJWC8PR`; resolve via `slack_search_channels` if unknown)
-- **Post shape:** top-level message **+** thread reply
-- **Thread tag:** `@smartcontract_core` — Slack user group, subteam ID `S096X6MCB0C`
-- **Mention syntax (REQUIRED):** `<!subteam^S096X6MCB0C>` — plain `@smartcontract_core` does NOT trigger notifications (verified 2026-05-13)
+`@smartcontract_core` MUST be sent as `<!subteam^S096X6MCB0C>` — plain `@…` does not notify (verified 2026-05-13).
 
-### Route B — Backend services
+For unknown repos (frontend, tooling, etc.) — ask the user. Do not guess.
 
-Repos that route to backend: `lifinance/lifi-backend`, `lifinance/tenderly-sim`, and other LI.FI backend-services repos (any repo under `lifinance/*` that is clearly a backend service rather than the smart-contract monorepo or a frontend).
+## Post format (both routes)
 
-- **Channel:** `#dev-backend-expansion-review` (resolve via `slack_search_channels`)
-- **Post shape:** single top-level message only — **no thread reply, no tag**
-- **Why no tag:** the channel's existing convention (verified from history) is terse PR drops without notifications; reviewers self-serve from the channel.
+Top-level:
 
-### Unknown repo
-
-If the PR is from a repo you can't confidently place in Route A or Route B (e.g., a frontend repo, a tooling repo, or a private repo you haven't seen), **ask the user** which channel to post to rather than guessing. Do not invent a route.
-
-## Format (match the channel's existing convention exactly)
-
-Top-level message (both routes use the same shape):
 ```text
 <PR_URL> << <PR_TITLE>
 ```
 
-Example from `#dev-sc-review`:
-```text
-https://github.com/lifinance/contracts/pull/1776 << claude skill for creating user stories
-```
+No prefixes ("New PR:"), no decorative emoji. Both channels are high-signal / low-noise.
 
-Example from `#dev-backend-expansion-review`:
-```text
-https://github.com/lifinance/lifi-backend/pull/8345 << Add Polygon and BSC support LI.FI Intents
-```
+Route A thread reply:
 
-**Do not** add prefixes like "New PR:" or decorative emoji to the top-level message. Both channels are high-signal/low-noise.
-
-Route A thread reply (first reply, posted by the same skill run):
 ```text
 <!subteam^S096X6MCB0C> please review 🙏
 ```
 
-Route B: **no thread reply.** Stop after the top-level message.
-
 ## Workflow
 
-1. **Resolve PR + pick route**
-   - If URL given, parse `owner/repo/pull/N`.
-   - Else: `gh pr view --json url,title,number,body,headRefName,isDraft` (in the current repo).
-   - Extract `title`, `url`, `number`, `isDraft`, plus `owner` and `repo` from the URL.
-   - **Pick route from `owner/repo`** (see "Routing" section above): Route A for `lifinance/contracts`, Route B for backend repos, ask the user if unsure. Carry the chosen route through every remaining step — channel ID, post shape, and the confirmation message all depend on it.
+### 1. Resolve PR + pick route
 
-2. **Pre-flight checks** — what you check depends on the route. The goal is simple: don't waste reviewers' attention on a PR that obviously isn't ready, but don't impose more friction than the team actually wants.
+Parse `owner/repo/pull/N` from URL or `gh pr view`. Extract `title`, `url`, `number`, `isDraft`, `owner`, `repo`. Pick route from `owner/repo` per table above.
 
-   - **Route A (SC):** run all three checks below — unresolved threads, CI status, draft status. SC reviews are expensive; we gate hard.
-   - **Route B (backend):** check **unresolved review threads** + **squad label**. Skip the CI and draft checks — the backend team is fine reviewing PRs with in-progress CI.
+### 2. Pre-flight
 
-   ### Route B — squad label requirement
+| Check | Route A | Route B |
+|---|---|---|
+| Unresolved review threads | ✓ | ✓ |
+| Failing CI | ✓ | skip |
+| Draft status | ✓ | skip |
+| Squad label | — | ✓ (`Expansion`) |
 
-   `lifinance/lifi-backend` requires every PR to carry either an `Expansion` or `Core` label (enforced by the repo's `label` CI check). Because we're posting to `#dev-backend-expansion-review`, the right label is **`Expansion`** — the channel name itself confirms the squad.
+**Unresolved threads** (REST lacks `isResolved`; use GraphQL):
 
-   Workflow:
-   1. Check current labels: `gh pr view <N> --repo lifinance/lifi-backend --json labels --jq '.labels[].name'`
-   2. If the PR already has `Expansion` or `Core` → continue.
-   3. If it has neither → **add `Expansion`** without asking (the channel determines the squad; this isn't a judgment call):
-      ```bash
-      gh pr edit <N> --repo lifinance/lifi-backend --add-label Expansion
-      ```
-   4. If the user explicitly says the PR is `Core` (e.g., "post #1234 to dev-backend-expansion-review, it's core" — note: would be unusual, since Core PRs wouldn't normally go to the expansion channel), surface the contradiction and ask.
+```bash
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$num:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$num){
+        reviewThreads(first:100){
+          nodes{ isResolved isOutdated
+            comments(first:1){ nodes{ author{login} body url path } } } } } } }' \
+  -f owner=<owner> -f repo=<repo> -F num=<N> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes
+        | map(select(.isResolved == false and .isOutdated == false))'
+```
 
-   Run pre-flight, then jump to step 3. We surface problems to the executor and let them decide what to fix — this skill does NOT auto-create fix PRs (a sibling skill, planned as `address-pr-review-comments`, owns that separate concern).
+Group by author; CodeRabbit is `coderabbitai` / `coderabbitai[bot]`.
 
-   **a) Unresolved review threads** — especially CodeRabbit, but any unresolved thread counts. REST doesn't expose `isResolved`, so use GraphQL:
-   ```bash
-   gh api graphql -f query='
-     query($owner:String!,$repo:String!,$num:Int!){
-       repository(owner:$owner,name:$repo){
-         pullRequest(number:$num){
-           reviewThreads(first:100){
-             nodes{
-               isResolved
-               isOutdated
-               comments(first:1){ nodes{ author{login} body url path } }
-             }
-           }
-         }
-       }
-     }' -f owner=<owner> -f repo=<repo> -F num=<N> \
-     --jq '.data.repository.pullRequest.reviewThreads.nodes
-           | map(select(.isResolved == false and .isOutdated == false))'
-   ```
-   Group results by author. CodeRabbit appears as `coderabbitai` / `coderabbitai[bot]`.
+**CI** (`gh pr checks <N>`): block on `FAILURE`/`CANCELLED`/`TIMED_OUT`/`ACTION_REQUIRED`. Ignore any check whose name ends in `(pull_request_review)` — those are review-gated workflows that haven't fired yet; posting is what triggers them, so blocking would be circular. Match on the suffix only — `version-control`, `audit-verification`, and some `protect-*` checks appear in both push and `(pull_request_review)` forms; only the latter is exempt. Surface unfamiliar checks; don't silently widen the allowlist.
 
-   **b) CI status**
-   ```bash
-   gh pr checks <N>
-   ```
-   Treat as blockers: non-success terminal states (`FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`) **except** for review-gated checks (see allowlist below). `IN_PROGRESS`/`QUEUED`/`PENDING`/`SKIPPED` is informational, not a blocker on its own.
+**Squad label (Route B)**:
 
-   **Review-triggered check allowlist** — workflows wired to GitHub's `pull_request_review` event only fire *after* a reviewer submits a review. Pre-review they sit in `SKIPPED`/`PENDING`/`ACTION_REQUIRED` by design — they haven't been triggered yet. GitHub renders these in the checks list with a `(pull_request_review)` suffix on the check name. Posting to the review channel is literally how we trigger them, so blocking on them would be circular.
+```bash
+gh pr view <N> --repo lifinance/lifi-backend --json labels --jq '.labels[].name'
+```
 
-   Rule: ignore (don't block, don't mention) any check whose name ends in `(pull_request_review)`. This is the only allowlist criterion — it's a workflow-trigger fact, not a name-match.
+If neither `Expansion` nor `Core` present → `gh pr edit <N> --repo lifinance/lifi-backend --add-label Expansion`. The channel determines the squad — not a judgment call. If user explicitly says it's `Core`, surface the contradiction.
 
-   Important: the same workflow often appears twice in the checks list — once `push`-triggered (runs on every commit, expected to pass) and once `pull_request_review`-triggered (runs only on review). E.g., in `lifinance/contracts` the names `version-control`, `audit-verification`, and a few `protect-*` checks appear in both forms. The push-triggered instance is a real blocker if it fails; the `(pull_request_review)` instance is not. Match on the suffix, not the bare name.
+### 3. Gate on pre-flight
 
-   Some checks (e.g. `SC Core Dev Approval Check`, `Protect security-critical code/system`) only exist as `pull_request_review` workflows — they'll still match the suffix rule and be ignored automatically.
+- **Unresolved threads OR failing CI** → don't post. Summarize and stop:
 
-   When in doubt about an unfamiliar check, surface it to the user and ask — don't silently allowlist anything beyond the `(pull_request_review)` rule.
+  ```text
+  Not posting to <#channel> yet — please resolve these first:
 
-   **c) Draft status** — already captured from step 1 (`isDraft`).
+  Unresolved review threads (N): • <author> (X): <url>, <url>…
+  Failing CI: • <name>: <conclusion> — <details_url>
 
-3. **Decide based on pre-flight**
+  Re-run after fixing.
+  ```
 
-   - **Unresolved comments OR failing CI** → do NOT post. Summarize to the executor and stop (substitute the route's channel name):
-     ```text
-     Not posting to <#channel> yet — please resolve these first:
+  The executor owns fix vs. override; this skill does NOT auto-fix (sibling `address-pr-review-comments` planned).
 
-     Unresolved review threads (N total):
-       • coderabbitai (X): <url>, <url>, ...
-       • <other> (Y): <url>, ...
+- **CI in progress, nothing failing** → tell user, default to waiting.
+- **Draft + clean** → offer `gh pr ready <N>` (Route A); confirm first.
+- **Clean + ready** → step 4.
 
-     Failing CI checks:
-       • <check name>: <conclusion> — <details_url>
+### 4. Confirm
 
-     Once addressed (push fixes, mark CodeRabbit threads resolved), re-run this skill.
-     A separate skill (`address-pr-review-comments`, planned) will help draft a fix PR
-     that closes review comments — keeping that concern out of this skill.
-     ```
-     Do not prompt to post anyway. The executor owns the call to fix vs. override.
+Skip confirmation if the invoking message includes explicit intent ("post for review", "ship it", "send it", "post to dev-sc-review", "post to dev-backend-expansion-review", "move to ready and push"). Re-asking is friction the user has cleared.
 
-   - **CI in progress, nothing failing yet** → tell the user, ask whether to wait or post anyway. Default: wait.
+Otherwise show the planned post (URL + title + thread reply text on Route A) and wait for go.
 
-   - **Draft + everything else clean** → offer to mark ready via `gh pr ready <N>` before posting. Confirm first (visible to watchers). If user declines, ask whether to post anyway — drafts can be reviewed, but it's unusual.
+Step 3's pre-flight is the real safety net; step 4 is content-check only.
 
-   - **Everything clean and PR is ready** → proceed to step 4.
+### 5. Auto-merge — Route A only
 
-4. **Confirm with user before posting** — but skip the confirmation if the user's invoking message already constitutes consent.
+```bash
+gh pr merge <N> --repo <owner>/<repo> --auto --squash
+```
 
-   Skip confirmation when the request includes an explicit imperative to post, e.g. "post for review", "push for review", "send it", "ship it", "post to dev-sc-review", "post to dev-backend-expansion-review", "move to ready and push", or similar. In that case, post immediately and report what was posted afterward — re-asking is friction the user has already cleared.
+Squash is LI.FI's default for contracts and backend repos.
 
-   Otherwise (the user only named the PR, asked to "prepare" a post, or the intent is ambiguous), confirm first. Slack posts are visible to others and reversible only by deletion, so when in doubt, ask. Use the route's channel name and post shape:
+Silently log + continue on:
 
-   Route A (smart contracts):
-   ```text
-   About to post to #dev-sc-review:
+- Already enabled → no-op.
+- "Auto-merge is not enabled for this repository" → skip with a one-line note.
+- Already mergeable → do NOT auto-merge before posting; surface: "PR is already mergeable; not enabling auto-merge so reviewers can still see it. Merge now instead?"
+- Any other `gh` error → surface verbatim, ask.
 
-     <url> << <title>
+Opt-out: invoking message contains "without auto-merge" / "no auto-merge" / "manual merge" → skip.
 
-   Then reply in thread: "<!subteam^S096X6MCB0C> please review 🙏"
+### 6. Resolve channel + post
 
-   Proceed? (y/n)
-   ```
+Channel ID via `slack_search_channels` (use known ID `C088UJWC8PR` as primary for Route A; search is the safety net). Pick the exact-name non-archived match.
 
-   Route B (backend):
-   ```text
-   About to post to #dev-backend-expansion-review:
+Top-level (both routes): `slack_send_message` with `text = "<url> << <title>"`. Capture `ts`.
 
-     <url> << <title>
+Thread reply (Route A only): `slack_send_message` with `thread_ts = ts`, `text = "<!subteam^S096X6MCB0C> please review 🙏"`.
 
-   (No thread reply, no tag — channel convention.)
+### 7. Report
 
-   Proceed? (y/n)
-   ```
-   If user says yes/y/go/ship, proceed. Otherwise wait for edits.
+Include permalink, route, and (Route A) auto-merge state:
 
-   Note: the pre-flight gate in step 3 is the real safety net — it blocks accidental posts of broken PRs regardless of whether step 4 confirms. Step 4 is just about content/wording, which is fixed and predictable here.
+```text
+Posted to #dev-sc-review ✓ — auto-merge (squash) enabled
+```
 
-5. **Enable auto-merge** — **Route A (SC) only.** Skip this step entirely on Route B; the backend team doesn't use auto-merge as a default (they prefer the author to merge after review).
-
-   Why for SC: the reviewers' approval is the last gate. Once they approve and CI is green, the PR should merge itself — no second round-trip to the author. The reviewer's approval doubles as the merge signal.
-
-   Command:
-   ```bash
-   gh pr merge <N> --repo <owner>/<repo> --auto --squash
-   ```
-   Squash is the LI.FI default merge method for `lifinance/contracts` and our backend repos. If a future repo uses a different default, mirror it (`--merge` or `--rebase`); when unsure, surface to the user.
-
-   Handle these outcomes silently (just log a one-line note, then continue):
-   - **Already enabled** → no-op, move on.
-   - **"Pull request is already in clean status"** / mergeable now → it would merge immediately. Do NOT auto-merge before posting — disable and surface to user: "PR is already mergeable; not enabling auto-merge so the reviewers can still see it. Want me to merge now instead?"
-   - **"Auto-merge is not enabled for this repository"** → skip with a note: "Auto-merge isn't enabled on this repo; posting without it." Don't ask.
-   - **Any other gh error** → surface verbatim, ask whether to post anyway.
-
-   **Opt-out**: if the user's invoking message includes "without auto-merge", "no auto-merge", "don't auto-merge", or "manual merge", skip this step entirely.
-
-6. **Resolve channel ID** via `slack_search_channels`, using the route's channel name as the query:
-   - Route A → `dev-sc-review` (known ID `C088UJWC8PR`; the search is a safety net in case it ever moves)
-   - Route B → `dev-backend-expansion-review` (resolve via search; no hard-coded ID yet)
-
-   Pick the exact-name match. If multiple results come back, prefer the non-archived public channel whose name matches exactly.
-
-7. **Post top-level** via `slack_send_message` (both routes):
-   - `channel_id`: resolved ID
-   - `text`: `<url> << <title>`
-   - Capture the returned `ts` (message timestamp) — only needed if the route has a thread reply.
-
-8. **Post thread reply** — **Route A only.** Skip this step entirely on Route B.
-   Via `slack_send_message`:
-   - `channel_id`: same
-   - `thread_ts`: the `ts` from step 7
-   - `text`: `<!subteam^S096X6MCB0C> please review 🙏`
-
-9. **Confirm to user** — include the Slack permalink (if returned), the route used, and (Route A only) the auto-merge state, e.g.:
-   ```text
-   Posted to #dev-sc-review ✓ — auto-merge (squash) enabled
-   ```
-   or for Route B:
-   ```text
-   Posted to #dev-backend-expansion-review ✓ (no thread, no tag, no auto-merge — backend convention)
-   ```
+```text
+Posted to #dev-backend-expansion-review ✓ (no thread, no tag, no auto-merge — backend convention)
+```
 
 ## Failure modes
 
-- **MCP not connected:** Tell user to connect the Slack MCP and retry. Do NOT fall back to webhooks (different identity model — see notes below).
-- **Channel not found:** Surface the search results; channel may have been renamed.
-- **gh CLI missing or unauthenticated:** Ask user to paste the PR URL directly; skip pre-flight checks and warn that they were skipped.
-- **GraphQL query fails / rate limited:** Fall back to `gh pr view --json reviewDecision,comments` and surface raw comment count; warn that resolution-state could not be determined.
+- **MCP not connected** → ask user to connect Slack MCP. Do NOT fall back to webhooks (wrong identity).
+- **Channel not found** → surface search results; may have been renamed.
+- **`gh` missing / unauthenticated** → ask for URL, skip pre-flight, warn.
+- **GraphQL fails** → fall back to `gh pr view --json reviewDecision,comments` with a warning that resolution state is unknown.
 
-## Design notes (why this skill exists)
+## Variations
 
-- Posts via Slack MCP → message appears as the *human user*, preserving thread-reply notifications and author attribution. This is the right channel etiquette for both `#dev-sc-review` and `#dev-backend-expansion-review`.
-- Webhook-based posting (used by `audit-request-slack-relay` in CI) is intentionally NOT used here — it would post as a bot and lose attribution.
-- No secrets stored anywhere; each teammate authenticates the Slack MCP once via their own Claude Code config.
-- Route is derived from the PR's `owner/repo`, not the user's phrasing — this avoids the failure mode where the user says "post for review" but the message lands in the wrong channel because the skill defaulted to SC.
+- Route A: "also @ <person>" → append `@<person>` after the group tag in thread reply.
+- Route A: "add context: <msg>" → append as a second thread reply, never the top-level.
+- Route A: "quiet ping" → drop the 🙏, just `@smartcontract_core please review`.
+- Both: "without auto-merge" → skip step 5.
+- Both: explicit channel override → use that channel; keep the route's post shape unless overridden too.
+- Route B: "ping <person>" → do it via thread reply (soft deviation from convention, OK when explicit).
 
-## Variations the user may request
+## Why this design
 
-Route A (SC) only:
-- "Also @ Daniela specifically" → add `@Daniela` after the group tag in the thread reply.
-- "Add context: <message>" → append the message as a second thread reply, NOT to the top-level post.
-- "Quiet ping" → drop the 🙏 emoji; keep just `@smartcontract_core please review`.
-
-Both routes:
-- "Without auto-merge" / "no auto-merge" → skip step 5 entirely.
-- Explicit channel override ("post to #some-other-channel") → use that channel instead of the route's default, but keep the route's post shape (thread + tag for SC-like requests, no-thread for backend-like requests) unless the user also overrides that.
-
-Route B (backend) only:
-- If the user asks to "ping someone in particular" on a backend PR, do it via a thread reply (not the top-level message) — this is a soft deviation from channel convention but acceptable when the user explicitly wants attention from a specific reviewer. Default backend behavior remains no-thread, no-tag.
+Slack MCP posts as the human user, preserving thread-reply notifications and attribution — right etiquette for both review channels. Webhook posting (used by `audit-request-slack-relay`) is intentionally NOT used here (wrong identity). No secrets stored; each teammate authenticates the MCP themselves. Route is derived from `owner/repo`, not phrasing, to avoid wrong-channel posts when the user says "post for review" generically.

--- a/.claude/skills/post-pr-for-review/SKILL.md
+++ b/.claude/skills/post-pr-for-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-pr-for-review
-description: Post a pull request to the LI.FI `#dev-sc-review` Slack channel for smart-contract team review. Posts the PR URL + title as a top-level message (matching the existing channel format `<URL> << <title>`), then replies in-thread tagging the `@smartcontract_core` user group. Use when the user says "post PR for review", "send to sc review", "share PR with sc team", "post to dev-sc-review", or supplies a PR URL with intent to request review from the smart-contract core team. Requires the Slack MCP server to be connected.
+description: Post a pull request to the LI.FI `#dev-sc-review` Slack channel for smart-contract team review. Enables auto-merge (squash) on the PR by default, posts the PR URL + title as a top-level message (matching the existing channel format `<URL> << <title>`), then replies in-thread tagging the `@smartcontract_core` user group. Use when the user says "post PR for review", "send to sc review", "share PR with sc team", "post to dev-sc-review", or supplies a PR URL with intent to request review from the smart-contract core team. Requires the Slack MCP server to be connected.
 ---
 
 # Post PR for Review
@@ -48,11 +48,80 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
 
 1. **Resolve PR**
    - If URL given, parse `owner/repo/pull/N`.
-   - Else: `gh pr view --json url,title,number,body,headRefName` (in the current repo).
-   - Extract `title` and `url`.
+   - Else: `gh pr view --json url,title,number,body,headRefName,isDraft` (in the current repo).
+   - Extract `title`, `url`, `number`, `isDraft`.
 
-2. **Confirm with user before posting** (Slack posts are visible to others — reversible only by deletion).
-   Show:
+2. **Pre-flight checks** — run all three before touching Slack. The goal is simple: don't waste the SC team's attention on a PR that obviously isn't ready. We surface problems to the executor and let them decide what to fix — this skill does NOT auto-create fix PRs (a sibling skill, planned as `address-pr-review-comments`, owns that separate concern).
+
+   **a) Unresolved review threads** — especially CodeRabbit, but any unresolved thread counts. REST doesn't expose `isResolved`, so use GraphQL:
+   ```bash
+   gh api graphql -f query='
+     query($owner:String!,$repo:String!,$num:Int!){
+       repository(owner:$owner,name:$repo){
+         pullRequest(number:$num){
+           reviewThreads(first:100){
+             nodes{
+               isResolved
+               isOutdated
+               comments(first:1){ nodes{ author{login} body url path } }
+             }
+           }
+         }
+       }
+     }' -f owner=<owner> -f repo=<repo> -F num=<N> \
+     --jq '.data.repository.pullRequest.reviewThreads.nodes
+           | map(select(.isResolved == false and .isOutdated == false))'
+   ```
+   Group results by author. CodeRabbit appears as `coderabbitai` / `coderabbitai[bot]`.
+
+   **b) CI status**
+   ```bash
+   gh pr checks <N>
+   ```
+   Treat as blockers: non-success terminal states (`FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`) **except** for review-gated checks (see allowlist below). `IN_PROGRESS`/`QUEUED`/`PENDING`/`SKIPPED` is informational, not a blocker on its own.
+
+   **Review-triggered check allowlist** — workflows wired to GitHub's `pull_request_review` event only fire *after* a reviewer submits a review. Pre-review they sit in `SKIPPED`/`PENDING`/`ACTION_REQUIRED` by design — they haven't been triggered yet. GitHub renders these in the checks list with a `(pull_request_review)` suffix on the check name. Posting to `#dev-sc-review` is literally how we trigger them, so blocking on them would be circular.
+
+   Rule: ignore (don't block, don't mention) any check whose name ends in `(pull_request_review)`. This is the only allowlist criterion — it's a workflow-trigger fact, not a name-match.
+
+   Important: the same workflow often appears twice in the checks list — once `push`-triggered (runs on every commit, expected to pass) and once `pull_request_review`-triggered (runs only on review). E.g., in `lifinance/contracts` the names `version-control`, `audit-verification`, and a few `protect-*` checks appear in both forms. The push-triggered instance is a real blocker if it fails; the `(pull_request_review)` instance is not. Match on the suffix, not the bare name.
+
+   Some checks (e.g. `SC Core Dev Approval Check`, `Protect security-critical code/system`) only exist as `pull_request_review` workflows — they'll still match the suffix rule and be ignored automatically.
+
+   When in doubt about an unfamiliar check, surface it to the user and ask — don't silently allowlist anything beyond the `(pull_request_review)` rule.
+
+   **c) Draft status** — already captured from step 1 (`isDraft`).
+
+3. **Decide based on pre-flight**
+
+   - **Unresolved comments OR failing CI** → do NOT post. Summarize to the executor and stop:
+     ```
+     Not posting to #dev-sc-review yet — please resolve these first:
+
+     Unresolved review threads (N total):
+       • coderabbitai (X): <url>, <url>, ...
+       • <other> (Y): <url>, ...
+
+     Failing CI checks:
+       • <check name>: <conclusion> — <details_url>
+
+     Once addressed (push fixes, mark CodeRabbit threads resolved), re-run this skill.
+     A separate skill (`address-pr-review-comments`, planned) will help draft a fix PR
+     that closes review comments — keeping that concern out of this skill.
+     ```
+     Do not prompt to post anyway. The executor owns the call to fix vs. override.
+
+   - **CI in progress, nothing failing yet** → tell the user, ask whether to wait or post anyway. Default: wait.
+
+   - **Draft + everything else clean** → offer to mark ready via `gh pr ready <N>` before posting. Confirm first (visible to watchers). If user declines, ask whether to post anyway — drafts can be reviewed, but it's unusual.
+
+   - **Everything clean and PR is ready** → proceed to step 4.
+
+4. **Confirm with user before posting** — but skip the confirmation if the user's invoking message already constitutes consent.
+
+   Skip confirmation when the request includes an explicit imperative to post, e.g. "post for review", "push for review", "send it", "ship it", "post to dev-sc-review", "move to ready and push", or similar. In that case, post immediately and report what was posted afterward — re-asking is friction the user has already cleared.
+
+   Otherwise (the user only named the PR, asked to "prepare" a post, or the intent is ambiguous), confirm first. Slack posts are visible to others and reversible only by deletion, so when in doubt, ask:
    ```
    About to post to #dev-sc-review:
 
@@ -64,26 +133,49 @@ That's it. No long description, no checklist. The channel is high-signal/low-noi
    ```
    If user says yes/y/go/ship, proceed. Otherwise wait for edits.
 
-3. **Resolve channel ID** via `slack_search_channels` (query: `dev-sc-review`). Pick the exact-name match.
+   Note: the pre-flight gate in step 3 is the real safety net — it blocks accidental posts of broken PRs regardless of whether step 4 confirms. Step 4 is just about content/wording, which is fixed and predictable here.
 
-4. **Post top-level** via `slack_send_message`:
+5. **Enable auto-merge** (default; do this *before* posting to Slack).
+
+   Why: the SC team's review is the last gate. Once they approve and CI is green, the PR should merge itself — no second round-trip to the author. The reviewer's approval doubles as the merge signal.
+
+   Command:
+   ```bash
+   gh pr merge <N> --repo <owner>/<repo> --auto --squash
+   ```
+   Squash is the LI.FI default merge method for `lifinance/contracts`. If a future repo uses a different default, mirror it (`--merge` or `--rebase`); when unsure, surface to the user.
+
+   Handle these outcomes silently (just log a one-line note, then continue):
+   - **Already enabled** → no-op, move on.
+   - **"Pull request is already in clean status"** / mergeable now → it would merge immediately. Do NOT auto-merge before posting — disable and surface to user: "PR is already mergeable; not enabling auto-merge so the SC team can still review. Want me to merge now instead?"
+   - **"Auto-merge is not enabled for this repository"** → skip with a note: "Auto-merge isn't enabled on this repo; posting without it." Don't ask.
+   - **Any other gh error** → surface verbatim, ask whether to post anyway.
+
+   **Opt-out**: if the user's invoking message includes "without auto-merge", "no auto-merge", "don't auto-merge", or "manual merge", skip this step entirely.
+
+6. **Resolve channel ID** via `slack_search_channels` (query: `dev-sc-review`). Pick the exact-name match.
+
+7. **Post top-level** via `slack_send_message`:
    - `channel_id`: resolved ID
    - `text`: `<url> << <title>`
    - Capture the returned `ts` (message timestamp) — needed for threading.
 
-5. **Post thread reply** via `slack_send_message`:
+8. **Post thread reply** via `slack_send_message`:
    - `channel_id`: same
-   - `thread_ts`: the `ts` from step 4
+   - `thread_ts`: the `ts` from step 7
    - `text`: `<!subteam^S096X6MCB0C> please review 🙏`
 
-6. **Confirm to user** with the Slack permalink (if returned) or just `Posted ✓`.
+9. **Confirm to user** — include both the Slack permalink (if returned) and the auto-merge state (enabled / skipped / already-mergeable), e.g.:
+   ```
+   Posted ✓ — auto-merge (squash) enabled
+   ```
 
 ## Failure modes
 
 - **MCP not connected:** Tell user to connect the Slack MCP and retry. Do NOT fall back to webhooks (different identity model — see notes below).
 - **Channel not found:** Surface the search results; channel may have been renamed.
-- **gh CLI missing or unauthenticated:** Ask user to paste the PR URL directly.
-- **PR is draft:** Warn the user and ask whether to proceed anyway.
+- **gh CLI missing or unauthenticated:** Ask user to paste the PR URL directly; skip pre-flight checks and warn that they were skipped.
+- **GraphQL query fails / rate limited:** Fall back to `gh pr view --json reviewDecision,comments` and surface raw comment count; warn that resolution-state could not be determined.
 
 ## Design notes (why this skill exists)
 


### PR DESCRIPTION
Automated sync of `post-pr-for-review` skill from local `~/.claude/skills/post-pr-for-review/` by sync-skills.py.

Draft — review for sanity before marking ready.