### PR TITLE
fix(safe-cli): decode Diamond call args in nested timelock display

### DIFF
--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -747,6 +747,16 @@ export async function formatDecodedTxDataForDisplay(
         // fall through
       }
     }
+    if (!decoded) {
+      const abiItem = getDiamondAbiItemForSelector(data.slice(0, 10))
+      if (abiItem?.type === 'function') {
+        try {
+          decoded = decodeFunctionData({ abi: [abiItem], data })
+        } catch {
+          // fall through
+        }
+      }
+    }
 
     if (decoded?.functionName === 'diamondCut' && decoded.args) {
       await decodeDiamondCut(decoded, chainId, network, pre)
@@ -826,10 +836,23 @@ export async function formatDecodedTxDataForDisplay(
       log(`Function: \u001b[34m${decoded.functionName}\u001b[0m`)
       const args = decoded.args
       if (args && args.length > 0) {
+        const abiItem = getDiamondAbiItemForSelector(data.slice(0, 10))
+        const inputs =
+          abiItem?.type === 'function' &&
+          'inputs' in abiItem &&
+          Array.isArray(abiItem.inputs)
+            ? abiItem.inputs
+            : []
         log('Decoded Arguments:')
         args.forEach((arg: unknown, index: number) => {
+          const input = inputs[index]
+          const paramName =
+            input && typeof input === 'object' && 'name' in input
+              ? (input as { name: string }).name
+              : undefined
+          const label = paramName ? paramName : `[${index}]`
           log(
-            `  [${index}]: \u001b[33m${formatDecodedArg(arg, network)}\u001b[0m`
+            `  ${label}: \u001b[33m${formatDecodedArg(arg, network)}\u001b[0m`
           )
         })
       } else {
@@ -839,6 +862,11 @@ export async function formatDecodedTxDataForDisplay(
     }
 
     if (functionName) {
+      const pretty = tryFormatDiamondPayload(data, network)
+      if (pretty) {
+        log(`Call: \u001b[34m${pretty}\u001b[0m`)
+        return
+      }
       log(`Function: \u001b[34m${functionName}\u001b[0m`)
       return
     }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

trivial — display bugfix in `safe-decode-utils` (no ticket)

# Why did I implement it this way?

When `confirm-safe-tx` recurses into timelock `scheduleBatch` payloads, Diamond functions matched via `diamond.json` (e.g. `transferOwnership`) only resolved the function name without decoding calldata. Reviewers could not see who ownership was being transferred to.

Added a diamond-ABI fallback decode step after the 4byte/Sourcify lookup, named argument labels from the ABI (e.g. `newOwner`), and a last-resort `tryFormatDiamondPayload` formatter before the name-only fallback.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

Made with [Cursor](https://cursor.com)