### PR TITLE
feat: fund DevWallet alongside PauserWallet in deployment Stage 9

### DIFF
--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -348,36 +348,39 @@ deployAllContracts() {
     fi
 
     # --- Fund DevWallet ---
-    # DevWallet is used for executing timelock proposals on production and for staging deployments.
-    # It must have a native balance on every new network before execution scripts can run.
-    local DEV_WALLET_ADDRESS
-    DEV_WALLET_ADDRESS=$(getValueFromJSONFile "./config/global.json" "devWallet")
-    if [[ $? -ne 0 ]]; then
-      error "failed to read devWallet address from ./config/global.json"
-      exit 1
-    fi
-    if [[ -z "$DEV_WALLET_ADDRESS" || "$DEV_WALLET_ADDRESS" == "null" ]]; then
-      error "DevWallet address not found. Cannot fund DevWallet"
-      exit 1
-    fi
-
-    BALANCE=$(cast balance "$DEV_WALLET_ADDRESS" --rpc-url "$RPC_URL")
-    checkFailure $? "get DevWallet balance for $DEV_WALLET_ADDRESS on $NETWORK"
-    echo "DevWallet Balance: $BALANCE"
-
-    if [[ "$BALANCE" == "0" ]]; then
-      echo "DevWallet balance is 0. How much wei would you like to send to $DEV_WALLET_ADDRESS?"
-      read -r FUNDING_AMOUNT || FUNDING_AMOUNT=""
-
-      # Validate that FUNDING_AMOUNT is a non-empty numeric value
-      if [[ -z "$FUNDING_AMOUNT" ]] || ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
-        error "Invalid funding amount. Please provide a valid wei amount (numeric value)."
+    # DevWallet executes timelock proposals; the timelock only exists on production non-testnet networks.
+    if [[ "$ENVIRONMENT" == "production" ]] && ! isTestnetNetwork "$NETWORK"; then
+      local DEV_WALLET_ADDRESS
+      DEV_WALLET_ADDRESS=$(getValueFromJSONFile "./config/global.json" "devWallet")
+      if [[ $? -ne 0 ]]; then
+        error "failed to read devWallet address from ./config/global.json"
+        exit 1
+      fi
+      if [[ -z "$DEV_WALLET_ADDRESS" || "$DEV_WALLET_ADDRESS" == "null" ]]; then
+        error "DevWallet address not found. Cannot fund DevWallet"
         exit 1
       fi
 
-      echo "Funding DevWallet $DEV_WALLET_ADDRESS with $FUNDING_AMOUNT wei"
-      universalCast "sendValue" "$NETWORK" "$ENVIRONMENT" "$DEV_WALLET_ADDRESS" "$FUNDING_AMOUNT" "$PRIVATE_KEY_TO_USE"
-      checkFailure $? "fund DevWallet $DEV_WALLET_ADDRESS on $NETWORK"
+      BALANCE=$(cast balance "$DEV_WALLET_ADDRESS" --rpc-url "$RPC_URL")
+      checkFailure $? "get DevWallet balance for $DEV_WALLET_ADDRESS on $NETWORK"
+      echo "DevWallet Balance: $BALANCE"
+
+      if [[ "$BALANCE" == "0" ]]; then
+        echo "DevWallet balance is 0. How much wei would you like to send to $DEV_WALLET_ADDRESS?"
+        read -r FUNDING_AMOUNT || FUNDING_AMOUNT=""
+
+        # Validate that FUNDING_AMOUNT is a non-empty numeric value
+        if [[ -z "$FUNDING_AMOUNT" ]] || ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
+          error "Invalid funding amount. Please provide a valid wei amount (numeric value)."
+          exit 1
+        fi
+
+        echo "Funding DevWallet $DEV_WALLET_ADDRESS with $FUNDING_AMOUNT wei"
+        universalCast "sendValue" "$NETWORK" "$ENVIRONMENT" "$DEV_WALLET_ADDRESS" "$FUNDING_AMOUNT" "$PRIVATE_KEY_TO_USE"
+        checkFailure $? "fund DevWallet $DEV_WALLET_ADDRESS on $NETWORK"
+      fi
+    else
+      echo "[info] Skipping DevWallet funding for $ENVIRONMENT/$NETWORK (no Timelock; only funded on production non-testnet)"
     fi
 
     echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< STAGE 9 completed"

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -64,7 +64,7 @@ deployAllContracts() {
       "6) Deploy periphery contracts" \
       "7) Add periphery to diamond" \
       "8) Update whitelist.json and execute sync whitelist script" \
-      "9) Fund PauserWallet" \
+      "9) Fund PauserWallet and DevWallet" \
       "10) Update ERC20Proxy" \
       "11) Run health check only" \
       "12) Ownership transfer to timelock (production only)"
@@ -292,23 +292,12 @@ deployAllContracts() {
     echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< STAGE 8 completed"
   fi
 
-  # Stage 9: Fund PauserWallet
+  # Stage 9: Fund PauserWallet and DevWallet
   if [[ $START_STAGE -le 9 ]]; then
     echo ""
-    echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 9: Fund PauserWallet"
-    # get pauserWallet address
-    local PAUSER_WALLET_ADDRESS
-    PAUSER_WALLET_ADDRESS=$(getValueFromJSONFile "./config/global.json" "pauserWallet")
-    if [[ $? -ne 0 ]]; then
-      error "failed to read pauserWallet address from ./config/global.json"
-      exit 1
-    fi
-    if [[ -z "$PAUSER_WALLET_ADDRESS" || "$PAUSER_WALLET_ADDRESS" == "null" ]]; then
-      error "PauserWallet address not found. Cannot fund PauserWallet"
-      exit 1
-    fi
+    echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 9: Fund PauserWallet and DevWallet"
 
-    # get RPC URL
+    # get RPC URL (shared for both wallet funding steps)
     local RPC_URL
     RPC_URL=$(getRPCUrl "$NETWORK")
     if [[ $? -ne 0 ]]; then
@@ -320,7 +309,25 @@ deployAllContracts() {
       exit 1
     fi
 
-    # get balance in current network
+    local PRIVATE_KEY_TO_USE
+    PRIVATE_KEY_TO_USE=$(getPrivateKey "$NETWORK" "$ENVIRONMENT")
+    if [[ $? -ne 0 || -z "$PRIVATE_KEY_TO_USE" ]]; then
+      error "could not determine private key for network $NETWORK in $ENVIRONMENT environment"
+      exit 1
+    fi
+
+    # --- Fund PauserWallet ---
+    local PAUSER_WALLET_ADDRESS
+    PAUSER_WALLET_ADDRESS=$(getValueFromJSONFile "./config/global.json" "pauserWallet")
+    if [[ $? -ne 0 ]]; then
+      error "failed to read pauserWallet address from ./config/global.json"
+      exit 1
+    fi
+    if [[ -z "$PAUSER_WALLET_ADDRESS" || "$PAUSER_WALLET_ADDRESS" == "null" ]]; then
+      error "PauserWallet address not found. Cannot fund PauserWallet"
+      exit 1
+    fi
+
     BALANCE=$(cast balance "$PAUSER_WALLET_ADDRESS" --rpc-url "$RPC_URL")
     checkFailure $? "get PauserWallet balance for $PAUSER_WALLET_ADDRESS on $NETWORK"
     echo "PauserWallet Balance: $BALANCE"
@@ -335,16 +342,42 @@ deployAllContracts() {
         exit 1
       fi
 
-      local PRIVATE_KEY_TO_USE
-      PRIVATE_KEY_TO_USE=$(getPrivateKey "$NETWORK" "$ENVIRONMENT")
-      if [[ $? -ne 0 || -z "$PRIVATE_KEY_TO_USE" ]]; then
-        error "could not determine private key for network $NETWORK in $ENVIRONMENT environment"
-        exit 1
-      fi
-
       echo "Funding PauserWallet $PAUSER_WALLET_ADDRESS with $FUNDING_AMOUNT wei"
       universalCast "sendValue" "$NETWORK" "$ENVIRONMENT" "$PAUSER_WALLET_ADDRESS" "$FUNDING_AMOUNT" "$PRIVATE_KEY_TO_USE"
       checkFailure $? "fund PauserWallet $PAUSER_WALLET_ADDRESS on $NETWORK"
+    fi
+
+    # --- Fund DevWallet ---
+    # DevWallet is used for executing timelock proposals on production and for staging deployments.
+    # It must have a native balance on every new network before execution scripts can run.
+    local DEV_WALLET_ADDRESS
+    DEV_WALLET_ADDRESS=$(getValueFromJSONFile "./config/global.json" "devWallet")
+    if [[ $? -ne 0 ]]; then
+      error "failed to read devWallet address from ./config/global.json"
+      exit 1
+    fi
+    if [[ -z "$DEV_WALLET_ADDRESS" || "$DEV_WALLET_ADDRESS" == "null" ]]; then
+      error "DevWallet address not found. Cannot fund DevWallet"
+      exit 1
+    fi
+
+    BALANCE=$(cast balance "$DEV_WALLET_ADDRESS" --rpc-url "$RPC_URL")
+    checkFailure $? "get DevWallet balance for $DEV_WALLET_ADDRESS on $NETWORK"
+    echo "DevWallet Balance: $BALANCE"
+
+    if [[ "$BALANCE" == "0" ]]; then
+      echo "DevWallet balance is 0. How much wei would you like to send to $DEV_WALLET_ADDRESS?"
+      read -r FUNDING_AMOUNT || FUNDING_AMOUNT=""
+
+      # Validate that FUNDING_AMOUNT is a non-empty numeric value
+      if [[ -z "$FUNDING_AMOUNT" ]] || ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
+        error "Invalid funding amount. Please provide a valid wei amount (numeric value)."
+        exit 1
+      fi
+
+      echo "Funding DevWallet $DEV_WALLET_ADDRESS with $FUNDING_AMOUNT wei"
+      universalCast "sendValue" "$NETWORK" "$ENVIRONMENT" "$DEV_WALLET_ADDRESS" "$FUNDING_AMOUNT" "$PRIVATE_KEY_TO_USE"
+      checkFailure $? "fund DevWallet $DEV_WALLET_ADDRESS on $NETWORK"
     fi
 
     echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< STAGE 9 completed"

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -333,11 +333,13 @@ deployAllContracts() {
     echo "PauserWallet Balance: $BALANCE"
 
     if [[ "$BALANCE" == "0" ]]; then
-      echo "PauserWallet balance is 0. How much wei would you like to send to $PAUSER_WALLET_ADDRESS?"
-      read -r FUNDING_AMOUNT || FUNDING_AMOUNT=""
+      local DEFAULT_FUND_AMOUNT=2000000000000000
+      echo "PauserWallet balance is 0. Enter wei to send to $PAUSER_WALLET_ADDRESS (edit or press Enter to confirm default):"
+      FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+      FUNDING_AMOUNT="${FUNDING_AMOUNT:-$DEFAULT_FUND_AMOUNT}"
 
-      # Validate that FUNDING_AMOUNT is a non-empty numeric value
-      if [[ -z "$FUNDING_AMOUNT" ]] || ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
+      # Validate that FUNDING_AMOUNT is a numeric value
+      if ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
         error "Invalid funding amount. Please provide a valid wei amount (numeric value)."
         exit 1
       fi
@@ -366,11 +368,13 @@ deployAllContracts() {
       echo "DevWallet Balance: $BALANCE"
 
       if [[ "$BALANCE" == "0" ]]; then
-        echo "DevWallet balance is 0. How much wei would you like to send to $DEV_WALLET_ADDRESS?"
-        read -r FUNDING_AMOUNT || FUNDING_AMOUNT=""
+        local DEFAULT_FUND_AMOUNT=2000000000000000
+        echo "DevWallet balance is 0. Enter wei to send to $DEV_WALLET_ADDRESS (edit or press Enter to confirm default):"
+        FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+        FUNDING_AMOUNT="${FUNDING_AMOUNT:-$DEFAULT_FUND_AMOUNT}"
 
-        # Validate that FUNDING_AMOUNT is a non-empty numeric value
-        if [[ -z "$FUNDING_AMOUNT" ]] || ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
+        # Validate that FUNDING_AMOUNT is a numeric value
+        if ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
           error "Invalid funding amount. Please provide a valid wei amount (numeric value)."
           exit 1
         fi


### PR DESCRIPTION
# Which Linear task belongs to this PR?

<!-- No Linear task — operational deployment script improvement -->

# Why did I implement it this way?

Stage 9 of `deployAllContracts.sh` previously only funded the PauserWallet. The DevWallet is used to execute timelock proposals on production and to run staging deployments, so it also needs a native-token balance on every new network before execution scripts can run. Rather than adding a separate stage, I extended Stage 9 to fund both wallets in a single step, reusing the already-fetched RPC URL and private key. The private-key lookup was also hoisted above both funding sub-steps to avoid a redundant call.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>