### PR TITLE
fix(propose-to-safe): guard runMain with import.meta.main

### DIFF
--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -308,4 +308,6 @@ const main = defineCommand({
   },
 })
 
-runMain(main)
+if (import.meta.main) {
+  runMain(main)
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A (trivial fix — `import.meta.main` guard)

# Why did I implement it this way?

`propose-to-safe.ts` exported `runPropose()` for programmatic use, but also called `runMain()` unconditionally at module level. Any script that imported `runPropose` would trigger citty's CLI handler, which exited with "Missing required argument: --network" before any code in the caller ran.

The fix wraps the `runMain` call in `if (import.meta.main)` — the standard Node/Bun idiom for "run when executed directly, not when imported as a module". The existing CLI behaviour is unchanged; only programmatic callers are unblocked.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>