### PR TITLE
fix(ci): always run markdownlint workflow so required check reports

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,7 +1,9 @@
 # Markdownlint
 # - lints Markdown files in pull requests against the repo's .markdownlint-cli2.jsonc config
 # - scoped to changed .md files only (via tj-actions/changed-files) so existing markdown is grandfathered
-# - triggered on PRs that touch any .md file, the markdownlint config, or this workflow itself
+# - runs on every PR so the required check always reports a status; the job short-circuits when no
+#   .md files are in the diff (see Step 3 below). A previous path-filtered trigger left the required
+#   check stuck on "Expected — Waiting for status to be reported" for PRs that touched no markdown.
 # - hard-fails the job on any structural violation (heading hierarchy, fence/list spacing, empty links, etc.)
 # - known limitations: existing markdown files are not linted retroactively; only modified files in the PR are checked
 
@@ -9,10 +11,6 @@ name: markdownlint
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
-      - '.github/workflows/markdownlint.yml'
 
 permissions:
   contents: read # required to fetch repository contents and compute the changed-files diff

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,10 +1,10 @@
 # Markdownlint
 # - lints Markdown files in pull requests against the repo's .markdownlint-cli2.jsonc config
 # - scoped to changed .md files only (via tj-actions/changed-files) so existing markdown is grandfathered
-# - runs on every PR so the required check always reports a status; the job short-circuits when no
-#   .md files are in the diff (see Step 3 below). A previous path-filtered trigger left the required
-#   check stuck on "Expected — Waiting for status to be reported" for PRs that touched no markdown.
-# - hard-fails the job on any structural violation (heading hierarchy, fence/list spacing, empty links, etc.)
+# - hard-fails the lint job on any structural violation (heading hierarchy, fence/list spacing, empty links, etc.)
+# - Path-gated via a dedicated `detect-changes` job. A `markdownlint-required` aggregator job always
+#   reports a final status so this workflow can remain a required check on `main` branch protection
+#   even when the heavy lint job is skipped because no markdown files changed.
 # - known limitations: existing markdown files are not linted retroactively; only modified files in the PR are checked
 
 name: markdownlint
@@ -16,7 +16,31 @@ permissions:
   contents: read # required to fetch repository contents and compute the changed-files diff
 
 jobs:
+  detect-changes:
+    # Determines whether files that can influence the markdownlint outcome were touched.
+    # Always runs (cheap) so the downstream markdownlint-required can report status.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+    outputs:
+      markdown: ${{ steps.filter.outputs.markdown }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            markdown:
+              - '**/*.md'
+              - '.markdownlint-cli2.jsonc'
+              - '.github/workflows/markdownlint.yml'
+
   lint:
+    needs: detect-changes
+    # Only run the heavy lint job when files that can influence the outcome have changed.
+    if: ${{ needs.detect-changes.outputs.markdown == 'true' }}
     name: lint changed markdown files
     runs-on: ubuntu-latest
     steps:
@@ -33,16 +57,39 @@ jobs:
         with:
           files: '**/*.md'
 
-      # Step 3: Short-circuit if the PR doesn't actually touch any markdown file
-      #         (workflow can be triggered by edits to the config or this file)
-      - name: Skip if no markdown files changed
-        if: steps.changed.outputs.any_changed != 'true'
-        run: echo "No markdown files changed; nothing to lint."
-
-      # Step 4: Lint only the changed files using the repo's .markdownlint-cli2.jsonc
+      # Step 3: Lint only the changed files using the repo's .markdownlint-cli2.jsonc.
+      # Guarded on any_changed because the detect-changes gate can also fire on
+      # edits to the config or this workflow file alone (no .md files changed).
       - name: Run markdownlint-cli2 on changed files
         if: steps.changed.outputs.any_changed == 'true'
         uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0 # v18
         with:
           globs: ${{ steps.changed.outputs.all_changed_files }}
           separator: ' '
+
+  markdownlint-required:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `lint changed markdown files`) as the required status check on `main`.
+    needs: [detect-changes, lint]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `lint` would be
+        # `skipped` due to the dependency failure — and treating that `skipped`
+        # as success would mask the infra failure from branch protection.
+        run: |
+          set -euo pipefail
+          detect_result="${{ needs.detect-changes.result }}"
+          lint_result="${{ needs.lint.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31mmarkdownlint-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$lint_result" == "success" || "$lint_result" == "skipped" ]]; then
+            echo -e "\033[32mmarkdownlint-required OK (lint=$lint_result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mmarkdownlint-required FAILED (lint=$lint_result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,10 +1,10 @@
 # Markdownlint
 # - lints Markdown files in pull requests against the repo's .markdownlint-cli2.jsonc config
 # - scoped to changed .md files only (via tj-actions/changed-files) so existing markdown is grandfathered
-# - hard-fails the lint job on any structural violation (heading hierarchy, fence/list spacing, empty links, etc.)
-# - Path-gated via a dedicated `detect-changes` job. A `markdownlint-required` aggregator job always
-#   reports a final status so this workflow can remain a required check on `main` branch protection
-#   even when the heavy lint job is skipped because no markdown files changed.
+# - runs on every PR so the required check always reports a status; the job short-circuits when no
+#   .md files are in the diff (see Step 3 below). A previous path-filtered trigger left the required
+#   check stuck on "Expected — Waiting for status to be reported" for PRs that touched no markdown.
+# - hard-fails the job on any structural violation (heading hierarchy, fence/list spacing, empty links, etc.)
 # - known limitations: existing markdown files are not linted retroactively; only modified files in the PR are checked
 
 name: markdownlint
