### PR TITLE
fix(config): update Tron FeeForwarder address in whitelist

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -10035,7 +10035,7 @@
       },
       {
         "name": "FeeForwarder",
-        "address": "TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ",
+        "address": "TBiwoFZpHoSG1NkdpTvgSi7bDm1W8DdAF8",
         "selectors": [
           {
             "selector": "0x0e8ae67f",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — hotfix for production Tron revert (KriptoK-Collection integrator, NEAR Intents route)

# Why did I implement it this way?

`config/whitelist.json` referenced the old Tron FeeForwarder address (`TCipFFZJkZQ9Ny3W4y6kyZEKrU3FVnzbNQ`). The contract was redeployed in October 2025 to `TBiwoFZpHoSG1NkdpTvgSi7bDm1W8DdAF8` (recorded in `deployments/tron.json`) but the whitelist was never synced. Because `diamondSyncWhitelist.sh` derives the on-chain allowlist from this file, the new FeeForwarder was never whitelisted on the Diamond — causing any route that calls `forwardNativeFees` (0x0e8ae67f) to revert with `ContractCallNotAllowed` (0x94539804).

Single-line address change to match `deployments/tron.json`. After merging, run `diamondSyncWhitelist.sh → tron / production` to push the change on-chain (the companion PR #1872 fixes the sync script itself so that run will succeed).

Failing tx: `b82410a112f3eec910a71b6d0ad92931d324f8e67e29754e6e6a2d80a57d9faa`

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>