### PR TITLE
chore(emergency-pause): mirror staging pause script + workflow into prod

### DIFF
--- a/.github/workflows/diamondEmergencyPause.yml
+++ b/.github/workflows/diamondEmergencyPause.yml
@@ -111,5 +111,5 @@ jobs:
           # cleanly without YAML's single-quote escaping.
           payload: |
             {
-              "text": "ATTENTION - the emergency diamond pause action was just executed on PROD by ${{ github.actor }} — ${{ job.status == 'success' && 'Success ✅' || 'Failed ❌' }} — ${{ steps.jobinfo.outputs.url }}"
+              "text": "ATTENTION - PROD emergency-pause workflow was triggered by ${{ github.actor }} — ${{ job.status == 'success' && 'Success ✅' || 'Failed ❌' }} — ${{ steps.jobinfo.outputs.url }}"
             }

--- a/.github/workflows/diamondEmergencyPause.yml
+++ b/.github/workflows/diamondEmergencyPause.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read # required to fetch repository contents
+  actions: read # required to resolve the current job ID for the Slack deep-link
 
 jobs:
   diamond-emergency-pause:
@@ -19,7 +20,7 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-      
+
       - name: Install dev dependencies
         run: bun install
 
@@ -79,10 +80,37 @@ jobs:
         env:
           PRIVATE_KEY_PAUSER_WALLET: ${{ secrets.PRIV_KEY_PAUSER_WALLET }}
 
