### PR TITLE
chore(skills): add start-linear-ticket skill & add mcp servers [RelayFacet v1.0.1]

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,48 @@
+# Claude Code in this repo
+
+This directory configures Claude Code (the CLI) for the `lifinance/contracts` repo:
+
+- `skills/` — repo-bundled skills (workflows you can invoke by name, e.g. `post-pr-for-review`, `start-linear-ticket`). See each skill's `SKILL.md` for what it does and when to trigger it.
+- `rules/` — coding rules and guardrails surfaced to Claude when working in this repo.
+- `settings.json` — repo-scoped Claude Code settings (hooks, permissions, etc.).
+- `../.mcp.json` — MCP servers bundled with this repo (see below).
+
+If you don't use Claude Code, you can ignore this directory entirely — none of it affects normal `forge`/`bun`/`gh` workflows.
+
+## MCP servers bundled with this repo
+
+`.mcp.json` at the repo root declares the MCP (Model Context Protocol) servers that this repo's skills depend on. When you run `claude` in this directory for the first time, Claude Code will prompt you to approve each server before connecting — nothing connects silently.
+
+### Why bundle them
+
+Several of the bundled skills (`post-pr-for-review`, `sc-design-review`, `start-linear-ticket`, etc.) call out to external services via MCP. Without the right servers configured, the skills fail with cryptic errors. Bundling them via project-level `.mcp.json` means anyone who clones this repo gets a one-click setup instead of hunting through docs.
+
+### Security model
+
+- **Each server uses OAuth**, not shared secrets. No tokens, API keys, or credentials are stored in this repo — every teammate authenticates against their own account on first use.
+- **Claude Code prompts before connecting.** On first encounter with `.mcp.json`, Claude Code shows you each declared server and asks whether to enable it for this workspace. You can approve some and decline others; the choice is per-server and per-workspace.
+- **Revoking access** is done in the source-of-truth tool (e.g. Linear → Settings → API → revoke), not here.
+
+### Current servers
+
+| Server | Endpoint | Used by | Auth |
+|---|---|---|---|
+| `linear` | `https://mcp.linear.app/mcp` | `start-linear-ticket` | OAuth (linear.app) — browser flow on first call |
+
+### First-time setup
+
+1. `cd` into this repo and run `claude` (or open Claude Code in this directory).
+2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares 1 MCP server. Approve?"** Accept.
+3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX`), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** when prompted — that's the account our Linear workspace is provisioned against.
+4. The token is stored locally by Claude Code (per-user); subsequent calls reuse it without prompting.
+
+### Troubleshooting
+
+- **"Needs authentication"** when running `claude mcp list` → re-run the skill that uses the server; Claude Code will re-trigger the OAuth flow.
+- **Token expired / 401 errors** → run `claude mcp` to re-auth, or sign out + back in via the server's web app.
+- **MCP not showing up at all** → make sure you ran `claude` from the repo root (where `.mcp.json` lives), not from a subdirectory you've cd'd into. The file is detected at session start.
+- **Want to opt out for this workspace** → decline the server at the approval prompt, or delete `.mcp.json` locally (don't commit the deletion).
+
+### Adding a new MCP server
+
+If you're adding a skill that depends on a new MCP server, also add the server to `.mcp.json` and document it in the table above. Keep the criterion strict: only servers that something *in this repo* actively calls. Personal productivity MCPs (Gmail, Calendar, etc.) belong in your user-level Claude Code config, not here.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -28,13 +28,18 @@ Several of the bundled skills (`post-pr-for-review`, `sc-design-review`, `start-
 | Server | Endpoint | Used by | Auth |
 |---|---|---|---|
 | `linear` | `https://mcp.linear.app/mcp` | `start-linear-ticket` | OAuth (linear.app) — browser flow on first call |
+| `slack` | `https://mcp.slack.com/mcp` | `post-pr-for-review` | OAuth (LI.FI Slack workspace) — sign in once, your messages post as you |
+| `notion` | `https://mcp.notion.com/mcp` | `sc-design-review` (PRD ingestion) | OAuth (notion.so) — grant access to the LI.FI Notion workspace |
+| `blockscout` | `https://mcp.blockscout.com/mcp` | Ad-hoc onchain inspection of deployed contracts (no specific skill yet) | No login — public read-only endpoint |
 
 ### First-time setup
 
 1. `cd` into this repo and run `claude` (or open Claude Code in this directory).
