### PR TITLE
EXSC-301: add bulk contract verification helper for one network

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -515,7 +515,10 @@ function getContractNamesFromNetworkDeploymentFile() {
     return 1
   fi
 
-  jq -r 'to_entries[] | select(.value != null and .value != "" and .value != "0x") | .key' "$ADDRESSES_FILE"
+  if ! jq -r 'to_entries[] | select(.value != null and .value != "" and .value != "0x") | .key' "$ADDRESSES_FILE"; then
+    error "Failed to parse deployment file: $ADDRESSES_FILE"
+    return 1
+  fi
   return 0
 }
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -496,6 +496,29 @@ function getUnverifiedContractsFromMongo() {
   return $?
 }
 
+# getContractNamesFromNetworkDeploymentFile: List contract names from deployments/<network>.json.
+#
+# Usage: getContractNamesFromNetworkDeploymentFile NETWORK ENVIRONMENT
+#   NETWORK     - Network key from networks.json
+#   ENVIRONMENT - production or staging (selects .json vs .staging.json)
+#
+# Returns: One contract name per line on stdout; exit 0 on success, 1 on failure
+function getContractNamesFromNetworkDeploymentFile() {
+  local NETWORK="$1"
+  local ENVIRONMENT="$2"
+  local FILE_SUFFIX
+  FILE_SUFFIX=$(getFileSuffix "$ENVIRONMENT")
+  local ADDRESSES_FILE="./deployments/${NETWORK}.${FILE_SUFFIX}json"
+
+  if ! checkIfFileExists "$ADDRESSES_FILE" >/dev/null; then
+    error "Deployment file not found: $ADDRESSES_FILE"
+    return 1
+  fi
+
+  jq -r 'to_entries[] | select(.value != null and .value != "" and .value != "0x") | .key' "$ADDRESSES_FILE"
+  return 0
+}
+
 function getSolcVersion() {
   local NETWORK="$1"
 

--- a/script/playgroundHelpers.sh
+++ b/script/playgroundHelpers.sh
@@ -132,13 +132,15 @@ function verifyAllUnverifiedContractsOnNetwork() {
     esac
   fi
 
+  local CONTRACT_LIST
+  if ! CONTRACT_LIST=$(getContractNamesFromNetworkDeploymentFile "$NETWORK" "$ENVIRONMENT"); then
+    return 1
+  fi
+
   local -a CONTRACTS=()
   while IFS= read -r CONTRACT; do
     [[ -n "$CONTRACT" ]] && CONTRACTS+=("$CONTRACT")
-  done < <(getContractNamesFromNetworkDeploymentFile "$NETWORK" "$ENVIRONMENT")
-  if [[ $? -ne 0 ]]; then
-    return 1
-  fi
+  done <<< "$CONTRACT_LIST"
 
   local TOTAL=${#CONTRACTS[@]}
   if [[ $TOTAL -eq 0 ]]; then

--- a/script/playgroundHelpers.sh
+++ b/script/playgroundHelpers.sh
@@ -89,6 +89,96 @@ function getContractVerified() {
   fi
 }
 
+# verifyAllUnverifiedContractsOnNetwork: Verify contracts listed in deployments/<network>.json.
+# Contract list comes from the local deployment file; verified status is read from MongoDB.
+# On success, MongoDB is updated via getContractVerified.
+#
+# Usage: verifyAllUnverifiedContractsOnNetwork NETWORK [ENVIRONMENT]
+#   NETWORK     - Network key from networks.json (e.g. arc, base)
+#   ENVIRONMENT - Optional: production (default) or staging
+#
+# Returns: 0 if all contracts verified or already verified; 1 if any verification failed
+# Example: verifyAllUnverifiedContractsOnNetwork arc production
+function verifyAllUnverifiedContractsOnNetwork() {
+  local NETWORK="$1"
+  local ENVIRONMENT="${2:-production}"
+
+  if [[ -z "$NETWORK" ]]; then
+    error "Usage: verifyAllUnverifiedContractsOnNetwork NETWORK [ENVIRONMENT]"
+    return 1
+  fi
+
+  if [[ "$ENVIRONMENT" != "production" && "$ENVIRONMENT" != "staging" ]]; then
+    error "ENVIRONMENT must be 'production' or 'staging' (got: $ENVIRONMENT)"
+    return 1
+  fi
+
+  if ! jq -e --arg network "$NETWORK" '.[$network] != null' "$NETWORKS_JSON_FILE_PATH" >/dev/null; then
+    error "Network '$NETWORK' not found in networks.json"
+    return 1
+  fi
+
+  if isTronNetwork "$NETWORK"; then
+    warning "[$NETWORK] Tron networks do not support forge verification — skipping"
+    return 0
+  fi
+
+  if [[ -n "${DO_NOT_VERIFY_IN_THESE_NETWORKS:-}" ]]; then
+    case ",$DO_NOT_VERIFY_IN_THESE_NETWORKS," in
+    *,"$NETWORK",*)
+      warning "[$NETWORK] excluded by DO_NOT_VERIFY_IN_THESE_NETWORKS — skipping"
+      return 0
+      ;;
+    esac
+  fi
+
+  local -a CONTRACTS=()
+  while IFS= read -r CONTRACT; do
+    [[ -n "$CONTRACT" ]] && CONTRACTS+=("$CONTRACT")
+  done < <(getContractNamesFromNetworkDeploymentFile "$NETWORK" "$ENVIRONMENT")
+  if [[ $? -ne 0 ]]; then
+    return 1
+  fi
+
+  local TOTAL=${#CONTRACTS[@]}
+  if [[ $TOTAL -eq 0 ]]; then
+    warning "[$NETWORK] No contracts found in deployments file for environment $ENVIRONMENT"
+    return 0
+  fi
+
+  local FILE_SUFFIX
+  FILE_SUFFIX=$(getFileSuffix "$ENVIRONMENT")
+  echo "[info] [$NETWORK] Processing $TOTAL contract(s) from deployments/${NETWORK}.${FILE_SUFFIX}json (env=$ENVIRONMENT)"
+
+  local SKIPPED_VERIFIED=0
+  local VERIFIED_NOW=0
+  local FAILED=0
+  local CONTRACT
+
+  for CONTRACT in "${CONTRACTS[@]}"; do
+    if isContractAlreadyVerified "$CONTRACT" "$NETWORK" "$ENVIRONMENT"; then
+      echo "[info] [$NETWORK] $CONTRACT already verified in MongoDB — skipping"
+      SKIPPED_VERIFIED=$((SKIPPED_VERIFIED + 1))
+      continue
+    fi
+
+    echo "[info] [$NETWORK] Verifying $CONTRACT..."
+    if getContractVerified "$NETWORK" "$ENVIRONMENT" "$CONTRACT"; then
+      VERIFIED_NOW=$((VERIFIED_NOW + 1))
+    else
+      FAILED=$((FAILED + 1))
+    fi
+  done
+
+  echo ""
+  echo "[info] [$NETWORK] Done: $VERIFIED_NOW newly verified, $SKIPPED_VERIFIED already verified, $FAILED failed (of $TOTAL contracts)"
+
+  if [[ $FAILED -gt 0 ]]; then
+    return 1
+  fi
+  return 0
+}
+
 # =============================================================================
 # NETWORK QUERY FUNCTIONS
 # =============================================================================
@@ -294,8 +384,9 @@ function isContractAlreadyVerified() {
         return 1  # No log entry found
     fi
 
-    # Extract verification status
-    local VERIFIED=$(echo "$LOG_ENTRY" | jq -r ".VERIFIED" 2>/dev/null)
+    # Extract verification status (MongoDB uses .verified; legacy JSON used .VERIFIED)
+    local VERIFIED
+    VERIFIED=$(echo "$LOG_ENTRY" | jq -r '.verified // .VERIFIED // "false"' 2>/dev/null)
     if [[ "$VERIFIED" == "true" ]]; then
         return 0  # Contract is verified
     fi
@@ -2395,6 +2486,7 @@ EOF
 
 # Contract verification and deployment
 export -f getContractVerified
+export -f verifyAllUnverifiedContractsOnNetwork
 export -f deployContract
 export -f getContractDeploymentStatusSummary
 export -f compareContractBytecode


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-301

# Why did I implement it this way?

## Use case

When we **deploy to a new network**, contract verification often cannot run at deploy time. Typical reasons:

- The block explorer is not live yet
- The explorer API is not wired up in `foundry.toml` / `networks.json`
- The explorer is password-protected or otherwise unavailable during the initial deploy window

Deployments still land in `deployments/<network>.json` and MongoDB with `verified: false`. Once the explorer is ready, we need a **single follow-up step** to verify every contract on that chain and flip the MongoDB flags — without manually calling `getContractVerified` dozens of times.

`verifyAllUnverifiedContractsOnNetwork` is that follow-up helper.

## What it does

1. Reads the contract list from **`deployments/<network>.json`** (or `.staging.json`) — the canonical set of addresses for that network, not the full MongoDB history (which may include old versions, staging rows, etc.).
2. For each contract, checks whether it is already marked **verified in MongoDB**; skips if yes.
3. Otherwise runs the existing **`getContractVerified`** path (forge `verify-contract` + MongoDB update via `logContractDeploymentInfo`).

**Example (after Arc explorer went live):**

```bash
source .env
source script/helperFunctions.sh
source script/playgroundHelpers.sh
verifyAllUnverifiedContractsOnNetwork arc production
```

Also fixes `isContractAlreadyVerified` to read MongoDB's `.verified` field (not only legacy `.VERIFIED`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
