### PR TITLE
fix(scripts): use Tron base58 addresses in Tronscan explorer links

### DIFF
--- a/script/utils/viemScriptHelpers.ts
+++ b/script/utils/viemScriptHelpers.ts
@@ -9,6 +9,7 @@ import readline from 'readline'
 
 import {
   applyTronGridViemTransportExtras,
+  formatAddressForNetworkCliDisplay,
   isTronNetworkKey,
 } from '@lifi/tron-devkit'
 import { consola } from 'consola'
@@ -104,9 +105,10 @@ export const buildExplorerAddressUrl = (
   // Handle special explorers that do NOT follow the default /address/<address> pattern.
   // This list can be extended over time as we discover exceptions.
   switch (network.verificationType) {
-    // Tron-style explorers – use /#/address/<address>
+    // Tron-style explorers – use /#/address/<address> with base58 address
     case 'tronscan': {
-      return `${base}/#/address/${addr}`
+      const tronAddr = formatAddressForNetworkCliDisplay(networkId, addr)
+      return `${base}/#/address/${tronAddr}`
     }
 
     // Sourcify-style explorer (Ronin) – contract details live under /address/<address>
@@ -142,7 +144,8 @@ export const buildExplorerContractPageUrl = (
 
   // TronScan contract tab: /#/contract/<address>/code (not /#/address/...#code).
   if (network.verificationType === 'tronscan') {
-    return `${base}/#/contract/${address}/code`
+    const tronAddr = formatAddressForNetworkCliDisplay(networkId, address)
+    return `${base}/#/contract/${tronAddr}/code`
   }
 
   const addressUrl = buildExplorerAddressUrl(networkId, address)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-376

# Why did I implement it this way?

`buildExplorerAddressUrl` and `buildExplorerContractPageUrl` in `viemScriptHelpers.ts` were passing the raw EVM hex address directly into TronScan URLs (e.g. `https://tronscan.org/#/address/0xc6594cd...`). TronScan expects base58 addresses (`T...`), so the links were technically functional but inconsistent with how TronScan displays addresses and could confuse operators. The fix calls `formatAddressForNetworkCliDisplay` (already available from `@lifi/tron-devkit`) in the `tronscan` switch case before constructing the URL — no new dependency, no API change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>