### PR TITLE
fix(emergency-pause): send pauseDiamond() directly, not via Safe proposal

### DIFF
--- a/script/utils/diamondEMERGENCYPauseGitHub.sh
+++ b/script/utils/diamondEMERGENCYPauseGitHub.sh
@@ -179,13 +179,20 @@ function handleNetwork() {
     echo "[network: $NETWORK] registered pauser wallet matches with stored private key (= ready to execute)"
   fi
 
+  # Pre-build pauseDiamond() calldata so we can dispatch via `universalCast sendRaw`.
+  # `universalCast send` with "production" routes through sendOrPropose → propose-to-safe.ts,
+  # but the PauserWallet is registered as an EOA on the diamond and must call pauseDiamond()
+  # directly — no Safe involvement, no multisig signers.
+  local PAUSE_CALLDATA
+  PAUSE_CALLDATA=$(cast calldata "pauseDiamond()")
+
   # repeatedly try to pause the diamond until it's done (or attempts are exhausted)
   local ATTEMPTS=1
   while [ $ATTEMPTS -le $MAX_ATTEMPTS ]; do
     echo ""
     echo "[network: $NETWORK] pausing diamond $DIAMOND_ADDRESS now from PauserWallet: $PRIV_KEY_ADDRESS (attempt: $ATTEMPTS)"
     echo ""
-    universalCast "send" "$NETWORK" "production" "$DIAMOND_ADDRESS" "pauseDiamond()" "" "" "$PAUSER_PRIVATE_KEY"
+    universalCast "sendRaw" "$NETWORK" "production" "$DIAMOND_ADDRESS" "$PAUSE_CALLDATA" "$PAUSER_PRIVATE_KEY"
 
     # check the return code of the last call
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — incident-driven fix surfaced from a failed `diamondEmergencyPause` workflow run.

# Why did I implement it this way?

The prod emergency pause GitHub workflow was failing with `The current signer is not an owner of this Safe` (see screenshot in originating chat). Root cause: `script/utils/diamondEMERGENCYPauseGitHub.sh` called

```bash
universalCast "send" "$NETWORK" "production" "$DIAMOND_ADDRESS" "pauseDiamond()" "" "" "$PAUSER_PRIVATE_KEY"
```

Per the `universalCast` routing table in `.agents/rules/300-bash.md`, `universalSend` for EVM **production** routes through `sendOrPropose` → `propose-to-safe.ts`, i.e. it tries to create a Safe proposal. But the `PauserWallet` is an EOA registered directly on the diamond (`pauserWallet()`) — it must call `pauseDiamond()` directly, not propose a Safe transaction.

Fix: switch to `universalCast "sendRaw"`, which always dispatches via `cast send` regardless of environment, and pre-build the `pauseDiamond()` calldata. The script logic around the call (retry loop, on-chain verification, summary printing) is unchanged.

Considered alternatives:

- Setting `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true` in the workflow env. Rejected because it's an environment-wide override for a script-specific concern; `sendRaw` is the precise, self-documenting tool.
- Calling `cast send` directly. Rejected to keep all cast-like ops going through `universalCast`, matching the rule "Never hardcode network checks; use the helpers".

The staging mirror (`diamondEMERGENCYPauseStagingGitHub.sh`) already uses `"staging"` which routes directly via `cast send`, so no change needed there.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

Notes on unchecked items:

- `/pr-ready`: skipped at author's request given the surgical scope (single-line routing fix in a bash script + a comment block); cloud CodeRabbit will run as the safety net.
- Tests: this is a bash-script change to an incident-response workflow that is exercised end-to-end by `diamondEmergencyPauseStaging.yml`. No new automated test added — the staging workflow remains the regression check.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
