### PR TITLE
fix(safe-cli): show periphery name in registerPeripheryContract decode

### DIFF
--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -796,6 +796,7 @@ export async function formatDecodedTxDataForDisplay(
       log(`Function: \u001b[34m${decoded.functionName}\u001b[0m`)
       const peripheryName = String(decoded.args[0] ?? '')
       const peripheryAddress = String(decoded.args[1] ?? '')
+      log(`Periphery Name: \u001b[33m${peripheryName}\u001b[0m`)
       const deploymentSuffix = await getPeripheryDeploymentCheckSuffix(
         network,
         peripheryName,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

trivial — small CLI display fix for colleague review (stacked on `feat/tron-cli-hex-suffix`).

# Why did I implement it this way?

`formatDecodedTxDataForDisplay` already decoded the first argument of `registerPeripheryContract(string,address)` but never printed it. On EVM, reviewers often still saw a contract label via address lookup in `deployments/*.json`; on Tron (especially when the proposed address mismatches deployments) only the raw address and mismatch warning appeared. Logging `Periphery Name:` from the decoded string makes the registered contract identity explicit on every network.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

Made with [Cursor](https://cursor.com)