### PR TITLE
feat(ci): verify all PR commits are signed

### DIFF
--- a/.github/workflows/verifyCommitsSigned.yml
+++ b/.github/workflows/verifyCommitsSigned.yml
@@ -1,0 +1,135 @@
+# Verify Commits Are Signed
+# - Fails a PR if any of its commits is not GitHub-Verified (GPG, SSH, or S/MIME).
+# - Uses GitHub's `pulls.listCommits` REST endpoint as the source of truth;
+#   no local GPG keyring, no third-party action.
+# - Triggers on every PR open/push/reopen/ready-for-review against `main`.
+#   `synchronize` is the "new commit pushed to PR branch" event, so the
+#   workflow re-runs on every push, including force-pushes.
+# - Skips draft PRs.
+# - Exposes `signed-commits-required` as the stable aggregator job name to
+#   register in branch-protection settings (mirrors coverage-required in
+#   enforceTestCoverage.yml).
+# - Known limitation: GitHub's pulls.listCommits API truncates at 250 commits
+#   per PR. PRs with more commits will emit a warning; only the first 250
+#   are checked.
+
+name: Verify Commits Are Signed
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read # required to read PR metadata via the REST API
+  pull-requests: read # required by pulls.listCommits (per GitHub fine-grained permission spec)
+
+# Cancel any in-progress run for the same PR when a new commit is pushed.
+# The status check that lands on the PR will reflect the latest commit only.
+concurrency:
+  group: verify-commits-signed-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify-signed-commits:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: List PR commits and check verification
+        id: check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number
+            const { owner, repo } = context.repo
+
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner, repo, pull_number: prNumber, per_page: 100 }
+            )
+
+            // GitHub's listCommits caps at 250 commits per PR. Surface this
+            // so a >250-commit PR can't silently slip through unverified
+            // tail commits.
+            if (commits.length >= 250) {
+              core.warning(
+                `PR has ${commits.length}+ commits; GitHub's pulls.listCommits ` +
+                `API truncates at 250. Verification only covers the first 250.`
+              )
+            }
+
+            const unsigned = commits
+              .filter((c) => !c.commit?.verification?.verified)
+              .map((c) => ({
+                shortSha: c.sha.slice(0, 7),
+                author:
+                  c.commit?.author?.name || c.author?.login || 'unknown',
+                reason: c.commit?.verification?.reason || 'unknown',
+                subject: (c.commit?.message || '').split('\n')[0],
+              }))
+
+            core.setOutput('total_commits', String(commits.length))
+            core.setOutput('unsigned_count', String(unsigned.length))
+
+            if (unsigned.length === 0) {
+              core.info(`All ${commits.length} commits are verified.`)
+              await core.summary
+                .addHeading('✅ Signed-commit check')
+                .addRaw(`All ${commits.length} commits are verified.`)
+                .write()
+              return
+            }
+
+            const rows = unsigned.map(
+              (c) =>
+                `- \`${c.shortSha}\` (${c.author}) — \`${c.reason}\` — ${c.subject}`
+            )
+            const summary = [
+              `### ❌ Unsigned commits detected`,
+              ``,
+              `${unsigned.length} of ${commits.length} commit(s) in this PR are not GitHub-verified.`,
+              `All commits must be signed (GPG, SSH, or S/MIME) before this PR can be merged.`,
+              ``,
+              ...rows,
+              ``,
+              `**How to fix:**`,
+              `1. Set up signing locally — https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification`,
+              `2. Re-sign existing commits: \`git rebase --exec 'git commit --amend --no-edit -S' -i origin/main\``,
+              `3. Force-push: \`git push --force-with-lease\``,
+            ].join('\n')
+
+            await core.summary.addRaw(summary).write()
+
+            // Also write each offending SHA into the live log so the Actions
+            // log itself is self-contained for triage.
+            for (const c of unsigned) {
+              core.error(
+                `Unverified commit ${c.shortSha} (${c.author}): ${c.reason} — ${c.subject}`
+              )
+            }
+
+      - name: Fail job if any commit is unsigned
+        if: ${{ steps.check.outputs.unsigned_count != '0' }}
+        run: |
+          echo -e "\033[31m${{ steps.check.outputs.unsigned_count }} unsigned commit(s) detected. See the job summary above for the full list.\033[0m"
+          exit 1
+
+  # Aggregator job for branch protection. Reports green when the main job
+  # either succeeded or was skipped (e.g. on draft PRs).
+  # Register THIS job (not `verify-signed-commits`) as the required status check on `main`.
+  signed-commits-required:
+    needs: verify-signed-commits
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        run: |
+          set -euo pipefail
+          result="${{ needs.verify-signed-commits.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo -e "\033[32msigned-commits-required OK (verify-signed-commits=$result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31msigned-commits-required FAILED (verify-signed-commits=$result)\033[0m" >&2
+          exit 1


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-342 — Enforce signed commits on PRs to main](https://linear.app/lifi-linear/issue/EXSC-342/enforce-signed-commits-on-prs-to-main)

Slack thread that surfaced the gap: https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1779294789022249

# Why did I implement it this way?

Adds a single PR-time workflow that fails when any commit in the PR is not GitHub-Verified (covers GPG, SSH, and S/MIME under one API field). Two jobs:

1. `verify-signed-commits` — calls GitHub's `pulls.listCommits` REST endpoint and checks `commit.verification.verified` on every commit in the PR. On failure: lists each offending SHA in the Actions job summary and via `core.error()` in the live log, then a separate shell step prints a red message and `exit 1`s. No PR comment (keeps `permissions:` at read-only).
2. `signed-commits-required` — small aggregator job mirroring the existing `coverage-required` pattern in `enforceTestCoverage.yml`. Treats both `success` and `skipped` (draft PRs) from the upstream job as green, so branch protection can pin **this** stable name as the required status check.

Other design notes:

- Uses GitHub's API field as source of truth (no local GPG keyring, no third-party action) so it transparently accepts any signing method GitHub already trusts: GPG, SSH, S/MIME, web-edit, GitHub Mobile, merge commits the platform produces.
- Triggers mirror `enforceTestCoverage.yml`: `pull_request: [opened, synchronize, reopened, ready_for_review]` with `branches: [main]`. `synchronize` re-runs the workflow on every new commit pushed to the PR.
- Skips draft PRs (matches every other PR-validation workflow in this repo).
- Pinned to the same `actions/github-script` SHA already used elsewhere in the repo — no new third-party actions introduced.
- Surfaces a warning if a PR has 250+ commits (GitHub's `pulls.listCommits` API truncates there).
- Permissions: `contents: read` + `pull-requests: read` (the latter is the documented requirement for `pulls.listCommits` under GitHub's fine-grained permission spec; the call happens to work without it on public repos but the explicit grant is defensive and self-documenting).

## Live validation done on this PR

- Draft path: inner job SKIPPED, aggregator SUCCESS — run [`26228664263`](https://github.com/lifinance/contracts/actions/runs/26228664263).
- Positive path (signed commit): both jobs SUCCESS — run [`26246273474`](https://github.com/lifinance/contracts/actions/runs/26246273474).
- Negative path (unsigned commit): inner job FAILURE with `::error::Unverified commit … : unsigned — …`; aggregator FAILURE with `signed-commits-required FAILED (verify-signed-commits=failure)` — run [`26246371972`](https://github.com/lifinance/contracts/actions/runs/26246371972).
- Token-permissions audit: confirmed `Contents: read`, `Metadata: read`, `PullRequests: read` after the post-review permission fix — run [`26246770454`](https://github.com/lifinance/contracts/actions/runs/26246770454).

## Local validation done

- `actionlint` clean.
- `prettier --check` clean.
- Pre-commit hooks pass.
- Filter logic exercised against real PR data (all-verified PR → exit 0; synthetic mixed → exit 1 with correct list; empty array → exit 0; bot author with only `author.login` → falls back correctly; missing `verification` field → safely flagged as `unsigned/unknown`).
- `coderabbit review --base origin/main --plain` → **No findings**.

## Post-merge handoff (out of scope for this PR)

- Admin needs to add `signed-commits-required` to the branch-protection required-checks list on `main` for the rule to be load-bearing.
- Optional follow-up: add a `Commits are signed` line to the author checklist in `.github/pull_request_template.md`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug — N/A for a GitHub Actions workflow; validated via local fixtures + live-test on this PR's own commits (see "Live validation" above).
- [ ] For new facets: I have checked all points from this list — N/A, no facet changes.
- [ ] I have updated any required documentation — none needed; workflow is self-documenting via header comment and on-failure summary.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