-2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares 1 MCP server. Approve?"** Accept.
-3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX`), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** when prompted — that's the account our Linear workspace is provisioned against.
+2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares N MCP servers. Approve?"** Accept (or decline individual servers you don't need).
+3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX` → Linear), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** (Linear, Notion) or **LI.FI Slack identity** (Slack). Blockscout requires no auth.
 4. The token is stored locally by Claude Code (per-user); subsequent calls reuse it without prompting.
+
+> **Tip:** you don't have to authenticate everything upfront. Each server only triggers its OAuth flow the first time a skill actually calls it. If you only use `start-linear-ticket`, you'll only see the Linear prompt.
 
 ### Troubleshooting
 

--- a/.claude/skills/start-linear-ticket/SKILL.md
+++ b/.claude/skills/start-linear-ticket/SKILL.md
@@ -101,11 +101,15 @@ If `git status --porcelain` returns anything, **stop**. Show the user the dirty 
 Once clean:
 
 ```bash
-git fetch origin
+git fetch origin <default-branch>
 git checkout -b <branch> origin/<default-branch>
 ```
 
-Use `origin/main` for all repos in the mapping above. If a repo uses a different default (e.g. `master`, `develop`), detect via `git symbolic-ref refs/remotes/origin/HEAD` and use that.
+**Always base off fresh `origin/<default-branch>` — never off the local repo's current HEAD.** The local repo is very often parked on a feature branch from previous work, and silently inheriting whatever commits sit on that branch would mix unrelated changes into the new ticket. Explicitly using `origin/<default-branch>` as the base ref sidesteps this completely: the new branch starts from exactly the same commit a fresh `git clone` would land on.
+
+Do NOT use `git checkout main && git pull && git checkout -b <branch>` — that mutates the local `main` branch, which the user may have intentionally pinned for some reason, and it requires a temporary checkout of `main` that fails if the working tree is dirty in ways the step-5 clean check missed. The `git fetch` + `checkout -b origin/<default>` pattern updates only the remote-tracking ref and never touches local `main`.
+
+Use `origin/main` for all repos in the mapping above. If a repo uses a different default (e.g. `master`, `develop`), detect via `git symbolic-ref refs/remotes/origin/HEAD` (or `git remote show origin | grep "HEAD branch"` as a fallback) and use that.
 
 ### 6. Move the Linear ticket to In Progress
 

--- a/.claude/skills/start-linear-ticket/SKILL.md
+++ b/.claude/skills/start-linear-ticket/SKILL.md
@@ -60,7 +60,12 @@ If the issue can't be found, surface the error verbatim and stop. Don't invent.
 
 Skip-the-work conditions, in priority order:
 
