### PR TITLE
docs(post-pr-for-review): make audit checks non-blocking for posting

### DIFF
--- a/.agents/commands/post-pr-for-review.md
+++ b/.agents/commands/post-pr-for-review.md
@@ -70,7 +70,9 @@ Two blocking checks plus one workflow branch:
 
   Group by author; CodeRabbit is `coderabbitai` / `coderabbitai[bot]`.
 
-- **Failing CI** (blocking, `gh pr checks <N>`): block on `FAILURE` / `CANCELLED` / `TIMED_OUT` / `ACTION_REQUIRED`. Ignore any check whose name ends in `(pull_request_review)` — those are review-gated workflows that haven't fired yet; posting is what triggers them, so blocking would be circular. Match on the suffix only — `version-control`, `audit-verification`, and some `protect-*` checks appear in both push and `(pull_request_review)` forms; only the latter is exempt. Surface unfamiliar checks; don't silently widen the allowlist.
+- **Failing CI** (blocking, `gh pr checks <N>`): block on `FAILURE` / `CANCELLED` / `TIMED_OUT` / `ACTION_REQUIRED`. Ignore any check whose name ends in `(pull_request_review)` — those are review-gated workflows that haven't fired yet; posting is what triggers them, so blocking would be circular. Match on the suffix only — `version-control` and some `protect-*` checks appear in both push and `(pull_request_review)` forms; only the latter is exempt. Surface unfamiliar checks; don't silently widen the allowlist.
+
+- **Audit checks are NON-blocking** — a check matching `audit-verification` / `audit-*` reporting `FAILURE` (or pending) does NOT block posting, in either its push or `(pull_request_review)` form. LI.FI's flow is SC-team review *first*, then audit (Sujith): the PR is posted to `#dev-sc-review` precisely so reviewers can sign off before the audit is requested. If an audit check is red/pending, note it in a thread reply and still post. Continue to block on every non-audit failure.
 
 - **Draft status** (workflow branch) — if drafted, offer `gh pr ready <N>`; confirm first.
 

--- a/.agents/commands/post-pr-for-review.md
+++ b/.agents/commands/post-pr-for-review.md
@@ -72,7 +72,7 @@ Two blocking checks plus one workflow branch:
 
 - **Failing CI** (blocking, `gh pr checks <N>`): block on `FAILURE` / `CANCELLED` / `TIMED_OUT` / `ACTION_REQUIRED`. Ignore any check whose name ends in `(pull_request_review)` — those are review-gated workflows that haven't fired yet; posting is what triggers them, so blocking would be circular. Match on the suffix only — `version-control` and some `protect-*` checks appear in both push and `(pull_request_review)` forms; only the latter is exempt. Surface unfamiliar checks; don't silently widen the allowlist.
 
-- **Audit checks are NON-blocking** — a check matching `audit-verification` / `audit-*` reporting `FAILURE` (or pending) does NOT block posting, in either its push or `(pull_request_review)` form. LI.FI's flow is SC-team review *first*, then audit (Sujith): the PR is posted to `#dev-sc-review` precisely so reviewers can sign off before the audit is requested. If an audit check is red/pending, note it in a thread reply and still post. Continue to block on every non-audit failure.
+- **Audit checks are NON-blocking** — a check matching `audit-verification` / `audit-*` reporting `FAILURE` (or pending) does NOT block posting, in either its push or `(pull_request_review)` form. LI.FI's flow is SC-team review *first*, then audit (Sujith): the PR is posted to `#dev-sc-review` precisely so reviewers can sign off before the audit is requested. Continue to block on every non-audit failure.
 
 - **Draft status** (workflow branch) — if drafted, offer `gh pr ready <N>`; confirm first.
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

<!-- No Linear task — trivial, doc-only change to a skill/command file. Suggest labelling `trivial`. -->

# Why did I implement it this way?

LI.FI's `request-audit` flow is review-first, audit-second: a PR is posted to `#dev-sc-review` for the SC team to sign off *before* the external audit (Sujith) is requested. The `post-pr-for-review` skill previously listed the `audit-verification` CI check among the blocking failures, which would stop a PR from being posted for review just because its audit hadn't happened yet — backwards for our process. This change makes audit checks (`audit-verification` / `audit-*`) non-blocking for posting, in both their push and `(pull_request_review)` forms, while still blocking on every non-audit failure, and updates the pre-flight wording to match.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>