### PR TITLE
chore: bundle Slack, Notion, Blockscout MCP servers

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -28,13 +28,18 @@ Several of the bundled skills (`post-pr-for-review`, `sc-design-review`, `start-
 | Server | Endpoint | Used by | Auth |
 |---|---|---|---|
 | `linear` | `https://mcp.linear.app/mcp` | `start-linear-ticket` | OAuth (linear.app) — browser flow on first call |
+| `slack` | `https://mcp.slack.com/mcp` | `post-pr-for-review` | OAuth (LI.FI Slack workspace) — sign in once, your messages post as you |
+| `notion` | `https://mcp.notion.com/mcp` | `sc-design-review` (PRD ingestion) | OAuth (notion.so) — grant access to the LI.FI Notion workspace |
+| `blockscout` | `https://mcp.blockscout.com/mcp` | Ad-hoc onchain inspection of deployed contracts (no specific skill yet) | No login — public read-only endpoint |
 
 ### First-time setup
 
 1. `cd` into this repo and run `claude` (or open Claude Code in this directory).
-2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares 1 MCP server. Approve?"** Accept.
-3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX`), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** when prompted — that's the account our Linear workspace is provisioned against.
+2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares N MCP servers. Approve?"** Accept (or decline individual servers you don't need).
+3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX` → Linear), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** (Linear, Notion) or **LI.FI Slack identity** (Slack). Blockscout requires no auth.
 4. The token is stored locally by Claude Code (per-user); subsequent calls reuse it without prompting.
+
+> **Tip:** you don't have to authenticate everything upfront. Each server only triggers its OAuth flow the first time a skill actually calls it. If you only use `start-linear-ticket`, you'll only see the Linear prompt.
 
 ### Troubleshooting
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,18 @@
     "linear": {
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "blockscout": {
+      "type": "http",
+      "url": "https://mcp.blockscout.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Extends `.mcp.json` (introduced in #1796) with the remaining MCP servers that skills already in this repo actively depend on:

| Server | Why bundle | Used by |
|---|---|---|
| `slack` | Posts as the human author, preserves thread notifications | `post-pr-for-review` (already merged in #1780) |
| `notion` | Ingests PRDs from the LI.FI Notion workspace | `sc-design-review` (PR #1753) |
| `blockscout` | Public read-only onchain inspection; no auth needed | Ad-hoc — no skill yet, but trivially useful for SC dev work |

Also extends `.claude/README.md` with one row per new server, documenting the "used by" binding, the OAuth flow (or lack thereof for Blockscout), and the partial-approval option (decline individual servers you don't need).

## Stacking

**This PR is stacked on top of #1796.** Merge that first. The base branch is set to `chore/add-start-linear-ticket-skill`, so the GitHub diff shows only the new MCP entries — the Linear MCP entry and the original `.claude/README.md` arrive via the parent PR.

Once #1796 lands, GitHub will auto-rebase this PR's base onto `main`.

## Selection criteria

Bundled only servers that something *in this repo* actively calls. Personal productivity MCPs (Gmail, Calendar, Figma, HubSpot, etc.) deliberately left for users' personal Claude Code config — `.mcp.json` is for the repo's own dependencies, not personal preference.

## Test plan

- [ ] In a fresh `git clone` of this branch, run `claude` and verify the approval prompt lists all 4 servers
- [ ] Approve all, then invoke each skill that uses one of them:
  - [ ] `start ticket EXSC-XXX` → Linear OAuth fires
  - [ ] `post PR for review` → Slack OAuth fires
  - [ ] `/sc-design-review <Notion URL>` → Notion OAuth fires
  - [ ] Ask Claude to call Blockscout directly → no auth, just works
- [ ] Decline one server at the prompt; verify the dependent skill fails with a clear error and other skills still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)