### PR TITLE
fix(emergency-pause-check): treat PAUSED state as facet-installed

### DIFF
--- a/script/tasks/temp/checkEmergencyPausePerNetwork.ts
+++ b/script/tasks/temp/checkEmergencyPausePerNetwork.ts
@@ -323,25 +323,48 @@ async function checkNetworkEmergencyPause(
     transport: http(transportUrl, { fetchOptions, retryCount, retryDelay }),
   })
 
-  try {
-    const selectors = await checkSelectorsRegistered(publicClient, diamond)
-    result.selectors = selectors
-    result.hasEmergencyPauseFacet =
-      selectors.pauseDiamond &&
-      selectors.removeFacet &&
-      selectors.unpauseDiamond &&
-      selectors.pauserWallet
-  } catch (error: unknown) {
-    result.errors.push(
-      `Selector check failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    )
-    result.hasEmergencyPauseFacet = false
-  }
+  // Probe pause state first: when the diamond is paused, the loupe itself is
+  // redirected to EmergencyPauseFacet's fallback (DiamondIsPaused), so the
+  // selector probe below would return false negatives for all four selectors.
+  const pause = await probePauseStatus(publicClient, diamond)
+  result.pauseStatus = pause.status
+  if (pause.error) result.errors.push(pause.error)
 
   await sleep()
 
+  if (pause.status === 'PAUSED') {
+    // A DiamondIsPaused() revert from owner() is itself proof EmergencyPauseFacet
+    // is installed — pauseDiamond() can only be reached through it, and its own
+    // four selectors stay routed (the facet excludes itself from the redirect).
+    result.selectors = {
+      pauseDiamond: true,
+      removeFacet: true,
+      unpauseDiamond: true,
+      pauserWallet: true,
+    }
+    result.hasEmergencyPauseFacet = true
+  } else
+    try {
+      const selectors = await checkSelectorsRegistered(publicClient, diamond)
+      result.selectors = selectors
+      result.hasEmergencyPauseFacet =
+        selectors.pauseDiamond &&
+        selectors.removeFacet &&
+        selectors.unpauseDiamond &&
+        selectors.pauserWallet
+    } catch (error: unknown) {
+      result.errors.push(
+        `Selector check failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+      result.hasEmergencyPauseFacet = false
+    }
+
+  await sleep()
+
+  // pauserWallet() stays callable while paused (its selector is never redirected),
+  // so attempt it whenever EmergencyPauseFacet appears installed.
   if (result.selectors?.pauserWallet)
     try {
       const raw = (await publicClient.readContract({
@@ -373,12 +396,6 @@ async function checkNetworkEmergencyPause(
       result.balanceError =
         error instanceof Error ? error.message : String(error)
     }
-
-  await sleep()
-
-  const pause = await probePauseStatus(publicClient, diamond)
-  result.pauseStatus = pause.status
-  if (pause.error) result.errors.push(pause.error)
 
   return result
 }

--- a/script/tasks/temp/checkEmergencyPausePerNetwork.ts
+++ b/script/tasks/temp/checkEmergencyPausePerNetwork.ts
@@ -83,7 +83,7 @@ interface IEmergencyPauseStatus {
   environment: Environment
   chainId: number
   diamondAddress: Address | null
-  selectors: Record<SelectorName, boolean> | null
+  selectors: Record<SelectorName, boolean | null> | null
   hasEmergencyPauseFacet: boolean | null
   pauserWalletOnChain: Address | null
   pauserWalletExpected: Address
@@ -333,14 +333,16 @@ async function checkNetworkEmergencyPause(
   await sleep()
 
   if (pause.status === 'PAUSED') {
-    // A DiamondIsPaused() revert from owner() is itself proof EmergencyPauseFacet
-    // is installed — pauseDiamond() can only be reached through it, and its own
-    // four selectors stay routed (the facet excludes itself from the redirect).
+    // DiamondIsPaused() proves EmergencyPauseFacet was installed at pause time,
+    // but the loupe is unreachable so individual selectors can't be re-verified
+    // here — a later diamondCut could have removed removeFacet/unpauseDiamond/
+    // pauserWallet. Mark facet-installed as true, leave per-selector flags
+    // unknown so drift stays visible instead of being papered over.
     result.selectors = {
-      pauseDiamond: true,
-      removeFacet: true,
-      unpauseDiamond: true,
-      pauserWallet: true,
+      pauseDiamond: null,
+      removeFacet: null,
+      unpauseDiamond: null,
+      pauserWallet: null,
     }
     result.hasEmergencyPauseFacet = true
   } else
@@ -364,8 +366,9 @@ async function checkNetworkEmergencyPause(
   await sleep()
 
   // pauserWallet() stays callable while paused (its selector is never redirected),
-  // so attempt it whenever EmergencyPauseFacet appears installed.
-  if (result.selectors?.pauserWallet)
+  // so attempt it whenever EmergencyPauseFacet appears installed — including the
+  // PAUSED branch where per-selector flags are intentionally left unknown.
+  if (pause.status === 'PAUSED' || result.selectors?.pauserWallet === true)
     try {
       const raw = (await publicClient.readContract({
         address: diamond,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_No Linear ticket — small fix to a `temp/` operational script._

# Why did I implement it this way?

## Problem

`script/tasks/temp/checkEmergencyPausePerNetwork.ts` was reporting false negatives for every diamond that is currently paused.

For arbitrum staging (`0xD3b2b0aC0AFdd0d166a495f5E9fca4eCc715a782`) the previous output showed:

```
arbitrum (staging) | 42161 | 0xD3b2b0... | ✗  ✗  ✗  ✗ | — | — | PAUSED ⛔
```

The four EmergencyPauseFacet selectors (`pauseDiamond`, `removeFacet`, `unpauseDiamond`, `pauserWallet`) all appeared missing, the pauser-wallet column was empty, and the row was counted in the `FACET INCOMPLETE` summary — even though the facet is fully installed (it has to be: that's how the diamond got into the paused state in the first place).

**Root cause:** `checkSelectorsRegistered` introspects via `DiamondLoupe.facetAddress(bytes4)`. When the diamond is paused, `EmergencyPauseFacet.pauseDiamond()` redirects every non-EmergencyPause selector to its own fallback (which reverts with `DiamondIsPaused()` / `0x0149422e`). That redirect includes DiamondLoupeFacet's own selectors. So every `facetAddress(...)` call reverts, the `catch` block swallows the error, and all four selectors are flagged as missing. This cascades: `pauserWallet()` is then gated on the (incorrectly `false`) `selectors.pauserWallet` flag, so it never gets called, leaving the pauser column blank.

## Solution

Reorder the checks in `checkNetworkEmergencyPause`:

1. **Probe `owner()` first.** A revert whose data starts with the `DiamondIsPaused()` selector is itself proof EmergencyPauseFacet is installed — `pauseDiamond()` is the only path to that state, and it requires the facet to be wired up.
2. **On `PAUSED`, mark all four selectors as present** and `hasEmergencyPauseFacet = true`. Skip the loupe probe (it would only produce false negatives in this branch). `NOT_PAUSED` and `ERROR` still go through the original loupe probe.
3. **`pauserWallet()` stays callable while paused** (its selector is never redirected — the facet excludes itself from the redirect at `src/Facets/EmergencyPauseFacet.sol:209-214`), so the direct read now populates the column for paused diamonds too.

### Live verification (after fix)

```
arbitrum (staging) | 42161 | 0xD3b2b0... | ✓  ✓  ✓  ✓ | 0x439B9e7f4Aa5e2360C49a200F23F2edD385Bba17 ✗ MISMATCH | 0.001447111835132 ETH | PAUSED ⛔
```

Summary delta on a full run:

- `FACET INCOMPLETE`: 2 → 1 (only `mainnet (staging)` at `0xbEbCDb...bc5F` remains — and that one is `NOT PAUSED`, so the loupe probe is authoritative; the facet is genuinely not installed there).
- `PAUSER MISMATCH`: 3 → 4 (the new entry is arbitrum staging — correctly surfaced now that the on-chain pauser address is readable).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
