### PR TITLE
chore(emergency-pause): add prepareUnpauseProposals script for Phase 2b

### DIFF
--- a/script/tasks/temp/prepareUnpauseProposals.ts
+++ b/script/tasks/temp/prepareUnpauseProposals.ts
@@ -1,0 +1,72 @@
+/**
+ * Pre-stages Safe unpause transaction proposals for Phase 2b emergency-pause testing.
+ * Proposes unpauseDiamond([]) on gnosis, moonbeam, and rootstock to MongoDB so signers
+ * can confirm and execute without needing to reconstruct the calldata during the test.
+ *
+ * Prerequisites: PRIVATE_KEY_PRODUCTION must be set and belong to a Safe owner.
+ * Run once before the Phase 2b test session: `bunx tsx ./script/tasks/temp/prepareUnpauseProposals.ts`
+ */
+
+import 'dotenv/config'
+
+import { consola } from 'consola'
+
+import { EnvironmentEnum } from '../../common/types'
+import { runPropose } from '../../deploy/safe/propose-to-safe'
+import { getDeployments } from '../../utils/deploymentHelpers'
+
+// unpauseDiamond([]) calldata: selector 0x2fc487ae + ABI-encoded empty address array
+const UNPAUSE_CALLDATA =
+  '0x2fc487ae00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000'
+
+const NETWORKS = ['gnosis', 'moonbeam', 'rootstock'] as const
+
+async function main(): Promise<number> {
+  consola.info(
+    'Pre-staging unpauseDiamond([]) proposals for Phase 2b test networks...'
+  )
+  consola.info(`Networks: ${NETWORKS.join(', ')}`)
+  consola.box(
+    'This will sign and store Safe transactions in MongoDB.\nEnsure PRIVATE_KEY_PRODUCTION belongs to a Safe owner.'
+  )
+
+  let succeeded = 0
+  let failed = 0
+
+  for (const network of NETWORKS) {
+    consola.start(`Proposing unpause for ${network}...`)
+    try {
+      const deployments = await getDeployments(
+        network,
+        EnvironmentEnum.production
+      )
+      const diamondAddress = deployments.LiFiDiamond as string | undefined
+      if (!diamondAddress)
+        throw new Error(`No diamond deployment found for ${network}`)
+
+      await runPropose({
+        network,
+        to: diamondAddress,
+        calldata: UNPAUSE_CALLDATA,
+        timelock: false,
+      })
+      consola.success(`[${network}] Proposal stored in MongoDB`)
+      succeeded++
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      consola.error(`[${network}] Failed to propose: ${msg}`)
+      failed++
+    }
+  }
+
+  console.log('')
+  consola.info(`Done. Succeeded: ${succeeded}, Failed: ${failed}`)
+  return failed
+}
+
+main()
+  .then((failed) => process.exit(failed > 0 ? 1 : 0))
+  .catch((err) => {
+    consola.error('Fatal error:', err)
+    process.exit(1)
+  })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A (Phase 2b emergency-pause tooling)

# Why did I implement it this way?

Phase 2b validates that `PRIV_KEY_PAUSER_WALLET` holds the correct key by running a real pause on **3 low-volume production networks** (gnosis, moonbeam, rootstock). The safety net for this test is having `unpauseDiamond([])` Safe transactions pre-staged and M-of-N signed **before** the pause fires — so the unpause is a single "Execute" click, not a scramble to reconstruct calldata under time pressure.

This script must be **merged to `main` before test day** (not just pushed to a feature branch) so it can be re-run on the fly if proposals need to be recreated — e.g. if a nonce collision invalidates a queued tx — without checking out a branch mid-test. See [Phase 2b test plan (section 9a)](https://www.notion.so/lifi/How-to-test-the-production-Diamond-emergency-pause-workflow-end-to-end-via-Hexagate-361f0ff14ac780599741e7e4dec2d9cc).

### What the script does

Proposes `unpauseDiamond([])` (calldata `0x2fc487ae` + ABI-encoded empty `address[]`) to the Safe multisig for each of the 3 target networks in sequence (gnosis → moonbeam → rootstock) via `runPropose()`. Diamond and Safe addresses are loaded from production deployment files — nothing hardcoded.

Each call stores a 1-of-N unsigned Safe transaction in MongoDB. After running, collect the remaining signatures via `confirm-safe-tx.ts` or [app.safe.global](https://app.safe.global) until M-of-N is reached on each network. The transactions sit in the queue until executed — leave them there until Phase 2b fires.

### Timing requirement

Run **at least 3 hours before the test** to allow time to collect signatures and leave proposals fully staged. The test plan readiness gate (section 9d) requires M-of-N signatures on all 3 networks before proceeding.

> ⚠️ **Nonce timing**: run when no other Safe txs are pending on these networks. If another tx executes and increments the nonce before the unpause tx runs, the queued tx becomes invalid and must be re-proposed (which is why this script being on `main` matters).

### How to run

```bash
bunx tsx ./script/tasks/temp/prepareUnpauseProposals.ts
```

**Prerequisites**: `PRIVATE_KEY_PRODUCTION` must be set in your environment (or `.env`) and the corresponding address must be a Safe owner on all 3 networks (gnosis, moonbeam, rootstock).

### Dependency

Requires [PR #1830](https://github.com/lifinance/contracts/pull/1830) (`fix/propose-to-safe-import-meta-main`) — without the `import.meta.main` guard, importing `runPropose` triggered the citty CLI handler and exited before any proposal logic ran.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
