### PR TITLE
fix(workflows): stop cancelled version-control runs from showing as failures

### DIFF
--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -25,7 +25,14 @@ name: VersionControlAndAuditVerification
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, review_requested, ready_for_review]
+    types: [opened, synchronize, review_requested, ready_for_review]
+    # `pull_request_review` is intentionally not a trigger: this check is a pure
+    # function of the PR diff, so review events can't change the outcome and
+    # only create same-SHA duplicate runs that show up as cancelled (red) rows.
+    # `edited` is also intentionally omitted: this workflow updates the PR title
+    # itself via `gh pr edit`, which re-triggers an `edited` event on the same
+    # SHA and cancels the run in progress. Human title edits don't change the
+    # contract diff, and the next `synchronize` would catch any real change.
 
 permissions:
   contents: read # required to fetch repository contents
@@ -36,13 +43,8 @@ jobs:
   version-control:
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
-    # Key concurrency by PR + head SHA so only redundant runs on the *same* commit
-    # cancel each other. A new commit (synchronize) gets its own group and runs to
-    # completion instead of being cancelled by — or cancelling — runs on the prior SHA.
-    # Without the SHA in the key, GitHub renders the cancelled run as a red "fail"
-    # row in the Checks UI even though nothing actually broke.
     concurrency:
-      group: sc-core-dev-approval-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      group: sc-core-dev-approval-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     env:
       CONTINUE: false # makes sure that variable is correctly initialized in all cases

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -26,8 +26,6 @@ name: VersionControlAndAuditVerification
 on:
   pull_request:
     types: [opened, edited, synchronize, review_requested, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: read # required to fetch repository contents
@@ -38,8 +36,13 @@ jobs:
   version-control:
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.base.ref == 'main' }}
     runs-on: ubuntu-latest
+    # Key concurrency by PR + head SHA so only redundant runs on the *same* commit
+    # cancel each other. A new commit (synchronize) gets its own group and runs to
+    # completion instead of being cancelled by — or cancelling — runs on the prior SHA.
+    # Without the SHA in the key, GitHub renders the cancelled run as a red "fail"
+    # row in the Checks UI even though nothing actually broke.
     concurrency:
-      group: sc-core-dev-approval-${{ github.event.pull_request.number }}
+      group: sc-core-dev-approval-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
       cancel-in-progress: true
     env:
       CONTINUE: false # makes sure that variable is correctly initialized in all cases


### PR DESCRIPTION
# Which Linear task belongs to this PR?

n/a — CI hygiene, no Linear task.

# Why I implemented it this way

PRs were regularly showing red `version-control` rows in the Checks UI that turned green on a manual re-run. The "failures" are cancelled runs: GitHub renders cancellations as red rows next to the eventual green pass.

Survey of the last 100 `VersionControlAndAuditVerification` runs: 9 cancellations, 2 real failures (legitimate missing-audit-log errors, not addressed here).

Walking through each of the 9 cancellations and locating the killer run on the same SHA:

- **8 of 9** are killed by a `pull_request_review` event arriving within seconds of a `synchronize` (or another `pull_request`) on the same SHA. This check is a pure function of the PR diff, so review events can't change the outcome.
- **1 of 9** is two `pull_request` events on the same SHA, 14s apart — the title-bot's `edited` event re-triggering after this workflow's own `gh pr edit` updates the title.

All 9 are same-SHA, so two minimal trigger removals cover them:

- **Drop the `pull_request_review` trigger.** Removes the 8 review-driven cancellations.
- **Drop `edited` from the `pull_request` trigger types.** Breaks the title-bot's self-trigger loop. Human title edits don't change the contract diff, and the next `synchronize` catches anything content-relevant.

Concurrency key is left as PR-number-only with `cancel-in-progress: true`. An earlier draft of this PR added the head SHA to the key, but on closer inspection it wasn't load-bearing for any observed cancellation (all 9 are same-SHA) and would have opened a race in the downstream `audit-verification` job, which writes the `AuditRequired`/`AuditNotRequired`/`AuditCompleted` labels and has no concurrency block of its own. Thanks to @mirooon for catching this.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
