### PR TITLE
fix(ci): authenticate ERC-7730 sync clone via token-in-URL

### DIFF
--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -95,12 +95,19 @@ jobs:
 
           echo -e "\033[32mCloning fork: ${LEDGER_FORK}\033[0m"
           rm -rf ledger-registry
-          # Clone without baking the PAT into remote.origin.url. A token in the
-          # URL persists in `.git/config` and would surface via any later
-          # `git remote -v` / `git config -l` / verbose git invocation. Set an
-          # auth header instead — same effect, token never on disk.
-          git clone "https://github.com/${LEDGER_FORK}.git" ledger-registry
+          # Authenticate the initial clone via a transient token-in-URL: the
+          # runner's prior `actions/checkout` leaves a credential helper that
+          # makes an anonymous clone of github.com prompt for a username and
+          # fail (`fatal: could not read Username for 'https://github.com'`)
+          # even though the fork is public. Once cloned, immediately rewrite
+          # `remote.origin.url` to the bare HTTPS form so the token does not
+          # surface from `git remote -v` (the common debug command), and
+          # install it as an HTTP auth header for subsequent fetch/push.
+          # The header still lands in `.git/config` (visible via `git config
+          # -l`), but the workspace is destroyed at job end.
+          git clone "https://x-access-token:${LEDGER_SYNC_TOKEN}@github.com/${LEDGER_FORK}.git" ledger-registry
           cd ledger-registry
+          git remote set-url origin "https://github.com/${LEDGER_FORK}.git"
           git config "http.https://github.com/.extraheader" "AUTHORIZATION: bearer ${LEDGER_SYNC_TOKEN}"
 
           git remote add upstream "https://github.com/${LEDGER_UPSTREAM}.git"


### PR DESCRIPTION
## Summary

- The dry-run of the ERC-7730 registry sync (added in #1821) fails on the hosted runner with `fatal: could not read Username for 'https://github.com'` at the clone of `lifinance/clear-signing-erc7730-registry`, even though the fork is public.
- Root cause: the runner's prior `actions/checkout` step (with `persist-credentials: false`) leaves git's credential helper in a state where an anonymous clone of github.com prompts for a username and fails.
- Fix: bake a transient PAT (`LEDGER_SYNC_TOKEN`) into the clone URL, then immediately rewrite `remote.origin.url` back to the bare HTTPS form, and install the token as an HTTP auth header (`http.https://github.com/.extraheader`) for subsequent fetch/push. Token is no longer surfaced by `git remote -v`; the extraheader still lands in `.git/config` (visible via `git config -l`), but the workspace is destroyed at job end.

Unblocks [EXSC-338](https://linear.app/lifi-linear/issue/EXSC-338/erc-7730-clear-signing-dry-run-first-real-sync-to-ef-registry-post) (dry-run + first real sync to EF registry).

## Local validation

Reproduced the exact sync logic against `lifinance/clear-signing-erc7730-registry` on my laptop with the same PAT the workflow uses. Generator output:

```text
display.formats merge: +101 added, ~0 replaced, =7 preserved (unowned)
1 file changed, +21855 / -100
```

— matches EXSC-338's expected dry-run signature (~101 new entries on first run). The 7 preserved-unowned entries are display.formats other working-group parties added for selectors LI.FI doesn't own; merge correctly leaves them alone.

## Test plan

- [ ] Merge.
- [ ] Re-trigger the dry-run on `main`:
  ```
  gh workflow run "Sync Clear Signing (ERC-7730) Registry" --ref main --field dry_run=true
  ```
- [ ] Confirm the "Sync Ledger registry file" step now reaches the generator and prints the `display.formats merge: +101 added …` line + the truncated diff banner, with the `[dry-run] Skipping commit/push/PR-create/Slack` exit.
- [ ] If dry-run looks clean, run for real (`--field dry_run=false`) and verify a PR opens at `ethereum/clear-signing-erc7730-registry` + Slack ping lands in `#sc-general`.