### PR TITLE
feat(whitelist): add Fly support on Etherlink

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4511,6 +4511,14 @@
               "0x46ec278a": "swapWithBackendSignature(bytes)"
             }
           }
+        ],
+        "etherlink": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
         ]
       }
     },


### PR DESCRIPTION
## Summary

- Adds Etherlink (`etherlink`) to the Fly DEX in `config/whitelist.json`
- Whitelists the Fly backend-signature contract `0x20f6ee51340adeed01a59b0e65cb3703f3dc860c` with the `swapWithBackendSignature(bytes)` (`0x46ec278a`) selector
- Mirrors the existing pattern used for Fly's most recent additions (`plasma`, `somnia`, `telos`)

Resolves [EXSC-326](https://linear.app/lifi-linear/issue/EXSC-326/sc-fly-add-etherlink-support).

## Test plan

- [x] `jq . config/whitelist.json` — file is valid JSON
- [x] `jq -e '.DEXS[] | select(.key=="fly") | .contracts.etherlink[0].address == "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c"'` returns `true`
- [x] `git diff origin/main` shows ONLY the 8-line `etherlink` block added under the Fly entry
- [x] Local `coderabbit review --base origin/main --plain` — no findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)