-      - name: Send Reminder to Slack SC-general Channel
+      # Resolve a deep-link to the current job's log view so the Slack message
+      # lets on-call open logs in one click. Falls back to the run-level URL if
+      # the API call fails so the notification still contains a usable link.
+      - name: Resolve current job URL
+        if: ${{ always() }}
+        id: jobinfo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          job_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq ".jobs[] | select(.name == \"${{ github.job }}\") | .id" 2>/dev/null || true)
+          if [[ -n "${job_id}" ]]; then
+            url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${job_id}"
+          else
+            url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack SC-general channel of pause execution
+        # always() so the alert fires even when the pause script exits non-zero
+        # (per-network isolation now lets the script partially succeed and still
+        # return 1 — on-call must still be paged in that case).
+        if: ${{ always() }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
           webhook-type: incoming-webhook
+          # JSON payload so the inline ternary for status emoji interpolates
+          # cleanly without YAML's single-quote escaping.
           payload: |
-            text: 'ATTENTION - the emergency diamond pause action was just executed by ${{ github.actor }}'
+            {
+              "text": "ATTENTION - the emergency diamond pause action was just executed on PROD by ${{ github.actor }} — ${{ job.status == 'success' && 'Success ✅' || 'Failed ❌' }} — ${{ steps.jobinfo.outputs.url }}"
+            }

--- a/.github/workflows/diamondEmergencyPause.yml
+++ b/.github/workflows/diamondEmergencyPause.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       warning:
-        description: "By clicking the next button you are pausing all PROUCTION diamonds. Please proceed with extreme caution !!! You must type 'UNDERSTOOD' to proceed"
+        description: "By clicking the next button you are pausing all PRODUCTION diamonds. Please proceed with extreme caution !!! You must type 'UNDERSTOOD' to proceed"
         required: true
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
 
       - name: Install dev dependencies
         run: bun install
@@ -33,7 +33,7 @@ jobs:
       - name: Authenticate git user (check membership in 'DiamondPauser' group)
         if: ${{ inputs.warning == 'UNDERSTOOD' }}
         id: authenticate-user
-        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         with:
           username: ${{ github.actor }}
           organization: lifinance
@@ -75,8 +75,7 @@ jobs:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
 
       - name: Pause Diamond
-        run: |
-          ./script/utils/diamondEMERGENCYPauseGitHub.sh
+        run: bash script/utils/diamondEMERGENCYPauseGitHub.sh
         env:
           PRIVATE_KEY_PAUSER_WALLET: ${{ secrets.PRIV_KEY_PAUSER_WALLET }}
 

--- a/script/utils/diamondEMERGENCYPauseGitHub.sh
+++ b/script/utils/diamondEMERGENCYPauseGitHub.sh
@@ -4,10 +4,6 @@
 # it can only pause the main PROD diamond on all networks
 # for all other actions the diamondEMERGENCYPause.sh script should be called
 # via scriptMaster.sh in local CLI for more flexibility
-#
-# The staging mirror lives at `diamondEMERGENCYPauseStagingGitHub.sh` and runs
-# the same logic against the staging diamonds on a small representative set of
-# networks - any change here should usually land in the staging script first.
 
 
 # load helper functions
@@ -21,8 +17,7 @@ MAX_ATTEMPTS=10
 # RPC pacing for read calls. Send retries use MAX_ATTEMPTS above (intentionally
 # larger). RPCs can throttle reads under load - paid tiers included, and
 # especially under the kind of incident-response load this script runs under.
-# So we pace and retry transient failures. The staging mirror script
-# (diamondEMERGENCYPauseStagingGitHub.sh) carries the same constants.
+# So we pace and retry transient failures.
 RPC_MAX_ATTEMPTS=5
 RPC_RETRY_SLEEP_SECONDS=3
 RPC_CALL_DELAY_SECONDS=1

--- a/script/utils/diamondEMERGENCYPauseGitHub.sh
+++ b/script/utils/diamondEMERGENCYPauseGitHub.sh
@@ -4,6 +4,10 @@
 # it can only pause the main PROD diamond on all networks
 # for all other actions the diamondEMERGENCYPause.sh script should be called
 # via scriptMaster.sh in local CLI for more flexibility
+#
+# The staging mirror lives at `diamondEMERGENCYPauseStagingGitHub.sh` and runs
+# the same logic against the staging diamonds on a small representative set of
+# networks - any change here should usually land in the staging script first.
 
 
 # load helper functions
@@ -14,12 +18,59 @@ DIAMOND_IS_PAUSED_SELECTOR="0x0149422e"
 # the number of attempts the script will max try to execute the pause transaction
 MAX_ATTEMPTS=10
 
+# RPC pacing for read calls. Send retries use MAX_ATTEMPTS above (intentionally
+# larger). RPCs can throttle reads under load - paid tiers included, and
+# especially under the kind of incident-response load this script runs under.
+# So we pace and retry transient failures. The staging mirror script
+# (diamondEMERGENCYPauseStagingGitHub.sh) carries the same constants.
+RPC_MAX_ATTEMPTS=5
+RPC_RETRY_SLEEP_SECONDS=3
+RPC_CALL_DELAY_SECONDS=1
+
+# rpcCallWithRetry: Run an RPC-touching command up to $RPC_MAX_ATTEMPTS times with
+# $RPC_RETRY_SLEEP_SECONDS between failures. Captures stdout cleanly so callers
+# get clean values back (no stderr mixed in), while stderr is preserved in a
+# temp file and surfaced in retry logs / the final failure message. Returns 0
+# on first success, 1 if exhausted.
+# Usage: VAR=$(rpcCallWithRetry "label" cast balance "$ADDR" --rpc-url "$RPC")
+function rpcCallWithRetry() {
+  local LABEL="$1"
+  shift
+  local ATTEMPT=1
+  local OUT=""
+  local ERR_FILE
+  ERR_FILE=$(mktemp)
+  while [ "$ATTEMPT" -le "$RPC_MAX_ATTEMPTS" ]; do
+    if OUT=$("$@" 2>"$ERR_FILE"); then
+      rm -f "$ERR_FILE"
+      printf "%s" "$OUT"
+      return 0
+    fi
+    if [ "$ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
+      echo "[retry] $LABEL attempt $ATTEMPT failed ($(< "$ERR_FILE")), sleeping ${RPC_RETRY_SLEEP_SECONDS}s..." >&2
+      sleep "$RPC_RETRY_SLEEP_SECONDS"
+    fi
+    ATTEMPT=$((ATTEMPT + 1))
+  done
+  # On exhaustion, surface diagnostic context to the caller. Prefer stderr
+  # (cleaner), but fall back to stdout when stderr was empty - some wrapped
+  # helpers (e.g. universalCall) merge cast's stderr into stdout via 2>&1
+  # internally, so the revert reason / RPC error ends up in OUT, not ERR_FILE.
+  local LAST_ERR
+  LAST_ERR=$(< "$ERR_FILE")
+  rm -f "$ERR_FILE"
+  printf "%s" "${LAST_ERR:-$OUT}"
+  return 1
+}
+
 # Define function to handle each network operation
 function handleNetwork() {
   echo ""
   echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> start network $1 >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
   local NETWORK=$1
-  local PRIVATE_KEY=$2
+  # Renamed from `PRIVATE_KEY` to avoid shadowing the `.env` PRIVATE_KEY global
+  # (per .agents/rules/300-bash.md "No local shadowing of .env globals").
+  local PAUSER_PRIVATE_KEY=$2
 
 
   # skip any non-prod networks
@@ -31,7 +82,7 @@ function handleNetwork() {
   esac
 
   # convert the provided private key of the pauser wallet (from github) to an address
-  PRIV_KEY_ADDRESS=$(cast wallet address "$PRIVATE_KEY")
+  PRIV_KEY_ADDRESS=$(cast wallet address "$PAUSER_PRIVATE_KEY")
 
   # get RPC URL for given network using helper function
   RPC_KEY=$(getRPCEnvVarName "$NETWORK")
@@ -57,25 +108,56 @@ function handleNetwork() {
     echo "[network: $NETWORK] diamond address found in deploy log file: $DIAMOND_ADDRESS"
   fi
 
-  # check if the diamond is already paused by calling owner() function and analyzing the response
-  local RESPONSE=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)" 2>&1)
+  # check if the diamond is already paused by calling owner() function and analyzing the response.
+  # Retry if the response is neither a clean address nor a recognized pause selector, since that
+  # indicates a transient RPC/rate-limit issue rather than an unambiguous answer.
+  local PRE_PAUSE_RESPONSE=""
+  local PRE_PAUSE_CHECK_ATTEMPT=1
+  while [ "$PRE_PAUSE_CHECK_ATTEMPT" -le "$RPC_MAX_ATTEMPTS" ]; do
+    PRE_PAUSE_RESPONSE=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)" 2>&1)
+    if [[ "$PRE_PAUSE_RESPONSE" =~ ^0x[0-9a-fA-F]{40}$ ]] \
+      || [[ "$PRE_PAUSE_RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* ]] \
+      || [[ "$PRE_PAUSE_RESPONSE" == *"DiamondIsPaused"* ]]; then
+      break
+    fi
+    if [ "$PRE_PAUSE_CHECK_ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
+      echo "[network: $NETWORK] pre-pause owner() returned unclear response (attempt $PRE_PAUSE_CHECK_ATTEMPT/$RPC_MAX_ATTEMPTS), retrying in ${RPC_RETRY_SLEEP_SECONDS}s..."
+      sleep "$RPC_RETRY_SLEEP_SECONDS"
+    fi
+    PRE_PAUSE_CHECK_ATTEMPT=$((PRE_PAUSE_CHECK_ATTEMPT + 1))
+  done
     # Check for errors in the response
-  if [[ "$RESPONSE" == 0x* ]]; then
-      # If the response starts with "0x", it is a valid response, and the diamond is not paused
+  if [[ "$PRE_PAUSE_RESPONSE" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+      # Clean address response - diamond is not paused
       echo "[network: $NETWORK] The diamond is not yet paused. Proceeding..."
-  elif [[ "$RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* || "$RESPONSE" == *"DiamondIsPaused"* ]]; then
+  elif [[ "$PRE_PAUSE_RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* || "$PRE_PAUSE_RESPONSE" == *"DiamondIsPaused"* ]]; then
       # If the response contains the pause selector or "DiamondIsPaused", the diamond is paused
       success "[network: $NETWORK] The diamond is already paused."
       echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
       return 0
   else
-      # Handle other RPC or network errors
-      error "[network: $NETWORK] RPC or network error while checking if diamond is paused: $RESPONSE"
+      # Fail closed: we couldn't determine pause state after $RPC_MAX_ATTEMPTS attempts.
+      # Do NOT send pauseDiamond() blindly - abort this network and let the workflow report.
+      error "[network: $NETWORK] RPC or network error while checking if diamond is paused after $RPC_MAX_ATTEMPTS attempts: $PRE_PAUSE_RESPONSE"
+      echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+      return 1
   fi
 
-  # ensure PauserWallet has positive balance
-  BALANCE_PAUSER_WALLET=$(cast balance "$PRIV_KEY_ADDRESS" --rpc-url "$RPC_URL")
-  if [[ "$BALANCE_PAUSER_WALLET" == 0 ]]; then
+  # ensure PauserWallet has positive balance (wrap in retry: balance reads can fail under throttling)
+  sleep "$RPC_CALL_DELAY_SECONDS"
+  if ! BALANCE_PAUSER_WALLET=$(rpcCallWithRetry "[$NETWORK] cast balance pauser" cast balance "$PRIV_KEY_ADDRESS" --rpc-url "$RPC_URL"); then
+    error "[network: $NETWORK] failed to read PauserWallet balance after $RPC_MAX_ATTEMPTS attempts: $BALANCE_PAUSER_WALLET"
+    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    return 1
+  fi
+  # Validate the value is a clean non-negative decimal then compare via bc.
+  # bash 64-bit arithmetic overflows above ~9.2 ETH in wei; bc handles arbitrary precision.
+  if ! [[ "$BALANCE_PAUSER_WALLET" =~ ^[0-9]+$ ]]; then
+    error "[network: $NETWORK] PauserWallet balance unparseable: $BALANCE_PAUSER_WALLET. Cannot continue"
+    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    return 1
+  fi
+  if [[ $(echo "$BALANCE_PAUSER_WALLET <= 0" | bc) -eq 1 ]]; then
     error "[network: $NETWORK] PauserWallet has no balance. Cannot continue"
     echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
     return 1
@@ -83,8 +165,15 @@ function handleNetwork() {
     echo "[network: $NETWORK] balance pauser wallet: $BALANCE_PAUSER_WALLET"
   fi
 
-  # this fails currently since the EmergencyPauseFacet is not yet deployed to all diamonds
-  DIAMOND_PAUSER_WALLET=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "pauserWallet() returns (address)")
+  # read on-chain registered pauser (wrap in retry: this is the call that historically
+  # failed on chains where EmergencyPauseFacet wasn't yet deployed; with the facet now
+  # in place, transient failures are RPC throttling rather than missing selectors)
+  sleep "$RPC_CALL_DELAY_SECONDS"
+  if ! DIAMOND_PAUSER_WALLET=$(rpcCallWithRetry "[$NETWORK] pauserWallet()" universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "pauserWallet() returns (address)"); then
+    error "[network: $NETWORK] failed to read pauserWallet() after $RPC_MAX_ATTEMPTS attempts: $DIAMOND_PAUSER_WALLET"
+    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    return 1
+  fi
 
   # compare addresses in lowercase format
   if [[ "$(echo "$DIAMOND_PAUSER_WALLET" | tr '[:upper:]' '[:lower:]')" != "$(echo "$PRIV_KEY_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]]; then
@@ -101,46 +190,61 @@ function handleNetwork() {
     echo ""
     echo "[network: $NETWORK] pausing diamond $DIAMOND_ADDRESS now from PauserWallet: $PRIV_KEY_ADDRESS (attempt: $ATTEMPTS)"
     echo ""
-    universalCast "send" "$NETWORK" "production" "$DIAMOND_ADDRESS" "pauseDiamond()" "" "" "$PRIVATE_KEY_PAUSER_WALLET"
+    universalCast "send" "$NETWORK" "production" "$DIAMOND_ADDRESS" "pauseDiamond()" "" "" "$PAUSER_PRIVATE_KEY"
 
     # check the return code of the last call
     if [ $? -eq 0 ]; then
       break # exit the loop if the operation was successful
     fi
 
-    ATTEMPTS=$((ATTEMPTS + 1)) # increment attempts
-    sleep 3                    # wait for 3 seconds before trying the operation again
+    ATTEMPTS=$((ATTEMPTS + 1))           # increment attempts
+    sleep "$RPC_RETRY_SLEEP_SECONDS"      # back-off before next attempt
   done
 
-  # check if call was executed successfully or used all attempts
+  # If all our send attempts failed, do NOT short-circuit to failure - the
+  # on-chain state below is the source of truth. Another caller (a parallel
+  # pauser, a manual safe tx, an incident-response runbook) may have already
+  # paused the diamond, in which case our sends would revert with
+  # DiamondIsPaused, causing the loop above to exhaust even though the
+  # diamond is correctly paused. Falling through to the final-pause check
+  # lets the chain decide.
   if [ $ATTEMPTS -gt "$MAX_ATTEMPTS" ]; then
-    error "[network: $NETWORK] failed to pause diamond ($DIAMOND_ADDRESS)"
-    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    return 1
+    warning "[network: $NETWORK] all $MAX_ATTEMPTS pause-send attempts failed - verifying on-chain state before declaring failure"
   fi
 
-  # try to call the diamond
-  OWNER=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)")
+  # Final pause check: owner() must revert with DiamondIsPaused. universalCall
+  # internally merges cast's stderr into stdout (universalCast.sh:51), so the
+  # revert reason ends up in the captured stream and we inspect it for the
+  # DiamondIsPaused selector. Relying on $? alone is brittle - some RPCs
+  # return slightly stale state right after the pause tx is mined
+  # (read-after-write lag), so cast may succeed and exit 0 even though the
+  # diamond is in fact paused. Retries cushion that lag. This loop is the
+  # canonical truth source for whether the diamond ended up paused
+  # (regardless of who paused it).
+  local FINAL_CHECK_ATTEMPT=1
+  local FINAL_CHECK_RESPONSE=""
+  sleep "$RPC_CALL_DELAY_SECONDS"
+  while [ "$FINAL_CHECK_ATTEMPT" -le "$RPC_MAX_ATTEMPTS" ]; do
+    FINAL_CHECK_RESPONSE=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)" 2>&1)
+    if [[ "$FINAL_CHECK_RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* || "$FINAL_CHECK_RESPONSE" == *"DiamondIsPaused"* ]]; then
+      success "[network: $NETWORK] diamond ($DIAMOND_ADDRESS) successfully paused"
+      echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+      return 0
+    fi
+    if [ "$FINAL_CHECK_ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
+      echo "[network: $NETWORK] final pause check returned unclear response (attempt $FINAL_CHECK_ATTEMPT/$RPC_MAX_ATTEMPTS), retrying in ${RPC_RETRY_SLEEP_SECONDS}s..."
+      sleep "$RPC_RETRY_SLEEP_SECONDS"
+    fi
+    FINAL_CHECK_ATTEMPT=$((FINAL_CHECK_ATTEMPT + 1))
+  done
 
-  # check if last call was successful and throw error if it was (it should not be successful, we expect the diamond to be paused now)
-  if [ $? -eq 0 ]; then
-    error "[network: $NETWORK] final pause check failed - please check the status of diamond ($DIAMOND_ADDRESS) manually"
-    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    return 1
-  else
-    success "[network: $NETWORK] diamond ($DIAMOND_ADDRESS) successfully paused"
-    echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-    return 0
-  fi
+  error "[network: $NETWORK] final pause check failed after $RPC_MAX_ATTEMPTS attempts - please check the status of diamond ($DIAMOND_ADDRESS) manually (last response: $FINAL_CHECK_RESPONSE)"
+  echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+  return 1
 }
 
 function printStatus() {
   local NETWORK="$1"
-
-  # get RPC URL for given network using helper function
-  local RPC_KEY=$(getRPCEnvVarName "$NETWORK")
-  # Use eval to read the environment variable named like the RPC_KEY (our normal syntax like 'RPC_URL=${!RPC_URL}' doesnt work on Github)
-  eval "RPC_URL=\$$RPC_KEY"
 
     # skip any non-prod networks
   case "$NETWORK" in
@@ -153,18 +257,32 @@ function printStatus() {
   # get diamond address for this network
   DIAMOND_ADDRESS=$(getContractAddressFromDeploymentLogs "$NETWORK" "production" "LiFiDiamond")
 
-  # check if the diamond is paused by calling owner() function and analyzing the response
-  local RESPONSE=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)" 2>&1)
+  # check if the diamond is paused by calling owner() function and analyzing the response.
+  # Retry on unclear responses (transient RPC/throttling) so the summary doesn't misreport state.
+  local STATUS_RESPONSE=""
+  local STATUS_ATTEMPT=1
+  while [ "$STATUS_ATTEMPT" -le "$RPC_MAX_ATTEMPTS" ]; do
+    STATUS_RESPONSE=$(universalCast "call" "$NETWORK" "$DIAMOND_ADDRESS" "owner() returns (address)" 2>&1)
+    if [[ "$STATUS_RESPONSE" =~ ^0x[0-9a-fA-F]{40}$ ]] \
+      || [[ "$STATUS_RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* ]] \
+      || [[ "$STATUS_RESPONSE" == *"DiamondIsPaused"* ]]; then
+      break
+    fi
+    if [ "$STATUS_ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
+      sleep "$RPC_RETRY_SLEEP_SECONDS"
+    fi
+    STATUS_ATTEMPT=$((STATUS_ATTEMPT + 1))
+  done
     # Check for errors in the response
-  if [[ "$RESPONSE" == 0x* ]]; then
-      # If the response starts with "0x", it is a valid response, and the diamond is not paused
+  if [[ "$STATUS_RESPONSE" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+      # Clean address response - diamond is not paused
       error "[network: $NETWORK] diamond not paused."
-  elif [[ "$RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* || "$RESPONSE" == *"DiamondIsPaused"* ]]; then
+  elif [[ "$STATUS_RESPONSE" == *"$DIAMOND_IS_PAUSED_SELECTOR"* || "$STATUS_RESPONSE" == *"DiamondIsPaused"* ]]; then
       # If the response contains the pause selector or "DiamondIsPaused", the diamond is paused
       success "[network: $NETWORK] diamond paused."
   else
       # Handle other RPC or network errors
-      error "[network: $NETWORK] RPC or network error while checking if diamond is paused: $RESPONSE"
+      error "[network: $NETWORK] RPC or network error while checking if diamond is paused after $RPC_MAX_ATTEMPTS attempts: $STATUS_RESPONSE"
   fi
 }
 
@@ -186,31 +304,46 @@ function main {
   echo "Watch out for red and green colored entries as they mark endpoints of each network thread"
   echo "A summary will be printed after all jobs/networks have been completed"
 
-  # go through all networks and start background tasks for each network (to execute in parallel)
-  RETURN=0
+  # Launch handleNetwork in parallel and capture PIDs explicitly. We rely on
+  # PIDs (not `jobs -p` after a no-arg `wait`) because the latter returns an
+  # empty list once jobs have been reaped, which silently swallows per-network
+  # failures. Each network's work happens in its own subshell so a failure on
+  # one diamond does NOT abort the others - aggregation only happens after
+  # every job has finished.
+  local -a PIDS=()
   for NETWORK in "${NETWORKS[@]}"; do
       handleNetwork "$NETWORK" "$PRIVATE_KEY_PAUSER_WALLET" &
+      PIDS+=("$!")
   done
 
-  # Wait for all background jobs to finish
-  wait
-  # Check exit status of each background job
-  for JOB in $(jobs -p); do
-    wait $JOB || RETURN=1
+  # Aggregate exit codes: if ANY network failed, surface that as the script's
+  # exit code so the GitHub Actions workflow turns red. Aggregation does NOT
+  # short-circuit - we wait for every job even after we've seen a failure.
+  local RETURN=0
+  for PID in "${PIDS[@]}"; do
+    wait "$PID" || RETURN=1
   done
 
   echo "-------------------------------------------------------------------------------------"
   echo "--------------------------------ALL JOBS DONE----------------------------------------"
   echo "-------------------------------------------------------------------------------------"
   echo "[info] all jobs completed, now going through all networks again to print their status"
-  # run through all networks to print a easy-to-read summary
+  # Run through all networks to print an easy-to-read summary. Wait on them
+  # explicitly so the summary block is complete before main returns - without
+  # this, the parent script can exit while printStatus children are still
+  # writing, truncating the summary on-call uses to triage.
+  local -a STATUS_PIDS=()
   for NETWORK in "${NETWORKS[@]}"; do
       printStatus "$NETWORK" &
+      STATUS_PIDS+=("$!")
+  done
+  for PID in "${STATUS_PIDS[@]}"; do
+    wait "$PID" || true
   done
 
   echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< script diamondEMERGENCYPause completed"
+  return "$RETURN"
 }
 
 # call main function with all parameters the script was called with
 main "$@"
-


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — operational follow-up to #1828.

# Why did I implement it this way?

Verbatim port of the staging emergency-pause script + workflow shipped in #1828 to their prod counterparts. Differences between staging and prod are limited to the values listed below; all behavioral hardening (RPC retries, fail-closed checks, PID aggregation, Slack deep-link, etc.) is copied byte-for-byte from staging.

| Aspect | Staging (#1828) | Prod (this PR) |
|---|---|---|
| Workflow name | `EMERGENCY >> Pause STAGING diamonds (multi-network test)` | `EMERGENCY >> Pause all PROD diamonds` |
| DiamondPauser team check | commented out | enforced |
| Pause script invoked | `diamondEMERGENCYPauseStagingGitHub.sh` | `diamondEMERGENCYPauseGitHub.sh` |
| Pauser-wallet secret | `PRIV_KEY_PAUSER_WALLET_STAGING` | `PRIV_KEY_PAUSER_WALLET` |
| Slack message text | `TEST TEST TEST ATTENTION … STAGING (bsc/arbitrum/optimism/base) …` | `ATTENTION - PROD emergency-pause workflow was triggered …` |
| Networks iterated | hardcoded `STAGING_NETWORKS=("bsc" "arbitrum" "optimism" "base")` | all keys from `networks.json` |
| `getContractAddressFromDeploymentLogs` env arg | `"staging"` | `"production"` |
| `universalCast "send"` env arg | `"staging"` | `"production"` |

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug (#1828's E2E cycles validate the identical code path; prod cannot be E2E-tested without pausing prod diamonds)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
