### PR TITLE
EXSC-301 Reconcile arc native asset, target state, healthcheck (follow-up to #1846)

### DIFF
--- a/config/networks.json
+++ b/config/networks.json
@@ -162,7 +162,7 @@
   "arc": {
     "name": "arc",
     "chainId": 5042,
-    "nativeAddress": "0x0000000000000000000000000000000000000000",
+    "nativeAddress": "0x3600000000000000000000000000000000000000",
     "nativeCurrency": "USDC",
     "wrappedNativeAddress": "0x0000000000000000000000000000000000000001",
     "status": "active",
@@ -178,7 +178,9 @@
     "deployedWithEvmVersion": "cancun",
     "deployedWithSolcVersion": "0.8.29",
     "create3Factory": "0xDe367507f70A1f57a7203bD7A88ced24A79fb53d",
-    "castSendAsync": true
+    "castSendAsync": true,
+    "devNotes": "Native gas asset is USDC, exposed via the ERC20 predeploy at 0x3600000000000000000000000000000000000000 (nativeAddress); wrappedNativeAddress is a dummy because the native path is not activated. TokenWrapper is intentionally not deployed (nothing to wrap) and GasZip is unsupported at launch, so the automated periphery healthcheck cannot pass: skipHealthcheck is set and the healthcheck is run manually before merge to verify deployed addresses.",
+    "skipHealthcheck": true
   },
   "avalanche": {
     "name": "avalanche",

--- a/script/deploy/_targetState.json
+++ b/script/deploy/_targetState.json
@@ -2483,7 +2483,6 @@
         "Executor": "2.1.0",
         "FeeForwarder": "1.0.0",
         "GasZipPeriphery": "1.0.2",
-        "TokenWrapper": "1.2.1",
         "Permit2Proxy": "1.0.4",
         "PolymerCCTPFacet": "2.1.0"
       }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-301 (follow-up). Resolves review feedback on #1846, which deploys the Arc mainnet core setup. Stacked on top of `feature/exsc-301-sc-deploy-sc-core-setup` so it merges into that branch.

# Why did I implement it this way?

Three config corrections raised in review of #1846 that were discussed but not yet committed:

- **`arc.nativeAddress` → `0x3600000000000000000000000000000000000000`.** Arc's native gas asset is USDC, exposed via the ERC20 predeploy at `0x36…00`. This matches `arctestnet.nativeAddress` and the `arc.usdc` address already set in `config/polymercctp.json`. The native path is not activated (`wrappedNativeAddress` is a dummy `0x…01`), consistent with the testnet sibling.
- **Removed `TokenWrapper 1.2.1` from `arc` target state.** With USDC as the native gas asset there is nothing to wrap, so TokenWrapper is not deployed (and is empty in `arc.diamond.json`). Keeping it in target state created a permanent phantom target. `GasZipFacet`/`GasZipPeriphery` are intentionally kept — GasZip is planned (not live at launch), and its healthcheck checks are already auto-skipped while `gasZipChainId` is `0`.
- **Added `skipHealthcheck: true` + `devNotes` to the `arc` entry.** The periphery deploy-status check (`script/deploy/healthCheck.ts`) iterates `getCorePeriphery()` and flags `TokenWrapper` as not deployed; it only auto-skips `GasZipPeriphery`/`LiFiTimelockController`, so arc cannot pass otherwise. `tempo` is the existing precedent. Per the flag's own guidance, the healthcheck is still run manually before merge.

**Out of scope (operational, not a code change):** the "Executor is not authorized in ERC20Proxy" finding is on-chain state — it requires `setAuthorizedCaller(Executor, true)` from the ERC20Proxy owner (refundWallet), not a diff. It is being handled separately by ops and must be completed before Arc goes live. Note that `skipHealthcheck` will mask this from CI, so it is tracked here explicitly.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
