### PR TITLE
feat(safe-cli): show EVM hex next to Tron base58 in confirm-safe-tx

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -15,7 +15,10 @@ import { type Account, type Address, type Hex } from 'viem'
 import networksData from '../../../config/networks.json'
 import { buildExplorerAddressUrl } from '../../utils/viemScriptHelpers'
 import { isTronNetworkKey } from '../shared/tron-network-keys'
-import { formatAddressForNetworkCliDisplay } from '../tron/helpers/formatAddressForCliDisplay'
+import {
+  formatAddressForNetworkCliDisplay,
+  tronHexSuffix,
+} from '../tron/helpers/formatAddressForCliDisplay'
 
 import type { ILedgerAccountResult } from './ledger'
 import { reconcileSubmittedSafeTxs } from './reconcile'
@@ -410,10 +413,10 @@ const processTxs = async (
 
     // Get target name for display
     const targetName = await getTargetName(tx.safeTx.data.to, network)
-    const toAddrDisplay = formatAddressForNetworkCliDisplay(
+    const toAddrDisplay = `${formatAddressForNetworkCliDisplay(
       network,
       tx.safeTx.data.to
-    )
+    )}${tronHexSuffix(network, tx.safeTx.data.to)}`
     const toDisplay = targetName
       ? `${toAddrDisplay} \u001b[33m${targetName}\u001b[0m`
       : toAddrDisplay
@@ -422,10 +425,10 @@ const processTxs = async (
       tx.safeTx.data.to
     )
     const toExplorerSuffix = toExplorerUrl ? ` [36m${toExplorerUrl}[0m` : ''
-    const proposerDisplay = formatAddressForNetworkCliDisplay(
+    const proposerDisplay = `${formatAddressForNetworkCliDisplay(
       network,
       tx.proposer
-    )
+    )}${tronHexSuffix(network, tx.proposer)}`
 
     const nonceColor =
       nonceStatus === 'current' ? '32' : nonceStatus === 'stale' ? '31' : '33'

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -27,7 +27,10 @@ import { getDeployments } from '../../utils/deploymentHelpers'
 import { fetchWithTimeout } from '../../utils/fetchWithTimeout'
 import { normalizeAddressForNetwork } from '../../utils/normalizeAddressStringForViem'
 import { buildExplorerContractPageUrl } from '../../utils/viemScriptHelpers'
-import { formatAddressForNetworkCliDisplay } from '../tron/helpers/formatAddressForCliDisplay'
+import {
+  formatAddressForNetworkCliDisplay,
+  tronHexSuffix,
+} from '../tron/helpers/formatAddressForCliDisplay'
 
 import { decodeDiamondCut } from './safe-utils'
 
@@ -402,7 +405,10 @@ function formatDecodedArg(arg: unknown, network?: string): string {
     s.startsWith('0x') &&
     /^0x[a-fA-F0-9]{40}$/.test(s)
   ) {
-    return formatAddressForNetworkCliDisplay(network, s)
+    return `${formatAddressForNetworkCliDisplay(network, s)}${tronHexSuffix(
+      network,
+      s
+    )}`
   }
   return s
 }

--- a/script/deploy/tron/helpers/formatAddressForCliDisplay.test.ts
+++ b/script/deploy/tron/helpers/formatAddressForCliDisplay.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the Tron CLI address display helpers.
+ *
+ * Covers `formatAddressForNetworkCliDisplay` (hex/41/base58 → base58 for Tron,
+ * pass-through otherwise) and `tronHexSuffix` (the ` (0x…)` companion suffix
+ * for showing the EVM-style hex alongside Tron base58 in CLI output).
+ */
+// eslint-disable-next-line import/no-unresolved
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+
+import {
+  formatAddressForNetworkCliDisplay,
+  tronHexSuffix,
+} from './formatAddressForCliDisplay'
+
+// TronWeb's codec only needs a fullHost string; no network calls happen for
+// address codec ops, so any URL works for unit tests.
+const originalRpc = process.env.ETH_NODE_URI_TRON
+
+// Mainnet deployer wallet from config/global.json: stable EVM↔base58 pair.
+const EVM_DEPLOYER = '0xb137683965ADC470f140df1a1D05B0D25C14E269'
+const EVM_DEPLOYER_LOWER = EVM_DEPLOYER.toLowerCase()
+const B58_DEPLOYER = 'TS8EymUNucdNwseZMcLZRzTLy7Yz768yeD'
+const TRON_41_DEPLOYER = '41b137683965adc470f140df1a1d05b0d25c14e269'
+
+beforeAll(() => {
+  process.env.ETH_NODE_URI_TRON =
+    process.env.ETH_NODE_URI_TRON ?? 'http://localhost'
+})
+
+afterAll(() => {
+  if (originalRpc === undefined) delete process.env.ETH_NODE_URI_TRON
+  else process.env.ETH_NODE_URI_TRON = originalRpc
+})
+
+describe('formatAddressForNetworkCliDisplay', () => {
+  it('passes through unchanged for non-Tron networks', () => {
+    expect(formatAddressForNetworkCliDisplay('mainnet', EVM_DEPLOYER)).toBe(
+      EVM_DEPLOYER
+    )
+  })
+
+  it('returns base58 untouched on Tron', () => {
+    expect(formatAddressForNetworkCliDisplay('tron', B58_DEPLOYER)).toBe(
+      B58_DEPLOYER
+    )
+  })
+
+  it('converts 0x hex to base58 on Tron', () => {
+    expect(formatAddressForNetworkCliDisplay('tron', EVM_DEPLOYER)).toBe(
+      B58_DEPLOYER
+    )
+  })
+
+  it('converts lowercase 0x hex to base58 on Tron', () => {
+    expect(formatAddressForNetworkCliDisplay('tron', EVM_DEPLOYER_LOWER)).toBe(
+      B58_DEPLOYER
+    )
+  })
+
+  it('converts 41-prefixed hex to base58 on Tron', () => {
+    expect(formatAddressForNetworkCliDisplay('tron', TRON_41_DEPLOYER)).toBe(
+      B58_DEPLOYER
+    )
+  })
+
+  it('returns input unchanged when value is not a recognizable address', () => {
+    expect(formatAddressForNetworkCliDisplay('tron', 'not-an-address')).toBe(
+      'not-an-address'
+    )
+  })
+
+  it('is case-insensitive for the network key', () => {
+    expect(formatAddressForNetworkCliDisplay('TRON', EVM_DEPLOYER)).toBe(
+      B58_DEPLOYER
+    )
+  })
+})
+
+describe('tronHexSuffix', () => {
+  it('returns empty string for non-Tron networks', () => {
+    expect(tronHexSuffix('mainnet', EVM_DEPLOYER)).toBe('')
+    expect(tronHexSuffix('mainnet', B58_DEPLOYER)).toBe('')
+  })
+
+  it('returns checksummed hex in parens for a base58 Tron address', () => {
+    expect(tronHexSuffix('tron', B58_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+  })
+
+  it('returns checksummed hex in parens for a 0x EVM-style address on Tron', () => {
+    expect(tronHexSuffix('tron', EVM_DEPLOYER_LOWER)).toBe(` (${EVM_DEPLOYER})`)
+  })
+
+  it('returns checksummed hex in parens for a 41-prefixed Tron hex', () => {
+    expect(tronHexSuffix('tron', TRON_41_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+  })
+
+  it('returns empty string for unrecognizable input on Tron', () => {
+    expect(tronHexSuffix('tron', 'not-an-address')).toBe('')
+  })
+
+  it('returns empty string when checksum conversion throws', () => {
+    // Too-short 0x string fails getAddress() — exercises the catch branch.
+    expect(tronHexSuffix('tron', '0xdeadbeef')).toBe('')
+  })
+
+  it('is case-insensitive for the network key', () => {
+    expect(tronHexSuffix('TRON', B58_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+  })
+})

--- a/script/deploy/tron/helpers/formatAddressForCliDisplay.test.ts
+++ b/script/deploy/tron/helpers/formatAddressForCliDisplay.test.ts
@@ -80,31 +80,25 @@ describe('formatAddressForNetworkCliDisplay', () => {
 describe('tronHexSuffix', () => {
   it('returns empty string for non-Tron networks', () => {
     expect(tronHexSuffix('mainnet', EVM_DEPLOYER)).toBe('')
-    expect(tronHexSuffix('mainnet', B58_DEPLOYER)).toBe('')
-  })
-
-  it('returns checksummed hex in parens for a base58 Tron address', () => {
-    expect(tronHexSuffix('tron', B58_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
   })
 
   it('returns checksummed hex in parens for a 0x EVM-style address on Tron', () => {
     expect(tronHexSuffix('tron', EVM_DEPLOYER_LOWER)).toBe(` (${EVM_DEPLOYER})`)
   })
 
-  it('returns checksummed hex in parens for a 41-prefixed Tron hex', () => {
-    expect(tronHexSuffix('tron', TRON_41_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+  it('returns checksummed hex unchanged when input is already checksummed', () => {
+    expect(tronHexSuffix('tron', EVM_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+  })
+
+  it('returns empty string when getAddress throws (too-short hex)', () => {
+    expect(tronHexSuffix('tron', '0xdeadbeef')).toBe('')
   })
 
   it('returns empty string for unrecognizable input on Tron', () => {
     expect(tronHexSuffix('tron', 'not-an-address')).toBe('')
   })
 
-  it('returns empty string when checksum conversion throws', () => {
-    // Too-short 0x string fails getAddress() — exercises the catch branch.
-    expect(tronHexSuffix('tron', '0xdeadbeef')).toBe('')
-  })
-
   it('is case-insensitive for the network key', () => {
-    expect(tronHexSuffix('TRON', B58_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
+    expect(tronHexSuffix('TRON', EVM_DEPLOYER)).toBe(` (${EVM_DEPLOYER})`)
   })
 })

--- a/script/deploy/tron/helpers/formatAddressForCliDisplay.ts
+++ b/script/deploy/tron/helpers/formatAddressForCliDisplay.ts
@@ -4,7 +4,6 @@ import { isTronNetworkKey } from '../../shared/tron-network-keys'
 import {
   evmHexToTronBase58,
   tronAddressLikeToBase58,
-  tronAddressToHex,
 } from '../tronAddressHelpers'
 
 import { getTronWebCodecOnly } from './tronWebCodecOnly'
@@ -47,29 +46,19 @@ export function formatAddressForNetworkCliDisplay(
 
 /**
  * Returns ` (0x…)` (checksummed EVM hex) for Tron addresses so CLI output can
- * show both base58 and the hex form familiar from EVM contexts. Returns `''`
- * for non-Tron networks or when the input can't be resolved to a 20-byte hex.
- * Designed to be concatenated *after* `formatAddressForNetworkCliDisplay`; keep
- * it separate so the plain-base58 output can still feed explorer URL builders.
+ * show the hex form familiar from EVM contexts alongside the displayed base58.
+ * Returns `''` for non-Tron networks or unrecognizable input. Assumes the input
+ * is an EVM `0x`-form address — matches every current caller in confirm-safe-tx
+ * / safe-decode-utils, which pass addresses sourced from MongoDB or viem-decoded
+ * args (always `0x`). Kept separate from `formatAddressForNetworkCliDisplay` so
+ * the plain-base58 output can still feed explorer URL builders.
  */
-export function tronHexSuffix(networkKey: string, address: string): string {
+export function tronHexSuffix(networkKey: string, evmAddress: string): string {
   if (!isTronNetworkKey(networkKey.toLowerCase())) return ''
 
-  const codec = getTronWebCodecOnly()
-  const trimmed = address.trim()
-
   try {
-    if (trimmed.startsWith('0x') && trimmed.length >= 42)
-      return ` (${getAddress(trimmed as Address)})`
-
-    if (
-      (trimmed.startsWith('T') && trimmed.length >= 34) ||
-      trimmed.startsWith('41')
-    )
-      return ` (${getAddress(tronAddressToHex(codec, trimmed) as Address)})`
+    return ` (${getAddress(evmAddress.trim() as Address)})`
   } catch {
     return ''
   }
-
-  return ''
 }

--- a/script/deploy/tron/helpers/formatAddressForCliDisplay.ts
+++ b/script/deploy/tron/helpers/formatAddressForCliDisplay.ts
@@ -4,6 +4,7 @@ import { isTronNetworkKey } from '../../shared/tron-network-keys'
 import {
   evmHexToTronBase58,
   tronAddressLikeToBase58,
+  tronAddressToHex,
 } from '../tronAddressHelpers'
 
 import { getTronWebCodecOnly } from './tronWebCodecOnly'
@@ -42,4 +43,33 @@ export function formatAddressForNetworkCliDisplay(
   }
 
   return address
+}
+
+/**
+ * Returns ` (0x…)` (checksummed EVM hex) for Tron addresses so CLI output can
+ * show both base58 and the hex form familiar from EVM contexts. Returns `''`
+ * for non-Tron networks or when the input can't be resolved to a 20-byte hex.
+ * Designed to be concatenated *after* `formatAddressForNetworkCliDisplay`; keep
+ * it separate so the plain-base58 output can still feed explorer URL builders.
+ */
+export function tronHexSuffix(networkKey: string, address: string): string {
+  if (!isTronNetworkKey(networkKey.toLowerCase())) return ''
+
+  const codec = getTronWebCodecOnly()
+  const trimmed = address.trim()
+
+  try {
+    if (trimmed.startsWith('0x') && trimmed.length >= 42)
+      return ` (${getAddress(trimmed as Address)})`
+
+    if (
+      (trimmed.startsWith('T') && trimmed.length >= 34) ||
+      trimmed.startsWith('41')
+    )
+      return ` (${getAddress(tronAddressToHex(codec, trimmed) as Address)})`
+  } catch {
+    return ''
+  }
+
+  return ''
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

n/a — small CLI/UX improvement, no Linear ticket.

# Why did I implement it this way?

Reviewing a Safe proposal on Tron via `confirm-safe-tx` only shows base58 addresses (e.g. `TPkxVf7jNUMp8x59u7fZxpg4sjgfP4aNcW`). There's no quick way to match a decoded argument against the `0x…` addresses people keep in `config/global.json` or paste from EVM explorers. Appending the checksummed EVM hex inline removes that friction.

I considered two designs:

1. **Modify `formatAddressForNetworkCliDisplay` directly.** Single touch point, but its output is also fed to `buildExplorerContractPageUrl(...)` in `safe-decode-utils.ts` and similar URL builders elsewhere. Appending `(0x…)` to the address would break URL construction.
2. **Add a sibling helper `tronHexSuffix(networkKey, address)`.** Pure display helper that returns ` (0x…)` (checksummed via viem `getAddress`) for Tron and `''` everywhere else. `formatAddressForNetworkCliDisplay`'s output stays a bare address.

Went with (2). The two helpers are colocated in `script/deploy/tron/helpers/formatAddressForCliDisplay.ts` so callers can compose them without surprise.

Wired into the three sites that surface Tron addresses to the operator in `confirm-safe-tx` output:

- `formatDecodedArg` in `safe-decode-utils.ts` — the decoded-args block (main pain point).
- The `To:` line in `confirm-safe-tx.ts`.
- The `Proposer:` line in `confirm-safe-tx.ts`.

EVM mainnet output is unchanged.

**Before**:
```
Decoded Arguments:
  [0]: TPkxVf7jNUMp8x59u7fZxpg4sjgfP4aNcW
  [1]: 3
```

**After**:
```
Decoded Arguments:
  [0]: TPkxVf7jNUMp8x59u7fZxpg4sjgfP4aNcW (0x9740A8E0197689d144B19DA4bDc9eF65fEf11Cda)
  [1]: 3
```

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
