### PR TITLE
fix(scripts): route Tron mainnet whitelist sync through the Timelock

### DIFF
--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -221,7 +221,7 @@ function diamondSyncWhitelist {
   function getTimelockFlag {
     local NET="$1"
     local ENV="$2"
-    if [[ "$ENV" == "production" && "$SEND_PROPOSALS_DIRECTLY_TO_DIAMOND" != "true" ]] && ! isTronNetwork "$NET" && ! isTestnetNetwork "$NET"; then
+    if [[ "$ENV" == "production" && "$SEND_PROPOSALS_DIRECTLY_TO_DIAMOND" != "true" ]] && ! isTestnetNetwork "$NET"; then
       echo "true"
     else
       echo "false"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — fixes the on-chain submission path for Tron whitelist sync (root cause of the FeeForwarder allowlist update reverting). Companion to #1872 (address-conversion fix) and #1873 (whitelist address update).

# Why did I implement it this way?

`getTimelockFlag` in `diamondSyncWhitelist.sh` excluded **all** Tron networks from the timelock flow (`! isTronNetwork`). On Tron production this made the sync propose a **direct Safe → Diamond** call.

But the Tron Diamond (`TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt`) is owned by the **LiFiTimelockController** (`TBzBFjsCh3LJh9avAKy9oF3StZMn4hUBhu`), not the Safe (`TG7unADV9rXUNzH1Q1FkEnqhQ3xxJdXeBs`). `batchSetContractSelectorWhitelist` is owner-gated, and the Safe is neither the owner nor holds a `LibAccess` grant (`addressCanExecuteMethod(0x1171c007, Safe)` = `false`). So the inner call reverts and the Safe `execTransaction` fails with **GS013** (signatures valid + threshold met, but inner call reverted — verified against `safe/Safe_flattened.sol:1204`).

Observed on the two failed Safe txs when scheduling the FeeForwarder add/remove:
- `6896141aaf2708b42b11aee514e6fd0b811c15e6480fae3fa1efbfaf05de7a9f` — removal, **GS013**
- `1a5f637c2db6709095563a8e6f25d04f7ddebc29ab014a6fe24076b39ed3c8d7` — addition, GS026

The Tron carve-out predated the ownership transfer to the Timelock (`script/deploy/tron/transfer-ownership-to-timelock.ts`) and is now stale.

**Fix:** drop `! isTronNetwork "$NET"` from the predicate. Tron mainnet production now sets `TIMELOCK_FLAG=true`, which `propose-to-safe-tron.ts` honours via `--timelock` — wrapping the call as `Safe → Timelock.scheduleBatch → execute → Diamond`. `tronshasta` is unaffected: it is typed `testnet` in `networks.json`, so the existing `! isTestnetNetwork` guard keeps it on the direct path. The downstream routing (`sendOrPropose` → `propose-to-safe-tron.ts --timelock`) already supports this; only the flag was wrong.

Verified the predicate in isolation across the cases: tron-mainnet/prod → true, tronshasta/prod → false, evm-mainnet/prod → true, staging → false, `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true` → false.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>