### PR TITLE
chore(whitelist): add nexroute, remove deprecated fantom and polygonzkevm

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -853,26 +853,6 @@
             }
           }
         ],
-        "fantom": [
-          {
-            "address": "0xd0c22a5435f4e8e5770c1fafb5374015fc12f7cd",
-            "functions": {
-              "0x3b635ce4": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,uint32)",
-              "0x83bd37f9": "swapCompact()",
-              "0x7bf2d6d4": "swapMulti((address,uint256,address)[],(address,uint256,address)[],uint256,bytes,address,uint32)",
-              "0x84a7f3dd": "swapMultiCompact()"
-            }
-          },
-          {
-            "address": "0x0d05a7d3448512b78fa8a9e46c4872c88c4a0d05",
-            "functions": {
-              "0x83bd37f9": "swapCompact()",
-              "0x84a7f3dd": "swapMultiCompact()",
-              "0x30f80b4c": "swap((address,uint256,address,address,uint256,uint256,address),bytes,address,(uint64,uint64,address))",
-              "0xfef828dc": "swapMulti((address,uint256,address)[],(address,uint256,uint256,address)[],bytes,address,(uint64,uint64,address))"
-            }
-          }
-        ],
         "fraxtal": [
           {
             "address": "0x56c85a254dd12ee8d9c04049a4ab62769ce98210",
@@ -1456,14 +1436,6 @@
             }
           }
         ],
-        "fantom": [
-          {
-            "address": "0x6352a56caadc4f1e25cd6c75970fa768a3304e64",
-            "functions": {
-              "0x90411a32": "swap(address,(address,address,address,address,uint256,uint256,uint256,uint256,address,bytes),(uint256,uint256,uint256,bytes)[])"
-            }
-          }
-        ],
         "zksync": [
           {
             "address": "0x36a1acbbcafca2468b85011ddd16e7cb4d673230",
@@ -1483,14 +1455,6 @@
         "metis": [
           {
             "address": "0x6352a56caadc4f1e25cd6c75970fa768a3304e64",
-            "functions": {
-              "0x90411a32": "swap(address,(address,address,address,address,uint256,uint256,uint256,uint256,address,bytes),(uint256,uint256,uint256,bytes)[])"
-            }
-          }
-        ],
-        "polygonzkevm": [
-          {
-            "address": "0x6dd434082eab5cd134b33719ec1ff05fe985b97b",
             "functions": {
               "0x90411a32": "swap(address,(address,address,address,address,uint256,uint256,uint256,uint256,address,bytes),(uint256,uint256,uint256,bytes)[])"
             }
@@ -2328,51 +2292,6 @@
             }
           }
         ],
-        "fantom": [
-          {
-            "address": "0x3d2f8ae0344d38525d2ae96ab750b83480c0844f",
-            "functions": {
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
-            }
-          },
-          {
-            "address": "0x2214a42d8e2a1d20635c2cb0664422c528b6a432",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
-            }
-          },
-          {
-            "address": "0x46b3fdf7b5cde91ac049936bf0bdb12c5d22202e",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
-            }
-          },
-          {
-            "address": "0xf2614a233c7c3e7f08b1f887ba133a13f1eb2c55",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)",
-              "0x47f8bd41": ""
-            }
-          },
-          {
-            "address": "0x85cd07ea01423b1e937929b44e4ad8c40bbb5e71",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0xdd9c5f96": "",
-              "0xee623204": ""
-            }
-          },
-          {
-            "address": "0xac4c6e212a361c968f1725b4d055b47e63f80b75",
-            "functions": {
-              "0x5f3bd1c8": "snwap(address,uint256,address,address,uint256,address,bytes)",
-              "0xd33721a5": "snwapMultiple((address,uint256,address)[],(address,address,uint256)[],(address,uint256,bytes)[])"
-            }
-          }
-        ],
         "boba": [
           {
             "address": "0x85cd07ea01423b1e937929b44e4ad8c40bbb5e71",
@@ -2429,45 +2348,6 @@
         "metis": [
           {
             "address": "0xb45e53277a7e0f1d35f2a77160e91e25507f1763",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
-            }
-          },
-          {
-            "address": "0xf2614a233c7c3e7f08b1f887ba133a13f1eb2c55",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)",
-              "0x47f8bd41": ""
-            }
-          },
-          {
-            "address": "0x85cd07ea01423b1e937929b44e4ad8c40bbb5e71",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0xdd9c5f96": "",
-              "0xee623204": ""
-            }
-          },
-          {
-            "address": "0xac4c6e212a361c968f1725b4d055b47e63f80b75",
-            "functions": {
-              "0x5f3bd1c8": "snwap(address,uint256,address,address,uint256,address,bytes)",
-              "0xd33721a5": "snwapMultiple((address,uint256,address)[],(address,address,uint256)[],(address,uint256,bytes)[])"
-            }
-          }
-        ],
-        "polygonzkevm": [
-          {
-            "address": "0x2f686751b19a9d91cc3d57d90150bc767f050066",
-            "functions": {
-              "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
-              "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
-            }
-          },
-          {
-            "address": "0x57bffa72db682f7eb6c132dae03ff36bbeb0c459",
             "functions": {
               "0xfa461e33": "uniswapV3SwapCallback(int256,int256,bytes)",
               "0x2646478b": "processRoute(address,uint256,address,uint256,address,bytes)"
@@ -4143,21 +4023,6 @@
             }
           }
         ],
