### PR TITLE
EXSC-339: feat(ci): add monthly ticket-linkage metric workflow

### DIFF
--- a/.agents/context.md
+++ b/.agents/context.md
@@ -30,14 +30,26 @@ are embedded in rule files.
 | Solhint | `bunx solhint <file>` |
 | Bash syntax | `bash -n <file>` |
 
+## Ticket linkage
+
+The PR template's "Which Linear task belongs to this PR?" field is the source of
+truth. The monthly **Ticket Linkage Metric** workflow
+(`.github/workflows/ticketLinkageMetric.yml`) posts to Slack on the 1st of each
+month with the % of merged PRs that reference a Linear ticket ID (regex
+`[A-Z]+-[0-9]+`) in their title, branch, or body. Target: 80%+.
+
+Carve-out: PRs labelled `trivial` (typo / doc-only / dep-bump / single-line fix)
+are counted as linked. Use sparingly — the carve-out exists so the metric
+doesn't punish genuinely tiny PRs, not as an opt-out for skipping ticket creation.
+
 ## Creating and editing PRs via gh
 
 When creating or editing a PR body, always start from the repo template at
 `.github/pull_request_template.md` (sections, headings, and reviewer checklist
 verbatim). Fill in the Linear task link and "Why I implemented it this way";
 tick only the items in the author checklist that genuinely apply; leave the
-reviewer checklist unchecked. Do not substitute a custom layout (e.g. `## Summary`
-+ `## Test plan`) — the template's wording feeds the review process.
+reviewer checklist unchecked. Do not substitute a custom layout
+(e.g. `## Summary` + `## Test plan`) — the template's wording feeds the review process.
 
 Use the REST API to update PR title/body:
 