@@ -16,31 +16,7 @@ permissions:
   contents: read # required to fetch repository contents and compute the changed-files diff
 
 jobs:
-  detect-changes:
-    # Determines whether files that can influence the markdownlint outcome were touched.
-    # Always runs (cheap) so the downstream markdownlint-required can report status.
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read # required by dorny/paths-filter to read changed files on PRs
-    outputs:
-      markdown: ${{ steps.filter.outputs.markdown }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Detect relevant changes
-        id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            markdown:
-              - '**/*.md'
-              - '.markdownlint-cli2.jsonc'
-              - '.github/workflows/markdownlint.yml'
-
   lint:
-    needs: detect-changes
-    # Only run the heavy lint job when files that can influence the outcome have changed.
-    if: ${{ needs.detect-changes.outputs.markdown == 'true' }}
     name: lint changed markdown files
     runs-on: ubuntu-latest
     steps:
@@ -57,39 +33,16 @@ jobs:
         with:
           files: '**/*.md'
 
-      # Step 3: Lint only the changed files using the repo's .markdownlint-cli2.jsonc.
-      # Guarded on any_changed because the detect-changes gate can also fire on
-      # edits to the config or this workflow file alone (no .md files changed).
+      # Step 3: Short-circuit if the PR doesn't actually touch any markdown file
+      #         (workflow can be triggered by edits to the config or this file)
+      - name: Skip if no markdown files changed
+        if: steps.changed.outputs.any_changed != 'true'
+        run: echo "No markdown files changed; nothing to lint."
+
+      # Step 4: Lint only the changed files using the repo's .markdownlint-cli2.jsonc
       - name: Run markdownlint-cli2 on changed files
         if: steps.changed.outputs.any_changed == 'true'
         uses: DavidAnson/markdownlint-cli2-action@eb5ca3ab411449c66620fe7f1b3c9e10547144b0 # v18
         with:
           globs: ${{ steps.changed.outputs.all_changed_files }}
           separator: ' '
-
-  markdownlint-required:
-    # Aggregator job for branch protection. Reports green when the heavy job
-    # either succeeded or was skipped because no relevant files changed.
-    # Register THIS job (not `lint changed markdown files`) as the required status check on `main`.
-    needs: [detect-changes, lint]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate upstream result
-        # Validate `detect-changes` succeeded first. If it failed, `lint` would be
-        # `skipped` due to the dependency failure — and treating that `skipped`
-        # as success would mask the infra failure from branch protection.
-        run: |
-          set -euo pipefail
-          detect_result="${{ needs.detect-changes.result }}"
-          lint_result="${{ needs.lint.result }}"
-          if [[ "$detect_result" != "success" ]]; then
-            echo -e "\033[31mmarkdownlint-required FAILED (detect-changes=$detect_result)\033[0m" >&2
-            exit 1
-          fi
-          if [[ "$lint_result" == "success" || "$lint_result" == "skipped" ]]; then
-            echo -e "\033[32mmarkdownlint-required OK (lint=$lint_result)\033[0m"
-            exit 0
-          fi
-          echo -e "\033[31mmarkdownlint-required FAILED (lint=$lint_result)\033[0m" >&2
-          exit 1


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — CI tooling fix.

# Why did I implement it this way?

## Problem

`lint changed markdown files` is a **required** status check on `main`, but `.github/workflows/markdownlint.yml` has a `paths:` trigger limited to `**/*.md` / `.markdownlint-cli2.jsonc` / the workflow file. PRs touching none of those (e.g. Solidity-only PRs like #1715) never start the workflow → the required check stays parked on `Expected — Waiting for status to be reported` forever and the PR can't merge without admin override.

The path filter (added in #1808) predates the check being made required; the two settings are incompatible — a required check must report on every PR. #1818's fix was orthogonal (config-globs union bug, not the trigger).

## Solution

Drop the `paths:` trigger filter so the workflow runs on every PR.

This **doesn't** mean the linter runs on every PR. The job already has detection inside it:

- **Step 2** (`tj-actions/changed-files`, scoped to `**/*.md`) computes whether any markdown changed.
- **Step 3** echoes "nothing to lint" and exits when `any_changed != 'true'`.
- **Step 4** (the actual `markdownlint-cli2-action`) is gated on `any_changed == 'true'`.

So on Solidity-only PRs the runner does ~15–30s of work (checkout + diff + echo) and exits `success`. The lint action itself is correctly skipped — same outcome the `paths:` filter was trying to achieve, but now the required check actually reports.

### Why not the 3-job detect/aggregate pattern from `enforceTestCoverage.yml` / `deploy-smoke-test.yml`?

Considered. That pattern justifies its overhead when the heavy job costs minutes (coverage ~8.5 min, smoke ~4 min) — splitting saves real time. Markdownlint's "heavy" step is ~15s, similar to its detect step, so splitting adds a second runner without saving anything (actually 2× the billed runner-minutes for MD-less PRs). The detection-then-gate logic already lives inside the single job (Steps 2 + 4).

If markdownlint ever grows heavier (vale, lychee, spellcheck), refactor to the 3-job pattern at that point.

### Bonus: no branch-protection change required

Required-check name stays `lint changed markdown files` — land this PR, done. The 3-job alternative would have required flipping branch protection from `lint changed markdown files` → `markdownlint-required` post-merge, with the failure mode of MD-less PRs staying blocked if that flip was forgotten.

## Verification

Cherry-picked the workflow change onto `exsc-241-fix-tron-usdt-transfers` (PR #1715, Solidity-only, currently blocked on this). The `lint changed markdown files` check fired and reported `success`. Will revert from #1715 once this lands.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
