### PR TITLE
fix(safe): reconcile orphaned submitted Safe-tx rows at startup

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -23,6 +23,7 @@ import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 import type { ILedgerAccountResult } from './ledger'
 import {
   reconcileAllSubmittedSafeTxs,
+  reconcileCoverageKey,
   reconcileSubmittedSafeTxs,
 } from './reconcile'
 import {
@@ -68,9 +69,10 @@ const globalTimeoutExecutions: Array<{
   error: string
 }> = []
 
-// Networks whose `submitted` rows were resolved by the startup reconcile sweep.
-// Used to skip the redundant per-network reconcile inside processTxs.
-const startupReconciledNetworks = new Set<string>()
+// `reconcileCoverageKey` values for each Safe whose `submitted` rows were
+// resolved by the startup reconcile sweep. Used to skip the redundant in-loop
+// reconcile inside processTxs — per Safe, not per network.
+const startupReconciledKeys = new Set<string>()
 
 // Quickfix to allow BigInt printing https://stackoverflow.com/a/70315718
 ;(BigInt.prototype as unknown as Record<string, unknown>).toJSON = function () {
@@ -324,7 +326,9 @@ const processTxs = async (
   const networkKey = network.toLowerCase()
   if (
     !isTronNetworkKey(network) &&
-    !startupReconciledNetworks.has(networkKey)
+    !startupReconciledKeys.has(
+      reconcileCoverageKey(networkKey, chain.id, safeAddress)
+    )
   ) {
     try {
       await reconcileSubmittedSafeTxs(
@@ -872,9 +876,11 @@ const main = defineCommand({
       try {
         const reconciled = await reconcileAllSubmittedSafeTxs(
           pendingTransactions,
-          args.network ? { network: args.network } : undefined
+          args.network
+            ? { network: args.network, rpcUrl: args.rpcUrl }
+            : undefined
         )
-        reconciled.forEach((n) => startupReconciledNetworks.add(n))
+        reconciled.forEach((k) => startupReconciledKeys.add(k))
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error)
         consola.warn(`Startup reconcile sweep failed: ${errorMsg}`)

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -21,7 +21,10 @@ import { buildExplorerAddressUrl } from '../../utils/viemScriptHelpers'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import type { ILedgerAccountResult } from './ledger'
-import { reconcileSubmittedSafeTxs } from './reconcile'
+import {
+  reconcileAllSubmittedSafeTxs,
+  reconcileSubmittedSafeTxs,
+} from './reconcile'
 import {
   formatDecodedTxDataForDisplay,
   getTargetName,
@@ -64,6 +67,10 @@ const globalTimeoutExecutions: Array<{
   safeTxHash: string
   error: string
 }> = []
+
+// Networks whose `submitted` rows were resolved by the startup reconcile sweep.
+// Used to skip the redundant per-network reconcile inside processTxs.
+const startupReconciledNetworks = new Set<string>()
 
 // Quickfix to allow BigInt printing https://stackoverflow.com/a/70315718
 ;(BigInt.prototype as unknown as Record<string, unknown>).toJSON = function () {
@@ -315,7 +322,10 @@ const processTxs = async (
   // the Safe's ExecutionSuccess/ExecutionFailure logs when a nonce gap is
   // detected. Read-only on-chain — failures are warnings, not throws.
   const networkKey = network.toLowerCase()
-  if (!isTronNetworkKey(network)) {
+  if (
+    !isTronNetworkKey(network) &&
+    !startupReconciledNetworks.has(networkKey)
+  ) {
     try {
       await reconcileSubmittedSafeTxs(
         pendingTransactions,
@@ -854,6 +864,21 @@ const main = defineCommand({
       // Connect to MongoDB early to use it for network detection
       const { client: mongoClient, pendingTransactions } =
         await getSafeMongoCollection()
+
+      // Resolve in-flight `submitted` rows across all networks before the
+      // pending-only selection runs. A network whose only row is `submitted`
+      // (no sibling `pending` proposal) is otherwise never reconciled, so its
+      // timelock op is never enqueued for auto-execution. Read-only on-chain.
+      try {
+        const reconciled = await reconcileAllSubmittedSafeTxs(
+          pendingTransactions,
+          args.network ? { network: args.network } : undefined
+        )
+        reconciled.forEach((n) => startupReconciledNetworks.add(n))
+      } catch (error: unknown) {
+        const errorMsg = error instanceof Error ? error.message : String(error)
+        consola.warn(`Startup reconcile sweep failed: ${errorMsg}`)
+      }
 
       // Get signer address early (needed for filtering actionable networks)
       let signerAddress: Address

--- a/script/deploy/safe/reconcile.test.ts
+++ b/script/deploy/safe/reconcile.test.ts
@@ -30,6 +30,7 @@ import {
 } from 'viem'
 
 import {
+  reconcileAllSubmittedSafeTxs,
   reconcileSubmittedSafeTxs,
   RECONCILE_LOOKBACK_BLOCKS,
   SUBMITTED_GRACE_MS,
@@ -1040,5 +1041,162 @@ describe('reconcileSubmittedSafeTxs — timelock enqueue plumbing', () => {
     )
 
     expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('reconcileAllSubmittedSafeTxs — startup sweep across networks', () => {
+  function submittedRow(
+    network: string,
+    chainId: number,
+    executionHash: Hex,
+    overrides: Partial<ISafeTxDocument> = {}
+  ): ISafeTxDocument {
+    return buildRow({
+      network,
+      chainId,
+      safeAddress: SAFE_ADDR,
+      status: 'submitted',
+      executionHash,
+      submittedAt: new Date(),
+      safeTxHash: executionHash,
+      ...overrides,
+    })
+  }
+
+  it('reconciles a network whose only row is submitted (no pending sibling)', async () => {
+    const execHash = ('0x' + 'c1'.repeat(32)) as Hex
+    const calldata = ('0x' + 'a1'.repeat(36)) as Hex
+    const target = ('0x' + '12'.repeat(20)) as Address
+    const collection = createFakeCollection([
+      submittedRow('base', 8453, execHash, {
+        safeTx: {
+          data: {
+            to: target,
+            value: 0n,
+            data: calldata,
+            operation: 0,
+            nonce: 4n,
+          },
+          signatures: new Map(),
+        } as ISafeTransaction,
+      }),
+    ])
+    const client = createFakeClient({ receipts: { [execHash]: 'success' } })
+    const enqueueSpy = mock(noopEnqueueImpl)
+    const factoryCalls: string[] = []
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      publicClientFactory: (network) => {
+        factoryCalls.push(network)
+        return client
+      },
+      readSafeNonce: async () => 5n,
+      enqueueTimelockOpFn: enqueueSpy,
+    })
+
+    expect(factoryCalls).toEqual(['base'])
+    expect([...covered]).toEqual(['base'])
+    expect(collection.rows[0]?.status).toBe('executed')
+    expect(enqueueSpy).toHaveBeenCalledTimes(1)
+    expect(enqueueSpy.mock.calls[0]).toEqual([
+      calldata,
+      target,
+      execHash,
+      execHash,
+      8453,
+      'base',
+    ])
+  })
+
+  it('honors the network filter and sweeps only the named network', async () => {
+    const hashBase = ('0x' + 'b1'.repeat(32)) as Hex
+    const hashOp = ('0x' + 'b2'.repeat(32)) as Hex
+    const collection = createFakeCollection([
+      submittedRow('base', 8453, hashBase),
+      submittedRow('optimism', 10, hashOp),
+    ])
+    const client = createFakeClient({
+      receipts: { [hashBase]: 'success', [hashOp]: 'success' },
+    })
+    const factoryCalls: string[] = []
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      network: 'base',
+      publicClientFactory: (network) => {
+        factoryCalls.push(network)
+        return client
+      },
+      readSafeNonce: async () => 1n,
+      enqueueTimelockOpFn: mock(noopEnqueueImpl),
+    })
+
+    expect(factoryCalls).toEqual(['base'])
+    expect([...covered]).toEqual(['base'])
+    expect(collection.rows.find((r) => r.network === 'optimism')?.status).toBe(
+      'submitted'
+    )
+  })
+
+  it('skips Tron networks without building a client or touching the row', async () => {
+    const execHash = ('0x' + 'd1'.repeat(32)) as Hex
+    const collection = createFakeCollection([
+      submittedRow('tron', 728_126_428, execHash),
+    ])
+    const factoryCalls: string[] = []
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      publicClientFactory: (network) => {
+        factoryCalls.push(network)
+        return createFakeClient()
+      },
+      readSafeNonce: async () => 1n,
+    })
+
+    expect(factoryCalls).toEqual([])
+    expect([...covered]).toEqual([])
+    expect(collection.rows[0]?.status).toBe('submitted')
+  })
+
+  it('continues past a network whose client construction fails', async () => {
+    const hashBase = ('0x' + 'e1'.repeat(32)) as Hex
+    const hashOp = ('0x' + 'e2'.repeat(32)) as Hex
+    const collection = createFakeCollection([
+      submittedRow('base', 8453, hashBase),
+      submittedRow('optimism', 10, hashOp),
+    ])
+    const okClient = createFakeClient({ receipts: { [hashOp]: 'success' } })
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      publicClientFactory: (network) => {
+        if (network === 'base') throw new Error('rpc down')
+        return okClient
+      },
+      readSafeNonce: async () => 1n,
+      enqueueTimelockOpFn: mock(noopEnqueueImpl),
+    })
+
+    expect([...covered]).toEqual(['optimism'])
+    expect(collection.rows.find((r) => r.network === 'optimism')?.status).toBe(
+      'executed'
+    )
+    expect(collection.rows.find((r) => r.network === 'base')?.status).toBe(
+      'submitted'
+    )
+  })
+
+  it('returns an empty set when there are no submitted rows', async () => {
+    const collection = createFakeCollection([buildRow({ status: 'pending' })])
+    const factoryCalls: string[] = []
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      publicClientFactory: (network) => {
+        factoryCalls.push(network)
+        return createFakeClient()
+      },
+      readSafeNonce: async () => 0n,
+    })
+
+    expect([...covered]).toEqual([])
+    expect(factoryCalls).toEqual([])
   })
 })

--- a/script/deploy/safe/reconcile.test.ts
+++ b/script/deploy/safe/reconcile.test.ts
@@ -31,6 +31,7 @@ import {
 
 import {
   reconcileAllSubmittedSafeTxs,
+  reconcileCoverageKey,
   reconcileSubmittedSafeTxs,
   RECONCILE_LOOKBACK_BLOCKS,
   SUBMITTED_GRACE_MS,
@@ -1095,7 +1096,9 @@ describe('reconcileAllSubmittedSafeTxs — startup sweep across networks', () =>
     })
 
     expect(factoryCalls).toEqual(['base'])
-    expect([...covered]).toEqual(['base'])
+    expect([...covered]).toEqual([
+      reconcileCoverageKey('base', 8453, SAFE_ADDR),
+    ])
     expect(collection.rows[0]?.status).toBe('executed')
     expect(enqueueSpy).toHaveBeenCalledTimes(1)
     expect(enqueueSpy.mock.calls[0]).toEqual([
@@ -1131,7 +1134,9 @@ describe('reconcileAllSubmittedSafeTxs — startup sweep across networks', () =>
     })
 
     expect(factoryCalls).toEqual(['base'])
-    expect([...covered]).toEqual(['base'])
+    expect([...covered]).toEqual([
+      reconcileCoverageKey('base', 8453, SAFE_ADDR),
+    ])
     expect(collection.rows.find((r) => r.network === 'optimism')?.status).toBe(
       'submitted'
     )
@@ -1175,11 +1180,44 @@ describe('reconcileAllSubmittedSafeTxs — startup sweep across networks', () =>
       enqueueTimelockOpFn: mock(noopEnqueueImpl),
     })
 
-    expect([...covered]).toEqual(['optimism'])
+    expect([...covered]).toEqual([
+      reconcileCoverageKey('optimism', 10, SAFE_ADDR),
+    ])
     expect(collection.rows.find((r) => r.network === 'optimism')?.status).toBe(
       'executed'
     )
     expect(collection.rows.find((r) => r.network === 'base')?.status).toBe(
+      'submitted'
+    )
+  })
+
+  it('tracks coverage per Safe — a sibling Safe failure is not masked by a success', async () => {
+    const SAFE_A = ('0x' + '1a'.repeat(20)) as Address
+    const SAFE_B = ('0x' + '2b'.repeat(20)) as Address
+    const hashA = ('0x' + 'f1'.repeat(32)) as Hex
+    const hashB = ('0x' + 'f2'.repeat(32)) as Hex
+    const collection = createFakeCollection([
+      submittedRow('base', 8453, hashA, { safeAddress: SAFE_A }),
+      submittedRow('base', 8453, hashB, { safeAddress: SAFE_B }),
+    ])
+    const client = createFakeClient({ receipts: { [hashA]: 'success' } })
+
+    const covered = await reconcileAllSubmittedSafeTxs(collection, {
+      publicClientFactory: () => client,
+      readSafeNonce: async (_c, addr) => {
+        if (addr === SAFE_B) throw new Error('nonce read failed')
+        return 5n
+      },
+      enqueueTimelockOpFn: mock(noopEnqueueImpl),
+    })
+
+    // Only Safe A's key is covered; Safe B's failure is isolated per Safe,
+    // not masked by the same-network success.
+    expect([...covered]).toEqual([reconcileCoverageKey('base', 8453, SAFE_A)])
+    expect(collection.rows.find((r) => r.safeAddress === SAFE_A)?.status).toBe(
+      'executed'
+    )
+    expect(collection.rows.find((r) => r.safeAddress === SAFE_B)?.status).toBe(
       'submitted'
     )
   })

--- a/script/deploy/safe/reconcile.ts
+++ b/script/deploy/safe/reconcile.ts
@@ -35,7 +35,7 @@ import {
 
 import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
 
-import { SAFE_EVENTS_ABI } from './config'
+import { SAFE_EVENTS_ABI, SAFE_SINGLETON_ABI } from './config'
 import type { ISafeTxDocument } from './safe-utils'
 import { enqueueTimelockOpIfApplicable } from './timelock-queue'
 
@@ -152,17 +152,6 @@ export async function reconcileSubmittedSafeTxs(
   return result
 }
 
-/** Minimal ABI for reading a Safe's current nonce. */
-const SAFE_NONCE_ABI = [
-  {
-    type: 'function',
-    name: 'nonce',
-    stateMutability: 'view',
-    inputs: [],
-    outputs: [{ type: 'uint256' }],
-  },
-] as const
-
 export interface IReconcileAllOptions extends IReconcileOptions {
   /**
    * Restrict the sweep to a single network. Sweeps every network with
@@ -197,9 +186,9 @@ async function defaultReadSafeNonce(
 ): Promise<bigint> {
   return client.readContract({
     address: safeAddress,
-    abi: SAFE_NONCE_ABI,
+    abi: SAFE_SINGLETON_ABI,
     functionName: 'nonce',
-  }) as Promise<bigint>
+  })
 }
 
 /**

--- a/script/deploy/safe/reconcile.ts
+++ b/script/deploy/safe/reconcile.ts
@@ -159,8 +159,15 @@ export interface IReconcileAllOptions extends IReconcileOptions {
    */
   network?: string
   /**
+   * RPC URL override for the read-only client. Honored only by the default
+   * client factory and only meaningful for a single-network sweep (one URL
+   * cannot serve every chain); ignored when `publicClientFactory` is supplied.
+   */
+  rpcUrl?: string
+  /**
    * Builds a read-only public client for a network. Injectable for tests;
-   * defaults to a viem client using the RPC from `networks.json`.
+   * defaults to a viem client using `rpcUrl` when set, else the RPC from
+   * `networks.json`.
    */
   publicClientFactory?: (network: string) => PublicClient
   /**
@@ -173,13 +180,15 @@ export interface IReconcileAllOptions extends IReconcileOptions {
   ) => Promise<bigint>
 }
 
-function defaultPublicClientFactory(network: string): PublicClient {
+/** Builds a read-only viem client for a network, honoring an optional RPC override. */
+function buildReadOnlyClient(network: string, rpcUrl?: string): PublicClient {
   return createPublicClient({
     chain: getViemChainForNetworkName(network),
-    transport: http(),
+    transport: http(rpcUrl),
   }) as PublicClient
 }
 
+/** Reads a Safe's current on-chain nonce via the standard `nonce()` view. */
 async function defaultReadSafeNonce(
   client: PublicClient,
   safeAddress: Address
@@ -189,6 +198,25 @@ async function defaultReadSafeNonce(
     abi: SAFE_SINGLETON_ABI,
     functionName: 'nonce',
   })
+}
+
+/**
+ * Coverage key identifying a single Safe on a chain. Producers and consumers of
+ * the startup-sweep coverage set MUST use this so an in-loop reconcile is
+ * skipped only for the exact `(network, chainId, safeAddress)` that was swept —
+ * never for a sibling Safe on the same network.
+ *
+ * @param network - Network name (case-insensitive).
+ * @param chainId - Chain ID.
+ * @param safeAddress - Safe address (case-insensitive).
+ * @returns A normalized composite key.
+ */
+export function reconcileCoverageKey(
+  network: string,
+  chainId: number,
+  safeAddress: Address
+): string {
+  return `${network.toLowerCase()}:${chainId}:${safeAddress.toLowerCase()}`
 }
 
 /**
@@ -202,20 +230,21 @@ async function defaultReadSafeNonce(
  * in-loop reconcile for any returned network.
  *
  * A network can host more than one Safe, so rows are grouped by
- * `(network, chainId, safeAddress)` and reconciled per group. Per-network
+ * `(network, chainId, safeAddress)` and reconciled per group. Per-group
  * failures are logged and skipped so one unreachable RPC cannot abort the run.
  * Read-only on-chain; writes only to MongoDB; does not require Safe ownership.
  *
  * @param pendingTransactions - Safe tx collection.
  * @param options - Optional network filter and injectable client/nonce/enqueue seams.
- * @returns Lowercased network keys that were successfully swept.
+ * @returns `reconcileCoverageKey` values for each Safe that was successfully swept.
  */
 export async function reconcileAllSubmittedSafeTxs(
   pendingTransactions: Collection<ISafeTxDocument>,
   options?: IReconcileAllOptions
 ): Promise<Set<string>> {
   const clientFactory =
-    options?.publicClientFactory ?? defaultPublicClientFactory
+    options?.publicClientFactory ??
+    ((network: string) => buildReadOnlyClient(network, options?.rpcUrl))
   const nonceReader = options?.readSafeNonce ?? defaultReadSafeNonce
   const networkFilter = options?.network?.toLowerCase()
 
@@ -231,17 +260,14 @@ export async function reconcileAllSubmittedSafeTxs(
     const network = row.network.toLowerCase()
     if (networkFilter && network !== networkFilter) continue
     if (isTronNetworkKey(network)) continue
-    const key = `${network}:${row.chainId}:${row.safeAddress}`
+    const safeAddress = row.safeAddress as Address
+    const key = reconcileCoverageKey(network, row.chainId, safeAddress)
     if (!groups.has(key))
-      groups.set(key, {
-        network,
-        chainId: row.chainId,
-        safeAddress: row.safeAddress as Address,
-      })
+      groups.set(key, { network, chainId: row.chainId, safeAddress })
   }
 
   const covered = new Set<string>()
-  for (const { network, chainId, safeAddress } of groups.values())
+  for (const [key, { network, chainId, safeAddress }] of groups)
     try {
       const client = clientFactory(network)
       const onChainNonce = await nonceReader(client, safeAddress)
@@ -254,7 +280,7 @@ export async function reconcileAllSubmittedSafeTxs(
         onChainNonce,
         options
       )
-      covered.add(network)
+      covered.add(key)
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       consola.warn(`[${network}] Startup reconcile failed: ${errorMsg}`)

--- a/script/deploy/safe/reconcile.ts
+++ b/script/deploy/safe/reconcile.ts
@@ -24,12 +24,16 @@ import { isTronNetworkKey } from '@lifi/tron-devkit'
 import { consola } from 'consola'
 import { type Collection } from 'mongodb'
 import {
+  createPublicClient,
   decodeEventLog,
+  http,
   TransactionReceiptNotFoundError,
   type Address,
   type Hex,
   type PublicClient,
 } from 'viem'
+
+import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
 
 import { SAFE_EVENTS_ABI } from './config'
 import type { ISafeTxDocument } from './safe-utils'
@@ -146,6 +150,128 @@ export async function reconcileSubmittedSafeTxs(
   )
 
   return result
+}
+
+/** Minimal ABI for reading a Safe's current nonce. */
+const SAFE_NONCE_ABI = [
+  {
+    type: 'function',
+    name: 'nonce',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+export interface IReconcileAllOptions extends IReconcileOptions {
+  /**
+   * Restrict the sweep to a single network. Sweeps every network with
+   * `submitted` rows when omitted.
+   */
+  network?: string
+  /**
+   * Builds a read-only public client for a network. Injectable for tests;
+   * defaults to a viem client using the RPC from `networks.json`.
+   */
+  publicClientFactory?: (network: string) => PublicClient
+  /**
+   * Reads the Safe's on-chain nonce. Injectable for tests; defaults to a
+   * `nonce()` contract read.
+   */
+  readSafeNonce?: (
+    client: PublicClient,
+    safeAddress: Address
+  ) => Promise<bigint>
+}
+
+function defaultPublicClientFactory(network: string): PublicClient {
+  return createPublicClient({
+    chain: getViemChainForNetworkName(network),
+    transport: http(),
+  }) as PublicClient
+}
+
+async function defaultReadSafeNonce(
+  client: PublicClient,
+  safeAddress: Address
+): Promise<bigint> {
+  return client.readContract({
+    address: safeAddress,
+    abi: SAFE_NONCE_ABI,
+    functionName: 'nonce',
+  }) as Promise<bigint>
+}
+
+/**
+ * Reconciles every network that has `submitted` Safe-tx rows, independent of
+ * the pending-only network selection in confirm-safe-tx.
+ *
+ * Closes the gap where a network whose only row is `submitted` (no sibling
+ * `pending` proposal) is never passed to `reconcileSubmittedSafeTxs` and stays
+ * stuck — its timelock op never enqueued for auto-execution. Each group runs
+ * the full reconcile (Sweep A + Sweep B), so the caller may skip a redundant
+ * in-loop reconcile for any returned network.
+ *
+ * A network can host more than one Safe, so rows are grouped by
+ * `(network, chainId, safeAddress)` and reconciled per group. Per-network
+ * failures are logged and skipped so one unreachable RPC cannot abort the run.
+ * Read-only on-chain; writes only to MongoDB; does not require Safe ownership.
+ *
+ * @param pendingTransactions - Safe tx collection.
+ * @param options - Optional network filter and injectable client/nonce/enqueue seams.
+ * @returns Lowercased network keys that were successfully swept.
+ */
+export async function reconcileAllSubmittedSafeTxs(
+  pendingTransactions: Collection<ISafeTxDocument>,
+  options?: IReconcileAllOptions
+): Promise<Set<string>> {
+  const clientFactory =
+    options?.publicClientFactory ?? defaultPublicClientFactory
+  const nonceReader = options?.readSafeNonce ?? defaultReadSafeNonce
+  const networkFilter = options?.network?.toLowerCase()
+
+  const submittedRows = await pendingTransactions
+    .find({ status: { $eq: 'submitted' } })
+    .toArray()
+
+  const groups = new Map<
+    string,
+    { network: string; chainId: number; safeAddress: Address }
+  >()
+  for (const row of submittedRows) {
+    const network = row.network.toLowerCase()
+    if (networkFilter && network !== networkFilter) continue
+    if (isTronNetworkKey(network)) continue
+    const key = `${network}:${row.chainId}:${row.safeAddress}`
+    if (!groups.has(key))
+      groups.set(key, {
+        network,
+        chainId: row.chainId,
+        safeAddress: row.safeAddress as Address,
+      })
+  }
+
+  const covered = new Set<string>()
+  for (const { network, chainId, safeAddress } of groups.values())
+    try {
+      const client = clientFactory(network)
+      const onChainNonce = await nonceReader(client, safeAddress)
+      await reconcileSubmittedSafeTxs(
+        pendingTransactions,
+        client,
+        network,
+        chainId,
+        safeAddress,
+        onChainNonce,
+        options
+      )
+      covered.add(network)
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      consola.warn(`[${network}] Startup reconcile failed: ${errorMsg}`)
+    }
+
+  return covered
 }
 
 /**


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-380

# Why did I implement it this way?

`reconcileSubmittedSafeTxs` already promotes a `submitted` row to `executed` and enqueues its timelock op (Sweep A) — but it was only ever called inside `processTxs`, which runs only for networks the pending-only selection queries return. A network whose sole row is `submitted` (no sibling `pending` proposal) was filtered out before reconcile could touch it, so the row stayed stuck and its timelock op was never enqueued for auto-execution. This is what left mainnet and hyperevm un-executed after a recent 16-network `PolymerCCTPFacet` redeploy.

Rather than broaden the pending-only selection (which would drag submitted-only networks through `processTxs`'s owner checks and signing prompts), I added a dedicated startup sweep, `reconcileAllSubmittedSafeTxs`, that runs before the pending loop and is independent of selection. It groups `submitted` rows by `(network, chainId, safeAddress)`, builds a read-only public client per group (no signer or Safe ownership required, since reconcile is read-only on-chain and only writes MongoDB), and reuses the existing `reconcileSubmittedSafeTxs` (Sweep A + B) per group. The client / nonce / enqueue dependencies are injectable so the orchestrator is unit-testable without live RPC. Networks covered by the sweep are returned so `processTxs` skips the now-redundant in-loop reconcile. Per-network failures are logged and skipped so one unreachable RPC can't abort the whole run.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>