--- a/.agents/context.md
+++ b/.agents/context.md
@@ -41,6 +41,7 @@ month with the % of merged PRs that reference a Linear ticket ID (regex
 Carve-out: PRs labelled `trivial` (typo / doc-only / dep-bump / single-line fix)
 are counted as linked. Use sparingly — the carve-out exists so the metric
 doesn't punish genuinely tiny PRs, not as an opt-out for skipping ticket creation.
+The monthly report lists every `trivial`-only PR by name so misuse is visible.
 
 ## Creating and editing PRs via gh
 

--- a/.github/scripts/ticket-linkage-metric.sh
+++ b/.github/scripts/ticket-linkage-metric.sh
@@ -42,16 +42,18 @@ TRIVIAL_ONLY=$(jq --arg re "$TICKET_RE" '[.[] |
 VIA_TICKET=$(( WITH_TICKET - TRIVIAL_ONLY ))
 
 if [ "$TOTAL" -eq 0 ]; then
-  PCT=100
+  PCT=0
+  PCT_TEXT="N/A"
+  EMOJI=":information_source:"
 else
   PCT=$(( (WITH_TICKET * 100) / TOTAL ))
+  PCT_TEXT="${PCT}%"
+  if   [ "$PCT" -ge 90 ]; then EMOJI=":white_check_mark:"
+  elif [ "$PCT" -ge 80 ]; then EMOJI=":large_yellow_circle:"
+  else                         EMOJI=":red_circle:"
+  fi
 fi
 MISSING=$(( TOTAL - WITH_TICKET ))
-
-if   [ "$PCT" -ge 90 ]; then EMOJI=":white_check_mark:"
-elif [ "$PCT" -ge 80 ]; then EMOJI=":large_yellow_circle:"
-else                         EMOJI=":red_circle:"
-fi
 
 REPO="${GITHUB_REPOSITORY:-lifinance/contracts}"
 
@@ -77,7 +79,7 @@ TRIVIAL_LIST=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
 
 {
   echo "${EMOJI} *Ticket linkage — ${SINCE} → ${UNTIL}*"
-  echo "${WITH_TICKET}/${TOTAL} merged PRs linked to a Linear ticket (*${PCT}%*) — target: 80%+"
+  echo "${WITH_TICKET}/${TOTAL} merged PRs linked to a Linear ticket (*${PCT_TEXT}*) — target: 80%+"
   if [ "$TRIVIAL_ONLY" -gt 0 ]; then
     echo "  ↳ ${VIA_TICKET} via ticket ID, ${TRIVIAL_ONLY} via \`trivial\` label"
   fi

--- a/.github/scripts/ticket-linkage-metric.sh
+++ b/.github/scripts/ticket-linkage-metric.sh
@@ -29,6 +29,18 @@ WITH_TICKET=$(jq --arg re "$TICKET_RE" '[.[] |
     ([.labels[].name] | any(. == "trivial"))
   )] | length' <<<"$PRS")
 
+# Counted-as-linked PRs that ONLY pass via the `trivial` label (no ticket ID match).
+# Surfaced separately so reviewers can audit whether the carve-out is being misused.
+TRIVIAL_ONLY=$(jq --arg re "$TICKET_RE" '[.[] |
+  select(
+    ([.labels[].name] | any(. == "trivial")) and
+    (.title       | test($re) | not) and
+    (.headRefName | test($re) | not) and
+    ((.body // "") | test($re) | not)
+  )] | length' <<<"$PRS")
+
+VIA_TICKET=$(( WITH_TICKET - TRIVIAL_ONLY ))
+
 if [ "$TOTAL" -eq 0 ]; then
   PCT=100
 else
@@ -53,13 +65,31 @@ OFFENDERS=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
      | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \(.title) — _\(.author.login)_")
      | join("\n")' <<<"$PRS")
 
+# Full list (no cap) of PRs that only qualified via the `trivial` label, for audit.
+TRIVIAL_LIST=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
+  select(
+    ([.labels[].name] | any(. == "trivial")) and
+    (.title       | test($re) | not) and
+    (.headRefName | test($re) | not) and
+    ((.body // "") | test($re) | not)
+  )] | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \(.title) — _\(.author.login)_")
+     | join("\n")' <<<"$PRS")
+
 {
   echo "${EMOJI} *Ticket linkage — ${SINCE} → ${UNTIL}*"
   echo "${WITH_TICKET}/${TOTAL} merged PRs linked to a Linear ticket (*${PCT}%*) — target: 80%+"
+  if [ "$TRIVIAL_ONLY" -gt 0 ]; then
+    echo "  ↳ ${VIA_TICKET} via ticket ID, ${TRIVIAL_ONLY} via \`trivial\` label"
+  fi
   if [ "$MISSING" -gt 0 ] && [ -n "$OFFENDERS" ]; then
     echo ""
     echo "Unlinked (top 10):"
     echo "${OFFENDERS}"
+  fi
+  if [ "$TRIVIAL_ONLY" -gt 0 ] && [ -n "$TRIVIAL_LIST" ]; then
+    echo ""
+    echo "\`trivial\`-labelled (audit for misuse):"
+    echo "${TRIVIAL_LIST}"
   fi
 } > /tmp/slack-text.txt
 

--- a/.github/scripts/ticket-linkage-metric.sh
+++ b/.github/scripts/ticket-linkage-metric.sh
@@ -64,7 +64,7 @@ OFFENDERS=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
      ((.body // "") | test($re)) or
      ([.labels[].name] | any(. == "trivial"))) | not
   )] | .[0:10]
-     | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \(.title) — _\(.author.login)_")
+     | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \((.title // "") | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) — _\(.author.login)_")
      | join("\n")' <<<"$PRS")
 
 # Full list (no cap) of PRs that only qualified via the `trivial` label, for audit.
@@ -74,7 +74,7 @@ TRIVIAL_LIST=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
     (.title       | test($re) | not) and
     (.headRefName | test($re) | not) and
     ((.body // "") | test($re) | not)
-  )] | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \(.title) — _\(.author.login)_")
+  )] | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \((.title // "") | gsub("&"; "&amp;") | gsub("<"; "&lt;") | gsub(">"; "&gt;")) — _\(.author.login)_")
      | join("\n")' <<<"$PRS")
 
 {

--- a/.github/scripts/ticket-linkage-metric.sh
+++ b/.github/scripts/ticket-linkage-metric.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Computes ticket-linkage % for merged PRs in the previous calendar month.
+# A PR "has a ticket" if a Linear-style ID (e.g. EXSC-123) appears in the title,
+# branch name, or body, OR if the PR carries the `trivial` label (documented carve-out).
+# Emits a multi-line `text` GitHub Actions output for the Slack step to consume.
+set -euo pipefail
+
+# Previous calendar month [SINCE, UNTIL] inclusive, in UTC.
+# Works on GNU date (Linux runners). Do not use BSD date syntax here.
+SINCE=$(date -u -d "$(date -u +%Y-%m-01) -1 month" +%Y-%m-%d)
+UNTIL=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m-%d)
+
+PRS=$(gh pr list \
+  --state merged \
+  --search "merged:${SINCE}..${UNTIL}" \
+  --limit 500 \
+  --json number,title,headRefName,body,labels,author,mergedAt)
+
+TOTAL=$(jq 'length' <<<"$PRS")
+
+# Matches any Linear-style ticket ID: <UPPERCASE_PREFIX>-<digits>
+TICKET_RE='[A-Z]+-[0-9]+'
+
+WITH_TICKET=$(jq --arg re "$TICKET_RE" '[.[] |
+  select(
+    (.title       | test($re)) or
+    (.headRefName | test($re)) or
+    ((.body // "") | test($re)) or
+    ([.labels[].name] | any(. == "trivial"))
+  )] | length' <<<"$PRS")
+
+if [ "$TOTAL" -eq 0 ]; then
+  PCT=100
+else
+  PCT=$(( (WITH_TICKET * 100) / TOTAL ))
+fi
+MISSING=$(( TOTAL - WITH_TICKET ))
+
+if   [ "$PCT" -ge 90 ]; then EMOJI=":white_check_mark:"
+elif [ "$PCT" -ge 80 ]; then EMOJI=":large_yellow_circle:"
+else                         EMOJI=":red_circle:"
+fi
+
+REPO="${GITHUB_REPOSITORY:-lifinance/contracts}"
+
+OFFENDERS=$(jq -r --arg re "$TICKET_RE" --arg repo "$REPO" '[.[] |
+  select(
+    ((.title       | test($re)) or
+     (.headRefName | test($re)) or
+     ((.body // "") | test($re)) or
+     ([.labels[].name] | any(. == "trivial"))) | not
+  )] | .[0:10]
+     | map("• <https://github.com/\($repo)/pull/\(.number)|#\(.number)> \(.title) — _\(.author.login)_")
+     | join("\n")' <<<"$PRS")
+
+{
+  echo "${EMOJI} *Ticket linkage — ${SINCE} → ${UNTIL}*"
+  echo "${WITH_TICKET}/${TOTAL} merged PRs linked to a Linear ticket (*${PCT}%*) — target: 80%+"
+  if [ "$MISSING" -gt 0 ] && [ -n "$OFFENDERS" ]; then
+    echo ""
+    echo "Unlinked (top 10):"
+    echo "${OFFENDERS}"
+  fi
+} > /tmp/slack-text.txt
+
+# Emit as multi-line output using a random delimiter (per GitHub Actions docs).
+DELIM="EOF_$(openssl rand -hex 8)"
+{
+  echo "text<<${DELIM}"
+  cat /tmp/slack-text.txt
+  echo "${DELIM}"
+} >> "$GITHUB_OUTPUT"
+
+# Also log to the Actions console for debugging
+echo "--- Slack message preview ---"
+cat /tmp/slack-text.txt
+echo "--- end preview ---"

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -33,4 +33,6 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook
           payload: |
-            text: ${{ toJSON(steps.metric.outputs.text) }}
+            {
+              "text": ${{ toJSON(steps.metric.outputs.text) }}
+            }

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -38,3 +38,15 @@ jobs:
             {
               "text": ${{ toJSON(steps.metric.outputs.text) }}
             }
+
+      # Silent missed reports defeat the purpose of a monthly forcing function — surface failures in the same channel.
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":warning: ticket-linkage metric run failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"
+            }

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -1,0 +1,38 @@
+# Monthly ticket-linkage metric
+# - computes % of merged PRs in the previous calendar month that reference a Linear ticket (or carry the `trivial` label)
+# - posts the result to Slack with a top-10 list of unlinked PRs so the number is actionable
+# - known limitations: regex-only "has ticket" check (no Linear API call); caps PR window at 500 results
+
+name: Ticket Linkage Metric
+
+on:
+  schedule:
+    - cron: '0 9 1 * *' # 09:00 UTC on the 1st of each month
+  workflow_dispatch: # manual trigger for testing
+
+permissions:
+  contents: read # required to checkout the metric script
+  pull-requests: read # required for gh pr list
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Compute linkage %
+        id: metric
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/ticket-linkage-metric.sh
+
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          # NOTE: pointing at DANIEL_TEST for the first scheduled run to validate output;
+          # follow-up PR swaps to SLACK_WEBHOOK_SC_GENERAL once verified end-to-end.
+          webhook: ${{ secrets.SLACK_WEBHOOK_DANIEL_TEST }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ${{ toJSON(steps.metric.outputs.text) }}

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -27,12 +27,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/ticket-linkage-metric.sh
 
-      - name: Post to Slack
+      - name: Post to Slack SC-general
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          # NOTE: pointing at DANIEL_TEST for the first scheduled run to validate output;
-          # follow-up PR swaps to SLACK_WEBHOOK_SC_GENERAL once verified end-to-end.
-          webhook: ${{ secrets.SLACK_WEBHOOK_DANIEL_TEST }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook
           payload: |
             text: ${{ toJSON(steps.metric.outputs.text) }}

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -1,6 +1,6 @@
 # Monthly ticket-linkage metric
 # - computes % of merged PRs in the previous calendar month that reference a Linear ticket (or carry the `trivial` label)
-# - posts the result to Slack with a top-10 list of unlinked PRs so the number is actionable
+# - posts to Slack with a top-10 list of unlinked PRs + the full list of `trivial`-labelled PRs (for audit of carve-out misuse)
 # - known limitations: regex-only "has ticket" check (no Linear API call); caps PR window at 500 results
 
 name: Ticket Linkage Metric

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false # only `gh pr list` runs here; no git push/tag/submodule operations
 
       - name: Compute linkage %
         id: metric


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-339](https://linear.app/lifi-linear/issue/EXSC-339/add-monthly-ticket-linkage-metric-workflow-for-contracts-repo)

# Why did I implement it this way?

Monthly visibility on PR↔Linear-ticket linkage as a forcing function for the
80%+ target. Posts to `#sc-general` on the 1st of each month via the same
`slackapi/slack-github-action@v2.0.0` pinned action that
`networkRpcsChecker.yml`, `updateScriptConfigReminder.yml`, and three other
workflows already use — same channel, same secret (`SLACK_WEBHOOK_SC_GENERAL`),
same pinning convention. No new infrastructure to maintain.

**"Has ticket" rule** (v1, regex-only): PR counts as linked if any of
- title, branch name, or body contains `[A-Z]+-[0-9]+`
- carries the `trivial` label (carve-out for typo / doc-only / dep-bump / single-line fixes)

No Linear API call — regex is ~95% as good for this purpose and needs no extra
secret. Upgradeable later if false-positive/false-negative rate is too high.

**Carve-out label**: `trivial` (already created in repo). The carve-out
exists so the metric doesn't punish genuinely tiny PRs, not as an opt-out for
skipping ticket creation.

**Message format**: validated locally by piping the same `metric.sh` output
into the `#daniel-test` channel via curl. Renders correctly — bold, clickable
PR links, italic author handles, `:red_circle:` emoji.

**Sample output** (baseline against April 2026 merged PRs in this repo):
> 🔴 *Ticket linkage — 2026-04-01 → 2026-04-30*
> 17/37 merged PRs linked to a Linear ticket (*45%*) — target: 80%+
> Unlinked (top 10): …

First scheduled run: 2026-06-01 09:00 UTC (allowing for GH Actions' usual
~30min cron jitter on busy days).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
