### PR TITLE
🧪 TEST (do not merge): negative test for verifyClearSigning gate

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -3,7 +3,7 @@
   "$count": 101,
   "formats": {
     "startBridgeTokensViaAcross((bytes32,string,string,address,address,address,uint256,uint256,bool,bool),(int64,uint32,bytes,uint256))": {
-      "intent": "Bridge via Across",
+      "intent": "DELIBERATELY_STALE_FOR_GATE_TEST",
       "interpolatedIntent": "Bridge {_bridgeData.minAmount} via Across to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
       "fields": [
         {


### PR DESCRIPTION
> ⚠️ **This PR is a test fixture. Do not merge. Will be closed after CI demonstrates the gate works.**

## Purpose

Negative-test the `verifyClearSigning` workflow added in #1821. Confirms the gate actually catches stale `config/clearSigningProposal.json` (i.e. someone hand-edited the JSON or forgot to re-run the generator after a relevant change).

## What this PR does

Single one-line edit to `config/clearSigningProposal.json`:

```diff
-      "intent": "Bridge via Across",
+      "intent": "DELIBERATELY_STALE_FOR_GATE_TEST",
```

The generator would never produce this value (it derives intents deterministically from facet names). So when CI runs the generator and diffs the output against the committed JSON, the diff is non-empty → CI must fail.

## Expected CI outcome

The `verify-clear-signing` job should:

1. ✅ Pass `Run clear-signing generator (strict mode)` — the edit is to a value, not a struct, so strict-mode validation still succeeds.
2. ❌ Fail `Verify config/clearSigningProposal.json is up-to-date` with this output:

   ```text
   ❌ config/clearSigningProposal.json is stale.
   Run this locally and commit the result:
     bunx tsx tasks/buildClearSigningProposal.ts
     git add config/clearSigningProposal.json
   ```

If CI reports both (1) ✅ and (2) ❌ → **gate works**, close + delete.

If CI reports anything else (e.g., (1) fails, or (2) passes), the gate has a bug — investigate before merging #1821.

## Base branch

Targets `chore/clear-signing-display-proposal` (i.e. #1821's branch), not `main` — because the workflow file isn't on `main` yet. Once #1821 lands, the gate file lives at `main` and any subsequent PR with the same edit would behave identically.

## Cleanup

After CI run completes (~3-5 min), close with `gh pr close <num> --delete-branch`.