-        "fantom": [
-          {
-            "address": "0x5affa5312ade198d9527acf058fee1c8ed8fe9f3",
-            "functions": {
-              "0x73fc4457": "swapWithMagpieSignature(bytes)",
-              "0x25e651ed": "swapWithUserSignature(bytes)"
-            }
-          },
-          {
-            "address": "0xf702814d2e1290f3d5f3202565df46272e1b1b92",
-            "functions": {
-              "0x46ec278a": "swapWithBackendSignature(bytes)"
-            }
-          }
-        ],
         "zksync": [
           {
             "address": "0xb44958ff91b4b67d8d4db010e38ccffe52551ecb",
@@ -4213,21 +4078,6 @@
           },
           {
             "address": "0xf702814d2e1290f3d5f3202565df46272e1b1b92",
-            "functions": {
-              "0x46ec278a": "swapWithBackendSignature(bytes)"
-            }
-          }
-        ],
-        "polygonzkevm": [
-          {
-            "address": "0x3950bf2fff93e5d502430f17924aef4c621ea772",
-            "functions": {
-              "0x73fc4457": "swapWithMagpieSignature(bytes)",
-              "0x25e651ed": "swapWithUserSignature(bytes)"
-            }
-          },
-          {
-            "address": "0xf5f3b8faf45023fd92c0c88fedf73fb0529fc1cd",
             "functions": {
               "0x46ec278a": "swapWithBackendSignature(bytes)"
             }
@@ -4986,6 +4836,23 @@
             "address": "0xbc1d9760bd6ca468ca9fb5ff2cfbeac35d86c973",
             "functions": {
               "0xd984396a": ""
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Nexroute",
+      "key": "nexroute",
+      "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/exchanges/nexroute.svg",
+      "webUrl": "https://nexroute.io",
+      "contracts": {
+        "bsc": [
+          {
+            "address": "0x6c9534e06a4aa13abf296278a194385f7ca16e70",
+            "functions": {
+              "0xafeb849c": "",
+              "0x72d76b4b": ""
             }
           }
         ]

--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4851,8 +4851,8 @@
           {
             "address": "0x6c9534e06a4aa13abf296278a194385f7ca16e70",
             "functions": {
-              "0xafeb849c": "",
-              "0x72d76b4b": ""
+              "0xafeb849c": "swapExactInput(address,address,uint256,uint256,uint256,bytes[])",
+              "0x72d76b4b": "swapExactInputETH(address,uint256,uint256,bytes[])"
             }
           }
         ]


### PR DESCRIPTION
## What

Updates `config/whitelist.json` for the Nexroute DEX integration (Linear: EXBE-332).

- **Add Nexroute** (BSC router `0x6c9534e06a4aa13abf296278a194385f7ca16e70` with selectors `0xafeb849c`, `0x72d76b4b`), mirroring the backend-generated `whitelisting_config.json`.
- **Remove deprecated chains** `fantom` (4 DEXs) and `polygonzkevm` (3 DEXs) — no longer active per `config/networks.json`.

The JSON serializer matches the original byte-for-byte, so the diff is purely the additions/removals above (no formatting churn). PERIPHERY untouched.

Paired with backend PR: https://github.com/lifinance/lifi-backend/pull/8387