### PR TITLE
feat(unpause): add optional --networks flag to unpauseAllDiamonds

### DIFF
--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -58,7 +58,10 @@ const main = defineCommand({
 
     if (args.networks) {
       const requested = new Set(
-        args.networks.split(',').map((n: string) => n.trim())
+        args.networks
+          .split(',')
+          .map((n: string) => n.trim())
+          .filter((n) => n.length > 0)
       )
       activeNetworks = activeNetworks.filter((n) => requested.has(n.name))
       const found = new Set(activeNetworks.map((n) => n.name))

--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -140,7 +140,7 @@ const main = defineCommand({
     }
 
     // Pass 2: production mainnets — propose to Safe. Initialize Safe / Mongo only now.
-    const privateKey = getPrivateKey('SAFE_SIGNER_PRIVATE_KEY')
+    const privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION')
     const senderAddress = privateKeyToAccount(`0x${privateKey}`).address
     const { client: mongoClient, pendingTransactions } =
       await getSafeMongoCollection()

--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -46,10 +46,37 @@ const main = defineCommand({
       type: 'string',
       description: 'Names of the facet(s) to be blacklisted',
     },
+    networks: {
+      type: 'string',
+      description:
+        'Optional comma-separated list of network names to process (default: all active networks). Example: --networks gnosis,moonbeam,rootstock',
+    },
   },
   async run({ args }) {
     const blacklist = args.blacklist
-    const activeNetworks = getAllActiveNetworks()
+    let activeNetworks = getAllActiveNetworks()
+
+    if (args.networks) {
+      const requested = new Set(
+        args.networks.split(',').map((n: string) => n.trim())
+      )
+      activeNetworks = activeNetworks.filter((n) => requested.has(n.name))
+      const found = new Set(activeNetworks.map((n) => n.name))
+      const missing = [...requested].filter((n) => !found.has(n))
+      if (missing.length > 0)
+        consola.warn(
+          `Networks not found in active list (skipped): ${missing.join(', ')}`
+        )
+      if (activeNetworks.length === 0) {
+        consola.error('No matching active networks found. Exiting.')
+        process.exit(1)
+      }
+      consola.info(
+        `Restricted to networks: ${activeNetworks
+          .map((n) => n.name)
+          .join(', ')}`
+      )
+    }
     const testnets = activeNetworks.filter((n) => isTestnetNetwork(n.id))
     const mainnets = activeNetworks.filter((n) => !isTestnetNetwork(n.id))
 

--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -12,7 +12,7 @@ import {
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
-import { type SupportedChain } from '../common/types'
+import { EnvironmentEnum, type SupportedChain } from '../common/types'
 import {
   getNextNonce,
   getPrivateKey,
@@ -23,6 +23,7 @@ import {
   storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import {
+  castEnv,
   getAllActiveNetworks,
   getContractAddressForNetwork,
   getViemChainForNetworkName,
@@ -51,9 +52,15 @@ const main = defineCommand({
       description:
         'Optional comma-separated list of network names to process (default: all active networks). Example: --networks gnosis,moonbeam,rootstock',
     },
+    environment: {
+      type: 'string',
+      description:
+        'Target environment: production (default) or staging. Staging skips the Safe/MongoDB flow and sends directly to the diamond.',
+    },
   },
   async run({ args }) {
     const blacklist = args.blacklist
+    const environment = castEnv(args.environment ?? 'production')
     let activeNetworks = getAllActiveNetworks()
 
     if (args.networks) {
@@ -80,21 +87,32 @@ const main = defineCommand({
           .join(', ')}`
       )
     }
+    const isStaging = environment === EnvironmentEnum.staging
     const testnets = activeNetworks.filter((n) => isTestnetNetwork(n.id))
-    const mainnets = activeNetworks.filter((n) => !isTestnetNetwork(n.id))
+    // Staging mainnets are EOA-owned — treat them like testnets (direct send, no Safe/Mongo).
+    const mainnets = isStaging
+      ? []
+      : activeNetworks.filter((n) => !isTestnetNetwork(n.id))
+    const directSendNetworks = isStaging ? activeNetworks : testnets
 
-    // Pass 1: testnets (EOA-owned diamond). No Safe / Mongo / VPN required.
+    // Pass 1: direct-send networks (testnets always; all networks when staging).
     await Promise.all(
-      testnets.map(async (network) => {
+      directSendNetworks.map(async (network) => {
         try {
-          consola.info(`[${network.name}] Processing testnet`)
+          consola.info(
+            `[${network.name}] Processing ${
+              isStaging ? 'staging' : 'testnet'
+            } network`
+          )
           const diamondAddress = await getContractAddressForNetwork(
             'LiFiDiamond',
-            network.name as SupportedChain
+            network.name as SupportedChain,
+            environment
           )
           const blacklistedAddresses = await getBlacklistedFacetAddresses(
             network.name,
-            blacklist
+            blacklist,
+            environment
           )
           const calldata = encodeFunctionData({
             abi: unpauseDiamondABI,
@@ -104,7 +122,8 @@ const main = defineCommand({
           await sendUnpauseDirect(
             network.name,
             diamondAddress as Address,
-            calldata
+            calldata,
+            environment
           )
         } catch (error) {
           consola.error(
@@ -120,7 +139,7 @@ const main = defineCommand({
       process.exit(0)
     }
 
-    // Pass 2: mainnets — propose to Safe. Initialize Safe / Mongo only now.
+    // Pass 2: production mainnets — propose to Safe. Initialize Safe / Mongo only now.
     const privateKey = getPrivateKey('SAFE_SIGNER_PRIVATE_KEY')
     const senderAddress = privateKeyToAccount(`0x${privateKey}`).address
     const { client: mongoClient, pendingTransactions } =
@@ -134,13 +153,15 @@ const main = defineCommand({
           // get the diamond address for this network
           const diamondAddress = await getContractAddressForNetwork(
             'LiFiDiamond',
-            network.name as SupportedChain
+            network.name as SupportedChain,
+            environment
           )
 
           // get blacklisted addresses for this network
           const blacklistedAddresses = await getBlacklistedFacetAddresses(
             network.name,
-            blacklist
+            blacklist,
+            environment
           )
 
           // create calldata for unpausing the diamond with blacklisted addresses
@@ -234,19 +255,22 @@ const main = defineCommand({
 })
 
 /**
- * Send the unpause transaction directly to a testnet diamond using the deployer
- * wallet. Testnets have no Safe multisig, so the propose-to-Safe flow does not apply.
+ * Send the unpause transaction directly to the diamond.
+ * Used for testnets (EOA-owned, no Safe/Timelock) and staging environments.
+ * Production uses `PRIVATE_KEY_PRODUCTION`; staging uses `PRIVATE_KEY`.
  */
 async function sendUnpauseDirect(
   networkName: string,
   diamondAddress: Address,
-  calldata: `0x${string}`
+  calldata: `0x${string}`,
+  environment: EnvironmentEnum
 ): Promise<void> {
-  const pk = process.env.PRIVATE_KEY_PRODUCTION
-  if (!pk)
-    throw new Error(
-      `[${networkName}] Missing PRIVATE_KEY_PRODUCTION in environment`
-    )
+  const pkVar =
+    environment === EnvironmentEnum.production
+      ? 'PRIVATE_KEY_PRODUCTION'
+      : 'PRIVATE_KEY'
+  const pk = process.env[pkVar]
+  if (!pk) throw new Error(`[${networkName}] Missing ${pkVar} in environment`)
   const normalizedPk = pk.startsWith('0x') ? pk : `0x${pk}`
   const account = privateKeyToAccount(normalizedPk as `0x${string}`)
   const chain = getViemChainForNetworkName(networkName)
@@ -278,7 +302,8 @@ async function sendUnpauseDirect(
 
 async function getBlacklistedFacetAddresses(
   networkName: string,
-  blacklistFacets: string
+  blacklistFacets: string,
+  environment: EnvironmentEnum = EnvironmentEnum.production
 ): Promise<Address[]> {
   // if blacklist is empty we dont need to look for addresses
   if (!blacklistFacets) return []
@@ -296,7 +321,8 @@ async function getBlacklistedFacetAddresses(
     try {
       const facetAddress = await getContractAddressForNetwork(
         facetName,
-        networkName
+        networkName,
+        environment
       )
 
       facetAddresses.push(facetAddress as Address)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-343](https://linear.app/lifi-linear/issue/EXSC-343/featunpause-add-networks-and-environment-flags-to-unpausealldiamonds) — sub-issue of [EXSC-303](https://linear.app/lifi-linear/issue/EXSC-303/emergency-pause-end-to-end-testing-for-production-hexagate-flow)

# Why did I implement it this way?

`unpauseAllDiamonds.ts` already has the full Safe/MongoDB proposal infrastructure. Two flags were missing for Phase 2b recovery:

**`--networks`** — target a subset of networks. After the Phase 2b drill pauses only 3 low-volume networks (gnosis, moonbeam, rootstock), operators need to propose unpause for exactly those 3 without touching the rest:
```
bunx tsx ./script/tasks/unpauseAllDiamonds.ts --networks gnosis,moonbeam,rootstock
```

**`--environment`** — default `production`. Pass `staging` to skip the Safe/MongoDB flow entirely and send directly to the diamond using `PRIVATE_KEY` (vs `PRIVATE_KEY_PRODUCTION`). Useful for testing the unpause flow against staging diamonds before a real incident.

Both flags are fully optional — omitting them preserves the original behaviour (all active production networks, Safe proposals).

This supersedes PR #1832 (`prepareUnpauseProposals.ts`), which is now closed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [x] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
