### PR TITLE
fix(timelock-exec): throttle Tron RPC calls to TronGrid 15 req/s cap

### DIFF
--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -9,6 +9,7 @@
 
 import 'dotenv/config'
 
+import { isTronNetworkKey } from '@lifi/tron-devkit'
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import type { Address, Hex, PublicClient } from 'viem'
@@ -22,6 +23,7 @@ import {
   type SupportedChain,
 } from '../../common/types'
 import { setupEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import { sleep } from '../../utils/delay'
 import { getDeployments } from '../../utils/deploymentHelpers'
 import { normalizeAddressForNetwork } from '../../utils/normalizeAddressStringForViem'
 import {
@@ -416,17 +418,46 @@ const cmd = defineCommand({
 })
 
 /**
- * Checks the status of an operation in the LiFiTimelockController
+ * Checks the status of an operation in the LiFiTimelockController.
+ *
+ * On Tron the three readContract calls run sequentially with a small inter-call
+ * delay; TronGrid caps the API key at 15 req/s and a single Promise.all here
+ * combined with the per-row loop bursts past that and trips a 25-second penalty.
  */
 async function checkOperationStatus(
   publicClient: PublicClient,
   timelockAddress: Address,
-  operationId: Hex
+  operationId: Hex,
+  networkName: string
 ): Promise<{
   isDone: boolean
   isPending: boolean
   isReady: boolean
 }> {
+  if (isTronNetworkKey(networkName)) {
+    const isDone = await publicClient.readContract({
+      address: timelockAddress,
+      abi: TIMELOCK_ABI,
+      functionName: 'isOperationDone',
+      args: [operationId],
+    })
+    await sleep(100)
+    const isPending = await publicClient.readContract({
+      address: timelockAddress,
+      abi: TIMELOCK_ABI,
+      functionName: 'isOperationPending',
+      args: [operationId],
+    })
+    await sleep(100)
+    const isReady = await publicClient.readContract({
+      address: timelockAddress,
+      abi: TIMELOCK_ABI,
+      functionName: 'isOperationReady',
+      args: [operationId],
+    })
+    return { isDone, isPending, isReady }
+  }
+
   const [isDone, isPending, isReady] = await Promise.all([
     publicClient.readContract({
       address: timelockAddress,
@@ -615,7 +646,7 @@ async function processNetwork(
     let operationsSkipped = 0
     const totalGasUsed = 0n
 
-    for (const operation of readyOperations)
+    for (const operation of readyOperations) {
       if (rejectAll) {
         const rejectResult = await rejectOperation(
           chainCaller,
@@ -654,6 +685,10 @@ async function processNetwork(
         else if (result === 'rejected') operationsRejected++
         else if (result === 'skipped') operationsSkipped++
       }
+      // TronGrid caps the API key at 15 req/s; each op fires ~3-5 RPC calls
+      // (simulate + broadcast + receipt poll), so pace iterations on Tron.
+      if (isTronNetworkKey(network.name)) await sleep(200)
+    }
 
     // Only send network completion notification if there were actual operations executed or failures
     if (slackNotifier && (operationsSucceeded > 0 || operationsFailed > 0))
@@ -868,7 +903,8 @@ async function getPendingOperations(
         const status = await checkOperationStatus(
           publicClient,
           timelockAddress,
-          opId
+          opId,
+          networkName
         )
 
         if (status.isDone) {

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -420,7 +420,7 @@ const cmd = defineCommand({
 /**
  * Checks the status of an operation in the LiFiTimelockController.
  *
- * On Tron the three readContract calls run sequentially with a small inter-call
+ * On Tron the three readContract calls run sequentially with an inter-call
  * delay; TronGrid caps the API key at 15 req/s and a single Promise.all here
  * combined with the per-row loop bursts past that and trips a 25-second penalty.
  */
@@ -441,14 +441,14 @@ async function checkOperationStatus(
       functionName: 'isOperationDone',
       args: [operationId],
     })
-    await sleep(100)
+    await sleep(2000) // 2 s — TronGrid 15 req/s cap needs generous spacing
     const isPending = await publicClient.readContract({
       address: timelockAddress,
       abi: TIMELOCK_ABI,
       functionName: 'isOperationPending',
       args: [operationId],
     })
-    await sleep(100)
+    await sleep(2000) // 2 s — TronGrid 15 req/s cap needs generous spacing
     const isReady = await publicClient.readContract({
       address: timelockAddress,
       abi: TIMELOCK_ABI,
@@ -687,7 +687,7 @@ async function processNetwork(
       }
       // TronGrid caps the API key at 15 req/s; each op fires ~3-5 RPC calls
       // (simulate + broadcast + receipt poll), so pace iterations on Tron.
-      if (isTronNetworkKey(network.name)) await sleep(200)
+      if (isTronNetworkKey(network.name)) await sleep(2000) // 2 s
     }
 
     // Only send network completion notification if there were actual operations executed or failures


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-354](https://linear.app/lifi-linear/issue/EXSC-354/throttle-tron-rpc-calls-in-timelock-execution-to-stay-under-trongrid)

# Why did I implement it this way?

TronGrid limits API keys to 15 requests/second and suspends the key for ~25
seconds when exceeded. The Tron timelock execution job was firing the three
readiness reads (`isOperationDone` / `isOperationPending` / `isOperationReady`)
via `Promise.all` per pending op, then running the simulate+broadcast loop
without inter-op pacing. With a queue of 7+ ops, the first parallel read burst
alone exceeds 15 req/s, the key gets suspended, and every subsequent call
fails — both in CI and locally.

Fix is two narrow changes, both gated on `isTronNetworkKey()` so EVM
throughput is unchanged:

- `checkOperationStatus()` runs the three reads sequentially with a 100ms
  gap on Tron (≈10 req/s ceiling for the readiness phase).
- The `for (const operation of readyOperations)` body is wrapped in braces
  and pauses 200ms between iterations on Tron (≈7 req/s ceiling for
  simulate+broadcast).

**Why in the script rather than `tron-caller.ts`**: the rate limit isn't a
property of the chain — TronGrid happily serves 15 req/s. The problem is the
orchestrator firing 20+ in a burst. Other Tron scripts in the repo already
handle their own throttling, so a global throttle in `TronChainCaller` would
risk double-throttling them and impose an always-on tax on one-shot callers
that don't need it. Keeping the fix where the burst is generated is more
honest and surgical; the next workflow run benefits automatically.

Verified locally: a 7-op Tron queue that previously failed on the first
parallel read burst now clears end-to-end with this change.

**Follow-ups (not in this PR)**:

- Move the two sleep constants into `script/deploy/tron/constants.ts`
  alongside other Tron rate-limit knobs.
- Add a retry-on-429 helper in `tron-caller.ts` that reads the
  `suspended for X s` body from TronGrid's 429 and backs off accordingly.
  Would harden the workflow against bursts that do still slip through.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
