### PR TITLE
feat(whitelist): add Faroswap (DODO) router on Pharos

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -254,6 +254,28 @@
       }
     },
     {
+      "name": "Faroswap",
+      "key": "faroswap",
+      "logoURI": "https://static.pharosnetwork.xyz/ecosystem/faroswap.png",
+      "webUrl": "https://faroswap.xyz/",
+      "contracts": {
+        "pharos": [
+          {
+            "address": "0xA5cA5Fbe34e444F366B373170541ec6902b0F75c",
+            "functions": {
+              "0xff84aafa": "mixSwap(address,address,uint256,uint256,uint256,address[],address[],address[],uint256,bytes[],bytes,uint256)"
+            }
+          },
+          {
+            "address": "0xBF105f4ffBD3825f5433d074008B9A76237d849c",
+            "functions": {
+              "0xffffffff": "approveTo-only"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "Eisen",
       "key": "eisen",
       "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/exchanges/eisen.svg",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

No Linear ticket — this is a config-only whitelist addition that qualifies for the `trivial` label carve-out described in `.agents/context.md` (single-purpose JSON change, no Solidity / no logic).

# Why did I implement it this way?

**What this adds.** A new `Faroswap` entry in `config/whitelist.json` so that the LiFi Diamond on Pharos (`0xFf70F4A1d11995621854F3692acF286d8aCd04b2`) can route swaps through Faroswap.

**What Faroswap is.** Faroswap is the DODO V2 deployment on Pharos (chainId 1672) — the contract layout is identical to DODO on other chains (DODOFeeRouteProxy router + DODOApprove spender + UniV3 / UniV2 / DODOV2 adapters); only the deployment addresses are new. Frontend lives at https://faroswap.xyz/.

**Why a separate top-level entry instead of a `pharos` sub-key under `DODO`.** Faroswap is a distinct product/brand and we want LiFi's UI/SDK to surface it as such (similar to how `SushiSwap Aggregator` is its own entry rather than merged with other Sushi deployments). Technically both layouts work — `LibAllowList` keys on the (address, selector) pairs and ignores the `name` field — so this is a brand/UX call, not a behaviour change.

**Whitelisted contracts.**

| Address | Role | Selector |
|---|---|---|
| `0xA5cA5Fbe34e444F366B373170541ec6902b0F75c` | DODOFeeRouteProxy (router — Diamond calls this) | `0xff84aafa` → `mixSwap(address,address,uint256,uint256,uint256,address[],address[],address[],uint256,bytes[],bytes,uint256)` |
| `0xBF105f4ffBD3825f5433d074008B9A76237d849c` | DODOApprove (users approve here; Diamond never calls it) | `0xffffffff` (approveTo-only sentinel per `LibAllowList.sol` lines 17–23) |

The `mixSwap` selector `0xff84aafa` is already present in the existing `DODO` mainnet entry in `whitelist.json`, so the global V1 `selectorAllowList` already contains it; this PR only extends the granular `(contract, selector)` mapping with the Pharos router address.

Adapter contracts (`0x4fd44181…`, `0x3084d27A…`, `0x60611853…`) are deliberately **not** whitelisted: the Diamond only ever calls the router; the router internally dispatches to adapters. Adding them would be noise without security benefit.

**Verification.** All addresses and the selector were taken from working calldata against the live Pharos chain (the reference implementation has been driving real swaps via `mixSwap` on `0xA5cA…0F75c` and approving USDC to `0xBF10…d849c` for months). Per `.agents/rules/502-whitelist-branching.md`, this PR targets `main`.

**Out of scope.** Propagating the entry on-chain requires `script/tasks/diamondSyncWhitelist.sh pharos production LiFiDiamond`, which needs Safe multisig access and is owned by LI.FI maintainers.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

> Tests / new-facet checklist / docs N/A: config-only whitelist addition. No new contracts. No tests live alongside `config/whitelist.json` entries today; correctness is verified by the on-chain sync workflow run by maintainers.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