-- **Status is already In Progress AND a branch is linked** → don't create a new branch. Output the existing branch name and the linked PR (if any), then stop. Tell the user: "Looks like this is already in flight — branch `<name>` exists. Want me to switch to it locally?" If yes, run `git fetch origin && git checkout <branch>` in the repo.
+- **Status is already In Progress AND a branch is linked** → don't create a new branch. Output the existing branch name and the linked PR (if any), then stop. Tell the user: "Looks like this is already in flight — branch `<name>` exists. Want me to switch to it locally?" If yes:
+  1. `git fetch origin <branch>`
+  2. If a local branch with that name exists (`git show-ref --verify --quiet refs/heads/<branch>`) → `git checkout <branch>` and then `git merge --ff-only origin/<branch>` to pick up any remote commits.
+  3. Otherwise → `git checkout --track origin/<branch>` to create a local tracking branch from the remote.
+
+  This works regardless of whether the branch was created remotely (e.g. via Linear's "Create branch" button) or already exists locally from a previous session — the plain `git checkout <branch>` fails in the remote-only case.
 - **Assigned to someone else** → don't silently steal. Ask: "EXSC-282 is currently assigned to <name>. Take it over, or just create a branch without reassigning?" Default to the latter.
 - **Status is Done / Cancelled** → ask for confirmation before reopening. "EXSC-282 is in <state>. Are you sure you want to start it?"
 

--- a/.claude/skills/start-linear-ticket/SKILL.md
+++ b/.claude/skills/start-linear-ticket/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: start-linear-ticket
+description: Start work on a Linear ticket — fetches the issue, creates a properly-named local git branch in the right repo, moves the ticket to "In Progress", and assigns it to the current user. Use when the user says "start ticket", "start linear ticket", "begin work on EXSC-XXX", "/start-ticket", "let's start <ID>", or supplies a Linear issue ID/URL with intent to begin work. Mirrors the "Create branch" button from Jira, but also handles the status flip and ownership claim in one step — designed for orgs where PR-auto-assign is off but starting work is the right moment to claim a ticket. Requires the Linear MCP server. Skip if the user is just asking about a ticket (read intent) rather than starting work, or if the ticket is already In Progress and has a linked branch — in that case just show the existing branch.
+---
+
+# Start Linear Ticket
+
+## When to trigger
+
+User says any of:
+- "start ticket EXSC-282" / "start linear ticket" / "start <ID>"
+- "begin work on <ID>" / "let's start <ID>" / "pick up <ID>"
+- `/start-ticket <ID-or-URL>`
+- Pastes a Linear issue URL or ID and signals intent to begin work (e.g. "starting this now: https://linear.app/...")
+
+Do NOT trigger on read-only intents ("what's EXSC-282 about?", "show me <ID>", "any updates on <ID>"). Those are `get_issue` calls, not start-work.
+
+## Inputs
+
+- **Ticket reference** (required). Either:
+  - Linear ID like `EXSC-282`, `COM-14`, `EXP-377` (case-insensitive, normalize to upper)
+  - Linear URL like `https://linear.app/lifi-linear/issue/EXSC-282/some-slug`
+  - If missing, ask the user before proceeding.
+
+## Team → repo mapping
+
+Linear team prefix maps to the repo where work happens. Keep this list close to the user's actual workflow — extend by adding rows:
+
+| Team prefix | GitHub repo | Default branch | Local clone (default search) |
+|---|---|---|---|
+| `EXSC` | `lifinance/contracts` | `main` | `~/Documents/GitHub/contracts` |
+| `COM` | `lifinance/Yggdrasil` | `main` | `~/Documents/GitHub/Yggdrasil` |
+| `EXP` | `lifinance/lifi-backend` | `main` | `~/Documents/GitHub/lifi-backend` |
+| `DO` | `lifinance/devops` | `main` | `~/Documents/GitHub/devops` |
+
+If the team prefix isn't in the table, ask the user which repo before proceeding. Don't guess.
+
+**Finding the local clone** — try in order, stop at first hit:
+1. The default path above.
+2. `~/Projects/<repo-name>`, `~/Code/<repo-name>`, `~/dev/<repo-name>`, `~/src/<repo-name>`.
+3. `find ~/Documents ~/Projects ~/Code ~/dev ~/src -maxdepth 4 -type d -name "<repo-name>"` (case-sensitive).
+4. If still nothing: ask user for the path. Offer to `git clone` into the default location if they want.
+
+## Workflow
+
+### 1. Parse the ticket reference
+
+- URL form: extract the `EXSC-282`-style ID from the path segment after `/issue/`.
+- Bare ID form: uppercase the prefix, keep the number. Validate against `^[A-Z]+-\d+$`.
+
+### 2. Fetch the issue from Linear
+
+Use Linear MCP `get_issue` with the parsed ID. Pull these fields:
+- `id`, `identifier`, `title`, `state.name`, `assignee`, `team.key`, `url`
+- `attachments` / `gitBranches` (if exposed) — to detect existing linked branches
+
+If the issue can't be found, surface the error verbatim and stop. Don't invent.
+
+### 3. Check for "already started" state
+
+Skip-the-work conditions, in priority order:
+
+- **Status is already In Progress AND a branch is linked** → don't create a new branch. Output the existing branch name and the linked PR (if any), then stop. Tell the user: "Looks like this is already in flight — branch `<name>` exists. Want me to switch to it locally?" If yes, run `git fetch origin && git checkout <branch>` in the repo.
+- **Assigned to someone else** → don't silently steal. Ask: "EXSC-282 is currently assigned to <name>. Take it over, or just create a branch without reassigning?" Default to the latter.
+- **Status is Done / Cancelled** → ask for confirmation before reopening. "EXSC-282 is in <state>. Are you sure you want to start it?"
+
+If none of these apply, continue.
+
+### 4. Compute the branch name
+
+Format: `feature/<lowercase-id>-<slugified-title>` — this matches the workspace-configured Linear branch format (`feature/identifier-title`) so the integration auto-links on first push.
+
+Slugification rules (apply in order):
+1. Lowercase the title.
+2. Replace any run of non-alphanumeric characters with a single `-`.
+3. Trim leading/trailing `-`.
+4. Truncate to 60 chars total title length (don't break a word — cut at the last `-` within the limit).
+5. Drop the trailing `-` if truncation created one.
+
+Examples:
+- `EXSC-282` + "Earn Monetization v2: Custom Vault Wrapper Design & Estimate" → `feature/exsc-282-earn-monetization-v2-custom-vault-wrapper-design`
+- `COM-14` + "Fix flaky test in route resolver" → `feature/com-14-fix-flaky-test-in-route-resolver`
+
+Show the computed name to the user before checkout — they may want to override (e.g. `fix/`, `chore/`, scoped prefix). Accept any valid git ref name; if it doesn't contain the ID, warn that Linear won't auto-link.
+
+### 5. Create the branch locally
+
+In the resolved repo path:
+
+```bash
+# verify clean state — don't clobber uncommitted work
+cd <repo-path>
+git status --porcelain
+```
+
+If `git status --porcelain` returns anything, **stop**. Show the user the dirty state and ask what to do:
+- "Stash and proceed" → `git stash push -m "auto-stash before <ID>"`, then continue.
+- "Commit on current branch first" → exit and let them handle it.
+- "Proceed anyway" (rare) → continue but warn the branch will inherit the working changes.
+
+Once clean:
+
+```bash
+git fetch origin
+git checkout -b <branch> origin/<default-branch>
+```
+
+Use `origin/main` for all repos in the mapping above. If a repo uses a different default (e.g. `master`, `develop`), detect via `git symbolic-ref refs/remotes/origin/HEAD` and use that.
+
+### 6. Move the Linear ticket to In Progress
+
+Use Linear MCP `save_issue` with:
+- `id`: the issue ID from step 2
+- `state`: the team's "In Progress" state ID
+
+To find the state ID: call `list_issue_statuses` for the team once and cache mentally for this turn. Match by `name == "In Progress"` (case-sensitive; LI.FI's convention). If no exact match, surface the available states and ask.
+
+Skip if the ticket is already In Progress (idempotent — don't error).
+
+### 7. Assign to the current user
+
+Use Linear MCP `save_issue` with:
+- `id`: the issue ID
+- `assignee`: the current user
+
+To resolve "current user": call Linear MCP for the authenticated user's ID (via `read_me` or equivalent in the connected MCP). Don't hardcode an email or user ID in this skill — the skill should work for any teammate who installs it.
+
+Skip if the ticket is already assigned to the current user. If assigned to someone else, follow the rule from step 3 — only reassign if the user confirmed takeover.
+
+### 8. Report
+
+One-line summary:
+
+```
+Started <ID> — <title>
+  branch: <branch-name>
+  repo:   <local-path>
+  linear: <linear-url>
+```
+
+If anything was skipped (already In Progress, already assigned, etc.), note it in a second line so the user knows what state things are in.
+
+## Failure modes
+
+- **Linear MCP not connected** → tell user to connect it; do not fall back to the Linear web API (no auth available).
+- **Repo not found locally** → see step "Finding the local clone". Offer to clone.
+- **Branch name collision** (`git checkout -b` fails because branch exists) → surface the existing branch; offer to switch to it (`git checkout <branch>`) or pick a suffix like `-2`.
+- **Dirty working tree** → never `git stash` automatically; always ask.
+- **Linear state transition fails** (permissions, missing state) → branch was already created, so don't roll it back. Report partial success and the specific Linear error.
+
+## Design notes (why this skill exists)
+
+- **The Jira "create branch" equivalent, plus more.** Linear's native "Create branch" button creates the branch on GitHub remote only and doesn't change ticket state. This skill closes both gaps: local checkout + status flip + ownership claim in one shot.
+- **Ownership is claimed at start-of-work, not at PR-open.** PR-auto-assign is intentionally off in workspaces that want unassigned tickets to remain a pool. But the moment someone runs this skill, they're claiming the work — that's the right signal to assign.
+- **Branch naming matches Linear's configured format** (`feature/identifier-title`) so the auto-link works on first push without manual PR-body magic words. Magic words (`Fixes EXSC-282`) are still a fine fallback for ad-hoc branches that don't follow the format.
+- **No GitHub branch creation via the Linear button.** That path creates the branch on GitHub's HEAD of the default branch, which forces a `git fetch && git checkout` dance locally. Doing it locally is one step.
+- **Idempotent on re-run.** Running the skill twice on the same ticket should not error, double-assign, or duplicate branches — it should detect existing state and skip cleanly.
+
+## Variations the user may request
+
+- "Use branch prefix `fix/` instead of `feature/`" → honor for this run; don't persist.
+- "Don't assign to me, just create the branch" → skip step 7.
+- "Don't change status" → skip step 6 (useful when starting exploratory work that shouldn't tell the team you've committed).
+- "Take it over from <name>" → bypass the step-3 reassignment guard; proceed to assign to current user.
+- "Use worktree instead of branch" → run `git worktree add ../<repo>-wt-<short-id> -b <branch> origin/<default>` instead of `checkout -b`. Useful when the user has uncommitted work on the current branch they don't want to stash.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,18 @@
     "linear": {
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "blockscout": {
+      "type": "http",
+      "url": "https://mcp.blockscout.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

1. **New skill: `start-linear-ticket`** — automates the "I'm picking up this Linear ticket now" workflow. Parses a Linear ID or URL, fetches the issue, creates a properly-named local branch off fresh `origin/main` in the right repo, moves the ticket to **In Progress**, and assigns it to the current user. Idempotent on re-run.
2. **Bundles MCP servers via `.mcp.json`** — the skills in this repo depend on several external services (Linear, Slack, Notion). Bundling them at the repo root means anyone who clones the repo gets one-click setup via Claude Code's approval prompt, instead of hunting through docs.
3. **`.claude/README.md`** — user-facing docs explaining the MCP approval flow, per-server OAuth (no shared secrets in the repo), partial-approval, troubleshooting, and how to add new servers.

## MCP servers bundled

| Server | Used by | Auth |
|---|---|---|
| `linear` | `start-linear-ticket` (this PR) | OAuth (linear.app) |
| `slack` | `post-pr-for-review` (#1780, merged) | OAuth (LI.FI Slack) |
| `notion` | `sc-design-review` (#1753) | OAuth (notion.so) |
| `blockscout` | Ad-hoc onchain inspection | No auth — public endpoint |

Selection criterion: only servers something *in this repo* actively calls. Personal productivity MCPs (Gmail, Calendar, Figma, etc.) stay in each user's personal Claude Code config.

## Why a skill rather than Linear's "Create branch" button

Linear's native button creates the branch on GitHub HEAD only and doesn't change status or assignment. This skill closes both gaps in one shot and runs locally, so the branch is created from the local working state and rooted in fresh `origin/main` — never from whatever feature branch the local repo happens to be parked on.

## Why `.mcp.json` is safe to commit

- **No secrets.** Every bundled server uses OAuth (or is a public endpoint). Tokens are stored per-user by Claude Code, never in the repo.
- **Explicit consent.** Claude Code prompts users before connecting to any MCP declared in a project-level `.mcp.json`. Approval is per-server and per-workspace — declining is fine.
- **Lazy OAuth.** Each server only triggers its OAuth flow the first time a skill actually calls it; users who only ever use `start-linear-ticket` only see the Linear prompt.

## Test plan

- [ ] `start ticket EXSC-XXX` on a fresh ticket → verify branch checkout from origin/main, status flip, assignment
- [ ] Re-run on the same ticket → verify idempotency
- [ ] Run with the ticket assigned to someone else → verify the takeover prompt
- [ ] Run with a dirty working tree → verify the stash/abort prompt
- [ ] Run with a Linear URL instead of an ID
- [ ] In a fresh clone of this branch, run `claude` → verify the 4-server approval prompt
- [ ] Decline one server → verify the dependent skill fails clearly and other skills still work

## Notes

- Skill mirrored from the maintainer's local `~/.claude/skills/start-linear-ticket/`. Future edits land here as follow-up PRs per the local SYNC policy.
- Originally split as #1796 (skill + Linear) and #1797 (other MCPs). Consolidated into this PR — #1797 closed as no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)