### PR TITLE
feat(audit-knowledge): seed corpus + 39-audit backfill (EXP-479) [stack 2/5]

### DIFF
--- a/.agents/commands/extract-audit-knowledge.md
+++ b/.agents/commands/extract-audit-knowledge.md
@@ -117,14 +117,22 @@ For each in-scope finding:
 - **Existing finding** (some entry's `status_history` already references this `source_id`): append a new `status_history` row to that entry. Do NOT create a new `LF-NNN`. Update top-level `severity` only if the new appearance has higher severity than the recorded one
 - **Cross-audit echo** (same root cause appears in two audits under different `source_id`s): do NOT auto-merge. Log a warning to console; let the human decide via follow-up edit. Auto-merging is a future v2 enhancement
 
-### 8. Regenerate projections
+### 8. Record processing in `processed_audits`
+
+Append the audit's ID to `findings.json`'s top-level `processed_audits` array (schema 1.1+). This MUST happen even when zero findings were kept — the array records "we considered this audit", so the coverage check (`script/tasks/checkAuditKnowledgeCoverage.ts`) stops flagging zero-finding audits as drift.
+
+- Read `findings.json#processed_audits` (initialize to `[]` if missing)
+- If `audit_id` is not present, append it; keep the array sorted
+- If `audit_id` is already present (re-run), no-op (idempotent)
+
+### 9. Regenerate projections
 
 After `findings.json` is updated, regenerate the markdown surfaces:
 
 - **`lessons.md`** — totals tables + flat index of every finding
 - **`by-area/<area>.md`** — for each area that has at least one finding, write a file with all entries in that area, sorted severity-descending. Do not write files for areas with zero findings (downstream loaders should handle the missing file gracefully)
 
-### 9. Summary output
+### 10. Summary output
 
 Print to console:
 
@@ -142,6 +150,7 @@ Before finalizing the skill's output:
 - [ ] Every `source_id` is unique across the corpus
 - [ ] Every finding cites at least one page from the source PDF
 - [ ] No skipped categories slipped through (verify a sample)
+- [ ] `audit_id` appended to `findings.json#processed_audits` (Step 8) regardless of findings count
 - [ ] `lessons.md` totals match actual finding counts
 - [ ] `by-area/*.md` files contain only findings tagged with that area
 - [ ] `findings.json` is valid JSON (no trailing commas, well-formed strings)
@@ -151,8 +160,12 @@ Before finalizing the skill's output:
 
 ```jsonc
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "generated_at": "<ISO-8601 UTC>",
+  // Schema 1.1+: every audit_id we've considered (with or without findings).
+  // The coverage check uses this to distinguish "we looked and found nothing"
+  // from "we never looked". Sorted lexicographically; idempotent on re-run.
+  "processed_audits": ["audit20240201", "audit20240814", "audit20240902", ...],
   "findings": {
     "LF-001": {
       "id": "LF-001",

--- a/audit/knowledge/by-area/cross-cutting.md
+++ b/audit/knowledge/by-area/cross-cutting.md
@@ -1,0 +1,11 @@
+# Cross Cutting — past findings
+
+## LF-039 · LOW · GasZipFacet, GasZipPeriphery · acknowledged
+
+**Recognition signal:** Forwarding user-supplied amounts to an external partner that has documented input bounds, without enforcing those bounds in the smart contract layer.
+
+**Root cause:** Gas.zip documents per-chain deposit limits ($0.25-$50 USD), but neither GasZipFacet nor GasZipPeriphery enforces these bounds on-chain, so out-of-range amounts can reach the router and be rejected or behave unexpectedly off-chain.
+
+**Fix:** Acknowledged: limits are enforced at the LI.FI backend rather than on-chain.
+
+**Source:** `2025.01.10_Cantina_PreComp.pdf` p.5-5 · `audit20250110_1::3.2.1`

--- a/audit/knowledge/by-area/facets.md
+++ b/audit/knowledge/by-area/facets.md
@@ -1089,3 +1089,15 @@
 **Fix:** Acknowledged: LI.FI treats destinationCall=true as 'LI.FI-added destination calls only'; the Across swap API is treated as one opaque operation.
 
 **Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.10-12 · `audit20260409::6.5.3`
+
+---
+
+## LF-147 · INFO · LiFiIntentEscrowFacet · acknowledged
+
+**Recognition signal:** Facet-specific validateBridgeData modifier that checks receiver and minAmount but skips destinationChainId != 0, leaving a single field of BridgeData unvalidated at the facet entry.
+
+**Root cause:** The validateBridgeDataLiFiIntentEscrow() modifier only rejects a zero receiver and a zero minAmount, but does not check that _bridgeData.destinationChainId != 0. A malformed or misconfigured input can therefore pass facet-level validation with destinationChainId == 0, causing LiFiTransferStarted to be emitted with an invalid destination and any downstream off-chain routing to consume bad metadata.
+
+**Fix:** LI.FI acknowledged but declined to add the check to keep validateBridgeData modifiers consistent across facets (the check did not exist in the prior version). No code change landed.
+
+**Source:** `2026.02.05_LiFiIntentEscrowFacet(v1.0.1,v1.1.1).pdf` p.4-4 · `audit20260205::6.1.2`

--- a/audit/knowledge/by-area/facets.md
+++ b/audit/knowledge/by-area/facets.md
@@ -1,0 +1,1091 @@
+# Facets — past findings
+
+## LF-046 · HIGH · ChainflipFacet · fixed
+
+**Recognition signal:** Receiver address for a non-EVM destination chain stored or passed as fixed-size bytes32/address20 instead of variable-length bytes — silent truncation risks loss of funds or DoS on the destination chain.
+
+**Root cause:** ChainflipData.nonEVMReceiver is declared as bytes32 but Chainflip expects the bitcoin destination address as variable-length bytes (the SDK encodes 'tb1q…' as a >32-byte string). Forcing the address into a fixed 32-byte slot silently truncates it, so funds bridged to Bitcoin would be sent to a malformed address.
+
+**Fix:** Receiver parameter changed from bytes32 to bytes so the full non-EVM address can be passed through without truncation. Fixed in d623247e1dd21cc96111b47edabd04be09a1747d.
+
+**Source:** `2025.03.05_ChainflipFacet(v1.0.0).pdf` p.5-5 · `audit20250305::6.1.1`
+
+---
+
+## LF-135 · HIGH · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** A hard-coded chainId -> external-protocol-id table inside a facet without a corresponding exhaustive on-chain test, especially for less-popular chains or near-duplicate deployments.
+
+**Root cause:** Hard-coded chainId->LZ eid mappings used XDC eid 30136 (wrong; correct 30365) and Plume eid 30318 belonging to legacy Plume chainId 98865 rather than 98866 (correct 30370). The bad mapping mixes two distinct Plume deployments and would cause the OFT sponsored path's destination-chain validation either to reject valid quotes or accept ones targeting the wrong chain.
+
+**Fix:** Fixed in 8f46a81 by correcting both eids to 30365 (XDC) and 30370 (Plume).
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.4-4 · `audit20260409::6.1.1`
+
+---
+
+## LF-015 · MEDIUM · AcrossFacetV3 · acknowledged
+
+**Recognition signal:** Two parallel receiver / destination fields where the standard zero-address validation only covers the outer struct and is skipped (via a feature-flag branch) for the inner / bridge-specific field that is the actual on-chain recipient.
+
+**Root cause:** validateBridgeData enforces non-zero _bridgeData.receiver, but the bridge actually forwards _acrossData.receiverAddress. The cross-check `_bridgeData.receiver != _acrossData.receiverAddress` only runs when hasDestinationCall is false, so with destination calls enabled the across-side receiverAddress is never compared and can legitimately be zero, allowing a bridge to address(0) and a misleading event that still reports _bridgeData.receiver.
+
+**Fix:** Acknowledged but not patched; LI.FI considers guardrails sufficient and treats deliberate zero-address inputs as user error.
+
+**Source:** `2024.10.07_AcrossV3.pdf` p.4-4 · `audit20241007::6.1.1`
+
+---
+
+## LF-029 · MEDIUM · DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Facet validating an ILiFi.BridgeData field (e.g. receiver) via the shared modifier while actually consuming a parallel bridge-specific struct field for the same role, leaving the latter unchecked.
+
+**Root cause:** The validateBridgeData modifier checks _bridgeData.receiver != address(0), but the actual receiver passed to deBridge's createOrder comes from a separate _deBridgeData.receiver field. There is no sanity validation of _deBridgeData.receiver, so funds can be sent to address(0), where the resulting order also cannot be cancelled.
+
+**Fix:** Added validation for the _deBridgeData receiver/payload alongside the existing _bridgeData checks. Fixed in f561360dde2629e4ff624a87784bc01989b38bc6.
+
+**Source:** `2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf` p.4-4 · `audit20241205::6.1.1`
+
+---
+
+## LF-030 · MEDIUM · DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Bridge integration reusing the destination receiver address as the destination-chain order/cancellation authority, without considering that the receiver may be a contract incapable of making the required cancel call.
+
+**Root cause:** The facet sets orderAuthorityAddressDst = _deBridgeData.receiver. When the receiver is a smart contract that cannot make the destination-chain sendEvmOrderCancel call, no party can cancel an unfillable order, so funds get stuck until market conditions change (which may never happen).
+
+**Fix:** Added a separate orderAuthorityDst field to DeBridgeDlnData so callers can pick an EOA cancellation authority independent of the receiver. Fixed in 8bcb3927ebab0780cb54ba6306f7ecca2a09ff55.
+
+**Source:** `2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf` p.4-5 · `audit20241205::6.1.2`
+
+---
+
+## LF-033 · MEDIUM · AcrossFacetPackedV3 · fixed
+
+**Recognition signal:** Bridge facet hard-coding msg.sender into a destination-protocol role that later requires off-chain signing (ECDSA / EIP-712), without parameterizing that role for contract callers.
+
+**Root cause:** startBridgeTokensViaAcrossV3NativeMin / ERC20Min pass msg.sender as the depositor to spokePool.depositV3. Across's speedUpV3Deposit requires the depositor to ECDSA-sign a message, which a smart-contract msg.sender cannot do, leaving such deposits stuck without the speed-up escape hatch and giving inconsistent behavior across functions in the same facet.
+
+**Fix:** Added an explicit depositor parameter so non-EOA users can specify an EOA capable of signing speed-up messages. Fixed in 9a8ff404186a7df19d9dd5610a94b977bbfc233d.
+
+**Source:** `2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf` p.4-4 · `audit20241206::6.1.1`
+
+---
+
+## LF-088 · MEDIUM · MayanFacet · fixed
+
+**Recognition signal:** Receiver-extraction logic mapped per external selector that picks a positionally-convenient address parameter (e.g. trader/sender) as the receiver instead of decoding the destination from the protocol-specific payload struct.
+
+**Root cause:** When MayanFacet added support for Hypercore routes, the receiver decoder for the new deposit(0xe27dce37) and fastDeposit(0x4d1ed73b) selectors treats the third parameter (trader) as the destination receiver. The real receiver is inside the encoded depositPayload struct, so the receiver assertion will fail (or silently mismatch) when the user's sender differs from their destination wallet, causing permanent DoS for those flows.
+
+**Fix:** Updated the decoder to extract the receiver address from depositPayload for both new selectors. Fixed in commits 2e9eeda, 74a57f9, b1f7ea4.
+
+**Source:** `2025.08.25_MayanFacet(v1.2.2).pdf` p.4-4 · `audit20250825::6.1.1`
+
+---
+
+## LF-098 · MEDIUM · GardenFacet · fixed
+
+**Recognition signal:** Reusing the destination-chain receiver as the source-chain refund/initiator/owner in a cross-chain HTLC or escrow — same-address-different-chain control mismatches can let an unrelated party claim funds.
+
+**Root cause:** GardenFacet passes _bridgeData.receiver as the initiator parameter to Garden's HTLC initiateOnBehalf, which grants refund rights on the source chain after timelock expiry. The same address can be controlled by different parties on different chains (Safe with different owners, predictable CREATE deployments not yet deployed on source), so when a solver fails to redeem, whoever controls that address on the source chain can claim the refund.
+
+**Fix:** GardenData extended with an explicit refundAddress field used as initiator, decoupling source-chain refund rights from the destination-chain receiver. Fixed in 7431c2d25d1106cc03542a9a29248c57f2e0f457.
+
+**Source:** `2025.09.19_GardenFacet(v1.0.0).pdf` p.5-8 · `audit20250919::M-1`
+
+---
+
+## LF-111 · MEDIUM · EcoFacet · fixed
+
+**Recognition signal:** Bridge facet integrating with an external protocol whose funding/deposit entrypoint silently no-ops on a duplicate-state input rather than reverting, combined with a downstream sweep/leftover-refund mechanism that distributes the contract's full balance to the current caller.
+
+**Root cause:** Eco Protocol's Portal silently no-ops a second publishAndFund call for an already-funded intent (the onlyFundable modifier returns early without reverting), so a duplicate call to startBridgeTokensViaEco still pulls tokens from the user but never deposits them, leaving them in the diamond. SwapperV2's _refundLeftovers then sweeps the entire input-token balance to the next caller of swapAndStartBridge*, enabling theft of the trapped funds.
+
+**Fix:** Added IEcoPortal.getRewardStatus() query and a precomputed intent hash check inside _startBridge that reverts with IntentAlreadyFunded() if the intent is not in Initial status. Fixed in PR lifinance/contracts/pull/1421.
+
+**Source:** `2025.10.20_EcoFacet(v1.1.0).pdf` p.5-12 · `audit20251020::M-1`
+
+---
+
+## LF-112 · MEDIUM · EcoFacet · fixed
+
+**Recognition signal:** Bridge facet binding a downstream refund/cancellation beneficiary to msg.sender on the assumption the caller is the end user, ignoring legitimate intermediaries such as Permit2 proxies, batch routers, or integrator contracts.
+
+**Root cause:** EcoFacet hard-codes reward.creator to msg.sender when constructing the intent. When the caller is a relayer/proxy (Permit2Proxy) or an integrator contract rather than the end-user EOA, refunds for unfilled intents are delivered to that intermediate contract, where the actual user has no control over them.
+
+**Fix:** Added an explicit refundRecipient / intentCreator parameter to EcoData so the user can choose the address that receives refunds on intent expiry. Fixed in PR lifinance/contracts/pull/1421.
+
+**Source:** `2025.10.20_EcoFacet(v1.1.0).pdf` p.12-13 · `audit20251020::M-2`
+
+---
+
+## LF-136 · MEDIUM · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** Patching individual numeric fields of a routing struct on positive slippage while leaving an opaque bytes routerCalldata blob (generated for the pre-slippage amount) unmodified.
+
+**Root cause:** On positive slippage, _callSpokePoolPeripherySwapAndBridge scales outputAmount, minExpectedInputTokenAmount and swapTokenAmount, but forwards routerCalldata unchanged. The opaque router calldata was produced by the backend for the original (smaller) amount, so the periphery executes a swap whose parameters disagree with the upper-layer struct.
+
+**Fix:** Fixed in e6c6c82: switched to the sponsored-path strategy of bridging only the originally quoted amount and refunding the surplus to the user.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.4-4 · `audit20260409::6.2.1`
+
+---
+
+## LF-137 · MEDIUM · AcrossV4SwapFacet · acknowledged
+
+**Recognition signal:** Scaling an external quote's output amount linearly with input size when the underlying fee/liquidity curve is not actually linear.
+
+**Root cause:** SpokePool and SpokePoolPeriphery paths scale outputAmount linearly from the original quote ratio when positive slippage occurs. Across relayer fees and liquidity depth are not perfectly linear in input size, so the scaled outputAmount can exceed what any relayer is willing to fill, stranding funds until fillDeadline expires.
+
+**Fix:** Acknowledged: Across team confirmed proportional adjustment is their recommended approach; treated as approximately linear at these sizes. No change.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.5-5 · `audit20260409::6.2.2`
+
+---
+
+## LF-011 · LOW · CalldataVerificationFacet · fixed
+
+**Recognition signal:** Off-by-one length validation that uses strict-less-than (or strict-greater-than) where the minimum-valid case actually requires at least one byte beyond the fixed header, letting empty / zero-length variable-length tail fields slip through.
+
+**Root cause:** The function's sanity check (callData.length < 484) treats exactly 484 bytes as valid, but a 484-byte calldata corresponds to an empty inner callData inside SwapData. Decoders relying on this validation can therefore proceed with structurally invalid input and return zeroed or attacker-shaped parameters.
+
+**Fix:** Fixed in commit a4c2574f2f143dd732de02eeecb79db6c4864806 by changing the comparison to <= 484. Reviewer verified.
+
+**Source:** `2024.09.02_CalldataVerificationFacet.pdf` p.4-4 · `audit20240902::6.1.1`
+
+---
+
+## LF-012 · LOW · EmergencyPauseFacet · fixed
+
+**Recognition signal:** Admin recovery function takes a user-supplied list of components to exclude from re-activation without protecting the bootstrap/upgrade component itself, allowing a single misconfigured call to permanently disable upgrades.
+
+**Root cause:** The unpauseDiamond function accepts an arbitrary blacklist of facets to skip when re-adding selectors, but does not exclude the DiamondCutFacet from this blacklist. Because DiamondCutFacet is the only path to add/remove facets, blacklisting it bricks all future upgrades — including re-adding any facet — and there is no safeguard or warning at the function boundary.
+
+**Fix:** Fixed in 7709442ae76b0209a93c732c412fcb444216c618 by skipping DiamondCutFacet selectors during the unpause loop.
+
+**Source:** `2024.09.13_EmergencyPauseFacet.pdf` p.5-5 · `audit20240913::6.1.1`
+
+---
+
+## LF-013 · LOW · EmergencyPauseFacet · fixed
+
+**Recognition signal:** Lower-privilege role can invoke a destructive maintenance action against the very contract that contains the higher-privilege recovery action, with no self-protection of that recovery surface.
+
+**Root cause:** The pauserWallet can both pause the diamond (removing all facet selectors) and call removeFacet on the EmergencyPauseFacet, leaving no facet that can re-add selectors via the diamond's normal flows. Privilege boundaries between the lower-trust pauserWallet and the diamond owner are not enforced on functions that can destroy the recovery path.
+
+**Fix:** Fixed in d70d09b47dca3f36068311659510cc1764019f7a by restricting destructive operations on the EmergencyPauseFacet itself to the diamond owner.
+
+**Source:** `2024.09.13_EmergencyPauseFacet.pdf` p.5-5 · `audit20240913::6.1.2`
+
+---
+
+## LF-014 · LOW · EmergencyPauseFacet · acknowledged
+
+**Recognition signal:** Critical emergency action enumerates an unbounded protocol-state collection in a single transaction with no batching/pagination, becoming inoperable exactly when the protocol is most complex.
+
+**Root cause:** pauseDiamond enumerates every facet's selectors in a single transaction via _getAllFacetFunctionSelectorsToBeRemoved with no pagination or batching. As the diamond accumulates facets, the unbounded loop exceeds the block gas limit, making the emergency pause unusable precisely when the diamond is largest.
+
+**Fix:** Acknowledged; team relies on adding a new EmergencyPauseFacet and a watcher on the deploy pipeline rather than implementing pagination.
+
+**Source:** `2024.09.13_EmergencyPauseFacet.pdf` p.5-6 · `audit20240913::6.1.3`
+
+---
+
+## LF-016 · LOW · AcrossFacetPackedV3 · fixed
+
+**Recognition signal:** Function marked payable purely as a gas micro-optimization that has no native-token consumption path, leaving msg.value stuck in the contract where it can be swept or collide with other native-token flows.
+
+**Root cause:** startBridgeTokensViaAcrossV3ERC20Min and startBridgeTokensViaAcrossV3ERC20Packed are declared payable for a small gas saving, but the ERC20 bridge path never consumes msg.value. Any native tokens accidentally sent along with the call are retained by the facet and become consumable by other facets that lack native-token accounting.
+
+**Fix:** Fixed in commit ddc45f13a2007025fb62f8983d417b9a1ed233d4 by removing the payable keyword from the ERC20 entrypoints. Reviewer verified.
+
+**Source:** `2024.10.07_AcrossV3.pdf` p.4-4 · `audit20241007::6.2.1`
+
+---
+
+## LF-017 · LOW · AcrossFacetPackedV3 · fixed
+
+**Recognition signal:** Calldata encoder helper that emits an incomplete payload assuming the caller will concatenate additional trailing bytes off-chain, with no length self-check on the on-chain consumer to detect the missing tail.
+
+**Root cause:** encode_startBridgeTokensViaAcrossV3*Packed produces calldata without the 28-byte referrer suffix that the on-chain facet expects to consume; the caller is expected to append it off-chain. If a user feeds the encoder output directly to the facet, msg.data length is short and the referrer bytes are silently truncated from the bridge call.
+
+**Fix:** Referrer handling was removed from the packed flow entirely in commit f8cb0d8c4bfdba35686e63849095f63c516c5784, eliminating the latent footgun. Reviewer verified.
+
+**Source:** `2024.10.07_AcrossV3.pdf` p.4-5 · `audit20241007::6.2.2`
+
+---
+
+## LF-018 · LOW · AcrossFacetPackedV3 · acknowledged
+
+**Recognition signal:** Down-casting a wider identifier (bytes32 / uint256 / etc.) to a narrower type for packed encoding without surfacing the truncation back into the event / log used by off-chain indexers.
+
+**Root cause:** encode_startBridgeTokensViaAcrossV3NativePacked and encode_startBridgeTokensViaAcrossV3ERC20Packed cast the incoming bytes32 transactionId down to bytes8 to fit the packed calldata layout. The LiFiAcrossTransfer event subsequently emits this truncated id, breaking off-chain transaction tracking and correlation across chains.
+
+**Fix:** Acknowledged and accepted as a known gas trade-off; not patched.
+
+**Source:** `2024.10.07_AcrossV3.pdf` p.5-5 · `audit20241007::6.2.3`
+
+---
+
+## LF-019 · LOW · EmergencyPauseFacet · acknowledged
+
+**Recognition signal:** Admin loop that indexes the result of a registry lookup (e.g. facetFunctionSelectors) without first checking the returned array's length, turning a typo in admin input into an opaque panic that aborts the whole operation.
+
+**Root cause:** The blacklist loop fetches facetFunctionSelectors(_blacklist[i]) and immediately indexes into it; if the address is not a registered facet, the returned array is empty and accessing the first element triggers an out-of-bounds panic. There is no guard or explicit error, so a typo in an admin-supplied address aborts the entire unpause with an opaque revert reason.
+
+**Fix:** Not fixed. Acknowledged as an admin-only function where the operator is expected to craft inputs correctly.
+
+**Source:** `2024.11.05_EmergencyPauseFacet_ReAudit.pdf` p.4-4 · `audit20241105::6.1.1`
+
+---
+
+## LF-025 · LOW · RelayFacet · acknowledged
+
+**Recognition signal:** Bridging facet entrypoint that accepts pre-swap data and passes the result directly to a bridge call without asserting that the last swap's receiving asset matches the declared bridging asset.
+
+**Root cause:** After swapping, the function does not check that the final receiving asset (`_swapData[last].receivingAssetId`) equals `_bridgeData.sendingAssetId`. A mismatched swap output passes the entry-level checks and only reverts deeper in the stack with no actionable error.
+
+**Fix:** Acknowledged but not fixed - LI.FI optimizes for gas, and the mismatch causes a revert downstream anyway (though without a clear error message).
+
+**Source:** `2024.12.02_RelayFacet(v1.0.0).pdf` p.4-4 · `audit20241202::6.1.1`
+
+---
+
+## LF-026 · LOW · RelayFacet · acknowledged
+
+**Recognition signal:** Bridge integration where the source-chain refund recipient defaults to the contract address itself because the caller-supplied refund parameters are not set, even though the user has an EOA that should receive the refund.
+
+**Root cause:** When the Relay bridge refunds on the source chain (expired/invalid quote, mismatched depositor, destination unavailable, etc.), the refund recipient defaults to the diamond address. Refunded funds are not automatically forwarded to the original user, leaving them effectively stranded unless reclaimed via admin action.
+
+**Fix:** Acknowledged. Not fixable on smart contract side; must be addressed at the API layer by setting `refundTo` and `refundOnOrigin` parameters in the relay quote.
+
+**Source:** `2024.12.02_RelayFacet(v1.0.0).pdf` p.4-4 · `audit20241202::6.1.3`
+
+---
+
+## LF-027 · LOW · RelayFacet · fixed
+
+**Recognition signal:** Two parallel receiver fields (EVM vs non-EVM) where the modifier validates only the EVM one, while non-EVM destinations route through the unvalidated alternate field.
+
+**Root cause:** `validateBridgeData` enforces `_bridgeData.receiver != address(0)`, but when bridging to non-EVM chains the actual receiver is carried in `_relayData.nonEVMReceiver`, which is never checked for emptiness. The EVM-side check is thus a no-op while the actually-used field is unvalidated.
+
+**Fix:** Add explicit non-empty check on `_relayData.nonEVMReceiver` for non-EVM destinations. Fixed in commit f285130f.
+
+**Source:** `2024.12.02_RelayFacet(v1.0.0).pdf` p.5-5 · `audit20241202::6.1.4`
+
+---
+
+## LF-031 · LOW · DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Bridge order construction leaving an optional refund-recipient field empty, deferring the choice to a downstream actor instead of pinning the refund to the on-chain initiator.
+
+**Root cause:** When allowedCancelBeneficiarySrc is empty, the orderAuthorityAddressDst can choose any refund address on the source chain at cancel time, making refund accuracy dependent on a correctly behaving order authority instead of being pinned to the actual bridge initiator.
+
+**Fix:** Set allowedCancelBeneficiarySrc = msg.sender when building the OrderCreation in _startBridge so refunds always go back to the initiator. Fixed in 92d87722236f0d58992b7baac378b42501087f8c.
+
+**Source:** `2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf` p.5-6 · `audit20241205::6.2.1`
+
+---
+
+## LF-032 · LOW · DeBridgeDlnFacet · acknowledged
+
+**Recognition signal:** Init function that writes an initialized flag in storage but does not require !initialized as a precondition, leaving the bulk-config path callable repeatedly by admin.
+
+**Root cause:** initDeBridgeDln is owner-protected but never checks the storage's initialized flag before writing. The flag is set to true after init but no subsequent invocation reverts, so the same admin function can be used to wholesale rewrite the chain-id mapping bypassing the regular per-entry setter path.
+
+**Fix:** LI.FI acknowledged and kept the behavior to allow future re-initialization upgrades; recommended check (revert AlreadyInitialized when sm.initialized) was not applied.
+
+**Source:** `2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf` p.6-7 · `audit20241205::6.2.3`
+
+---
+
+## LF-034 · LOW · AcrossFacetPackedV3 · acknowledged
+
+**Recognition signal:** Gas-optimized packed entrypoints that omit sanity checks on user-provided fields because calldata is 'assumed to be backend-generated', without on-chain enforcement that the caller is the backend.
+
+**Root cause:** All four packed/min entrypoints skip basic sanity checks (receiver != 0, sendingAssetId != 0, inputAmount > 0, sane fillDeadline/quoteTimestamp, valid chain id). The functions trust calldata produced by the LI.FI API; if a user composes calldata directly with errors, funds can be sent to a wrong address or bridged with invalid parameters.
+
+**Fix:** Acknowledged. LI.FI states the facet is only meant to be used with calldata generated by their API and declined to add gas-costly validation; recommended users rely on provided encode helpers.
+
+**Source:** `2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf` p.4-5 · `audit20241206::6.2.1`
+
+---
+
+## LF-042 · LOW · GlacisFacet · fixed
+
+**Recognition signal:** Bridge facet that forwards a user-supplied refund/recovery address to an external protocol without validating it is non-zero, where the external protocol treats that address as the authoritative refund destination.
+
+**Root cause:** Both bridge entrypoints accept GlacisData.refundAddress as user input but never validate it. The Glacis airlift uses this address to refund failed bridge attempts. A zero address (e.g., from a frontend bug or careless caller) silently passes through and refunds are permanently lost.
+
+**Fix:** Fixed in commit f5cdbc279f0f15ed469650d5b9b4185c0c668547 by adding a zero-address revert before invoking airlift.send.
+
+**Source:** `2025.02.19_GlacisFacet(v1.0.0).pdf` p.5-5 · `audit20250219::6.1.1`
+
+---
+
+## LF-048 · LOW · ChainflipFacet · acknowledged
+
+**Recognition signal:** Encoding EVM-shaped payloads (Solidity structs, address-typed receiver) into cross-chain messages without branching on EVM vs non-EVM destination — assumptions about destination ABI silently break when the route is non-EVM.
+
+**Root cause:** When hasDestinationCall is true the facet abi.encodes (transactionId, dstCallSwapData, bridgeData.receiver) where SwapData is EVM-native and receiver is an address. For non-EVM destination chains the encoded message and the receiver field are not interpretable on the destination, so destination calls toward Bitcoin/Solana would silently fail or be malformed.
+
+**Fix:** Acknowledged. LI.FI states the API does not route destination calls to non-EVM chains, but no on-chain guard was added; users bypassing the API remain exposed.
+
+**Source:** `2025.03.05_ChainflipFacet(v1.0.0).pdf` p.5-6 · `audit20250305::6.2.2`
+
+---
+
+## LF-059 · LOW · DexManagerFacet · fixed
+
+**Recognition signal:** for-loop with manual unchecked counter increment that lives only in the happy path, alongside an early-continue (or branch) that does not advance the counter.
+
+**Root cause:** The loop body uses a manually-unchecked-incremented counter, but the early-continue branch for already-allowed dexes skips the increment. Any duplicate or pre-existing-allowed entry pins the loop on the same index until the transaction runs out of gas.
+
+**Fix:** Fixed in commit 47e4d8d7 by incrementing i inside the continue branch as well.
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.7-8 · `audit20250508::3.1.2`
+
+---
+
+## LF-060 · LOW · GasZipFacet · fixed
+
+**Recognition signal:** Address-to-bytes32 conversion via the uint256 intermediate (zero-pads on the left) where the downstream integration or non-EVM target expects right-padded bytes32, especially when invariant checks lock both sides to the same wrong encoding.
+
+**Root cause:** GasZipV2 requires bytes32 receivers to be right-padded (e.g. via bytes32(bytes20(uint160(addr)))). The facet's invariant check uses bytes32(uint256(uint160(addr))), which left-pads. Correctly-formatted requests always revert with InvalidCallData, and users who match the buggy encoding by left-padding their input pass the check but bridge funds to address(0) on the destination chain. The bug is camouflaged because the facet's tests use the same incorrect encoding.
+
+**Fix:** Fixed in commit 30caee47 by switching the conversion to bytes32(bytes20(uint160(_bridgeData.receiver))) and updating tests.
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.8-14 · `audit20250508::3.1.3`
+
+---
+
+## LF-063 · LOW · CelerIMFacetBase, RelayerCelerIM · fixed
+
+**Recognition signal:** Cross-chain code that hardcodes or auto-derives a contract address (e.g. address(this), address(relayer), CREATE-deployed clone) and assumes byte-identical addresses across chains, without handling chains with non-standard address derivation (zkSync Era, Starknet, etc.).
+
+**Root cause:** The facet sets _bridgeData.receiver = address(relayer) (the source-chain relayer it just deployed). It implicitly assumes the same address is used on every chain. zkSync derives contract addresses via a different CREATE scheme, so the source-chain relayer address has no code on zkSync (and vice-versa). Celer's executeTransfer then has no destination contract to call and refunds are also impossible.
+
+**Fix:** Fixed in commit b4ffcb7b by removing CelerIMFacet and RelayerCelerIM from zkSync entirely.
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.17-19 · `audit20250508::3.1.6`
+
+---
+
+## LF-064 · LOW · HopFacet, HopFacetOptimized · fixed
+
+**Recognition signal:** Bridge/integration facet that forwards msg.value = amount + extraFee to a downstream contract that strictly requires msg.value == amount (or ignores msg.value for ERC20), so the extra fee is either rejected or silently consumed.
+
+**Root cause:** Hop's L1_Bridge enforces msg.value == amount for native transfers and ignores msg.value for ERC20 transfers (fees are taken from the token amount). HopFacet always forwards nativeFee + minAmount for native and nativeFee for ERC20, which means: native transfers revert via Hop's internal check unless nativeFee is zero, and ERC20 transfers silently lose the entire nativeFee with no refund.
+
+**Fix:** Fixed in commit b04aaaf9. Synchronize msg.value with _bridgeData.minAmount and stop forwarding native value when bridging ERC20s.
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.19-21 · `audit20250508::3.1.7`
+
+---
+
+## LF-071 · LOW · PioneerFacet · fixed
+
+**Recognition signal:** Off-chain-coordinated bridging facet that accepts a user-supplied refund/recovery address without enforcing it is non-zero (or otherwise sane).
+
+**Root cause:** `refundAddress` is the off-chain solver's only path to return funds when bridging fails, but the facet accepts it without rejecting `address(0)`. An invalid refund address registered during bridging guarantees permanent loss of user funds if the bridge does not complete.
+
+**Fix:** Revert if `_pioneerData.refundAddress == address(0)`. Fixed in commit cd009186.
+
+**Source:** `2025.06.26_PioneerFacet(v1.0.0).pdf` p.4-4 · `audit20250626::6.1.1`
+
+---
+
+## LF-072 · LOW · PioneerFacet · fixed
+
+**Recognition signal:** Bridging entrypoint that relies on a user-supplied `transactionId`/correlation id for off-chain processing without rejecting `bytes32(0)`.
+
+**Root cause:** Pioneer bridging uses `transactionId` as the off-chain solver's identifier for the order. The facet accepts `bytes32(0)` without rejecting it; an empty id may confuse off-chain solvers and cause inconsistent state for that user.
+
+**Fix:** Revert if `_bridgeData.transactionId == bytes32(0)`. Fixed in commit 3d0ab5e2.
+
+**Source:** `2025.06.26_PioneerFacet(v1.0.0).pdf` p.4-4 · `audit20250626::6.1.2`
+
+---
+
+## LF-079 · LOW · AllBridgeFacet · acknowledged
+
+**Recognition signal:** Caller-supplied fee value is forwarded to a downstream bridge without an upper bound derived from the bridge's own on-chain quote, and the downstream does not refund overpayment.
+
+**Root cause:** The user-supplied _allBridgeData.fees parameter is forwarded to the AllBridge router without comparison against the on-chain quote (getTransactionCost + getMessageCost). The router itself does not refund overpayment, so any fees the user provides above the actual cost are absorbed by the router and unrecoverable.
+
+**Fix:** Acknowledged; team added documentation describing the behavior in commit d354cfa0129198d80d47f4ba6f70f05871a214a1 rather than capping at the on-chain quote.
+
+**Source:** `2025.07.18_AllBridgeFacet(v2.1.0).pdf` p.5-5 · `audit20250718::6.1.1`
+
+---
+
+## LF-091 · LOW · AcrossFacetPackedV4 · fixed
+
+**Recognition signal:** Truncating a 32-byte non-EVM receiver into a 20-byte address field during calldata decoding, losing data needed to identify the off-chain destination.
+
+**Root cause:** The packed-calldata decoders set bridgeData.receiver = address(uint160(uint256(bytes32(...)))), discarding the upper 12 bytes of a 32-byte receiver. For non-EVM destinations (Solana etc.) the raw bytes32 receiver is not round-trippable and a 32-byte value with 12 leading zero bytes can be misclassified as an EVM address.
+
+**Fix:** Fixed in 5e797a1 by special-casing receivers with 12 leading zero bytes as EVM and keeping the full bytes32 receiver in acrossData.receiverAddress for non-EVM flows.
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.4-5 · `audit20250901::6.1.1`
+
+---
+
+## LF-092 · LOW · AcrossFacetV4 · acknowledged
+
+**Recognition signal:** Computing a critical downstream amount via fixed-point multiplication and division without asserting the result is non-zero when the inputs are user/backend-controlled.
+
+**Root cause:** outputAmount is computed as (minAmount * outputAmountMultiplier) / 1e18 with no post-condition check. If outputAmountMultiplier is zero or the numerator is below 1e18, the result rounds to zero and an Across intent is created with zero output, locking user funds.
+
+**Fix:** Acknowledged in commit a265751: backend produces the multiplier so calldata is trusted; a disclaimer comment was added instead of an on-chain guard.
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.4-5 · `audit20250901::6.1.2`
+
+---
+
+## LF-093 · LOW · AcrossFacetV4 · fixed
+
+**Recognition signal:** Forwarding a user-supplied refund/recovery address to an external bridge without validating it is non-zero, leaving no recovery path for stuck transfers.
+
+**Root cause:** _startBridge forwards _acrossData.refundAddress to the spoke pool without checking != bytes32(0). A zero refundAddress means refunds for unfulfilled or expired intents cannot be received, leading to permanent fund loss.
+
+**Fix:** Fixed in ed698cc by adding an explicit revert when refundAddress is bytes32(0).
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.4-6 · `audit20250901::6.1.3`
+
+---
+
+## LF-099 · LOW · EcoFacet · fixed
+
+**Recognition signal:** Receiver-validation logic that treats the NON_EVM sentinel as authorized for any destination unless another branch explicitly rejects it, instead of whitelisting only the chains that legitimately use NON_EVM_ADDRESS.
+
+**Root cause:** `_validateEcoData()` branches on `receiver == NON_EVM_ADDRESS` and applies Solana-specific validation only when `isSolanaDestination` is true; the non-Solana branch merely checks that `encodedRoute` is non-empty. A user can therefore submit a NON_EVM_ADDRESS receiver to a regular EVM-compatible chain (e.g., TRON) and pass validation, producing an inconsistent on-chain order.
+
+**Fix:** Reject NON_EVM_ADDRESS receiver unless `isSolanaDestination`. Fixed in commit ca999e8.
+
+**Source:** `2025.10.01_EcoFacet(v1.0.0).pdf` p.4-4 · `audit20251001::6.1.1`
+
+---
+
+## LF-100 · LOW · EcoFacet · fixed
+
+**Recognition signal:** `payable` bridging entrypoint whose underlying call uses `value: 0` and does not refund leftover msg.value (missing `refundExcessNative`-style modifier).
+
+**Root cause:** `startBridgeTokensViaEco` is `payable` but the Eco portal is called with `value: 0` and no native asset is bridged or refunded, so any native sent stays in the diamond. `swapAndStartBridgeTokensViaEco` lacks the `refundExcessNative` modifier, so leftover msg.value after swaps is never returned to the user.
+
+**Fix:** Make `startBridgeTokensViaEco` non-payable and add `refundExcessNative` to `swapAndStartBridgeTokensViaEco`. Fixed in commit 8ee81f6.
+
+**Source:** `2025.10.01_EcoFacet(v1.0.0).pdf` p.4-5 · `audit20251001::6.1.2`
+
+---
+
+## LF-101 · LOW · EcoFacet · fixed
+
+**Recognition signal:** Variable-length address validation that enforces only the upper bound or only a non-zero length, while the chain's address format mandates a specific length range.
+
+**Root cause:** `_validateSolanaReceiver()` checks only `length == 0` and `length > 44`, despite a code comment stating Solana addresses must be 32-44 chars. A `nonEVMReceiver` of length 1-31 passes validation and could result in funds bridged to an invalid Solana destination.
+
+**Fix:** Replace zero-length check with `length < 32 || length > 44`. Fixed in commit 94b00df.
+
+**Source:** `2025.10.01_EcoFacet(v1.0.0).pdf` p.5-6 · `audit20251001::6.1.3`
+
+---
+
+## LF-102 · LOW · EcoFacet · fixed
+
+**Recognition signal:** Conditional event emission keyed on the length of an optional user-controlled field rather than the actual underlying state (destination chain, asset class, etc.) the event is meant to signal.
+
+**Root cause:** `_startBridge` emits `BridgeToNonEVMChain` based on `_ecoData.nonEVMReceiver.length > 0` rather than the actual destination chain. Because validation never requires `nonEVMReceiver` to be empty on EVM destinations, a user can populate that field while bridging to a regular EVM chain and pollute event logs with a false non-EVM signal.
+
+**Fix:** Switch event guard to destination-chain-id based check (e.g., `destinationChainId == LIFI_CHAIN_ID_SOLANA`). Fixed in commit e3249ef.
+
+**Source:** `2025.10.01_EcoFacet(v1.0.0).pdf` p.6-6 · `audit20251001::6.1.4`
+
+---
+
+## LF-104 · LOW · UnitFacet · acknowledged
+
+**Recognition signal:** Bridge or escrow facet that funnels user assets to a destination address authenticated only by a single off-chain signer, with no on-chain allow-list, cooldown, or challenge window.
+
+**Root cause:** The deposit address that user funds are routed to is delivered by an EIP-712 signature from a backend signer. There is no on-chain registry, whitelist, cooldown, or challenger gate that proves the destination is a legitimate Unit Protocol address. A compromised signer or backend can route every bridge to an attacker-controlled address.
+
+**Fix:** Acknowledged (mitigated off-chain). The backend re-signs P-256 MPC-verified guardian signatures into EIP-712; LI.FI agreed to relay the on-chain hardening recommendation to the Unit team.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.4-4 · `audit20251007::6.1.1`
+
+---
+
+## LF-105 · LOW · UnitFacet · acknowledged
+
+**Recognition signal:** swap-then-bridge flow where the bridge step assumes a specific output asset (native or specific ERC20) but never asserts that the last swap's receivingAssetId matches that expected asset.
+
+**Root cause:** The function performs an arbitrary swap then unconditionally treats the output as native ETH (passes the result amount to LibAsset.transferNativeAsset). If a misconfigured swap yields an ERC20, the transfer either reverts only when there is insufficient native balance or behaves incorrectly. There is no explicit check that swapData[length-1].receivingAssetId == NULL_ADDRESS.
+
+**Fix:** Acknowledged; LI.FI relies on the implicit revert from insufficient native balance to fail-stop instead of adding an explicit guard.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.4-6 · `audit20251007::6.1.2`
+
+---
+
+## LF-106 · LOW · UnitFacet · acknowledged
+
+**Recognition signal:** Signature verified over input parameters that are subsequently mutated (e.g., by a swap, slippage adjustment, or fee deduction) before the authorized side-effect executes.
+
+**Root cause:** _verifySignature reads bridgeData.minAmount before the swap mutates it; _depositAndSwap then overwrites minAmount with the swap output before _startBridge. The bridged amount is therefore not the one the backend signed for, so the signed authorization no longer binds the actual cross-chain transfer amount.
+
+**Fix:** Acknowledged; LI.FI treats the signature as authorizing initiation, not the post-swap amount.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.5-6 · `audit20251007::6.1.3`
+
+---
+
+## LF-115 · LOW · WhitelistManagerFacet, LibAllowList · fixed
+
+**Recognition signal:** Two-mapping invariant (e.g. allow-list bool + reverse-index uint) where a remove/cleanup path early-returns based on one mapping and skips clearing the other, leaving an inconsistent state that cannot be undone through the normal admin path.
+
+**Root cause:** The DexManager-to-WhitelistManager migration relies on an off-chain list of selectors to clear; any selector missed by the off-chain list stays true in selectorAllowList but has no entry in selectorToIndex. The remove path in _removeAllowedSelector early-returns when oneBasedIndex == 0, so the leftover whitelisted selector can never be removed and stays callable.
+
+**Fix:** Fixed in PR#1376: _removeAllowedSelector now unconditionally deletes als.selectorAllowList[_selector] before checking the index, so imperfect off-chain cleanup cannot leave selectors stuck in the on/true state.
+
+**Source:** `2025.11.04_WhitelistManagerFacet(v1.0.0).pdf` p.7-8 · `audit20251104::L-2`
+
+---
+
+## LF-118 · LOW · LiFiIntentEscrowFacet · fixed
+
+**Recognition signal:** Event/flag describing whether a destination call exists that is hardcoded false (or set independently of actual behavior) while another struct field carries calldata that is executed after delivery.
+
+**Root cause:** The facet applies the doesNotContainDestinationCalls modifier (forcing _bridgeData.hasDestinationCall = false) yet simultaneously forwards a non-empty _lifiIntentData.outputCall, which the OIF documentation defines as calldata executed after token delivery. Consumers of LiFiTransferStarted therefore see a flag that contradicts the actual on-destination behavior, breaking downstream monitoring and risk filters.
+
+**Fix:** Fixed in commit 67d51637 by removing the doesNotContainDestinationCalls modifier and synchronizing the flag with the actual outputCall presence.
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.4-4 · `audit20251119::6.1.1`
+
+---
+
+## LF-119 · LOW · LiFiIntentEscrowFacet · fixed
+
+**Recognition signal:** Intent/escrow flow that accepts a user-specified output amount and forwards it to a solver/settler without validating it is non-zero.
+
+**Root cause:** The intent's outputAmount is forwarded to the OIF settler without a non-zero check. If outputAmount is 0, a solver can satisfy the intent by sending zero tokens to the user while collecting the entire deposit on the source chain.
+
+**Fix:** Fixed in commit e769f33 by reverting when outputAmount == 0.
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.4-4 · `audit20251119::6.1.2`
+
+---
+
+## LF-120 · LOW · LiFiIntentEscrowFacet · fixed
+
+**Recognition signal:** Refund/recovery address taken from user input and forwarded to an external settler without a zero-address guard.
+
+**Root cause:** The user-supplied depositAndRefundAddress is forwarded to the settler without a non-zero check. A zero value (e.g., from a frontend bug) leaves refunds unreachable.
+
+**Fix:** Fixed in commit 7346115 by reverting with InvalidReceiver when depositAndRefundAddress is zero.
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.4-4 · `audit20251119::6.1.3`
+
+---
+
+## LF-132 · LOW · LiFiIntentEscrowFacet · fixed
+
+**Recognition signal:** Multiple refund paths in one entrypoint that send leftover funds to two different recipients (depositor-supplied address vs. msg.sender), so a relayer-or-forwarder caller silently captures part of the refund.
+
+**Root cause:** swapAndStartBridgeTokensViaLiFiIntentEscrow routes refund types differently: positive slippage to depositAndRefundAddress, but excess native ETH and swap leftovers via refundExcessNative(msg.sender). When msg.sender is a relayer/forwarder this misdirects user refunds to the relayer.
+
+**Fix:** Resolved in df0c3c2: aligned slippage refunds. Excess native flow kept on msg.sender across all facets to avoid implementation fragmentation; broader cross-facet fix deferred.
+
+**Source:** `2026.01.30_LiFiIntentEscrowFacet(v1.1.0).pdf` p.4-4 · `audit20260130::6.1.1`
+
+---
+
+## LF-138 · LOW · AcrossV4SwapFacet · acknowledged
+
+**Recognition signal:** A facet that enforces a backend signature on some swap-API targets but selectively bypasses it for others, creating an asymmetric trust model across otherwise-similar entry paths.
+
+**Root cause:** _verifySignatureIfRequired enforces the LI.FI backend EIP-712 signature only for SpokePool and SpokePoolPeriphery targets, returning early for SponsoredOFTSrcPeriphery and SponsoredCCTPSrcPeriphery. The two sponsored paths therefore accept any caller-crafted calldata as long as downstream periphery checks pass, breaking a uniform trust model.
+
+**Fix:** Acknowledged: sponsored paths are considered LI.FI-internal-only; risk accepted.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.5-7 · `audit20260409::6.3.1`
+
+---
+
+## LF-139 · LOW · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** Forwarding the original msg.value to a downstream payable call inside a function that may have already consumed part of that ETH for an internal swap.
+
+**Root cause:** _callSponsoredOftDeposit forwards the original msg.value to the LayerZero deposit for messaging fees. When called via swapAndStartBridgeTokensViaAcrossV4Swap with a native-to-ERC20 source swap, the swap already consumed part of the contract's ETH, so forwarding msg.value reverts and the OFT path becomes unusable with native source swaps.
+
+**Fix:** Fixed in 5db76ea by tracking the native amount actually needed for LZ fees rather than blindly forwarding msg.value.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.7-7 · `audit20260409::6.3.3`
+
+---
+
+## LF-140 · LOW · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** Token-address validation branch that is performed for ERC20 inputs but silently skipped for the native-token case, deferring all correctness to an off-chain signature.
+
+**Root cause:** When isNative == true, both the SpokePool and SpokePoolPeriphery paths skip the token-address check that ERC20 flows perform against _bridgeData.sendingAssetId, leaving correctness of the native-token address entirely to the backend signature.
+
+**Fix:** Fixed in e36cd4a by enforcing that the decoded native token matches the expected wrapped-native constant.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.7-7 · `audit20260409::6.3.4`
+
+---
+
+## LF-141 · LOW · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** Performing a refund/transfer at the very top of a function before downstream parameter checks, so a failing check reverts an already-attempted state-changing transfer.
+
+**Root cause:** In both _callSponsoredOftDeposit and _callSponsoredCctpDepositForBurn, the positive-slippage refund transfer happens before subsequent input checks (refundRecipient/receiver/amount/burnToken validations). This violates checks-effects-interactions and masks the real failure cause when later validations revert.
+
+**Fix:** Fixed in de6a839 by moving the refund block after all validation checks in both sponsored paths.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.7-9 · `audit20260409::6.3.5`
+
+---
+
+## LF-142 · LOW · AcrossV4SwapFacet · fixed
+
+**Recognition signal:** Inconsistent zero-address validation for an equivalent 'refund recipient' field across multiple sibling code paths in the same contract.
+
+**Root cause:** Three of four AcrossV4SwapFacet paths explicitly reject a zero depositor/refund address, but the SponsoredCCTP path does not, relying on a downstream LibAsset.transferERC20 NULL_ADDRESS check that only triggers when positive slippage occurs.
+
+**Fix:** Fixed in 93dda97 by adding an explicit refundRecipient != address(0) check before the positive-slippage block.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.8-8 · `audit20260409::6.3.6`
+
+---
+
+## LF-144 · LOW · DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Bridging order configuration where the only path to cancel/refund flows through a single user-supplied destination authority field, while the facet performs no sanity check (zero/empty) on that field.
+
+**Root cause:** Because `allowedCancelBeneficiarySrc` is hardcoded to empty in `_startBridge`, all cancellation and refund authority resides exclusively with `orderAuthorityAddressDst`. The facet does not check that `_deBridgeData.orderAuthorityDst` is non-empty/non-zero, so a misconfigured order is uncancellable and unrefundable, permanently stranding funds if unfilled.
+
+**Fix:** Revert if `_deBridgeData.orderAuthorityDst.length == 0`. Fixed in commit 36a8922.
+
+**Source:** `2026.04.30_DeBridgeDlnFacet(v1.1.0).pdf` p.4-4 · `audit20260430::6.1.1`
+
+---
+
+## LF-145 · LOW · DeBridgeDlnFacet · acknowledged
+
+**Recognition signal:** Authority/permission field set to `msg.sender` inside a facet, where the same facet is reachable indirectly via a proxy/meta-tx contract that becomes msg.sender instead of the real user.
+
+**Root cause:** DLN's `givePatchAuthoritySrc` is set to `msg.sender`. When the facet is invoked indirectly via Permit2Proxy (`callDiamondWithEIP2612Signature`, `callDiamondWithPermit2*`), `msg.sender` inside the facet is the Permit2Proxy contract address, not the end user. Permit2Proxy exposes no patch endpoint, so the economic owner has no path to patch their own order.
+
+**Fix:** Acknowledged - LI.FI argues the destination authority gives sufficient control. No contract change.
+
+**Source:** `2026.04.30_DeBridgeDlnFacet(v1.1.0).pdf` p.4-4 · `audit20260430::6.1.2`
+
+---
+
+## LF-020 · INFO · EmergencyPauseFacet · acknowledged
+
+**Recognition signal:** Admin-callable function that accepts an unconstrained list of facets/selectors to remove and does not blacklist itself or the emergency-pause facet, allowing the safety mechanism to be removed in a single transaction.
+
+**Root cause:** The unpause flow accepts an arbitrary blacklist of facets to remove from the diamond. Nothing prevents the owner from including the EmergencyPauseFacet itself in that list, which removes its selectors and irreversibly disables the emergency-pause kill-switch for the diamond.
+
+**Fix:** Not fixed. Acknowledged; the team will handle this function with extra caution operationally.
+
+**Source:** `2024.11.05_EmergencyPauseFacet_ReAudit.pdf` p.5-5 · `audit20241105::appendix`
+
+---
+
+## LF-028 · INFO · RelayFacet · fixed
+
+**Recognition signal:** Bridge facet that forwards an off-chain-supplied unique order/quote identifier without a contract-side mapping to mark it as consumed, leaving replay protection entirely to the external service.
+
+**Root cause:** `requestId` from the Relay quote is forwarded but the facet does not record consumed IDs. If the same `requestId` is replayed (the off-chain Relay side may not deduplicate within msg.data), funds are spent again on the source chain even though they will eventually be refunded.
+
+**Fix:** Add a mapping to track consumed `requestId`s and reject duplicates. Fixed in commit 4b3535fb.
+
+**Source:** `2024.12.02_RelayFacet(v1.0.0).pdf` p.5-5 · `audit20241202::6.2.2`
+
+---
+
+## LF-037 · INFO · AcrossFacetV3 · acknowledged
+
+**Recognition signal:** User-controlled multiplier or scaling factor applied via fixed-point math (e.g. * X / 1e18) with no min/max bounds, where extreme values produce either trivially-small results (silent loss) or implausibly-large results (waste / DoS).
+
+**Root cause:** swapAndStartBridgeTokensViaAcrossV3 computes outputAmount = (minAmount * outputAmountPercent) / 1e18 with no minimum or maximum check on outputAmountPercent. A near-zero value yields an essentially zero output (loss of funds on the destination), and a value greatly above 1e18 yields an unrealistically inflated output that would be rejected by Across but wastes user gas and may emit misleading state.
+
+**Fix:** Acknowledged but not patched; LI.FI argues that source/destination decimal mismatch makes a generic bound incorrect and chose not to add the limit. Reviewer suggested at least a non-zero guard.
+
+**Source:** `2025.01.06_AcrossFacetV3(v1.1.0).pdf` p.4-4 · `audit20250106::6.1.1`
+
+---
+
+## LF-043 · INFO · GlacisFacet · acknowledged
+
+**Recognition signal:** Facet that forwards a user-controlled `value:` to an external call without asserting that msg.value supplied by the caller covers it.
+
+**Root cause:** The facet passes _glacisData.nativeFee to airlift.send{value: ...} without checking that the caller actually supplied that value via msg.value. If the LiFiDiamond ever holds native balance (intentionally or not), a user could pay the bridge's native fee out of the diamond's funds.
+
+**Fix:** Acknowledged; LI.FI prioritized gas savings, accepting that the diamond is not expected to hold native balance.
+
+**Source:** `2025.02.19_GlacisFacet(v1.0.0).pdf` p.5-5 · `audit20250219::6.2.1`
+
+---
+
+## LF-044 · INFO · GlacisFacet · fixed
+
+**Recognition signal:** Bridge facet exposing entrypoints for an external integration that does not support native assets but omitting an upfront noNativeAsset / asset-type guard.
+
+**Root cause:** Glacis Airlift does not support bridging the native asset, but GlacisFacet exposes both bridge entrypoints without the noNativeAsset guard. Native-asset attempts revert several frames down inside the external airlift contract with an opaque custom-error selector.
+
+**Fix:** Fixed in commit f9276e33393986022f90b48fd0c5a025fa9702b6 by adding the noNativeAsset modifier to both bridge functions.
+
+**Source:** `2025.02.19_GlacisFacet(v1.0.0).pdf` p.6-6 · `audit20250219::6.2.2`
+
+---
+
+## LF-045 · INFO · GlacisFacet · acknowledged
+
+**Recognition signal:** swap-then-bridge function that uses _bridgeData.sendingAssetId for the bridge step without asserting that the last swap's receivingAssetId matches.
+
+**Root cause:** The function depositAndSwaps user assets, then bridges using _bridgeData.sendingAssetId, without confirming that swapData[length-1].receivingAssetId equals that bridging asset. A misconfigured route can leave funds in an unintended token while the bridge call attempts to transfer the wrong asset, causing a late and opaque revert.
+
+**Fix:** Acknowledged; LI.FI argues the call would revert anyway since the diamond does not hold funds.
+
+**Source:** `2025.02.19_GlacisFacet(v1.0.0).pdf` p.5-7 · `audit20250219::6.2.3`
+
+---
+
+## LF-068 · INFO · GnosisBridgeFacet · acknowledged
+
+**Recognition signal:** Bridge facet that issues max ERC20 approval to an external router on every bridge call instead of the exact transfer amount, accepting larger blast radius for gas savings.
+
+**Root cause:** _startBridge uses LibAsset.maxApproveERC20 on the Gnosis Bridge Router. Although the facet never holds balances persistently (funds flow through atomically), any future bug or compromise of the router would have a larger blast radius than a per-call exact-amount approval.
+
+**Fix:** Acknowledged as an intentional design choice across facets for gas efficiency; no change made.
+
+**Source:** `2025.06.03_GnosisBridgeFacet(v2.0.0).pdf` p.4-4 · `audit20250603::6.1.1`
+
+---
+
+## LF-069 · INFO · GnosisBridgeFacet · fixed
+
+**Recognition signal:** swapAndBridge entrypoint that validates the bridge's sending asset against an allowlist but does not also assert the last swap step's output equals that asset.
+
+**Root cause:** The facet checks that bridgeData.sendingAssetId is DAI or USDS, but never verifies that swapData[last].receivingAssetId matches it. A swap chain producing Token X while the bridge expects Token Y would not be caught, potentially attempting to bridge the wrong asset.
+
+**Fix:** Added a require that _swapData[last].receivingAssetId == _bridgeData.sendingAssetId, reverting with InvalidSendingToken otherwise. Fixed in 05ff21c84a27e110a71960f26b44499e33ef5fee.
+
+**Source:** `2025.06.03_GnosisBridgeFacet(v2.0.0).pdf` p.4-4 · `audit20250603::6.1.2`
+
+---
+
+## LF-073 · INFO · PioneerFacet · acknowledged
+
+**Recognition signal:** Bridging entrypoint that accepts pre-bridge swap data and forwards to the bridge step without asserting the last swap's receiving asset matches the declared bridging asset.
+
+**Root cause:** After the pre-bridge swap, the facet does not assert `_bridgeData.sendingAssetId == _swapData[last].receivingAssetId`. Mismatch is caught implicitly by the subsequent transfer to the Pioneer EOA reverting on insufficient balance.
+
+**Fix:** Acknowledged - relies on the implicit revert when the contract holds the wrong asset; no contract change.
+
+**Source:** `2025.06.26_PioneerFacet(v1.0.0).pdf` p.5-5 · `audit20250626::6.2.3`
+
+---
+
+## LF-080 · INFO · AllBridgeFacet · fixed
+
+**Recognition signal:** Bridge facet supports a non-EVM destination path but is missing the project-wide BridgeToNonEVM* event that captures the non-EVM receiver bytes for indexers and monitoring.
+
+**Root cause:** _startBridge supports bridging to non-EVM destinations but, unlike sibling facets, never emits the BridgeToNonEVMChain event with the non-EVM receiver bytes. This breaks the convention that off-chain indexers and security tooling depend on to track non-EVM destination addresses.
+
+**Fix:** Fixed in 240e8072a23c400a7ca870b8500ed0fc61d2b0df by emitting BridgeToNonEVMChain on the non-EVM path.
+
+**Source:** `2025.07.18_AllBridgeFacet(v2.1.0).pdf` p.4-5 · `audit20250718::6.2.3`
+
+---
+
+## LF-081 · INFO · MayanFacet, DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Facet constructor stores immutable external-protocol addresses without zero-address validation, diverging from the codebase's other facets that all validate.
+
+**Root cause:** The constructors of MayanFacet and DeBridgeDlnFacet store immutable bridge/router addresses passed in at deploy time without checking that they are non-zero. A misconfigured deployment can permanently brick the facet because the addresses are immutable.
+
+**Fix:** Fixed in af2a8591fa2db65563dd02c353163450bdff79be by validating constructor params in both facets.
+
+**Source:** `2025.07.18_AllBridgeFacet(v2.1.0).pdf` p.6-6 · `audit20250718::6.2.5`
+
+---
+
+## LF-089 · INFO · RelayDepositoryFacet · acknowledged
+
+**Recognition signal:** Facet that uses bridgeData fields only to populate emitted events while the authoritative bridge parameters live off-chain, allowing user-supplied event metadata to drift from the actual transfer.
+
+**Root cause:** The facet stores all real transfer details off-chain inside Relay's orderId; on-chain it only forwards the orderId and uses bridgeData.receiver/destinationChain solely to populate the LiFiTransferStarted event. A user can therefore submit bridgeData with arbitrary receiver/destinationChain values that do not match the actual off-chain order, and downstream consumers of the event have no way to detect the divergence. The facet also does not emit BridgeToNonEVMChainBytes32 when the off-chain destination is Solana.
+
+**Fix:** Acknowledged in commit 9d86e488b6f651205605dd65cb0086caed8507c3 with added contract and docs comments.
+
+**Source:** `2025.08.25_RelayDepositoryFacet(v1.0.0).pdf` p.6-7 · `audit20250825_1::I-02`
+
+---
+
+## LF-090 · INFO · RelayDepositoryFacet · acknowledged
+
+**Recognition signal:** Bridge integration that forwards full swap output (including positive slippage) instead of the off-chain-quoted input amount, relying on the external solver to refund the difference rather than returning excess to the user on-chain.
+
+**Root cause:** When a preswap step produces positive slippage, the facet forwards the full swap output to RelayDepository even though the off-chain order specified a smaller input. Refund of the overpaid amount is entirely dependent on Relay's solver implementation, which is an off-chain trust assumption not enforced on-chain.
+
+**Fix:** Acknowledged in commit 898c77f65632565d1de12013e08dd61681335b32 with contract/docs comments and a recommendation to monitor for solver behavior changes.
+
+**Source:** `2025.08.25_RelayDepositoryFacet(v1.0.0).pdf` p.7-8 · `audit20250825_1::I-03`
+
+---
+
+## LF-094 · INFO · AcrossFacetPackedV4 · acknowledged
+
+**Recognition signal:** An onlyOwner function that performs an unrestricted low-level call to a caller-supplied target with caller-supplied calldata and no whitelist or timelock.
+
+**Root cause:** executeCallAndWithdraw lets onlyOwner call any _callTo with arbitrary _callData and no whitelist or timelock. A compromised or malicious owner can revoke approvals, drain partner contracts, or otherwise weaponize the contract.
+
+**Fix:** Acknowledged: function is not added to the diamond and only standalone packedFacet is affected, used by a small set of partners.
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.5-7 · `audit20250901::6.2.3`
+
+---
+
+## LF-096 · INFO · AcrossFacetPackedV4 · fixed
+
+**Recognition signal:** Packed-calldata decoder whose declared minimum-length check is smaller than the highest byte index it indexes into.
+
+**Root cause:** Decoder validates data.length < 188 but then accesses data[216:220] for exclusivityDeadline and data[220:] for message, allowing inputs of length 188-219 to pass validation while producing out-of-bounds reads of packed fields.
+
+**Fix:** Fixed in 4bce2a1 (raising threshold to 220); later partially reverted as the related sendingAssetId parameter was removed in subsequent PRs.
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.7-7 · `audit20250901::6.2.6`
+
+---
+
+## LF-097 · INFO · GardenFacet · fixed
+
+**Recognition signal:** Cross-chain facet handling non-EVM destinations without emitting the standardized non-EVM bridging event or carrying a non-EVM-shaped receiver field — observability gap that also signals the address-encoding limitation.
+
+**Root cause:** GardenFacet's primary use-case is bridging to Bitcoin and BTC derivatives, but it does not emit the protocol-standard BridgeToNonEVMChain event and has no nonEvmReceiver field in GardenData. Off-chain indexers cannot reliably distinguish/track non-EVM transfers, and the bridgeData.receiver cannot fit a Bitcoin-format address.
+
+**Fix:** Added nonEvmReceiver field and BridgeToNonEVMChain event emission for non-EVM destinations. Fixed in 818de27b64a73879c91dbddc3195be03bafdc08f.
+
+**Source:** `2025.09.19_GardenFacet(v1.0.0).pdf` p.10-11 · `audit20250919::I-3`
+
+---
+
+## LF-103 · INFO · EcoFacet · fixed
+
+**Recognition signal:** Bridging facet that forwards user-supplied prover/relayer/deadline configuration into an external order without sanity-checking address-zero and timestamp-in-future invariants.
+
+**Root cause:** `_buildReward()` passes user-supplied `prover` and `rewardDeadline` into the Eco Reward struct without checking that prover is non-zero or that the deadline is non-zero and in the future. Invalid configuration silently produces an unfundable or unprovable order.
+
+**Fix:** Validate `prover != address(0)` and `rewardDeadline > block.timestamp`. Fixed in commit 0c8f825.
+
+**Source:** `2025.10.01_EcoFacet(v1.0.0).pdf` p.8-9 · `audit20251001::6.3.1`
+
+---
+
+## LF-107 · INFO · UnitFacet · fixed
+
+**Recognition signal:** Chain-id switch with explicit cases for a subset of chains and an implicit fall-through that allows the same function to operate on any other chain with no validation.
+
+**Root cause:** The chain-id switch contains explicit minimum-amount branches for chain IDs 1 (Ethereum) and 9745 (Plasma) and falls through with no guard for every other chain. Users can therefore originate a bridge from an unsupported chain with arbitrarily small amounts; the off-chain Unit Protocol cannot process them and funds risk being stuck.
+
+**Fix:** Fixed in commit 40b6c94e by adding an UnsupportedChain revert in the else branch.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.6-8 · `audit20251007::6.2.1`
+
+---
+
+## LF-108 · INFO · UnitFacet · fixed
+
+**Recognition signal:** Signature verification that performs ecrecover/hashing before checking the cheap expiration timestamp, so expired signatures consume the full verification cost.
+
+**Root cause:** The deadline comparison occurs after the expensive parts of _verifySignature complete. Stale signatures are still rejected, but the contract reaches that decision only after performing avoidable work.
+
+**Fix:** Fixed in commit e1648970 by moving the deadline check to the top of _verifySignature.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.7-9 · `audit20251007::6.2.3`
+
+---
+
+## LF-109 · INFO · UnitFacet · fixed
+
+**Recognition signal:** Backend-signed authorization with no nonce / no used-signature tracking, where uniqueness relies solely on a future deadline.
+
+**Root cause:** _verifySignature checks only the signer and the deadline. There is no nonce, transactionId allowlist, or used-signature mapping. While Unit Protocol's deposit addresses are tied to receivers (limiting third-party theft), the signature can still be replayed by the same user (or anyone) before expiry.
+
+**Fix:** Fixed in commit 32a032515 by adding transactionId-based replay protection.
+
+**Source:** `2025.10.07_UnitFacet(v1.0.0).pdf` p.8-8 · `audit20251007::6.2.5`
+
+---
+
+## LF-110 · INFO · EcoFacet · fixed
+
+**Recognition signal:** Bridge facet that funds a downstream vault using a totalAmount field encoding swap output, without skimming the delta between actual swap output and the intended minAmount back to the user.
+
+**Root cause:** The intent's reward.tokens.amount encodes a totalAmount (intent + reward + any positive slippage). When swap output exceeds _bridgeData.minAmount, the surplus is included in the funded vault amount and ends up claimed by the solver upon fill, rather than refunded to the user. The pre-existing code comment understated this by claiming excess remains in the diamond.
+
+**Fix:** Updated swapAndStartBridgeTokensViaEco to detect actualAmountAfterSwap > minAmount and transfer the positive slippage back to msg.sender before bridging. Fixed in PR lifinance/contracts/pull/1421.
+
+**Source:** `2025.10.20_EcoFacet(v1.1.0).pdf` p.15-17 · `audit20251020::I-3`
+
+---
+
+## LF-113 · INFO · WhitelistManagerFacet · mitigated
+
+**Recognition signal:** Off-chain-derived input to an irreversible on-chain migration / state cleanup where missing entries leave dangerous residual state, with no on-chain consistency check to flag the gap.
+
+**Root cause:** The off-chain-supplied _selectorsToRemove list for migration is assembled by parsing historical events across many chains, an error-prone process. Selectors absent from the list silently survive the migration with no on-chain detection, and one of the already-whitelisted contracts is a token (DEGENx on Base) for which an accidentally-whitelisted transferFrom selector would let any user drain outstanding approvals.
+
+**Fix:** Acknowledged; LI.FI aggregates the selector list from three sources (on-chain scan, sigs.json, whitelist.json) as defense in depth, and added a token-detection guard that rejects any contract whose decimals() returns 0-255. Reviewer verified.
+
+**Source:** `2025.11.04_WhitelistManagerFacet(v1.0.0).pdf` p.9-11 · `audit20251104::I-2`
+
+---
+
+## LF-117 · INFO · WhitelistManagerFacet, LibAllowList · fixed
+
+**Recognition signal:** One-shot storage-migration function whose tests assert only the new structure's happy path, without verifying the legacy storage layout was zeroed and all derived indices remain consistent.
+
+**Root cause:** The migration path from the legacy whitelist (V1) to the new granular system (V2) was not exercised by tests covering full state-clear-then-rebuild semantics. Without tests verifying mappings, arrays, reference counts, and indices are in sync after migration, latent bugs corrupting whitelist storage could pass unnoticed.
+
+**Fix:** Added migration-completeness and state-consistency tests covering legacy clearing, queryability via getters, and index integrity. Fixed in commit bb32542.
+
+**Source:** `2025.11.04_WhitelistManagerFacet(v1.0.0)_1.pdf` p.5-5 · `audit20251104_1::6.2.4`
+
+---
+
+## LF-121 · INFO · LiFiIntentEscrowFacet · acknowledged
+
+**Recognition signal:** Bridge facet that interacts with non-EVM-aware downstream protocols but lacks the standard NON_EVM_ADDRESS / receiver-encoding branch present in sibling facets.
+
+**Root cause:** Other LI.FI facets switch to a NON_EVM_ADDRESS sentinel and handle bridgeData.receiver specially for non-EVM destinations. The escrow facet has no such branch and the OIF settler call assumes an EVM receiver, so non-EVM intents either revert or send funds to a malformed receiver.
+
+**Fix:** Acknowledged; v1.0.0 ships EVM-only with a planned future update for non-EVM chains.
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.4-5 · `audit20251119::6.2.1`
+
+---
+
+## LF-122 · INFO · LiFiIntentEscrowFacet · raised
+
+**Recognition signal:** Struct destined for a downstream settler containing bytes32 oracle/settler identifiers that are passed through without zero-or-invalid validation.
+
+**Root cause:** outputOracle and outputSettler are bytes32 fields of MandateOutput passed through without validation. Zero or otherwise invalid values typically just trigger refunds, but malformed flows still degrade UX and could surface unexpected protocol-level outcomes.
+
+**Fix:** Status not recorded in the PDF (the LI.FI response line is empty).
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.5-5 · `audit20251119::6.2.2`
+
+---
+
+## LF-123 · INFO · LiFiIntentEscrowFacet · acknowledged
+
+**Recognition signal:** ERC20 approval to a downstream integration set to type(uint256).max (or via a max-approval helper) when the caller could just as easily set the exact per-call amount.
+
+**Root cause:** maxApproveERC20 sets approval to type(uint256).max on the settler when allowance is insufficient. A bug or compromise in the settler can drain every token the diamond currently holds approval for, even across unrelated transactions.
+
+**Fix:** Acknowledged; the LI.FI team accepts the unbounded approval pattern.
+
+**Source:** `2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf` p.5-5 · `audit20251119::6.2.3`
+
+---
+
+## LF-124 · INFO · PolymerCCTPFacet · acknowledged
+
+**Recognition signal:** Single-asset bridging facet that enforces source-token whitelist on `bridgeData` but does not assert that `_swapData[last].receivingAssetId` matches the same whitelisted asset.
+
+**Root cause:** The facet only supports USDC, enforced on `sendingAssetId` via the `onlyAllowSourceToken` modifier. The post-swap output token is not asserted to match USDC, so an inconsistent swap reverts deep in the bridge call without a clear error.
+
+**Fix:** Acknowledged. Mismatched swap output would revert because the diamond lacks the required USDC, and the `onlyAllowSourceToken` modifier on `bridgeData.sendingAssetId` provides indirect protection; no contract change.
+
+**Source:** `2025.12.01_PolymerCCTPFacet(v1.0.0).pdf` p.4-4 · `audit20251201::6.1.2`
+
+---
+
+## LF-125 · INFO · PolymerCCTPFacet · acknowledged
+
+**Recognition signal:** Subtracting a user-supplied fee from a user-supplied total without validating fee ≤ total, leaving the protocol to rely on Solidity's checked subtraction to catch the case.
+
+**Root cause:** `bridgeAmount = _bridgeData.minAmount - _polymerData.polymerTokenFee` is computed without ordering checks. If `polymerTokenFee >= minAmount`, the subtraction underflows (revert) or yields a zero-amount bridge that is wasted work.
+
+**Fix:** Acknowledged - won't fix to save gas; LI.FI added documentation in commit e31eef9 instead.
+
+**Source:** `2025.12.01_PolymerCCTPFacet(v1.0.0).pdf` p.5-5 · `audit20251201::6.1.4`
+
+---
+
+## LF-126 · INFO · PolymerCCTPFacet · fixed
+
+**Recognition signal:** Chain-ID-to-domain mapping that includes both mainnet and testnet entries in the same production lookup, allowing a testnet chain ID on a mainnet deployment to silently resolve to a mainnet target.
+
+**Root cause:** `_chainIdToDomainId()` maps Sepolia / OP Sepolia / Base Sepolia chain IDs to the same CCTP domain IDs as their mainnet counterparts. A user mistakenly supplying a testnet chain ID on a mainnet deployment will have USDC bridged to the mainnet destination instead of reverting.
+
+**Fix:** Remove testnet chain ID mappings from the production `_chainIdToDomainId()` function. Fixed in commit 15bca15.
+
+**Source:** `2025.12.01_PolymerCCTPFacet(v1.0.0).pdf` p.5-6 · `audit20251201::6.1.6`
+
+---
+
+## LF-127 · INFO · MegaETHBridgeFacet · fixed
+
+**Recognition signal:** User-supplied address forwarded to an external bridge / vault deposit function without any zero-address guard, where the external contract's own validation is assumed but never confirmed.
+
+**Root cause:** The MegaETHData.assetIdOnL2 field is forwarded directly into bridge.depositERC20To without a zero-address check on the non-requiresDepositTo branch. A user supplying address(0) (accidentally or maliciously) can drive a bridge call with a zero L2-token, which downstream may mint to an unusable token address or otherwise produce undefined behavior.
+
+**Fix:** Fixed in commit 740b0d9 by adding `if (LibUtil.isZeroAddress(_megaETHData.assetIdOnL2)) revert InvalidAssetIdOnL2();` before the depositERC20To call. Reviewer verified.
+
+**Source:** `2025.12.03_MegaETHBridgeFacet(v1.0.0).pdf` p.4-5 · `audit20251203_1::6.2.3`
+
+---
+
+## LF-131 · INFO · NEARIntentsFacet · fixed
+
+**Recognition signal:** Single-use off-chain quote/order identifier marked consumed before the actual on-chain transferred balance is validated, so a fee-on-transfer token (or any balance-shrinking transfer) silently wastes the quote.
+
+**Root cause:** The facet records the quote ID as consumed before validating that the actual delivered token balance matches the quoted amount. For fee-on-transfer tokens the received amount is strictly less than the supplied amount, so the bridge step fails (or underfunds), yet the quote ID has already been marked used and cannot be reused or refunded.
+
+**Fix:** Fixed in 4e5b2ec by documenting the limitation in the contract; protocol team will warn users off-chain not to use fee-on-transfer tokens with this facet.
+
+**Source:** `2025.12.16_NEARIntentsFacet(v1.0.0).pdf` p.5-5 · `audit20251216::6.2.2`
+
+---
+
+## LF-133 · INFO · LiFiIntentEscrowFacet · fixed
+
+**Recognition signal:** Reusing an unrelated semantic error (e.g. receiver-zero) for a different field's zero-address validation, hiding the real failure source from integrators.
+
+**Root cause:** _startBridge reverts InvalidReceiver() when depositAndRefundAddress is zero, but that field is semantically the depositor / refund recipient, not the destination receiver, masking the real cause of the revert for integrators.
+
+**Fix:** Fixed in df0c3c (dedicated error for the depositAndRefundAddress zero check).
+
+**Source:** `2026.01.30_LiFiIntentEscrowFacet(v1.1.0).pdf` p.4-5 · `audit20260130::6.2.1`
+
+---
+
+## LF-134 · INFO · PolymerCCTPFacet · fixed
+
+**Recognition signal:** Parallel non-EVM-receiver fields where one is validated at the facet level and the sibling is delegated entirely to a downstream contract's check, creating inconsistent error surfaces and reliance on external invariants.
+
+**Root cause:** _startBridge explicitly reverts on nonEVMReceiver == bytes32(0) but leaves solanaReceiverATA unchecked, relying on the downstream TokenMessenger to enforce mintRecipient != 0. The two branches therefore fail with different errors at different call-stack depths, and the facet-level guarantee is incomplete and brittle to changes in the external CCTP contract.
+
+**Fix:** Fixed in commit 59d992d by adding an explicit zero-value check on solanaReceiverATA when destinationChainId == LIFI_CHAIN_ID_SOLANA, mirroring the EcoFacet pattern. Reviewer verified.
+
+**Source:** `2026.02.16_PolymerCCTPFacet(v2.0.0).pdf` p.4-4 · `audit20260216::6.1.1`
+
+---
+
+## LF-143 · INFO · AcrossV4SwapFacet · acknowledged
+
+**Recognition signal:** Emitting a 'has destination call' analytics flag based only on the outer wrapper while the inner cross-chain message field that triggers remote execution is not consulted.
+
+**Root cause:** AcrossV4SwapFacet enforces doesNotContainDestinationCalls on bridgeData but the inner SpokePool/Periphery calldata can carry a non-empty Across message that triggers destination-side execution. The LiFiTransferStarted event therefore emits hasDestinationCall = false even when a destination call effectively happens. AcrossFacetV4 cross-checks message length vs the flag; the swap facet does not.
+
+**Fix:** Acknowledged: LI.FI treats destinationCall=true as 'LI.FI-added destination calls only'; the Across swap API is treated as one opaque operation.
+
+**Source:** `2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf` p.10-12 · `audit20260409::6.5.3`

--- a/audit/knowledge/by-area/libraries.md
+++ b/audit/knowledge/by-area/libraries.md
@@ -1,0 +1,95 @@
+# Libraries — past findings
+
+## LF-053 · MEDIUM · LibAsset · acknowledged
+
+**Recognition signal:** Batch handler iterating per-item native-asset deposits that validates msg.value per-item instead of validating the cumulative native amount against a single msg.value.
+
+**Root cause:** depositAssets() iterates LibSwap.SwapData entries and calls depositAsset() per swap; for native assets it only checks msg.value >= amount on each iteration individually. Because msg.value is fixed for the transaction, the same ETH balance is treated as sufficient for every native swap, so the function accepts a batch whose total native requirement exceeds the actual ETH sent.
+
+**Fix:** Not fixed. Acknowledged with a note that inheriting contracts should not call depositAssets in a loop with multiple native-asset swaps.
+
+**Source:** `2025.05.06_LibAsset(v2.0.0).pdf` p.4-4 · `audit20250506::6.1.1`
+
+---
+
+## LF-054 · MEDIUM · LibAsset · fixed
+
+**Recognition signal:** Internal ERC20 transfer helper that does not reject the native-asset sentinel before issuing a low-level call, so transfers to address(0) succeed silently due to empty returndata.
+
+**Root cause:** transferFromERC20 does not guard against assetId == address(0); the call falls through to a transferFrom on address(0), which has no code, so the low-level call returns success with empty returndata. The function therefore returns silently instead of reverting on an obviously invalid ERC20 address.
+
+**Fix:** Fixed in b1d0a6e248 by reverting with NullAddrIsNotAnERC20Token when assetId is the native asset placeholder.
+
+**Source:** `2025.05.06_LibAsset(v2.0.0).pdf` p.5-5 · `audit20250506::6.1.2`
+
+---
+
+## LF-055 · LOW · LibAsset · fixed
+
+**Recognition signal:** Library helper whose semantics around the native-asset sentinel changed between versions (revert vs. return), creating an implicit breaking change for inheriting facets.
+
+**Root cause:** The v2.0.0 approveERC20 reverts when called with the native-asset placeholder, while v1.0.2 maxApproveERC20 returned early. Callers that relied on the old behavior of safe no-op for native assets now revert unexpectedly.
+
+**Fix:** Fixed in 84a413732 by restoring the early-return-on-native-asset behavior.
+
+**Source:** `2025.05.06_LibAsset(v2.0.0).pdf` p.6-6 · `audit20250506::6.2.1`
+
+---
+
+## LF-056 · LOW · LibAsset · fixed
+
+**Recognition signal:** isContract helper that treats the EIP-7702 0xef0100 prefix as conclusive evidence of contract status without dereferencing and code-size-checking the delegated implementation.
+
+**Root cause:** isContract returns true as soon as the first three bytes of extcodecopy match the EIP-7702 delegation prefix 0xef0100, without checking that the delegated target has non-zero code. An EOA that delegates to address(0) therefore appears as a contract while behaving like an EOA, breaking any access-control or routing logic that relies on the contract-vs-EOA distinction.
+
+**Fix:** Fixed in dcb3125546 and 5927e648 by validating that the delegated implementation has non-zero code size.
+
+**Source:** `2025.05.06_LibAsset(v2.0.0).pdf` p.6-7 · `audit20250506::6.2.2`
+
+---
+
+## LF-114 · LOW · LibAllowList, WhitelistManagerFacet · mitigated
+
+**Recognition signal:** Allow-list / access-control gate that checks two related dimensions (target + function-selector, or sender + role + scope) via independent mappings instead of a composite key, enabling cross-combinations the author never intended to authorize.
+
+**Root cause:** AllowListStorage keeps contractAllowList and selectorAllowList as two independent mappings, and external-call gates check each membership separately. As a result, every whitelisted address is implicitly callable with every whitelisted selector, so an unintended selector that happens to be whitelisted on a different protocol (e.g. transferFrom on a token contract) becomes a valid call target on every whitelisted contract.
+
+**Fix:** Acknowledged for already-deployed contracts; a new granular pair-based whitelist (isContractSelectorWhitelisted) was introduced for new contracts. Migration safety fix in PR#1441 commit e87f69019e59b8060f9c53e00acd4ed07ac4084a; verified.
+
+**Source:** `2025.11.04_WhitelistManagerFacet(v1.0.0).pdf` p.4-6 · `audit20251104::L-1`
+
+---
+
+## LF-057 · INFO · LibAsset · fixed
+
+**Recognition signal:** Codehash equality check against only one of {bytes32(0), keccak256("")} when deciding whether an address has code.
+
+**Root cause:** extcodehash returns bytes32(0) for addresses that have never received a transaction and keccak256("") for addresses that have received ETH but have no code. Comparing only against keccak256("") therefore lets virgin EOAs satisfy the codehash != emptyHash condition and be misclassified as contracts.
+
+**Fix:** Addressed in dcb3125546 by removing the codehash-based check entirely.
+
+**Source:** `2025.05.06_LibAsset(v2.0.0).pdf` p.8-9 · `audit20250506::6.4.2`
+
+---
+
+## LF-070 · INFO · LibAsset · acknowledged
+
+**Recognition signal:** Using extcodesize > N as a contract/EOA discriminator where N is chosen for EIP-7702 compatibility, without considering hand-rolled bytecode of smaller size.
+
+**Root cause:** isContract() returns size > 23 to remain compatible with EIP-7702 delegated accounts (size 23). Hand-crafted minimal bytecode contracts deployed outside the Solidity compiler can have code size < 23 and are mis-classified as EOAs.
+
+**Fix:** Acknowledged: residual risk noted, no security impact at this time and no fix applied.
+
+**Source:** `2025.06.20_LibAsset(v2.1.0).pdf` p.4-5 · `audit20250620::6.1.1`
+
+---
+
+## LF-116 · INFO · LibAllowList, WhitelistManagerFacet · acknowledged
+
+**Recognition signal:** Storage helper exposing full-array view functions over an admin-grown unbounded list, with no pagination or cursor pattern.
+
+**Root cause:** LibAllowList's contracts, selectors, and whitelistedSelectorsByContract arrays grow without bound. The view helpers (getAllowedContracts, getAllowedSelectors, getWhitelistedSelectorsForContract) iterate the full array; at large sizes the call exhausts block gas, making whitelist enumeration unusable by integrators.
+
+**Fix:** Acknowledged; LI.FI did not add pagination but documents the warning.
+
+**Source:** `2025.11.04_WhitelistManagerFacet(v1.0.0)_1.pdf` p.4-4 · `audit20251104_1::6.2.1`

--- a/audit/knowledge/by-area/periphery.md
+++ b/audit/knowledge/by-area/periphery.md
@@ -513,3 +513,15 @@
 **Fix:** Acknowledged; team argues ReceiverOIF cannot meaningfully hold tokens because anyone can craft a withdrawal call, so a residual Executor approval is treated as insignificant.
 
 **Source:** `2025.12.15_ReceiverOIF(v1.0.0).pdf` p.6-6 · `audit20251215::6.2.2`
+
+---
+
+## LF-146 · INFO · LidoWrapper · acknowledged
+
+**Recognition signal:** Token-conversion entrypoint that derives output from an external accounting contract (e.g. wrap/unwrap, deposit/redeem) and forwards the resulting balance to the caller without a `minAmountOut` floor.
+
+**Root cause:** Both wrap/unwrap entrypoints call ST_ETH.wrap / ST_ETH.unwrap with the user-supplied `_amount` and forward the resulting wstETH/stETH balance without comparing it to a caller-specified floor. Because stETH/wstETH share-to-token math depends on Lido's accounting state, the realized output amount can diverge from the caller's expectation between transaction construction and inclusion, with no on-chain check to abort the call.
+
+**Fix:** Acknowledged, not fixed. LI.FI argued no direct AMM-pool-style exploit exists and preferred to save gas; researcher accepted but flagged it as a defense-in-depth gap.
+
+**Source:** `2025.06.10_LidoWrapper(v1.0.0).pdf` p.4-5 · `audit20250610::6.1.3`

--- a/audit/knowledge/by-area/periphery.md
+++ b/audit/knowledge/by-area/periphery.md
@@ -1,0 +1,515 @@
+# Periphery — past findings
+
+## LF-021 · HIGH · Permit2Proxy · fixed
+
+**Recognition signal:** Permit-style flow where token-pull authorization is signed but the downstream call target/calldata is left as caller-controlled arguments — any front-runner can hijack the pull and redirect the funds.
+
+**Root cause:** callDiamondWithEIP2612Signature accepts a signed EIP-2612 permit but the diamondAddress and diamondCalldata are not part of the signed payload. An attacker can observe the pending transaction, extract the signature, and resubmit with malicious calldata/recipient to redirect the user's pulled tokens.
+
+**Fix:** Calldata/diamond target are bound into the signed payload so the signature commits to the action being executed. Fixed in 0e3debb78abcdf9a9f934115338b611e16b039a0.
+
+**Source:** `2024.11.22_Permit2Proxy.pdf` p.5-5 · `audit20241122::6.1.1`
+
+---
+
+## LF-082 · HIGH · Patcher · acknowledged
+
+**Recognition signal:** A periphery contract that pulls tokens via transferFrom from msg.sender while invoking caller-supplied call targets/data, with no per-call approval pattern or sender/owner pairing.
+
+**Root cause:** depositAndExecuteWithMultiplePatches / depositAndExecuteWithDynamicPatches accept arbitrary call targets and pull tokens from msg.sender via existing approvals. A second caller can use the user's outstanding Patcher approval to invoke transferFrom-style calldata against the original approver, draining funds.
+
+**Fix:** Acknowledged in 68b91b10: documented as accepted risk in Patcher NatSpec and Patcher.md; no on-chain guard added.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.4-5 · `audit20250730::6.1.1`
+
+---
+
+## LF-001 · MEDIUM · RouteProcessor4 · fixed
+
+**Recognition signal:** Native-asset transfer that uses `address(this).balance` as the amount in a path that should only forward a function-scoped local amount, in contracts that can hold native balances across calls.
+
+**Root cause:** After unwrapping `amountIn` of WETH via `IWETH.withdraw`, the contract forwards `address(this).balance` to the user-supplied `to` address instead of `amountIn`. Any non-transient native balance held by the router (e.g., dust, mid-route balances) is therefore swept into `to` on every unwrap.
+
+**Fix:** Forward only `amountIn` instead of `address(this).balance`. Fixed in commit c7053b38.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.4-4 · `audit20240201::3.1.1`
+
+---
+
+## LF-002 · MEDIUM · RouteProcessor4 · fixed
+
+**Recognition signal:** Direct `IERC20.approve(...)` / `transfer(...)` calls on user-supplied tokens without going through SafeERC20 wrappers, in a router/aggregator that must support non-standard ERC20s.
+
+**Root cause:** `IERC20(tokenIn).approve(pool, amountIn)` decodes the return value as `bool`. Tokens like USDT do not return any value from `approve()`, so the call reverts on ABI return-data decoding even though the on-chain effect succeeded.
+
+**Fix:** Use OpenZeppelin SafeERC20 `safeIncreaseAllowance` (or equivalent) which tolerates non-standard return shapes. Fixed in commits bbb90746 and 5e854cc4.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.4-4 · `audit20240201::3.1.2`
+
+---
+
+## LF-003 · MEDIUM · RouteProcessor4 · fixed
+
+**Recognition signal:** Use of `payable(...).transfer(amount)` (or `.send`) for native-asset payout to a user-supplied address.
+
+**Root cause:** Native-token payout in `swapCurve()` uses `payable(to).transfer(amountOut)`. The 2300-gas stipend imposed by `transfer` is incompatible with recipients that perform non-trivial work on receive, and is brittle against future EVM gas-pricing changes.
+
+**Fix:** Replace `.transfer` with `.call{value: ...}('')` and check the success flag. Fixed in commit 03ee79b2.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.5-5 · `audit20240201::3.1.3`
+
+---
+
+## LF-038 · MEDIUM · Permit2Proxy · fixed
+
+**Recognition signal:** Submitting a user-signed EIP-2612 permit inside a multi-step transaction without wrapping the permit() call in try/catch so the surrounding logic still proceeds if the permit was front-run on-chain.
+
+**Root cause:** callDiamondWithEIP2612Signature calls ERC20.permit and then pulls funds in one transaction. An observer can submit the same permit signature directly to the ERC20 first, marking the nonce as used and causing the proxy's subsequent permit call to revert, blocking the user's intended action.
+
+**Fix:** Fixed in bdf16c01 by wrapping the ERC20.permit call in a try/catch and continuing when allowance is already sufficient.
+
+**Source:** `2025.01.10_Cantina_PreComp.pdf` p.4-6 · `audit20250110_1::3.1.1`
+
+---
+
+## LF-074 · MEDIUM · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Function pulls tokens at a wider integer width than it forwards them to the downstream callee, with neither a width check nor a refund of the truncated portion.
+
+**Root cause:** swapIzumiV3 accepts amountIn as uint256 and pulls that full amount from the caller, but truncates it to uint128 when calling the Izumi pool. There is no validation that amountIn fits in uint128 and no refund of the discarded high bits, so any value above type(uint128).max is silently swapped only up to uint128 capacity while the truncated remainder remains trapped in the aggregator.
+
+**Fix:** Fixed in d8935ac by reverting with InvalidCallData when amountIn exceeds type(uint128).max.
+
+**Source:** `2025.06.30_LiFiDexAggregator(v1.11.0).pdf` p.5-5 · `audit20250630::6.1.1`
+
+---
+
+## LF-083 · MEDIUM · Patcher · fixed
+
+**Recognition signal:** Reading a uint256 from a target via low-level call and abi.decode/bytes-cast without validating the target's function selector, return-type, or returndata length.
+
+**Root cause:** _getDynamicValue executes a low-level call against a target and reinterprets the entire returndata as uint256 without checking the called function's return type or length. Non-uint256 return values (bytes, address, bool, larger encodings) are silently coerced into nonsensical numbers used to patch downstream calldata, which can mis-size token amounts and lose user funds.
+
+**Fix:** Fixed in 68b91b10: partial mitigation via 32-byte length check; some 32-byte encoded types (bool, address) remain ambiguous and are documented as an accepted residual risk.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.4-5 · `audit20250730::6.2.1`
+
+---
+
+## LF-004 · LOW · RouteProcessor4 · acknowledged
+
+**Recognition signal:** Assuming a uniform interface across different versions of an external protocol (e.g., legacy vs current Curve `exchange`) when decoding return data, instead of dispatching by pool type or measuring before/after balances.
+
+**Root cause:** `swapCurve()` always decodes the return value of `exchange()` as `amountOut`. Legacy Curve pools' `exchange()` endpoint has no return value, so the call reverts even when the underlying swap would have succeeded with native token in.
+
+**Fix:** Recommended to differentiate pool type and either use the matching interface or compute amountOut from before/after balances. LI.FI acknowledged: no fix because no legacy pools above $1k TVL exist.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.5-5 · `audit20240201::3.2.1`
+
+---
+
+## LF-005 · LOW · RouteProcessor4 · acknowledged
+
+**Recognition signal:** Trusting a caller-supplied token identifier across a self-contained sub-routine without cross-checking it against the on-chain pool's token0/token1 metadata.
+
+**Root cause:** `swapUniV2()` reads `tokenIn` from the stream and uses it both for the `transferFrom` and the swap amount recomputation, but never verifies that `tokenIn` is one of `pool.token0()` / `pool.token1()`. A malformed stream could pass an unrelated token while the pool swap is initiated against a different one.
+
+**Fix:** Recommended adding a check that `tokenIn` matches one of the pool tokens. LI.FI acknowledged; relies on the off-chain library to construct streams correctly.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.5-5 · `audit20240201::3.2.2`
+
+---
+
+## LF-006 · LOW · RouteProcessor4 · fixed
+
+**Recognition signal:** Sentinel value (`0`, `address(0)`, empty bytes) used to switch a function into a privileged or full-balance branch, while upstream callers can produce that value through normal rounding or user input.
+
+**Root cause:** When share rounds down or the user supplies share=0, `amount` becomes 0 in the loop. `swap()` then forwards 0 to `bentoBridge()`, which interprets `amountIn == 0` as a sentinel to operate on the contract's full token balance (deposit excess or withdraw all), causing unintended deposits/withdrawals.
+
+**Fix:** Sushiswap repurposed the `amountIn == 0` sentinel: it now uses `from == INTERNAL_INPUT_SOURCE` to indicate liquidity is already at the pool. Fixed in commit a1d42b5a.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.6-6 · `audit20240201::3.2.3`
+
+---
+
+## LF-007 · LOW · RouteProcessor4 · fixed
+
+**Recognition signal:** After a low-level `call`, wrapping `returnBytes` in `string(abi.encodePacked(...))` instead of bubbling the raw revert data via assembly when `success == false`.
+
+**Root cause:** Failure path encodes `returnBytes` (raw revert data) via `string(abi.encodePacked(returnBytes))` and passes it as the `require` message. The structured ABI-encoded revert from the inner call is therefore lost and replaced by an unreadable string, hampering debugging and on-chain error matching.
+
+**Fix:** Replace `require(success, ...)` with an assembly `revert(add(32, returnBytes), mload(returnBytes))` to bubble up the original revert data. Fixed in commit 4e34380d.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.6-6 · `audit20240201::3.2.4`
+
+---
+
+## LF-022 · LOW · Permit2Proxy · fixed
+
+**Recognition signal:** EIP-712 typehash containing fields the contract no longer reads/enforces — drift between the signed schema and runtime checks erodes the meaning of the signature.
+
+**Root cause:** The LiFiCall witness typehash hashes (tokenReceiver, diamondAddress, diamondCalldataHash) but tokenReceiver is no longer used by the current code path. The typehash therefore commits to a field that has no on-chain effect, creating a mismatch between what users sign and what the contract enforces.
+
+**Fix:** tokenReceiver removed from the witness typehash so it reflects the actually-enforced parameters. Fixed in 6ab55d42168e4d58e2b1ffd24d60d7434a7a9ca6.
+
+**Source:** `2024.11.22_Permit2Proxy.pdf` p.5-5 · `audit20241122::6.2.1`
+
+---
+
+## LF-023 · LOW · Permit2Proxy · fixed
+
+**Recognition signal:** Intermediate proxy that forwards native value to a contract known to refund msg.sender, without implementing receive()/fallback — any refund branch in the callee will revert the whole flow.
+
+**Root cause:** Many facets (AcrossFacet, CBridgeFacet, StargateFacetV2, etc.) refund excess native to msg.sender, which in this flow is Permit2Proxy. Without a receive() function the proxy rejects the refund, causing the underlying bridge call to revert when any leftover ETH is returned.
+
+**Fix:** Added a receive() function and a path to forward refunded native back to the user. Fixed in 976966de7ba14d1782904ebe7bad1b3fd2e79281.
+
+**Source:** `2024.11.22_Permit2Proxy.pdf` p.6-6 · `audit20241122::6.2.2`
+
+---
+
+## LF-024 · LOW · Permit2Proxy · acknowledged
+
+**Recognition signal:** Stateless forwarding proxy that pulls user funds but does not snapshot/return residual balances after the downstream call — dust accumulates and can be taken by the next caller.
+
+**Root cause:** callDiamondWithPermit2Witness/callDiamondWithPermit2/callDiamondWithEIP2612Signature pull tokens from the user and forward arbitrary calldata to the diamond but never sweep leftover token balances. Any dust held in the proxy can be consumed/transferred by a subsequent unrelated user's call.
+
+**Fix:** Acknowledged; no code change applied.
+
+**Source:** `2024.11.22_Permit2Proxy.pdf` p.6-6 · `audit20241122::6.2.3`
+
+---
+
+## LF-035 · LOW · ReceiverAcrossV3 · acknowledged
+
+**Recognition signal:** Receiver/executor wrapper that fixes-input a swap call but never reconciles residual token balance against the incoming amount, relying on admin recovery rather than user refund.
+
+**Root cause:** _swapAndCompleteBridgeTokens does not sweep residual balances after the executor swap completes. If the swap path does not consume the entire received bridged amount, the unused tokens stay in the contract until an admin recovers them via pullToken.
+
+**Fix:** Acknowledged in favor of gas saving; LI.FI documents the behavior rather than sweeping.
+
+**Source:** `2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf` p.5-5 · `audit20241206::6.2.2`
+
+---
+
+## LF-047 · LOW · ReceiverChainflip · acknowledged
+
+**Recognition signal:** Force-sending native ETH to a user-provided receiver in a catch/fallback branch with no further recovery path — a non-payable receiver will permanently revert the refund and lock funds.
+
+**Root cause:** After a destination-swap attempt fails, the catch branch calls receiver.safeTransferETH(amount) unconditionally to the user-supplied receiver. If the receiver is a contract that cannot receive native ETH, the refund reverts and the funds become stuck because there is no further fallback (e.g. leaving funds in the receiver for later recovery).
+
+**Fix:** Acknowledged; LI.FI prefers not to let funds fall back to its own contract. No code change applied.
+
+**Source:** `2025.03.05_ChainflipFacet(v1.0.0).pdf` p.5-6 · `audit20250305::6.2.1`
+
+---
+
+## LF-049 · LOW · LiFiDEXAggregator · acknowledged
+
+**Recognition signal:** Final-balance-delta slippage check on a recipient that can be re-entered or asynchronously credited mid-swap (e.g. via a callback) — recipient-side balance manipulation invalidates the slippage guarantee.
+
+**Root cause:** processRouteInternal only checks the recipient's final balance after all hops complete. With Velodrome V2 callbacks the recipient contract is invoked inside the swap and can artificially raise its own output-token balance, so the final-balance slippage check passes even when the pool delivered less than amountOutMin.
+
+**Fix:** Acknowledged out of scope; documentation/comments added to warn integrators in a507f1e795f9e50b9d02655c3c06f126975f73b6.
+
+**Source:** `2025.04.11_LiFiDEXAggregator(v1.7.0).pdf` p.4-4 · `audit20250411::6.1.1`
+
+---
+
+## LF-050 · LOW · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Boolean flag decoded from a calldata/stream byte using > 0 instead of == 1 — non-canonical inputs can take paths the protocol did not intend to expose.
+
+**Root cause:** swapVelodromeV2 reads the callback flag via stream.readUint8() > 0, treating any value 1..255 as 'callback enabled'. Documentation contracts a strict equality to 1, so route encodings with non-canonical flag bytes can trigger unintended callback paths.
+
+**Fix:** Comparison changed to == 1 to enforce strict canonical encoding. Fixed in 92302f00d184e89f9683208fd48e02a8bf0a4a5f.
+
+**Source:** `2025.04.11_LiFiDEXAggregator(v1.7.0).pdf` p.4-4 · `audit20250411::6.1.2`
+
+---
+
+## LF-058 · LOW · ReceiverStargateV2 · fixed
+
+**Recognition signal:** Try/catch wrapping a user-facing swap/execution that, on failure, silently delivers a different (worse) outcome to the receiver, when the outer call's gas is attacker-controlled.
+
+**Root cause:** LayerZero V2's EndPoint allows anyone to invoke lzCompose with attacker-controlled gas. ReceiverStargateV2._swapAndCompleteBridgeTokens executes the swap inside a try/catch that, on revert, falls back to transferring only the un-swapped tokens to the receiver. An attacker can therefore call lzCompose with just enough gas to pass the recoverGas pre-check but not enough for the swap, deterministically forcing the catch path.
+
+**Fix:** Fixed in commit e3b354db (either restrict lzCompose caller to authorized executors, or remove the gas reservation so OOG bubbles up instead of entering catch).
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.4-7 · `audit20250508::3.1.1`
+
+---
+
+## LF-061 · LOW · Permit2Proxy, DeBridgeDlnFacet · fixed
+
+**Recognition signal:** Cross-chain order or escrow that captures msg.sender as the cancel/refund beneficiary when the call originates from a proxy or relayer (so msg.sender is not the end user).
+
+**Root cause:** When constructing a DeBridge OrderCreation through Permit2Proxy, msg.sender at the facet layer is the Permit2Proxy itself (since the proxy delegate-calls the diamond). Hardcoding allowedCancelBeneficiarySrc to msg.sender therefore pins refunds to the proxy address on cancel. DeBridge's cancellation flow enforces this beneficiary, so the user permanently loses the refund.
+
+**Fix:** Fixed in commit 6ba0608f, switching allowedCancelBeneficiarySrc to an empty bytes array per DeBridge documentation (lets the orderAuthorityAddressDst choose the refund recipient at cancel time).
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.14-15 · `audit20250508::3.1.4`
+
+---
+
+## LF-062 · LOW · Permit2Proxy · fixed
+
+**Recognition signal:** Try/catch around an external call that uses only `catch Error(string)` or `catch Panic(uint)` (no generic `catch (bytes memory)` / `catch`) when the goal is to swallow ANY revert reason from the callee.
+
+**Root cause:** The frontrun mitigation wraps the ERC20Permit.permit call in `try ... catch Error(string memory)`, which only catches Solidity revert(string). Tokens that revert with custom errors, panics, or empty data fall straight through, so an attacker that frontruns and consumes the permit can still grief callers whose tokens use those revert types.
+
+**Fix:** Fixed in commit 85952e3e by adding a generic `catch (bytes memory) { revert("Unexpected permit failure"); }` to cover all revert shapes.
+
+**Source:** `2025.05.08_Cantina_Comp.pdf` p.15-17 · `audit20250508::3.1.5`
+
+---
+
+## LF-065 · LOW · LiFiDEXAggregator · fixed
+
+**Recognition signal:** try/catch around a router/pool call that treats any revert as a method-missing fallback and silently routes to a different swap path, masking unrelated failures.
+
+**Root cause:** The try/catch around swapSupportingFeeOnInputTokens assumes the only failure mode is the method not existing on the pool, but any revert path (insufficient allowance, slippage triggered, OOG, access control, overflows, invalid parameters) falls through into the standard swap() call. The catch branch silently rerouting to a different swap function can produce semantically incorrect behavior for fee-on-transfer tokens.
+
+**Fix:** Fixed in 6da37c48d1f521395c41148a9b38651858ba9812 by removing the try/catch and letting the call revert naturally.
+
+**Source:** `2025.05.10_LiFiDexAggregator(v1.9.0).pdf` p.4-4 · `audit20250510::6.1.1`
+
+---
+
+## LF-075 · LOW · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Hardcoded numeric bounds in a DEX integration are taken from rounded "reasonable" values rather than the integration's actual valid-range constants, causing the call to drift outside the supported domain.
+
+**Root cause:** The price-boundary parameters passed to Izumi's swapX2Y/swapY2X are set to -80000 and 80000, which sit outside the protocol's documented valid range of -79999 to 79999. Passing out-of-range bounds causes Izumi to behave unpredictably, so swaps may revert or settle at unintended prices.
+
+**Fix:** Fixed in 36c3bbc by passing the correct price-boundary values to the Izumi swap functions.
+
+**Source:** `2025.06.30_LiFiDexAggregator(v1.11.0).pdf` p.6-6 · `audit20250630::6.2.1`
+
+---
+
+## LF-128 · LOW · ReceiverOIF · fixed
+
+**Recognition signal:** Cross-chain receiver decodes a final-destination address from caller-controlled payload and forwards it without a zero-address check, relying on a downstream contract to catch the burn.
+
+**Root cause:** outputFilled ABI-decodes (transactionId, swapData, receiver) from caller-supplied executionData and forwards receiver directly to the Executor without checking that it is non-zero. If the downstream Executor also does not validate, the tokens will be sent to address(0) and effectively burned.
+
+**Fix:** Fixed in 1ecae5a by validating that the decoded receiver is not the zero address in outputFilled.
+
+**Source:** `2025.12.15_ReceiverOIF(v1.0.0).pdf` p.5-5 · `audit20251215::6.1.1`
+
+---
+
+## LF-008 · INFO · RouteProcessor4 · acknowledged
+
+**Recognition signal:** Admin setter (privilege grant, pause toggle, immutable bootstrap) that mutates state controlling fund flow without emitting a corresponding event for off-chain monitoring.
+
+**Root cause:** Constructor and admin setters (`setPriviledge()`, `pause()`, `resume()`) mutate critical state but emit no events. Off-chain monitoring cannot detect privilege grants or pause toggles, weakening incident response and audit trail for an emergency-pause router.
+
+**Fix:** Recommended emitting events on every admin state change. LI.FI acknowledged; argued these functions should never fire outside an emergency.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.12-12 · `audit20240201::3.4.11`
+
+---
+
+## LF-009 · INFO · RouteProcessor4 · acknowledged
+
+**Recognition signal:** Multi-hop swap router that enforces slippage only on the final output amount and uses `0` as `minAmountOut` for intermediate hops in the call to the underlying DEX.
+
+**Root cause:** The router only enforces a final balance check against `amountOutMin` for `tokenOut`. Intermediate swaps (notably `swapCurve` which passes `0` to `pool.exchange(...)`) have no per-leg slippage guard, so MEV/sandwich attacks on intermediate legs are only constrained by the global output check, which may admit large mid-route losses if the route does not strictly chain through the protected output token.
+
+**Fix:** Per-leg minOut would add overhead; LI.FI acknowledged and chose not to fix.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.8-8 · `audit20240201::3.4.2`
+
+---
+
+## LF-010 · INFO · RouteProcessor4 · fixed
+
+**Recognition signal:** Granting a fresh ERC20 allowance on every call without first resetting to 0 when integrating with tokens or external contracts that may not consume the full allowance.
+
+**Root cause:** If a Curve pool's `exchange()` does not consume the full allowance, the router is left with a non-zero allowance for that token/pool pair. Subsequent `swapCurve()` calls will invoke `approve(pool, amountIn)` again, which reverts on tokens like USDT that require approval be reset to 0 first, DoS-ing the path.
+
+**Fix:** If `approve()` reverts, fall back to `approve(..., 0)` then `approve(..., amountIn)`. Fixed in commit bbb90746.
+
+**Source:** `2024.02.01_LiFiDexAggregator(v1.0.0).pdf` p.9-9 · `audit20240201::3.4.4`
+
+---
+
+## LF-036 · INFO · ReceiverAcrossV3 · acknowledged
+
+**Recognition signal:** Cross-protocol message receiver that executes arbitrary swap calldata while relying solely on an external contract's reentrancy lock rather than its own.
+
+**Root cause:** handleV3AcrossMessage runs an arbitrary swap via the Executor without its own reentrancy guard, relying on Across SpokePool's external nonReentrant. If the upstream guard is ever removed or bypassed, or if a future code path is reached without going through SpokePool, defence-in-depth is absent.
+
+**Fix:** Acknowledged; LI.FI did not add a local reentrancy guard.
+
+**Source:** `2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf` p.5-6 · `audit20241206::6.3.1`
+
+---
+
+## LF-051 · INFO · LiFiDEXAggregator · mitigated
+
+**Recognition signal:** Router/aggregator that forwards calls to a user-specified pool address triggering a recipient hook — recipients that trust msg.sender as a 'valid pool' without explicit allowlist can be tricked into running attacker-controlled inputs.
+
+**Root cause:** The pool address is taken from a user-controlled stream and the Velodrome V2 hook on the recipient does not validate that the caller is a legitimate pool. An attacker can supply a malicious 'pool' so the recipient's hook is invoked from the aggregator with attacker-chosen data, with impact depending on the recipient's hook logic.
+
+**Fix:** Documentation added warning integrators not to trust hook callers without validating the pool. Fixed in 778d22b1bbf1133bc2d583cb9a1d38b1fcf50ee4.
+
+**Source:** `2025.04.11_LiFiDEXAggregator(v1.7.0).pdf` p.5-5 · `audit20250411::6.3.1`
+
+---
+
+## LF-052 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Stream/calldata-decoded addresses (pool, recipient) used directly in transfers/calls with no zero-address guard — malformed inputs silently send funds to or call address(0).
+
+**Root cause:** swapVelodromeV2 reads the pool and to addresses from the input stream and uses them without zero-address checks. A malformed route encoding can cause a swap to address(0), losing tokens, or an interaction with address(0) as the pool.
+
+**Fix:** Added explicit zero-address reverts for pool and to. Fixed in 97781cd4f0c7fd7286401fc22f69f0c2fe22317f.
+
+**Source:** `2025.04.11_LiFiDEXAggregator(v1.7.0).pdf` p.6-6 · `audit20250411::6.3.5`
+
+---
+
+## LF-066 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Boolean control flag decoded from a byte stream as `> 0` rather than equality with the documented sentinel value, letting any non-zero byte select the alternate code path.
+
+**Root cause:** The flag is decoded as stream.readUint8() > 0, so any value from 1-255 enters the supportsFeeOnTransfer branch even though the documentation specifies only 1. A caller (or a buggy off-chain encoder) that emits a sentinel byte other than 1 will silently take a different swap path than intended.
+
+**Fix:** Fixed in 401b4a62bbdfd77d63c4e102952b0aadbad10d74 by switching to strict equality with a FEE_ON_TRANSFER_FLAG constant.
+
+**Source:** `2025.05.10_LiFiDexAggregator(v1.9.0).pdf` p.4-4 · `audit20250510::6.2.1`
+
+---
+
+## LF-067 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Stream-decoded address parameters (pool, recipient) used directly in external calls without the zero-address and sentinel-address checks that adjacent functions enforce.
+
+**Root cause:** Pool and recipient addresses are read directly from the stream and passed to the swap call with no checks against address(0) or the IMPOSSIBLE_POOL_ADDRESS sentinel, unlike other swap functions in the same contract. A malformed stream can send funds to address(0) or trigger an interaction with the sentinel pool.
+
+**Fix:** Fixed in a18db220dc3fcb3484962d7552600286184c5800 by validating pool, recipient, and the sentinel before issuing the swap call.
+
+**Source:** `2025.05.10_LiFiDexAggregator(v1.9.0).pdf` p.5-5 · `audit20250510::6.2.3`
+
+---
+
+## LF-076 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** An enum-like uint8 read from user-controlled calldata is forwarded to an external protocol without a bounds check against the documented set of valid mode values.
+
+**Root cause:** withdrawMode is a uint8 read from the encoded stream and forwarded directly to SyncSwap, which only defines modes 0–2. No bounds check exists, so a caller can supply 3–255 and reach downstream code paths whose behavior is undefined for this integration.
+
+**Fix:** Fixed in ec277e6 by reverting with InvalidCallData when withdrawMode > 2.
+
+**Source:** `2025.06.30_LiFiDexAggregator(v1.11.0).pdf` p.6-7 · `audit20250630::6.4.1`
+
+---
+
+## LF-077 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Two sibling branches in the same function diverge in how they handle a sentinel/special-case input — one validates explicitly, the other only documents the case in a comment.
+
+**Root cause:** For SyncSwap V1 pools the code explicitly reverts on INTERNAL_INPUT_SOURCE, but the V2 branch only documents this case in a comment and silently falls through without a revert. The asymmetry leaves the V2 path open to unexpected source-routing values that aren't validated.
+
+**Fix:** Fixed in ad4b814 by adding the explicit revert for the V2 branch matching the V1 behavior.
+
+**Source:** `2025.06.30_LiFiDexAggregator(v1.11.0).pdf` p.7-7 · `audit20250630::6.4.2`
+
+---
+
+## LF-078 · INFO · LiFiDEXAggregator · fixed
+
+**Recognition signal:** Newly added DEX handler accepts critical addresses from packed calldata and forwards them to external calls without the zero-address/sentinel validations that exist in every neighboring handler.
+
+**Root cause:** swapIzumiV3 decodes pool, direction, and recipient from the raw stream and forwards them straight into the Izumi pool call. There is no check that pool is non-zero or not the IMPOSSIBLE_POOL_ADDRESS sentinel, and no check that recipient is non-zero, in contrast with sibling DEX handlers that validate these.
+
+**Fix:** Fixed in 36c3bbc by validating pool, the IMPOSSIBLE_POOL_ADDRESS sentinel, and recipient before forwarding the call.
+
+**Source:** `2025.06.30_LiFiDexAggregator(v1.11.0).pdf` p.7-8 · `audit20250630::6.4.4`
+
+---
+
+## LF-084 · INFO · Patcher · fixed
+
+**Recognition signal:** Granting unbounded ERC20 approvals to caller-supplied external targets without resetting allowance after the external call.
+
+**Root cause:** Patcher grants unlimited (type(uint256).max) ERC20 approvals to user-supplied execution targets and does not reset them after the call. Compromised or buggy target contracts can drain the residual allowance if any tokens are later held by Patcher.
+
+**Fix:** Fixed in 699218d7 by adjusting approval flow and documenting the behaviour.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.5-5 · `audit20250730::6.4.1`
+
+---
+
+## LF-085 · INFO · Patcher · fixed
+
+**Recognition signal:** Privileged or user-callable functions that execute arbitrary external calls without emitting an event capturing target, calldata, or amounts.
+
+**Root cause:** All four functions that patch and execute external calldata complete without emitting any event, leaving indexers and monitoring with no on-chain trace of what was executed against which target.
+
+**Fix:** Fixed in 68f8b1c0 by adding events to the four execution functions.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.6-6 · `audit20250730::6.4.3`
+
+---
+
+## LF-086 · INFO · Patcher · fixed
+
+**Recognition signal:** An entrypoint that takes a 'requested amount' parameter but actually pulls the caller's full pre-approved allowance, with the discrepancy undocumented.
+
+**Root cause:** _depositAndApprove (used by depositAndExecuteWithMultiplePatches / depositAndExecuteWithDynamicPatches) transferFroms the caller's entire approved balance, ignoring the amount field in the calldata. Integrators expecting amount-bounded transfers can lose funds.
+
+**Fix:** Fixed in f25baadc by documenting the behaviour explicitly.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.6-6 · `audit20250730::6.4.4`
+
+---
+
+## LF-087 · INFO · Patcher · fixed
+
+**Recognition signal:** A pass-through periphery that pulls native or tokens for downstream calls but does not refund unspent amounts back to the caller, leaving dust in a contract reachable by anyone.
+
+**Root cause:** If the dynamic patched value is less than deposited tokens, the target does not spend the full approval, or msg.value exceeds the value parameter, excess assets stay in Patcher and can be swept by anyone since execution targets are unconstrained.
+
+**Fix:** Fixed in f25baadc by documenting that any excess is locked / stealable and recommending msg.value == value as a sanity check.
+
+**Source:** `2025.07.30_Patcher(v1.0.0).pdf` p.6-6 · `audit20250730::6.4.5`
+
+---
+
+## LF-095 · INFO · ReceiverAcrossV4 · acknowledged
+
+**Recognition signal:** A fallback/error-path token transfer to an address taken directly from cross-chain payload without validating it is non-zero.
+
+**Root cause:** When a destination swap fails, tokens are forwarded to the receiver decoded from the Across message without checking receiver != address(0). A malformed or buggy upstream message can route funds to 0x0 irrecoverably.
+
+**Fix:** Acknowledged: LI.FI relies on backend-produced data correctness; no on-chain check added.
+
+**Source:** `2025.09.01_AcrossV4(v1.0.0).pdf` p.5-7 · `audit20250901::6.2.4`
+
+---
+
+## LF-129 · INFO · ReceiverOIF · acknowledged
+
+**Recognition signal:** Cross-chain receiver executes user-supplied swap calldata without any contract-level minOut check, delegating slippage protection entirely to the encoded calldata's target.
+
+**Root cause:** outputFilled does not enforce any minimum output amount or aggregate slippage threshold around the inner swap. The only protection is whatever the SwapData calldata itself encodes, which depends entirely on the swap target. If the user's encoded calldata lacks slippage protection, the swap can settle at extreme adverse prices without reverting.
+
+**Fix:** Documentation added in c6ead50 noting that slippage protection must be embedded in the SwapData by the caller.
+
+**Source:** `2025.12.15_ReceiverOIF(v1.0.0).pdf` p.5-5 · `audit20251215::6.2.1`
+
+---
+
+## LF-130 · INFO · ReceiverOIF · acknowledged
+
+**Recognition signal:** Helper contract that approves a trusted-but-upgradable downstream contract before each call does not zero the allowance afterwards, leaving accumulating standing approvals from non-zero-allowance approval flows.
+
+**Root cause:** _swapAndCompleteBridgeTokens grants ERC20 approval to the Executor before the swap call but never resets the allowance to zero afterwards. Any residual allowance compounds across invocations and would be usable by a future-compromised or buggy Executor.
+
+**Fix:** Acknowledged; team argues ReceiverOIF cannot meaningfully hold tokens because anyone can craft a withdrawal call, so a residual Executor approval is treated as insignificant.
+
+**Source:** `2025.12.15_ReceiverOIF(v1.0.0).pdf` p.6-6 · `audit20251215::6.2.2`

--- a/audit/knowledge/by-area/security.md
+++ b/audit/knowledge/by-area/security.md
@@ -1,0 +1,23 @@
+# Security — past findings
+
+## LF-040 · LOW · LiFiTimelockController · fixed
+
+**Recognition signal:** Access-control modifier that interprets a role granted to address(0) as 'permissionless' — a single misconfiguration silently turns privileged functions into open ones.
+
+**Root cause:** The onlyRoleOrOpenRole modifier treats a role as 'open to anyone' when address(0) holds it. Functions like unpauseDiamond() are guarded with this modifier, so an accidental or compromised grant of TIMELOCK_ADMIN_ROLE to address(0) would make sensitive admin actions callable by any address.
+
+**Fix:** Switched to OpenZeppelin's strict onlyRole modifier, removing the 'open role via address(0)' bypass. Fixed in b26f9526c408fb0e2731e095b1188677706e97cb.
+
+**Source:** `2025.01.10_Timelock(v1.0.0).pdf` p.5-5 · `audit20250110_2::6.1.1`
+
+---
+
+## LF-041 · INFO · LiFiTimelockController · acknowledged
+
+**Recognition signal:** Timelock controller exposing a 'fast path' admin action (emergency unpause, emergency cancel) that skips the configured delay — even if scoped, it weakens the protocol's guaranteed observation window.
+
+**Root cause:** unpauseDiamond() is callable without enforcing the timelock's delay, so the multi-sig holding TIMELOCK_ADMIN_ROLE can immediately re-activate the Diamond. While the action is constrained (it can only remove facets while unpausing), it still bypasses the timelock's transparency window.
+
+**Fix:** Acknowledged; the multi-sig is trusted to use this safely. No code change.
+
+**Source:** `2025.01.10_Timelock(v1.0.0).pdf` p.5-5 · `audit20250110_2::6.2.1`

--- a/audit/knowledge/findings.json
+++ b/audit/knowledge/findings.json
@@ -1,0 +1,5243 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-05-19T14:56:58Z",
+  "findings": {
+    "LF-001": {
+      "source_id": "audit20240201::3.1.1",
+      "title": "wrapNative() drains entire native token balance instead of unwrapped amount",
+      "severity": "medium",
+      "severity_native": "Medium Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "After unwrapping `amountIn` of WETH via `IWETH.withdraw`, the contract forwards `address(this).balance` to the user-supplied `to` address instead of `amountIn`. Any non-transient native balance held by the router (e.g., dust, mid-route balances) is therefore swept into `to` on every unwrap.",
+      "fix_summary": "Forward only `amountIn` instead of `address(this).balance`. Fixed in commit c7053b38.",
+      "recognition_signal": "Native-asset transfer that uses `address(this).balance` as the amount in a path that should only forward a function-scoped local amount, in contracts that can hold native balances across calls.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.1.1",
+          "status": "fixed",
+          "severity_native": "Medium Risk",
+          "notes": "Fixed in commit c7053b38"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eth-transfer",
+        "balance-accounting"
+      ],
+      "id": "LF-001"
+    },
+    "LF-002": {
+      "source_id": "audit20240201::3.1.2",
+      "title": "swapCurve() approve() reverts on tokens that return no bool (USDT)",
+      "severity": "medium",
+      "severity_native": "Medium Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "`IERC20(tokenIn).approve(pool, amountIn)` decodes the return value as `bool`. Tokens like USDT do not return any value from `approve()`, so the call reverts on ABI return-data decoding even though the on-chain effect succeeded.",
+      "fix_summary": "Use OpenZeppelin SafeERC20 `safeIncreaseAllowance` (or equivalent) which tolerates non-standard return shapes. Fixed in commits bbb90746 and 5e854cc4.",
+      "recognition_signal": "Direct `IERC20.approve(...)` / `transfer(...)` calls on user-supplied tokens without going through SafeERC20 wrappers, in a router/aggregator that must support non-standard ERC20s.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.1.2",
+          "status": "fixed",
+          "severity_native": "Medium Risk",
+          "notes": "Fixed in commits bbb90746 and 5e854cc4"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "erc20",
+        "non-standard-tokens",
+        "approve"
+      ],
+      "id": "LF-002"
+    },
+    "LF-003": {
+      "source_id": "audit20240201::3.1.3",
+      "title": "swapCurve() uses .transfer() with 2300-gas stipend to send native tokens",
+      "severity": "medium",
+      "severity_native": "Medium Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "Native-token payout in `swapCurve()` uses `payable(to).transfer(amountOut)`. The 2300-gas stipend imposed by `transfer` is incompatible with recipients that perform non-trivial work on receive, and is brittle against future EVM gas-pricing changes.",
+      "fix_summary": "Replace `.transfer` with `.call{value: ...}('')` and check the success flag. Fixed in commit 03ee79b2.",
+      "recognition_signal": "Use of `payable(...).transfer(amount)` (or `.send`) for native-asset payout to a user-supplied address.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.1.3",
+          "status": "fixed",
+          "severity_native": "Medium Risk",
+          "notes": "Fixed in commit 03ee79b2"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eth-transfer",
+        "gas-stipend"
+      ],
+      "id": "LF-003"
+    },
+    "LF-004": {
+      "source_id": "audit20240201::3.2.1",
+      "title": "exchange() reverts when swapping legacy Curve pool with native token",
+      "severity": "low",
+      "severity_native": "Low Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "`swapCurve()` always decodes the return value of `exchange()` as `amountOut`. Legacy Curve pools' `exchange()` endpoint has no return value, so the call reverts even when the underlying swap would have succeeded with native token in.",
+      "fix_summary": "Recommended to differentiate pool type and either use the matching interface or compute amountOut from before/after balances. LI.FI acknowledged: no fix because no legacy pools above $1k TVL exist.",
+      "recognition_signal": "Assuming a uniform interface across different versions of an external protocol (e.g., legacy vs current Curve `exchange`) when decoding return data, instead of dispatching by pool type or measuring before/after balances.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.2.1",
+          "status": "acknowledged",
+          "severity_native": "Low Risk",
+          "notes": "Won't fix - no impacted pools above $1k"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "external-integration",
+        "abi-decoding"
+      ],
+      "id": "LF-004"
+    },
+    "LF-005": {
+      "source_id": "audit20240201::3.2.2",
+      "title": "swapUniV2 does not validate that tokenIn belongs to the pool",
+      "severity": "low",
+      "severity_native": "Low Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "`swapUniV2()` reads `tokenIn` from the stream and uses it both for the `transferFrom` and the swap amount recomputation, but never verifies that `tokenIn` is one of `pool.token0()` / `pool.token1()`. A malformed stream could pass an unrelated token while the pool swap is initiated against a different one.",
+      "fix_summary": "Recommended adding a check that `tokenIn` matches one of the pool tokens. LI.FI acknowledged; relies on the off-chain library to construct streams correctly.",
+      "recognition_signal": "Trusting a caller-supplied token identifier across a self-contained sub-routine without cross-checking it against the on-chain pool's token0/token1 metadata.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.2.2",
+          "status": "acknowledged",
+          "severity_native": "Low Risk",
+          "notes": "Acknowledged - relies on off-chain library to construct stream correctly"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "swap"
+      ],
+      "id": "LF-005"
+    },
+    "LF-006": {
+      "source_id": "audit20240201::3.2.3",
+      "title": "distributeAndSwap() can call swap() with amount of 0, triggering bentoBridge full-balance flow",
+      "severity": "low",
+      "severity_native": "Low Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "When share rounds down or the user supplies share=0, `amount` becomes 0 in the loop. `swap()` then forwards 0 to `bentoBridge()`, which interprets `amountIn == 0` as a sentinel to operate on the contract's full token balance (deposit excess or withdraw all), causing unintended deposits/withdrawals.",
+      "fix_summary": "Sushiswap repurposed the `amountIn == 0` sentinel: it now uses `from == INTERNAL_INPUT_SOURCE` to indicate liquidity is already at the pool. Fixed in commit a1d42b5a.",
+      "recognition_signal": "Sentinel value (`0`, `address(0)`, empty bytes) used to switch a function into a privileged or full-balance branch, while upstream callers can produce that value through normal rounding or user input.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.2.3",
+          "status": "fixed",
+          "severity_native": "Low Risk",
+          "notes": "Sentinel changed from amountIn==0 to from==INTERNAL_INPUT_SOURCE; commit a1d42b5a"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "sentinel-value",
+        "rounding",
+        "bento"
+      ],
+      "id": "LF-006"
+    },
+    "LF-007": {
+      "source_id": "audit20240201::3.2.4",
+      "title": "Revert reason bubbled up incorrectly in transferValueAndprocessRoute()",
+      "severity": "low",
+      "severity_native": "Low Risk",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "Failure path encodes `returnBytes` (raw revert data) via `string(abi.encodePacked(returnBytes))` and passes it as the `require` message. The structured ABI-encoded revert from the inner call is therefore lost and replaced by an unreadable string, hampering debugging and on-chain error matching.",
+      "fix_summary": "Replace `require(success, ...)` with an assembly `revert(add(32, returnBytes), mload(returnBytes))` to bubble up the original revert data. Fixed in commit 4e34380d.",
+      "recognition_signal": "After a low-level `call`, wrapping `returnBytes` in `string(abi.encodePacked(...))` instead of bubbling the raw revert data via assembly when `success == false`.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.2.4",
+          "status": "fixed",
+          "severity_native": "Low Risk",
+          "notes": "Fixed in commit 4e34380d"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "error-handling",
+        "revert-bubbling"
+      ],
+      "id": "LF-007"
+    },
+    "LF-008": {
+      "source_id": "audit20240201::3.4.11",
+      "title": "No events emitted when admin parameters bentoBox, priviledgedUsers, or paused are modified",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "Constructor and admin setters (`setPriviledge()`, `pause()`, `resume()`) mutate critical state but emit no events. Off-chain monitoring cannot detect privilege grants or pause toggles, weakening incident response and audit trail for an emergency-pause router.",
+      "fix_summary": "Recommended emitting events on every admin state change. LI.FI acknowledged; argued these functions should never fire outside an emergency.",
+      "recognition_signal": "Admin setter (privilege grant, pause toggle, immutable bootstrap) that mutates state controlling fund flow without emitting a corresponding event for off-chain monitoring.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.4.11",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Acknowledged - admin functions rare; no events added"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          12
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "events",
+        "access-control",
+        "monitoring"
+      ],
+      "id": "LF-008"
+    },
+    "LF-009": {
+      "source_id": "audit20240201::3.4.2",
+      "title": "Per-leg slippage protection missing; intermediate swaps have minOut hardcoded to 0",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "The router only enforces a final balance check against `amountOutMin` for `tokenOut`. Intermediate swaps (notably `swapCurve` which passes `0` to `pool.exchange(...)`) have no per-leg slippage guard, so MEV/sandwich attacks on intermediate legs are only constrained by the global output check, which may admit large mid-route losses if the route does not strictly chain through the protected output token.",
+      "fix_summary": "Per-leg minOut would add overhead; LI.FI acknowledged and chose not to fix.",
+      "recognition_signal": "Multi-hop swap router that enforces slippage only on the final output amount and uses `0` as `minAmountOut` for intermediate hops in the call to the underlying DEX.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.4.2",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Acknowledged; per-leg check considered too expensive"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "slippage",
+        "mev"
+      ],
+      "id": "LF-009"
+    },
+    "LF-010": {
+      "source_id": "audit20240201::3.4.4",
+      "title": "swapCurve() approve() leaves non-zero allowance that bricks future swaps for USDT-like tokens",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "RouteProcessor4"
+      ],
+      "root_cause": "If a Curve pool's `exchange()` does not consume the full allowance, the router is left with a non-zero allowance for that token/pool pair. Subsequent `swapCurve()` calls will invoke `approve(pool, amountIn)` again, which reverts on tokens like USDT that require approval be reset to 0 first, DoS-ing the path.",
+      "fix_summary": "If `approve()` reverts, fall back to `approve(..., 0)` then `approve(..., amountIn)`. Fixed in commit bbb90746.",
+      "recognition_signal": "Granting a fresh ERC20 allowance on every call without first resetting to 0 when integrating with tokens or external contracts that may not consume the full allowance.",
+      "status_history": [
+        {
+          "audit_id": "audit20240201",
+          "source_label": "3.4.4",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed in commit bbb90746 with allowance-reset retry"
+        }
+      ],
+      "source": {
+        "pdf": "2024.02.01_LiFiDexAggregator(v1.0.0).pdf",
+        "pages": [
+          9
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "erc20",
+        "approve",
+        "dos",
+        "non-standard-tokens"
+      ],
+      "id": "LF-010"
+    },
+    "LF-011": {
+      "source_id": "audit20240902::6.1.1",
+      "title": "extractGenericSwapParameters length check uses >= 484 instead of > 484, accepting calldata with empty SwapData",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "CalldataVerificationFacet"
+      ],
+      "root_cause": "The function's sanity check (callData.length < 484) treats exactly 484 bytes as valid, but a 484-byte calldata corresponds to an empty inner callData inside SwapData. Decoders relying on this validation can therefore proceed with structurally invalid input and return zeroed or attacker-shaped parameters.",
+      "fix_summary": "Fixed in commit a4c2574f2f143dd732de02eeecb79db6c4864806 by changing the comparison to <= 484. Reviewer verified.",
+      "recognition_signal": "Off-by-one length validation that uses strict-less-than (or strict-greater-than) where the minimum-valid case actually requires at least one byte beyond the fixed header, letting empty / zero-length variable-length tail fields slip through.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20240902",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Comparison changed to <= 484; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2024.09.02_CalldataVerificationFacet.pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "calldata-decoding",
+        "off-by-one",
+        "validation"
+      ],
+      "id": "LF-011"
+    },
+    "LF-012": {
+      "source_id": "audit20240913::6.1.1",
+      "title": "DiamondCutFacet can be accidentally permanently disabled by including it in the unpause blacklist",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EmergencyPauseFacet"
+      ],
+      "root_cause": "The unpauseDiamond function accepts an arbitrary blacklist of facets to skip when re-adding selectors, but does not exclude the DiamondCutFacet from this blacklist. Because DiamondCutFacet is the only path to add/remove facets, blacklisting it bricks all future upgrades — including re-adding any facet — and there is no safeguard or warning at the function boundary.",
+      "fix_summary": "Fixed in 7709442ae76b0209a93c732c412fcb444216c618 by skipping DiamondCutFacet selectors during the unpause loop.",
+      "recognition_signal": "Admin recovery function takes a user-supplied list of components to exclude from re-activation without protecting the bootstrap/upgrade component itself, allowing a single misconfigured call to permanently disable upgrades.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20240913",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 7709442ae76b0209a93c732c412fcb444216c618"
+        }
+      ],
+      "source": {
+        "pdf": "2024.09.13_EmergencyPauseFacet.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "access-control",
+        "diamond",
+        "upgrade-safety"
+      ],
+      "id": "LF-012"
+    },
+    "LF-013": {
+      "source_id": "audit20240913::6.1.2",
+      "title": "pauserWallet can brick the diamond by pausing then removing the EmergencyPauseFacet itself",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EmergencyPauseFacet"
+      ],
+      "root_cause": "The pauserWallet can both pause the diamond (removing all facet selectors) and call removeFacet on the EmergencyPauseFacet, leaving no facet that can re-add selectors via the diamond's normal flows. Privilege boundaries between the lower-trust pauserWallet and the diamond owner are not enforced on functions that can destroy the recovery path.",
+      "fix_summary": "Fixed in d70d09b47dca3f36068311659510cc1764019f7a by restricting destructive operations on the EmergencyPauseFacet itself to the diamond owner.",
+      "recognition_signal": "Lower-privilege role can invoke a destructive maintenance action against the very contract that contains the higher-privilege recovery action, with no self-protection of that recovery surface.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20240913",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit d70d09b47dca3f36068311659510cc1764019f7a"
+        }
+      ],
+      "source": {
+        "pdf": "2024.09.13_EmergencyPauseFacet.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "access-control",
+        "privilege-separation",
+        "diamond"
+      ],
+      "id": "LF-013"
+    },
+    "LF-014": {
+      "source_id": "audit20240913::6.1.3",
+      "title": "pauseDiamond can run out of gas as the number of facets grows because there is no pagination",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EmergencyPauseFacet"
+      ],
+      "root_cause": "pauseDiamond enumerates every facet's selectors in a single transaction via _getAllFacetFunctionSelectorsToBeRemoved with no pagination or batching. As the diamond accumulates facets, the unbounded loop exceeds the block gas limit, making the emergency pause unusable precisely when the diamond is largest.",
+      "fix_summary": "Acknowledged; team relies on adding a new EmergencyPauseFacet and a watcher on the deploy pipeline rather than implementing pagination.",
+      "recognition_signal": "Critical emergency action enumerates an unbounded protocol-state collection in a single transaction with no batching/pagination, becoming inoperable exactly when the protocol is most complex.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20240913",
+          "source_label": "6.1.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Will be mitigated via deploy-pipeline watcher / new pause facet"
+        }
+      ],
+      "source": {
+        "pdf": "2024.09.13_EmergencyPauseFacet.pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "dos",
+        "gas",
+        "emergency-action"
+      ],
+      "id": "LF-014"
+    },
+    "LF-015": {
+      "source_id": "audit20241007::6.1.1",
+      "title": "Across receiver address can be address(0) when destination call flag is enabled, bypassing zero-receiver validation",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetV3"
+      ],
+      "root_cause": "validateBridgeData enforces non-zero _bridgeData.receiver, but the bridge actually forwards _acrossData.receiverAddress. The cross-check `_bridgeData.receiver != _acrossData.receiverAddress` only runs when hasDestinationCall is false, so with destination calls enabled the across-side receiverAddress is never compared and can legitimately be zero, allowing a bridge to address(0) and a misleading event that still reports _bridgeData.receiver.",
+      "fix_summary": "Acknowledged but not patched; LI.FI considers guardrails sufficient and treats deliberate zero-address inputs as user error.",
+      "recognition_signal": "Two parallel receiver / destination fields where the standard zero-address validation only covers the outer struct and is skipped (via a feature-flag branch) for the inner / bridge-specific field that is the actual on-chain recipient.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20241007",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Medium",
+          "notes": "LI.FI considers zero address a deliberate user error and declines to fix."
+        }
+      ],
+      "source": {
+        "pdf": "2024.10.07_AcrossV3.pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "validation",
+        "branch-coverage",
+        "event-emission"
+      ],
+      "id": "LF-015"
+    },
+    "LF-016": {
+      "source_id": "audit20241007::6.2.1",
+      "title": "ERC20 bridging functions marked payable allow native ETH to be stuck in the contract",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV3"
+      ],
+      "root_cause": "startBridgeTokensViaAcrossV3ERC20Min and startBridgeTokensViaAcrossV3ERC20Packed are declared payable for a small gas saving, but the ERC20 bridge path never consumes msg.value. Any native tokens accidentally sent along with the call are retained by the facet and become consumable by other facets that lack native-token accounting.",
+      "fix_summary": "Fixed in commit ddc45f13a2007025fb62f8983d417b9a1ed233d4 by removing the payable keyword from the ERC20 entrypoints. Reviewer verified.",
+      "recognition_signal": "Function marked payable purely as a gas micro-optimization that has no native-token consumption path, leaving msg.value stuck in the contract where it can be swept or collide with other native-token flows.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20241007",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "payable removed from ERC20 entrypoints; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2024.10.07_AcrossV3.pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "payable",
+        "native-token",
+        "stuck-funds"
+      ],
+      "id": "LF-016"
+    },
+    "LF-017": {
+      "source_id": "audit20241007::6.2.2",
+      "title": "Packed Across calldata encoders silently drop trailing referrer bytes when used directly without out-of-band concatenation",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV3"
+      ],
+      "root_cause": "encode_startBridgeTokensViaAcrossV3*Packed produces calldata without the 28-byte referrer suffix that the on-chain facet expects to consume; the caller is expected to append it off-chain. If a user feeds the encoder output directly to the facet, msg.data length is short and the referrer bytes are silently truncated from the bridge call.",
+      "fix_summary": "Referrer handling was removed from the packed flow entirely in commit f8cb0d8c4bfdba35686e63849095f63c516c5784, eliminating the latent footgun. Reviewer verified.",
+      "recognition_signal": "Calldata encoder helper that emits an incomplete payload assuming the caller will concatenate additional trailing bytes off-chain, with no length self-check on the on-chain consumer to detect the missing tail.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20241007",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Referrer handling removed entirely; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2024.10.07_AcrossV3.pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "medium",
+      "tags": [
+        "calldata-encoding",
+        "footgun",
+        "packed-calldata"
+      ],
+      "id": "LF-017"
+    },
+    "LF-018": {
+      "source_id": "audit20241007::6.2.3",
+      "title": "transactionId truncated from bytes32 to bytes8 in packed Across encoders, producing 75% data loss in events",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV3"
+      ],
+      "root_cause": "encode_startBridgeTokensViaAcrossV3NativePacked and encode_startBridgeTokensViaAcrossV3ERC20Packed cast the incoming bytes32 transactionId down to bytes8 to fit the packed calldata layout. The LiFiAcrossTransfer event subsequently emits this truncated id, breaking off-chain transaction tracking and correlation across chains.",
+      "fix_summary": "Acknowledged and accepted as a known gas trade-off; not patched.",
+      "recognition_signal": "Down-casting a wider identifier (bytes32 / uint256 / etc.) to a narrower type for packed encoding without surfacing the truncation back into the event / log used by off-chain indexers.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20241007",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Known gas trade-off; LI.FI accepts information loss."
+        }
+      ],
+      "source": {
+        "pdf": "2024.10.07_AcrossV3.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "encoding",
+        "truncation",
+        "events",
+        "observability"
+      ],
+      "id": "LF-018"
+    },
+    "LF-019": {
+      "source_id": "audit20241105::6.1.1",
+      "title": "unpauseDiamond reverts with a panic when an unknown facet address is supplied in the blacklist array",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EmergencyPauseFacet"
+      ],
+      "root_cause": "The blacklist loop fetches facetFunctionSelectors(_blacklist[i]) and immediately indexes into it; if the address is not a registered facet, the returned array is empty and accessing the first element triggers an out-of-bounds panic. There is no guard or explicit error, so a typo in an admin-supplied address aborts the entire unpause with an opaque revert reason.",
+      "fix_summary": "Not fixed. Acknowledged as an admin-only function where the operator is expected to craft inputs correctly.",
+      "recognition_signal": "Admin loop that indexes the result of a registry lookup (e.g. facetFunctionSelectors) without first checking the returned array's length, turning a typo in admin input into an opaque panic that aborts the whole operation.",
+      "status_history": [
+        {
+          "audit_id": "audit20241105",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Acknowledged; mitigated off-chain with extra checks before calling the admin function."
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.05_EmergencyPauseFacet_ReAudit.pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "admin",
+        "input-validation",
+        "diamond"
+      ],
+      "id": "LF-019"
+    },
+    "LF-020": {
+      "source_id": "audit20241105::appendix",
+      "title": "EmergencyPauseFacet can be removed by the diamond owner during unpause, permanently disabling emergency-pause capability",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "EmergencyPauseFacet"
+      ],
+      "root_cause": "The unpause flow accepts an arbitrary blacklist of facets to remove from the diamond. Nothing prevents the owner from including the EmergencyPauseFacet itself in that list, which removes its selectors and irreversibly disables the emergency-pause kill-switch for the diamond.",
+      "fix_summary": "Not fixed. Acknowledged; the team will handle this function with extra caution operationally.",
+      "recognition_signal": "Admin-callable function that accepts an unconstrained list of facets/selectors to remove and does not blacklist itself or the emergency-pause facet, allowing the safety mechanism to be removed in a single transaction.",
+      "status_history": [
+        {
+          "audit_id": "audit20241105",
+          "source_label": "appendix",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Operational mitigation only; no code change."
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.05_EmergencyPauseFacet_ReAudit.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "medium",
+      "tags": [
+        "admin",
+        "self-destruct",
+        "kill-switch"
+      ],
+      "id": "LF-020"
+    },
+    "LF-021": {
+      "source_id": "audit20241122::6.1.1",
+      "title": "Frontrunning callDiamondWithEIP2612Signature steals user funds via unsigned diamond calldata",
+      "severity": "high",
+      "severity_native": "High",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "callDiamondWithEIP2612Signature accepts a signed EIP-2612 permit but the diamondAddress and diamondCalldata are not part of the signed payload. An attacker can observe the pending transaction, extract the signature, and resubmit with malicious calldata/recipient to redirect the user's pulled tokens.",
+      "fix_summary": "Calldata/diamond target are bound into the signed payload so the signature commits to the action being executed. Fixed in 0e3debb78abcdf9a9f934115338b611e16b039a0.",
+      "recognition_signal": "Permit-style flow where token-pull authorization is signed but the downstream call target/calldata is left as caller-controlled arguments — any front-runner can hijack the pull and redirect the funds.",
+      "status_history": [
+        {
+          "audit_id": "audit20241122",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "High",
+          "notes": "Verified fix in 0e3debb78abcdf9a9f934115338b611e16b039a0"
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.22_Permit2Proxy.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "permit",
+        "signature-replay",
+        "frontrunning",
+        "access-control"
+      ],
+      "id": "LF-021"
+    },
+    "LF-022": {
+      "source_id": "audit20241122::6.2.1",
+      "title": "Witness typehash includes fields not used in the newer Permit2 implementation",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "The LiFiCall witness typehash hashes (tokenReceiver, diamondAddress, diamondCalldataHash) but tokenReceiver is no longer used by the current code path. The typehash therefore commits to a field that has no on-chain effect, creating a mismatch between what users sign and what the contract enforces.",
+      "fix_summary": "tokenReceiver removed from the witness typehash so it reflects the actually-enforced parameters. Fixed in 6ab55d42168e4d58e2b1ffd24d60d7434a7a9ca6.",
+      "recognition_signal": "EIP-712 typehash containing fields the contract no longer reads/enforces — drift between the signed schema and runtime checks erodes the meaning of the signature.",
+      "status_history": [
+        {
+          "audit_id": "audit20241122",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in 6ab55d42168e4d58e2b1ffd24d60d7434a7a9ca6"
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.22_Permit2Proxy.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eip-712",
+        "permit",
+        "typehash"
+      ],
+      "id": "LF-022"
+    },
+    "LF-023": {
+      "source_id": "audit20241122::6.2.2",
+      "title": "Permit2Proxy lacks receive() so native refunds from the Diamond revert",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "Many facets (AcrossFacet, CBridgeFacet, StargateFacetV2, etc.) refund excess native to msg.sender, which in this flow is Permit2Proxy. Without a receive() function the proxy rejects the refund, causing the underlying bridge call to revert when any leftover ETH is returned.",
+      "fix_summary": "Added a receive() function and a path to forward refunded native back to the user. Fixed in 976966de7ba14d1782904ebe7bad1b3fd2e79281.",
+      "recognition_signal": "Intermediate proxy that forwards native value to a contract known to refund msg.sender, without implementing receive()/fallback — any refund branch in the callee will revert the whole flow.",
+      "status_history": [
+        {
+          "audit_id": "audit20241122",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in 976966de7ba14d1782904ebe7bad1b3fd2e79281"
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.22_Permit2Proxy.pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eth-transfer",
+        "receive",
+        "compatibility",
+        "refund"
+      ],
+      "id": "LF-023"
+    },
+    "LF-024": {
+      "source_id": "audit20241122::6.2.3",
+      "title": "Dust left in Permit2Proxy after diamond calls is claimable by next caller",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "callDiamondWithPermit2Witness/callDiamondWithPermit2/callDiamondWithEIP2612Signature pull tokens from the user and forward arbitrary calldata to the diamond but never sweep leftover token balances. Any dust held in the proxy can be consumed/transferred by a subsequent unrelated user's call.",
+      "fix_summary": "Acknowledged; no code change applied.",
+      "recognition_signal": "Stateless forwarding proxy that pulls user funds but does not snapshot/return residual balances after the downstream call — dust accumulates and can be taken by the next caller.",
+      "status_history": [
+        {
+          "audit_id": "audit20241122",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Not fixed"
+        }
+      ],
+      "source": {
+        "pdf": "2024.11.22_Permit2Proxy.pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "dust",
+        "proxy",
+        "leftover-funds"
+      ],
+      "id": "LF-024"
+    },
+    "LF-025": {
+      "source_id": "audit20241202::6.1.1",
+      "title": "swapAndStartBridgeTokensViaRelay does not validate swap output token equals sendingAssetId",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "RelayFacet"
+      ],
+      "root_cause": "After swapping, the function does not check that the final receiving asset (`_swapData[last].receivingAssetId`) equals `_bridgeData.sendingAssetId`. A mismatched swap output passes the entry-level checks and only reverts deeper in the stack with no actionable error.",
+      "fix_summary": "Acknowledged but not fixed - LI.FI optimizes for gas, and the mismatch causes a revert downstream anyway (though without a clear error message).",
+      "recognition_signal": "Bridging facet entrypoint that accepts pre-swap data and passes the result directly to a bridge call without asserting that the last swap's receiving asset matches the declared bridging asset.",
+      "status_history": [
+        {
+          "audit_id": "audit20241202",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Gas optimization - reverts downstream"
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.02_RelayFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "swap"
+      ],
+      "id": "LF-025"
+    },
+    "LF-026": {
+      "source_id": "audit20241202::6.1.3",
+      "title": "Source-chain refunds from Relay are sent to the diamond contract rather than the user",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "RelayFacet"
+      ],
+      "root_cause": "When the Relay bridge refunds on the source chain (expired/invalid quote, mismatched depositor, destination unavailable, etc.), the refund recipient defaults to the diamond address. Refunded funds are not automatically forwarded to the original user, leaving them effectively stranded unless reclaimed via admin action.",
+      "fix_summary": "Acknowledged. Not fixable on smart contract side; must be addressed at the API layer by setting `refundTo` and `refundOnOrigin` parameters in the relay quote.",
+      "recognition_signal": "Bridge integration where the source-chain refund recipient defaults to the contract address itself because the caller-supplied refund parameters are not set, even though the user has an EOA that should receive the refund.",
+      "status_history": [
+        {
+          "audit_id": "audit20241202",
+          "source_label": "6.1.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Off-chain (API) fix - no contract change"
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.02_RelayFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "refund-routing",
+        "external-integration"
+      ],
+      "id": "LF-026"
+    },
+    "LF-027": {
+      "source_id": "audit20241202::6.1.4",
+      "title": "Redundant validateBridgeData receiver check while bridging to Solana/Bitcoin",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "RelayFacet"
+      ],
+      "root_cause": "`validateBridgeData` enforces `_bridgeData.receiver != address(0)`, but when bridging to non-EVM chains the actual receiver is carried in `_relayData.nonEVMReceiver`, which is never checked for emptiness. The EVM-side check is thus a no-op while the actually-used field is unvalidated.",
+      "fix_summary": "Add explicit non-empty check on `_relayData.nonEVMReceiver` for non-EVM destinations. Fixed in commit f285130f.",
+      "recognition_signal": "Two parallel receiver fields (EVM vs non-EVM) where the modifier validates only the EVM one, while non-EVM destinations route through the unvalidated alternate field.",
+      "status_history": [
+        {
+          "audit_id": "audit20241202",
+          "source_label": "6.1.4",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit f285130f"
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.02_RelayFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "input-validation",
+        "receiver"
+      ],
+      "id": "LF-027"
+    },
+    "LF-028": {
+      "source_id": "audit20241202::6.2.2",
+      "title": "RelayFacet does not prevent requestId replay",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "RelayFacet"
+      ],
+      "root_cause": "`requestId` from the Relay quote is forwarded but the facet does not record consumed IDs. If the same `requestId` is replayed (the off-chain Relay side may not deduplicate within msg.data), funds are spent again on the source chain even though they will eventually be refunded.",
+      "fix_summary": "Add a mapping to track consumed `requestId`s and reject duplicates. Fixed in commit 4b3535fb.",
+      "recognition_signal": "Bridge facet that forwards an off-chain-supplied unique order/quote identifier without a contract-side mapping to mark it as consumed, leaving replay protection entirely to the external service.",
+      "status_history": [
+        {
+          "audit_id": "audit20241202",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed in commit 4b3535fb"
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.02_RelayFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "replay",
+        "nonce",
+        "external-integration"
+      ],
+      "id": "LF-028"
+    },
+    "LF-029": {
+      "source_id": "audit20241205::6.1.1",
+      "title": "DeBridgeDlnFacet validates _bridgeData.receiver but bridges to _deBridgeData.receiver, allowing zero/invalid receiver",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "The validateBridgeData modifier checks _bridgeData.receiver != address(0), but the actual receiver passed to deBridge's createOrder comes from a separate _deBridgeData.receiver field. There is no sanity validation of _deBridgeData.receiver, so funds can be sent to address(0), where the resulting order also cannot be cancelled.",
+      "fix_summary": "Added validation for the _deBridgeData receiver/payload alongside the existing _bridgeData checks. Fixed in f561360dde2629e4ff624a87784bc01989b38bc6.",
+      "recognition_signal": "Facet validating an ILiFi.BridgeData field (e.g. receiver) via the shared modifier while actually consuming a parallel bridge-specific struct field for the same role, leaving the latter unchecked.",
+      "status_history": [
+        {
+          "audit_id": "audit20241205",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed in commit f561360."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "duplicated-fields",
+        "zero-address"
+      ],
+      "id": "LF-029"
+    },
+    "LF-030": {
+      "source_id": "audit20241205::6.1.2",
+      "title": "Non-EOA receiver becomes orderAuthorityAddressDst and cannot call sendEvmOrderCancel, permanently locking funds",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "The facet sets orderAuthorityAddressDst = _deBridgeData.receiver. When the receiver is a smart contract that cannot make the destination-chain sendEvmOrderCancel call, no party can cancel an unfillable order, so funds get stuck until market conditions change (which may never happen).",
+      "fix_summary": "Added a separate orderAuthorityDst field to DeBridgeDlnData so callers can pick an EOA cancellation authority independent of the receiver. Fixed in 8bcb3927ebab0780cb54ba6306f7ecca2a09ff55.",
+      "recognition_signal": "Bridge integration reusing the destination receiver address as the destination-chain order/cancellation authority, without considering that the receiver may be a contract incapable of making the required cancel call.",
+      "status_history": [
+        {
+          "audit_id": "audit20241205",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed in commit 8bcb392."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "cancellation-authority",
+        "smart-contract-receiver",
+        "stuck-funds"
+      ],
+      "id": "LF-030"
+    },
+    "LF-031": {
+      "source_id": "audit20241205::6.2.1",
+      "title": "allowedCancelBeneficiarySrc left empty allows orderAuthorityAddressDst to redirect refunds away from the original sender",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "When allowedCancelBeneficiarySrc is empty, the orderAuthorityAddressDst can choose any refund address on the source chain at cancel time, making refund accuracy dependent on a correctly behaving order authority instead of being pinned to the actual bridge initiator.",
+      "fix_summary": "Set allowedCancelBeneficiarySrc = msg.sender when building the OrderCreation in _startBridge so refunds always go back to the initiator. Fixed in 92d87722236f0d58992b7baac378b42501087f8c.",
+      "recognition_signal": "Bridge order construction leaving an optional refund-recipient field empty, deferring the choice to a downstream actor instead of pinning the refund to the on-chain initiator.",
+      "status_history": [
+        {
+          "audit_id": "audit20241205",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit 92d8772."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "refund-flow",
+        "default-empty-field"
+      ],
+      "id": "LF-031"
+    },
+    "LF-032": {
+      "source_id": "audit20241205::6.2.3",
+      "title": "initDeBridgeDln does not gate on sm.initialized, allowing re-initialization of facet storage",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "initDeBridgeDln is owner-protected but never checks the storage's initialized flag before writing. The flag is set to true after init but no subsequent invocation reverts, so the same admin function can be used to wholesale rewrite the chain-id mapping bypassing the regular per-entry setter path.",
+      "fix_summary": "LI.FI acknowledged and kept the behavior to allow future re-initialization upgrades; recommended check (revert AlreadyInitialized when sm.initialized) was not applied.",
+      "recognition_signal": "Init function that writes an initialized flag in storage but does not require !initialized as a precondition, leaving the bulk-config path callable repeatedly by admin.",
+      "status_history": [
+        {
+          "audit_id": "audit20241205",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "LI.FI accepted the residual risk to retain a future upgrade path."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.05_DeBridgeDlnFacet(v1.0.0).pdf",
+        "pages": [
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "initialization",
+        "admin-function",
+        "storage"
+      ],
+      "id": "LF-032"
+    },
+    "LF-033": {
+      "source_id": "audit20241206::6.1.1",
+      "title": "AcrossFacetPackedV3 hard-codes depositor=msg.sender in non-packed entries, blocking speedUpV3Deposit for contract callers",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV3"
+      ],
+      "root_cause": "startBridgeTokensViaAcrossV3NativeMin / ERC20Min pass msg.sender as the depositor to spokePool.depositV3. Across's speedUpV3Deposit requires the depositor to ECDSA-sign a message, which a smart-contract msg.sender cannot do, leaving such deposits stuck without the speed-up escape hatch and giving inconsistent behavior across functions in the same facet.",
+      "fix_summary": "Added an explicit depositor parameter so non-EOA users can specify an EOA capable of signing speed-up messages. Fixed in 9a8ff404186a7df19d9dd5610a94b977bbfc233d.",
+      "recognition_signal": "Bridge facet hard-coding msg.sender into a destination-protocol role that later requires off-chain signing (ECDSA / EIP-712), without parameterizing that role for contract callers.",
+      "status_history": [
+        {
+          "audit_id": "audit20241206",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed in commit 9a8ff40."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-eoa-caller",
+        "signature-required",
+        "msg.sender-trust"
+      ],
+      "id": "LF-033"
+    },
+    "LF-034": {
+      "source_id": "audit20241206::6.2.1",
+      "title": "AcrossFacetPackedV3 packed/min entrypoints lack zero-address, amount and timestamp validation, enabling fund loss on bad calldata",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV3"
+      ],
+      "root_cause": "All four packed/min entrypoints skip basic sanity checks (receiver != 0, sendingAssetId != 0, inputAmount > 0, sane fillDeadline/quoteTimestamp, valid chain id). The functions trust calldata produced by the LI.FI API; if a user composes calldata directly with errors, funds can be sent to a wrong address or bridged with invalid parameters.",
+      "fix_summary": "Acknowledged. LI.FI states the facet is only meant to be used with calldata generated by their API and declined to add gas-costly validation; recommended users rely on provided encode helpers.",
+      "recognition_signal": "Gas-optimized packed entrypoints that omit sanity checks on user-provided fields because calldata is 'assumed to be backend-generated', without on-chain enforcement that the caller is the backend.",
+      "status_history": [
+        {
+          "audit_id": "audit20241206",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "LI.FI relies on API-generated calldata; no on-chain validation added."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "packed-calldata",
+        "trust-assumption"
+      ],
+      "id": "LF-034"
+    },
+    "LF-035": {
+      "source_id": "audit20241206::6.2.2",
+      "title": "Failed/partial swapData in ReceiverAcrossV3.handleV3AcrossMessage leaves dust trapped in the receiver contract",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverAcrossV3"
+      ],
+      "root_cause": "_swapAndCompleteBridgeTokens does not sweep residual balances after the executor swap completes. If the swap path does not consume the entire received bridged amount, the unused tokens stay in the contract until an admin recovers them via pullToken.",
+      "fix_summary": "Acknowledged in favor of gas saving; LI.FI documents the behavior rather than sweeping.",
+      "recognition_signal": "Receiver/executor wrapper that fixes-input a swap call but never reconciles residual token balance against the incoming amount, relying on admin recovery rather than user refund.",
+      "status_history": [
+        {
+          "audit_id": "audit20241206",
+          "source_label": "6.2.2",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Kept for gas; documentation added in lieu of sweep."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "leftover-dust",
+        "swap-residue",
+        "admin-recovery"
+      ],
+      "id": "LF-035"
+    },
+    "LF-036": {
+      "source_id": "audit20241206::6.3.1",
+      "title": "ReceiverAcrossV3.handleV3AcrossMessage lacks nonReentrant modifier despite executing untrusted swap calldata",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverAcrossV3"
+      ],
+      "root_cause": "handleV3AcrossMessage runs an arbitrary swap via the Executor without its own reentrancy guard, relying on Across SpokePool's external nonReentrant. If the upstream guard is ever removed or bypassed, or if a future code path is reached without going through SpokePool, defence-in-depth is absent.",
+      "fix_summary": "Acknowledged; LI.FI did not add a local reentrancy guard.",
+      "recognition_signal": "Cross-protocol message receiver that executes arbitrary swap calldata while relying solely on an external contract's reentrancy lock rather than its own.",
+      "status_history": [
+        {
+          "audit_id": "audit20241206",
+          "source_label": "6.3.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Defense-in-depth not added; relies on Across SpokePool guard."
+        }
+      ],
+      "source": {
+        "pdf": "2024.12.06_AcrossFacetPackedV3(v1.2.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "medium",
+      "tags": [
+        "reentrancy",
+        "defense-in-depth",
+        "untrusted-callback"
+      ],
+      "id": "LF-036"
+    },
+    "LF-037": {
+      "source_id": "audit20250106::6.1.1",
+      "title": "outputAmountPercent on AcrossFacetV3 swap-and-bridge has no bounds, allowing inflated or zero output amounts",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetV3"
+      ],
+      "root_cause": "swapAndStartBridgeTokensViaAcrossV3 computes outputAmount = (minAmount * outputAmountPercent) / 1e18 with no minimum or maximum check on outputAmountPercent. A near-zero value yields an essentially zero output (loss of funds on the destination), and a value greatly above 1e18 yields an unrealistically inflated output that would be rejected by Across but wastes user gas and may emit misleading state.",
+      "fix_summary": "Acknowledged but not patched; LI.FI argues that source/destination decimal mismatch makes a generic bound incorrect and chose not to add the limit. Reviewer suggested at least a non-zero guard.",
+      "recognition_signal": "User-controlled multiplier or scaling factor applied via fixed-point math (e.g. * X / 1e18) with no min/max bounds, where extreme values produce either trivially-small results (silent loss) or implausibly-large results (waste / DoS).",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250106",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "LI.FI declined to add bounds; cross-chain decimal differences make a generic limit incorrect."
+        }
+      ],
+      "source": {
+        "pdf": "2025.01.06_AcrossFacetV3(v1.1.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "bounds-check",
+        "math",
+        "user-input"
+      ],
+      "id": "LF-037"
+    },
+    "LF-038": {
+      "source_id": "audit20250110_1::3.1.1",
+      "title": "Griefing via frontrunning of callDiamondWithEIP2612Signature - attacker consumes user's permit signature before contract call",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "callDiamondWithEIP2612Signature calls ERC20.permit and then pulls funds in one transaction. An observer can submit the same permit signature directly to the ERC20 first, marking the nonce as used and causing the proxy's subsequent permit call to revert, blocking the user's intended action.",
+      "fix_summary": "Fixed in bdf16c01 by wrapping the ERC20.permit call in a try/catch and continuing when allowance is already sufficient.",
+      "recognition_signal": "Submitting a user-signed EIP-2612 permit inside a multi-step transaction without wrapping the permit() call in try/catch so the surrounding logic still proceeds if the permit was front-run on-chain.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250110_1",
+          "source_label": "3.1.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fix commit bdf16c01."
+        }
+      ],
+      "source": {
+        "pdf": "2025.01.10_Cantina_PreComp.pdf",
+        "pages": [
+          4,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "frontrunning",
+        "permit",
+        "griefing",
+        "eip2612"
+      ],
+      "id": "LF-038"
+    },
+    "LF-039": {
+      "source_id": "audit20250110_1::3.2.1",
+      "title": "Missing min/max bounds for Gas.zip deposit amounts in GasZipFacet/GasZipPeriphery",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "cross-cutting",
+      "contracts": [
+        "GasZipFacet",
+        "GasZipPeriphery"
+      ],
+      "root_cause": "Gas.zip documents per-chain deposit limits ($0.25-$50 USD), but neither GasZipFacet nor GasZipPeriphery enforces these bounds on-chain, so out-of-range amounts can reach the router and be rejected or behave unexpectedly off-chain.",
+      "fix_summary": "Acknowledged: limits are enforced at the LI.FI backend rather than on-chain.",
+      "recognition_signal": "Forwarding user-supplied amounts to an external partner that has documented input bounds, without enforcing those bounds in the smart contract layer.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250110_1",
+          "source_label": "3.2.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Enforced off-chain at backend."
+        }
+      ],
+      "source": {
+        "pdf": "2025.01.10_Cantina_PreComp.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "validation",
+        "input-bounds",
+        "gas-zip"
+      ],
+      "id": "LF-039"
+    },
+    "LF-040": {
+      "source_id": "audit20250110_2::6.1.1",
+      "title": "onlyRoleOrOpenRole exposes timelock-admin actions if role is granted to address(0)",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "security",
+      "contracts": [
+        "LiFiTimelockController"
+      ],
+      "root_cause": "The onlyRoleOrOpenRole modifier treats a role as 'open to anyone' when address(0) holds it. Functions like unpauseDiamond() are guarded with this modifier, so an accidental or compromised grant of TIMELOCK_ADMIN_ROLE to address(0) would make sensitive admin actions callable by any address.",
+      "fix_summary": "Switched to OpenZeppelin's strict onlyRole modifier, removing the 'open role via address(0)' bypass. Fixed in b26f9526c408fb0e2731e095b1188677706e97cb.",
+      "recognition_signal": "Access-control modifier that interprets a role granted to address(0) as 'permissionless' — a single misconfiguration silently turns privileged functions into open ones.",
+      "status_history": [
+        {
+          "audit_id": "audit20250110_2",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in b26f9526c408fb0e2731e095b1188677706e97cb"
+        }
+      ],
+      "source": {
+        "pdf": "2025.01.10_Timelock(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "access-control",
+        "governance",
+        "timelock"
+      ],
+      "id": "LF-040"
+    },
+    "LF-041": {
+      "source_id": "audit20250110_2::6.2.1",
+      "title": "Emergency unpause function bypasses timelock delay",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "security",
+      "contracts": [
+        "LiFiTimelockController"
+      ],
+      "root_cause": "unpauseDiamond() is callable without enforcing the timelock's delay, so the multi-sig holding TIMELOCK_ADMIN_ROLE can immediately re-activate the Diamond. While the action is constrained (it can only remove facets while unpausing), it still bypasses the timelock's transparency window.",
+      "fix_summary": "Acknowledged; the multi-sig is trusted to use this safely. No code change.",
+      "recognition_signal": "Timelock controller exposing a 'fast path' admin action (emergency unpause, emergency cancel) that skips the configured delay — even if scoped, it weakens the protocol's guaranteed observation window.",
+      "status_history": [
+        {
+          "audit_id": "audit20250110_2",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Trust placed on TIMELOCK_ADMIN_ROLE multi-sig"
+        }
+      ],
+      "source": {
+        "pdf": "2025.01.10_Timelock(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "timelock",
+        "governance",
+        "emergency-action"
+      ],
+      "id": "LF-041"
+    },
+    "LF-042": {
+      "source_id": "audit20250219::6.1.1",
+      "title": "GlacisFacet does not validate that GlacisData.refundAddress is non-zero, risking permanent loss of bridge refunds",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "GlacisFacet"
+      ],
+      "root_cause": "Both bridge entrypoints accept GlacisData.refundAddress as user input but never validate it. The Glacis airlift uses this address to refund failed bridge attempts. A zero address (e.g., from a frontend bug or careless caller) silently passes through and refunds are permanently lost.",
+      "fix_summary": "Fixed in commit f5cdbc279f0f15ed469650d5b9b4185c0c668547 by adding a zero-address revert before invoking airlift.send.",
+      "recognition_signal": "Bridge facet that forwards a user-supplied refund/recovery address to an external protocol without validating it is non-zero, where the external protocol treats that address as the authoritative refund destination.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250219",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit f5cdbc279f0f15ed469650d5b9b4185c0c668547"
+        }
+      ],
+      "source": {
+        "pdf": "2025.02.19_GlacisFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "refund",
+        "input-validation"
+      ],
+      "id": "LF-042"
+    },
+    "LF-043": {
+      "source_id": "audit20250219::6.2.1",
+      "title": "GlacisFacet does not verify msg.value covers nativeFee, allowing callers to drain native balance the diamond may hold",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "GlacisFacet"
+      ],
+      "root_cause": "The facet passes _glacisData.nativeFee to airlift.send{value: ...} without checking that the caller actually supplied that value via msg.value. If the LiFiDiamond ever holds native balance (intentionally or not), a user could pay the bridge's native fee out of the diamond's funds.",
+      "fix_summary": "Acknowledged; LI.FI prioritized gas savings, accepting that the diamond is not expected to hold native balance.",
+      "recognition_signal": "Facet that forwards a user-controlled `value:` to an external call without asserting that msg.value supplied by the caller covers it.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250219",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Accepted; diamond should not hold native balance"
+        }
+      ],
+      "source": {
+        "pdf": "2025.02.19_GlacisFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "msg-value",
+        "fee-handling",
+        "fund-siphon"
+      ],
+      "id": "LF-043"
+    },
+    "LF-044": {
+      "source_id": "audit20250219::6.2.2",
+      "title": "GlacisFacet lacks noNativeAsset modifier, so native-asset bridges revert deep in the external call instead of failing fast with a clear error",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "GlacisFacet"
+      ],
+      "root_cause": "Glacis Airlift does not support bridging the native asset, but GlacisFacet exposes both bridge entrypoints without the noNativeAsset guard. Native-asset attempts revert several frames down inside the external airlift contract with an opaque custom-error selector.",
+      "fix_summary": "Fixed in commit f9276e33393986022f90b48fd0c5a025fa9702b6 by adding the noNativeAsset modifier to both bridge functions.",
+      "recognition_signal": "Bridge facet exposing entrypoints for an external integration that does not support native assets but omitting an upfront noNativeAsset / asset-type guard.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250219",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit f9276e33393986022f90b48fd0c5a025fa9702b6"
+        }
+      ],
+      "source": {
+        "pdf": "2025.02.19_GlacisFacet(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "fail-fast",
+        "native-asset",
+        "modifier"
+      ],
+      "id": "LF-044"
+    },
+    "LF-045": {
+      "source_id": "audit20250219::6.2.3",
+      "title": "GlacisFacet.swapAndStartBridgeTokensViaGlacis does not assert the last swap's output asset equals the bridge's sendingAssetId",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "GlacisFacet"
+      ],
+      "root_cause": "The function depositAndSwaps user assets, then bridges using _bridgeData.sendingAssetId, without confirming that swapData[length-1].receivingAssetId equals that bridging asset. A misconfigured route can leave funds in an unintended token while the bridge call attempts to transfer the wrong asset, causing a late and opaque revert.",
+      "fix_summary": "Acknowledged; LI.FI argues the call would revert anyway since the diamond does not hold funds.",
+      "recognition_signal": "swap-then-bridge function that uses _bridgeData.sendingAssetId for the bridge step without asserting that the last swap's receivingAssetId matches.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250219",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Accepted; diamond does not hold funds, so revert is implicit"
+        }
+      ],
+      "source": {
+        "pdf": "2025.02.19_GlacisFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "swap-validation",
+        "asset-mismatch",
+        "fail-fast"
+      ],
+      "id": "LF-045"
+    },
+    "LF-046": {
+      "source_id": "audit20250305::6.1.1",
+      "title": "Improper receiver address encoding for Bitcoin chain truncates non-EVM destination address",
+      "severity": "high",
+      "severity_native": "High",
+      "area": "facets",
+      "contracts": [
+        "ChainflipFacet"
+      ],
+      "root_cause": "ChainflipData.nonEVMReceiver is declared as bytes32 but Chainflip expects the bitcoin destination address as variable-length bytes (the SDK encodes 'tb1q…' as a >32-byte string). Forcing the address into a fixed 32-byte slot silently truncates it, so funds bridged to Bitcoin would be sent to a malformed address.",
+      "fix_summary": "Receiver parameter changed from bytes32 to bytes so the full non-EVM address can be passed through without truncation. Fixed in d623247e1dd21cc96111b47edabd04be09a1747d.",
+      "recognition_signal": "Receiver address for a non-EVM destination chain stored or passed as fixed-size bytes32/address20 instead of variable-length bytes — silent truncation risks loss of funds or DoS on the destination chain.",
+      "status_history": [
+        {
+          "audit_id": "audit20250305",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "High",
+          "notes": "Verified fix in d623247e1dd21cc96111b47edabd04be09a1747d"
+        }
+      ],
+      "source": {
+        "pdf": "2025.03.05_ChainflipFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "encoding",
+        "bitcoin"
+      ],
+      "id": "LF-046"
+    },
+    "LF-047": {
+      "source_id": "audit20250305::6.2.1",
+      "title": "Permanent loss of funds when refund receiver cannot accept native ETH in catch branch",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverChainflip"
+      ],
+      "root_cause": "After a destination-swap attempt fails, the catch branch calls receiver.safeTransferETH(amount) unconditionally to the user-supplied receiver. If the receiver is a contract that cannot receive native ETH, the refund reverts and the funds become stuck because there is no further fallback (e.g. leaving funds in the receiver for later recovery).",
+      "fix_summary": "Acknowledged; LI.FI prefers not to let funds fall back to its own contract. No code change applied.",
+      "recognition_signal": "Force-sending native ETH to a user-provided receiver in a catch/fallback branch with no further recovery path — a non-payable receiver will permanently revert the refund and lock funds.",
+      "status_history": [
+        {
+          "audit_id": "audit20250305",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "LI.FI prefers to avoid funds falling back to them"
+        }
+      ],
+      "source": {
+        "pdf": "2025.03.05_ChainflipFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eth-transfer",
+        "error-handling",
+        "refund"
+      ],
+      "id": "LF-047"
+    },
+    "LF-048": {
+      "source_id": "audit20250305::6.2.2",
+      "title": "Destination-call message encoding assumes EVM SwapData when destination chain is non-EVM",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "ChainflipFacet"
+      ],
+      "root_cause": "When hasDestinationCall is true the facet abi.encodes (transactionId, dstCallSwapData, bridgeData.receiver) where SwapData is EVM-native and receiver is an address. For non-EVM destination chains the encoded message and the receiver field are not interpretable on the destination, so destination calls toward Bitcoin/Solana would silently fail or be malformed.",
+      "fix_summary": "Acknowledged. LI.FI states the API does not route destination calls to non-EVM chains, but no on-chain guard was added; users bypassing the API remain exposed.",
+      "recognition_signal": "Encoding EVM-shaped payloads (Solidity structs, address-typed receiver) into cross-chain messages without branching on EVM vs non-EVM destination — assumptions about destination ABI silently break when the route is non-EVM.",
+      "status_history": [
+        {
+          "audit_id": "audit20250305",
+          "source_label": "6.2.2",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "API mitigates but no on-chain enforcement"
+        }
+      ],
+      "source": {
+        "pdf": "2025.03.05_ChainflipFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "encoding",
+        "destination-call"
+      ],
+      "id": "LF-048"
+    },
+    "LF-049": {
+      "source_id": "audit20250411::6.1.1",
+      "title": "MEV exposure when Velodrome V2 callback recipient can boost its own balance during the swap",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "processRouteInternal only checks the recipient's final balance after all hops complete. With Velodrome V2 callbacks the recipient contract is invoked inside the swap and can artificially raise its own output-token balance, so the final-balance slippage check passes even when the pool delivered less than amountOutMin.",
+      "fix_summary": "Acknowledged out of scope; documentation/comments added to warn integrators in a507f1e795f9e50b9d02655c3c06f126975f73b6.",
+      "recognition_signal": "Final-balance-delta slippage check on a recipient that can be re-entered or asynchronously credited mid-swap (e.g. via a callback) — recipient-side balance manipulation invalidates the slippage guarantee.",
+      "status_history": [
+        {
+          "audit_id": "audit20250411",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Documentation added in a507f1e795f9e50b9d02655c3c06f126975f73b6"
+        }
+      ],
+      "source": {
+        "pdf": "2025.04.11_LiFiDEXAggregator(v1.7.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "mev",
+        "slippage",
+        "callback",
+        "swap"
+      ],
+      "id": "LF-049"
+    },
+    "LF-050": {
+      "source_id": "audit20250411::6.1.2",
+      "title": "Velodrome V2 callback flag accepts any non-zero byte instead of strict 1",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "swapVelodromeV2 reads the callback flag via stream.readUint8() > 0, treating any value 1..255 as 'callback enabled'. Documentation contracts a strict equality to 1, so route encodings with non-canonical flag bytes can trigger unintended callback paths.",
+      "fix_summary": "Comparison changed to == 1 to enforce strict canonical encoding. Fixed in 92302f00d184e89f9683208fd48e02a8bf0a4a5f.",
+      "recognition_signal": "Boolean flag decoded from a calldata/stream byte using > 0 instead of == 1 — non-canonical inputs can take paths the protocol did not intend to expose.",
+      "status_history": [
+        {
+          "audit_id": "audit20250411",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in 92302f00d184e89f9683208fd48e02a8bf0a4a5f"
+        }
+      ],
+      "source": {
+        "pdf": "2025.04.11_LiFiDEXAggregator(v1.7.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "encoding",
+        "input-validation",
+        "flags"
+      ],
+      "id": "LF-050"
+    },
+    "LF-051": {
+      "source_id": "audit20250411::6.3.1",
+      "title": "swapVelodromeV2 can be used to invoke arbitrary recipient hooks without sender validation",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "The pool address is taken from a user-controlled stream and the Velodrome V2 hook on the recipient does not validate that the caller is a legitimate pool. An attacker can supply a malicious 'pool' so the recipient's hook is invoked from the aggregator with attacker-chosen data, with impact depending on the recipient's hook logic.",
+      "fix_summary": "Documentation added warning integrators not to trust hook callers without validating the pool. Fixed in 778d22b1bbf1133bc2d583cb9a1d38b1fcf50ee4.",
+      "recognition_signal": "Router/aggregator that forwards calls to a user-specified pool address triggering a recipient hook — recipients that trust msg.sender as a 'valid pool' without explicit allowlist can be tricked into running attacker-controlled inputs.",
+      "status_history": [
+        {
+          "audit_id": "audit20250411",
+          "source_label": "6.3.1",
+          "status": "mitigated",
+          "severity_native": "Informational",
+          "notes": "Documentation-only mitigation in 778d22b1bbf1133bc2d583cb9a1d38b1fcf50ee4"
+        }
+      ],
+      "source": {
+        "pdf": "2025.04.11_LiFiDEXAggregator(v1.7.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "callback",
+        "trust-boundary",
+        "user-controlled-input"
+      ],
+      "id": "LF-051"
+    },
+    "LF-052": {
+      "source_id": "audit20250411::6.3.5",
+      "title": "swapVelodromeV2 missing zero-address validation for pool and recipient",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "swapVelodromeV2 reads the pool and to addresses from the input stream and uses them without zero-address checks. A malformed route encoding can cause a swap to address(0), losing tokens, or an interaction with address(0) as the pool.",
+      "fix_summary": "Added explicit zero-address reverts for pool and to. Fixed in 97781cd4f0c7fd7286401fc22f69f0c2fe22317f.",
+      "recognition_signal": "Stream/calldata-decoded addresses (pool, recipient) used directly in transfers/calls with no zero-address guard — malformed inputs silently send funds to or call address(0).",
+      "status_history": [
+        {
+          "audit_id": "audit20250411",
+          "source_label": "6.3.5",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in 97781cd4f0c7fd7286401fc22f69f0c2fe22317f"
+        }
+      ],
+      "source": {
+        "pdf": "2025.04.11_LiFiDEXAggregator(v1.7.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "zero-address"
+      ],
+      "id": "LF-052"
+    },
+    "LF-053": {
+      "source_id": "audit20250506::6.1.1",
+      "title": "depositAssets does not aggregate msg.value across multiple native-asset swaps, allowing the same ETH to be counted multiple times",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "depositAssets() iterates LibSwap.SwapData entries and calls depositAsset() per swap; for native assets it only checks msg.value >= amount on each iteration individually. Because msg.value is fixed for the transaction, the same ETH balance is treated as sufficient for every native swap, so the function accepts a batch whose total native requirement exceeds the actual ETH sent.",
+      "fix_summary": "Not fixed. Acknowledged with a note that inheriting contracts should not call depositAssets in a loop with multiple native-asset swaps.",
+      "recognition_signal": "Batch handler iterating per-item native-asset deposits that validates msg.value per-item instead of validating the cumulative native amount against a single msg.value.",
+      "status_history": [
+        {
+          "audit_id": "audit20250506",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Medium",
+          "notes": "Acknowledged; bug retained but documented as an integration constraint for inheriting contracts."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.06_LibAsset(v2.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "native-asset",
+        "msg-value",
+        "accounting"
+      ],
+      "id": "LF-053"
+    },
+    "LF-054": {
+      "source_id": "audit20250506::6.1.2",
+      "title": "transferFromERC20 silently succeeds when called with the native asset placeholder address",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "transferFromERC20 does not guard against assetId == address(0); the call falls through to a transferFrom on address(0), which has no code, so the low-level call returns success with empty returndata. The function therefore returns silently instead of reverting on an obviously invalid ERC20 address.",
+      "fix_summary": "Fixed in b1d0a6e248 by reverting with NullAddrIsNotAnERC20Token when assetId is the native asset placeholder.",
+      "recognition_signal": "Internal ERC20 transfer helper that does not reject the native-asset sentinel before issuing a low-level call, so transfers to address(0) succeed silently due to empty returndata.",
+      "status_history": [
+        {
+          "audit_id": "audit20250506",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Verified fix in commit b1d0a6e248."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.06_LibAsset(v2.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "native-asset",
+        "silent-failure",
+        "validation"
+      ],
+      "id": "LF-054"
+    },
+    "LF-055": {
+      "source_id": "audit20250506::6.2.1",
+      "title": "approveERC20 reverts on native asset instead of no-op, breaking the prior LibAsset contract",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "The v2.0.0 approveERC20 reverts when called with the native-asset placeholder, while v1.0.2 maxApproveERC20 returned early. Callers that relied on the old behavior of safe no-op for native assets now revert unexpectedly.",
+      "fix_summary": "Fixed in 84a413732 by restoring the early-return-on-native-asset behavior.",
+      "recognition_signal": "Library helper whose semantics around the native-asset sentinel changed between versions (revert vs. return), creating an implicit breaking change for inheriting facets.",
+      "status_history": [
+        {
+          "audit_id": "audit20250506",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 84a413732."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.06_LibAsset(v2.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "native-asset",
+        "backward-compat",
+        "validation"
+      ],
+      "id": "LF-055"
+    },
+    "LF-056": {
+      "source_id": "audit20250506::6.2.2",
+      "title": "isContract is spoofable to true by EIP-7702 delegation to address(0)",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "isContract returns true as soon as the first three bytes of extcodecopy match the EIP-7702 delegation prefix 0xef0100, without checking that the delegated target has non-zero code. An EOA that delegates to address(0) therefore appears as a contract while behaving like an EOA, breaking any access-control or routing logic that relies on the contract-vs-EOA distinction.",
+      "fix_summary": "Fixed in dcb3125546 and 5927e648 by validating that the delegated implementation has non-zero code size.",
+      "recognition_signal": "isContract helper that treats the EIP-7702 0xef0100 prefix as conclusive evidence of contract status without dereferencing and code-size-checking the delegated implementation.",
+      "status_history": [
+        {
+          "audit_id": "audit20250506",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commits dcb3125546, 5927e648."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.06_LibAsset(v2.0.0).pdf",
+        "pages": [
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eip-7702",
+        "isContract",
+        "access-control"
+      ],
+      "id": "LF-056"
+    },
+    "LF-057": {
+      "source_id": "audit20250506::6.4.2",
+      "title": "isContract uses only keccak256(\"\") as the empty-codehash sentinel, misclassifying never-interacted addresses",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "extcodehash returns bytes32(0) for addresses that have never received a transaction and keccak256(\"\") for addresses that have received ETH but have no code. Comparing only against keccak256(\"\") therefore lets virgin EOAs satisfy the codehash != emptyHash condition and be misclassified as contracts.",
+      "fix_summary": "Addressed in dcb3125546 by removing the codehash-based check entirely.",
+      "recognition_signal": "Codehash equality check against only one of {bytes32(0), keccak256(\"\")} when deciding whether an address has code.",
+      "status_history": [
+        {
+          "audit_id": "audit20250506",
+          "source_label": "6.4.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Codehash check removed entirely in commit dcb3125546."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.06_LibAsset(v2.0.0).pdf",
+        "pages": [
+          8,
+          9
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "isContract",
+        "codehash",
+        "edge-case"
+      ],
+      "id": "LF-057"
+    },
+    "LF-058": {
+      "source_id": "audit20250508::3.1.1",
+      "title": "ReceiverStargateV2 does not verify lzCompose caller, enabling gas-griefing that forces fallback to source-token transfer",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverStargateV2"
+      ],
+      "root_cause": "LayerZero V2's EndPoint allows anyone to invoke lzCompose with attacker-controlled gas. ReceiverStargateV2._swapAndCompleteBridgeTokens executes the swap inside a try/catch that, on revert, falls back to transferring only the un-swapped tokens to the receiver. An attacker can therefore call lzCompose with just enough gas to pass the recoverGas pre-check but not enough for the swap, deterministically forcing the catch path.",
+      "fix_summary": "Fixed in commit e3b354db (either restrict lzCompose caller to authorized executors, or remove the gas reservation so OOG bubbles up instead of entering catch).",
+      "recognition_signal": "Try/catch wrapping a user-facing swap/execution that, on failure, silently delivers a different (worse) outcome to the receiver, when the outer call's gas is attacker-controlled.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit e3b354db"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          4,
+          5,
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "gas-griefing",
+        "try-catch",
+        "cross-chain-receiver",
+        "layerzero"
+      ],
+      "id": "LF-058"
+    },
+    "LF-059": {
+      "source_id": "audit20250508::3.1.2",
+      "title": "DexManagerFacet.batchAddDex can enter an infinite loop when a dex is already allowed",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "DexManagerFacet"
+      ],
+      "root_cause": "The loop body uses a manually-unchecked-incremented counter, but the early-continue branch for already-allowed dexes skips the increment. Any duplicate or pre-existing-allowed entry pins the loop on the same index until the transaction runs out of gas.",
+      "fix_summary": "Fixed in commit 47e4d8d7 by incrementing i inside the continue branch as well.",
+      "recognition_signal": "for-loop with manual unchecked counter increment that lives only in the happy path, alongside an early-continue (or branch) that does not advance the counter.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 47e4d8d7"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "dos",
+        "loop",
+        "admin-config"
+      ],
+      "id": "LF-059"
+    },
+    "LF-060": {
+      "source_id": "audit20250508::3.1.3",
+      "title": "GasZipFacet's address-to-bytes32 conversion uses left-padding, breaking all bridges and silently directing funds to address(0) when caller compensates",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "GasZipFacet"
+      ],
+      "root_cause": "GasZipV2 requires bytes32 receivers to be right-padded (e.g. via bytes32(bytes20(uint160(addr)))). The facet's invariant check uses bytes32(uint256(uint160(addr))), which left-pads. Correctly-formatted requests always revert with InvalidCallData, and users who match the buggy encoding by left-padding their input pass the check but bridge funds to address(0) on the destination chain. The bug is camouflaged because the facet's tests use the same incorrect encoding.",
+      "fix_summary": "Fixed in commit 30caee47 by switching the conversion to bytes32(bytes20(uint160(_bridgeData.receiver))) and updating tests.",
+      "recognition_signal": "Address-to-bytes32 conversion via the uint256 intermediate (zero-pads on the left) where the downstream integration or non-EVM target expects right-padded bytes32, especially when invariant checks lock both sides to the same wrong encoding.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.3",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 30caee47"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "encoding",
+        "address-padding",
+        "loss-of-funds"
+      ],
+      "id": "LF-060"
+    },
+    "LF-061": {
+      "source_id": "audit20250508::3.1.4",
+      "title": "Permit2Proxy sets allowedCancelBeneficiarySrc=msg.sender on DeBridge orders, causing canceled-order refunds to land in the proxy instead of the user",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy",
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "When constructing a DeBridge OrderCreation through Permit2Proxy, msg.sender at the facet layer is the Permit2Proxy itself (since the proxy delegate-calls the diamond). Hardcoding allowedCancelBeneficiarySrc to msg.sender therefore pins refunds to the proxy address on cancel. DeBridge's cancellation flow enforces this beneficiary, so the user permanently loses the refund.",
+      "fix_summary": "Fixed in commit 6ba0608f, switching allowedCancelBeneficiarySrc to an empty bytes array per DeBridge documentation (lets the orderAuthorityAddressDst choose the refund recipient at cancel time).",
+      "recognition_signal": "Cross-chain order or escrow that captures msg.sender as the cancel/refund beneficiary when the call originates from a proxy or relayer (so msg.sender is not the end user).",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.4",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 6ba0608f"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          14,
+          15
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "proxy-msg-sender",
+        "refund",
+        "debridge",
+        "loss-of-funds"
+      ],
+      "id": "LF-061"
+    },
+    "LF-062": {
+      "source_id": "audit20250508::3.1.5",
+      "title": "Permit2Proxy catches only string Error reverts, leaving panic and custom-error reverts uncaught and exploitable for griefing",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "Permit2Proxy"
+      ],
+      "root_cause": "The frontrun mitigation wraps the ERC20Permit.permit call in `try ... catch Error(string memory)`, which only catches Solidity revert(string). Tokens that revert with custom errors, panics, or empty data fall straight through, so an attacker that frontruns and consumes the permit can still grief callers whose tokens use those revert types.",
+      "fix_summary": "Fixed in commit 85952e3e by adding a generic `catch (bytes memory) { revert(\"Unexpected permit failure\"); }` to cover all revert shapes.",
+      "recognition_signal": "Try/catch around an external call that uses only `catch Error(string)` or `catch Panic(uint)` (no generic `catch (bytes memory)` / `catch`) when the goal is to swallow ANY revert reason from the callee.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.5",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 85952e3e"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          15,
+          16,
+          17
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "try-catch",
+        "permit",
+        "griefing",
+        "error-handling"
+      ],
+      "id": "LF-062"
+    },
+    "LF-063": {
+      "source_id": "audit20250508::3.1.6",
+      "title": "CelerIMFacetBase assumes RelayerCelerIM has the same address across chains, but CREATE-opcode-driven address derivation differs on zkSync, sending bridged funds to a non-existent address",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "CelerIMFacetBase",
+        "RelayerCelerIM"
+      ],
+      "root_cause": "The facet sets _bridgeData.receiver = address(relayer) (the source-chain relayer it just deployed). It implicitly assumes the same address is used on every chain. zkSync derives contract addresses via a different CREATE scheme, so the source-chain relayer address has no code on zkSync (and vice-versa). Celer's executeTransfer then has no destination contract to call and refunds are also impossible.",
+      "fix_summary": "Fixed in commit b4ffcb7b by removing CelerIMFacet and RelayerCelerIM from zkSync entirely.",
+      "recognition_signal": "Cross-chain code that hardcodes or auto-derives a contract address (e.g. address(this), address(relayer), CREATE-deployed clone) and assumes byte-identical addresses across chains, without handling chains with non-standard address derivation (zkSync Era, Starknet, etc.).",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.6",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit b4ffcb7b (removed CelerIM from zkSync)"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          17,
+          18,
+          19
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-standard-evm",
+        "zksync",
+        "address-derivation",
+        "loss-of-funds"
+      ],
+      "id": "LF-063"
+    },
+    "LF-064": {
+      "source_id": "audit20250508::3.1.7",
+      "title": "HopFacet forwards msg.value = minAmount + nativeFee, but Hop bridge requires value == amount, leaking nativeFee and double-charging ERC20 users",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "HopFacet",
+        "HopFacetOptimized"
+      ],
+      "root_cause": "Hop's L1_Bridge enforces msg.value == amount for native transfers and ignores msg.value for ERC20 transfers (fees are taken from the token amount). HopFacet always forwards nativeFee + minAmount for native and nativeFee for ERC20, which means: native transfers revert via Hop's internal check unless nativeFee is zero, and ERC20 transfers silently lose the entire nativeFee with no refund.",
+      "fix_summary": "Fixed in commit b04aaaf9. Synchronize msg.value with _bridgeData.minAmount and stop forwarding native value when bridging ERC20s.",
+      "recognition_signal": "Bridge/integration facet that forwards msg.value = amount + extraFee to a downstream contract that strictly requires msg.value == amount (or ignores msg.value for ERC20), so the extra fee is either rejected or silently consumed.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250508",
+          "source_label": "3.1.7",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit b04aaaf9"
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.08_Cantina_Comp.pdf",
+        "pages": [
+          19,
+          20,
+          21
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "msg-value",
+        "fee-handling",
+        "hop",
+        "loss-of-funds"
+      ],
+      "id": "LF-064"
+    },
+    "LF-065": {
+      "source_id": "audit20250510::6.1.1",
+      "title": "swapAlgebra falls back from swapSupportingFeeOnInputTokens to swap() on any error, masking unrelated failures",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "The try/catch around swapSupportingFeeOnInputTokens assumes the only failure mode is the method not existing on the pool, but any revert path (insufficient allowance, slippage triggered, OOG, access control, overflows, invalid parameters) falls through into the standard swap() call. The catch branch silently rerouting to a different swap function can produce semantically incorrect behavior for fee-on-transfer tokens.",
+      "fix_summary": "Fixed in 6da37c48d1f521395c41148a9b38651858ba9812 by removing the try/catch and letting the call revert naturally.",
+      "recognition_signal": "try/catch around a router/pool call that treats any revert as a method-missing fallback and silently routes to a different swap path, masking unrelated failures.",
+      "status_history": [
+        {
+          "audit_id": "audit20250510",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 6da37c48."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.10_LiFiDexAggregator(v1.9.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "try-catch",
+        "fee-on-transfer",
+        "control-flow"
+      ],
+      "id": "LF-065"
+    },
+    "LF-066": {
+      "source_id": "audit20250510::6.2.1",
+      "title": "swapAlgebra activates fee-on-transfer route on any non-zero flag value instead of strict equality with 1",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "The flag is decoded as stream.readUint8() > 0, so any value from 1-255 enters the supportsFeeOnTransfer branch even though the documentation specifies only 1. A caller (or a buggy off-chain encoder) that emits a sentinel byte other than 1 will silently take a different swap path than intended.",
+      "fix_summary": "Fixed in 401b4a62bbdfd77d63c4e102952b0aadbad10d74 by switching to strict equality with a FEE_ON_TRANSFER_FLAG constant.",
+      "recognition_signal": "Boolean control flag decoded from a byte stream as `> 0` rather than equality with the documented sentinel value, letting any non-zero byte select the alternate code path.",
+      "status_history": [
+        {
+          "audit_id": "audit20250510",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit 401b4a62."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.10_LiFiDexAggregator(v1.9.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "stream-decoding",
+        "flag",
+        "routing"
+      ],
+      "id": "LF-066"
+    },
+    "LF-067": {
+      "source_id": "audit20250510::6.2.3",
+      "title": "swapAlgebra does not sanity-check pool and recipient addresses decoded from the stream",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "Pool and recipient addresses are read directly from the stream and passed to the swap call with no checks against address(0) or the IMPOSSIBLE_POOL_ADDRESS sentinel, unlike other swap functions in the same contract. A malformed stream can send funds to address(0) or trigger an interaction with the sentinel pool.",
+      "fix_summary": "Fixed in a18db220dc3fcb3484962d7552600286184c5800 by validating pool, recipient, and the sentinel before issuing the swap call.",
+      "recognition_signal": "Stream-decoded address parameters (pool, recipient) used directly in external calls without the zero-address and sentinel-address checks that adjacent functions enforce.",
+      "status_history": [
+        {
+          "audit_id": "audit20250510",
+          "source_label": "6.2.3",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit a18db220."
+        }
+      ],
+      "source": {
+        "pdf": "2025.05.10_LiFiDexAggregator(v1.9.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "stream-decoding",
+        "consistency"
+      ],
+      "id": "LF-067"
+    },
+    "LF-068": {
+      "source_id": "audit20250603::6.1.1",
+      "title": "GnosisBridgeFacet grants unlimited router approval every bridge call instead of approving exact amount",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "GnosisBridgeFacet"
+      ],
+      "root_cause": "_startBridge uses LibAsset.maxApproveERC20 on the Gnosis Bridge Router. Although the facet never holds balances persistently (funds flow through atomically), any future bug or compromise of the router would have a larger blast radius than a per-call exact-amount approval.",
+      "fix_summary": "Acknowledged as an intentional design choice across facets for gas efficiency; no change made.",
+      "recognition_signal": "Bridge facet that issues max ERC20 approval to an external router on every bridge call instead of the exact transfer amount, accepting larger blast radius for gas savings.",
+      "status_history": [
+        {
+          "audit_id": "audit20250603",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Intentional design choice; transient balances reduce risk."
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.03_GnosisBridgeFacet(v2.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "unlimited-approval",
+        "design-choice",
+        "blast-radius"
+      ],
+      "id": "LF-068"
+    },
+    "LF-069": {
+      "source_id": "audit20250603::6.1.2",
+      "title": "swapAndStartBridgeTokensViaGnosisBridge does not assert final swap output token equals bridgeData.sendingAssetId",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "GnosisBridgeFacet"
+      ],
+      "root_cause": "The facet checks that bridgeData.sendingAssetId is DAI or USDS, but never verifies that swapData[last].receivingAssetId matches it. A swap chain producing Token X while the bridge expects Token Y would not be caught, potentially attempting to bridge the wrong asset.",
+      "fix_summary": "Added a require that _swapData[last].receivingAssetId == _bridgeData.sendingAssetId, reverting with InvalidSendingToken otherwise. Fixed in 05ff21c84a27e110a71960f26b44499e33ef5fee.",
+      "recognition_signal": "swapAndBridge entrypoint that validates the bridge's sending asset against an allowlist but does not also assert the last swap step's output equals that asset.",
+      "status_history": [
+        {
+          "audit_id": "audit20250603",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed in commit 05ff21c."
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.03_GnosisBridgeFacet(v2.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "swap-bridge-consistency",
+        "input-validation",
+        "asset-mismatch"
+      ],
+      "id": "LF-069"
+    },
+    "LF-070": {
+      "source_id": "audit20250620::6.1.1",
+      "title": "LibAsset.isContract() classifies sub-23-byte contracts as EOAs",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "libraries",
+      "contracts": [
+        "LibAsset"
+      ],
+      "root_cause": "isContract() returns size > 23 to remain compatible with EIP-7702 delegated accounts (size 23). Hand-crafted minimal bytecode contracts deployed outside the Solidity compiler can have code size < 23 and are mis-classified as EOAs.",
+      "fix_summary": "Acknowledged: residual risk noted, no security impact at this time and no fix applied.",
+      "recognition_signal": "Using extcodesize > N as a contract/EOA discriminator where N is chosen for EIP-7702 compatibility, without considering hand-rolled bytecode of smaller size.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250620",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Acknowledged by both LI.FI and researcher."
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.20_LibAsset(v2.1.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eip-7702",
+        "extcodesize",
+        "eoa-detection"
+      ],
+      "id": "LF-070"
+    },
+    "LF-071": {
+      "source_id": "audit20250626::6.1.1",
+      "title": "PioneerFacet does not sanity-check refundAddress",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "PioneerFacet"
+      ],
+      "root_cause": "`refundAddress` is the off-chain solver's only path to return funds when bridging fails, but the facet accepts it without rejecting `address(0)`. An invalid refund address registered during bridging guarantees permanent loss of user funds if the bridge does not complete.",
+      "fix_summary": "Revert if `_pioneerData.refundAddress == address(0)`. Fixed in commit cd009186.",
+      "recognition_signal": "Off-chain-coordinated bridging facet that accepts a user-supplied refund/recovery address without enforcing it is non-zero (or otherwise sane).",
+      "status_history": [
+        {
+          "audit_id": "audit20250626",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit cd009186"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.26_PioneerFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "refund"
+      ],
+      "id": "LF-071"
+    },
+    "LF-072": {
+      "source_id": "audit20250626::6.1.2",
+      "title": "PioneerFacet does not sanity-check transactionId",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "PioneerFacet"
+      ],
+      "root_cause": "Pioneer bridging uses `transactionId` as the off-chain solver's identifier for the order. The facet accepts `bytes32(0)` without rejecting it; an empty id may confuse off-chain solvers and cause inconsistent state for that user.",
+      "fix_summary": "Revert if `_bridgeData.transactionId == bytes32(0)`. Fixed in commit 3d0ab5e2.",
+      "recognition_signal": "Bridging entrypoint that relies on a user-supplied `transactionId`/correlation id for off-chain processing without rejecting `bytes32(0)`.",
+      "status_history": [
+        {
+          "audit_id": "audit20250626",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit 3d0ab5e2"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.26_PioneerFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation"
+      ],
+      "id": "LF-072"
+    },
+    "LF-073": {
+      "source_id": "audit20250626::6.2.3",
+      "title": "swapAndStartBridgeTokensViaPioneer does not validate swap output equals bridging asset",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "PioneerFacet"
+      ],
+      "root_cause": "After the pre-bridge swap, the facet does not assert `_bridgeData.sendingAssetId == _swapData[last].receivingAssetId`. Mismatch is caught implicitly by the subsequent transfer to the Pioneer EOA reverting on insufficient balance.",
+      "fix_summary": "Acknowledged - relies on the implicit revert when the contract holds the wrong asset; no contract change.",
+      "recognition_signal": "Bridging entrypoint that accepts pre-bridge swap data and forwards to the bridge step without asserting the last swap's receiving asset matches the declared bridging asset.",
+      "status_history": [
+        {
+          "audit_id": "audit20250626",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Acknowledged - implicit revert via insufficient balance"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.26_PioneerFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "swap"
+      ],
+      "id": "LF-073"
+    },
+    "LF-074": {
+      "source_id": "audit20250630::6.1.1",
+      "title": "Unsafe uint256-to-uint128 cast of swap amount in swapIzumiV3 permanently locks excess funds",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "swapIzumiV3 accepts amountIn as uint256 and pulls that full amount from the caller, but truncates it to uint128 when calling the Izumi pool. There is no validation that amountIn fits in uint128 and no refund of the discarded high bits, so any value above type(uint128).max is silently swapped only up to uint128 capacity while the truncated remainder remains trapped in the aggregator.",
+      "fix_summary": "Fixed in d8935ac by reverting with InvalidCallData when amountIn exceeds type(uint128).max.",
+      "recognition_signal": "Function pulls tokens at a wider integer width than it forwards them to the downstream callee, with neither a width check nor a refund of the truncated portion.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250630",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Verified fix in commit d8935ac"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.30_LiFiDexAggregator(v1.11.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "integer-truncation",
+        "casting",
+        "stuck-funds",
+        "dex"
+      ],
+      "id": "LF-074"
+    },
+    "LF-075": {
+      "source_id": "audit20250630::6.2.1",
+      "title": "swapIzumiV3 uses out-of-range tick boundaries (-80000/80000) instead of the valid -79999/79999",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "The price-boundary parameters passed to Izumi's swapX2Y/swapY2X are set to -80000 and 80000, which sit outside the protocol's documented valid range of -79999 to 79999. Passing out-of-range bounds causes Izumi to behave unpredictably, so swaps may revert or settle at unintended prices.",
+      "fix_summary": "Fixed in 36c3bbc by passing the correct price-boundary values to the Izumi swap functions.",
+      "recognition_signal": "Hardcoded numeric bounds in a DEX integration are taken from rounded \"reasonable\" values rather than the integration's actual valid-range constants, causing the call to drift outside the supported domain.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250630",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 36c3bbc"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.30_LiFiDexAggregator(v1.11.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "dex-integration",
+        "boundary-values"
+      ],
+      "id": "LF-075"
+    },
+    "LF-076": {
+      "source_id": "audit20250630::6.4.1",
+      "title": "Missing sanity check on withdrawMode in swapSyncSwap allows out-of-domain values",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "withdrawMode is a uint8 read from the encoded stream and forwarded directly to SyncSwap, which only defines modes 0–2. No bounds check exists, so a caller can supply 3–255 and reach downstream code paths whose behavior is undefined for this integration.",
+      "fix_summary": "Fixed in ec277e6 by reverting with InvalidCallData when withdrawMode > 2.",
+      "recognition_signal": "An enum-like uint8 read from user-controlled calldata is forwarded to an external protocol without a bounds check against the documented set of valid mode values.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250630",
+          "source_label": "6.4.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit ec277e6"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.30_LiFiDexAggregator(v1.11.0).pdf",
+        "pages": [
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "enum-bounds",
+        "dex"
+      ],
+      "id": "LF-076"
+    },
+    "LF-077": {
+      "source_id": "audit20250630::6.4.2",
+      "title": "swapSyncSwap V2 branch missing explicit INTERNAL_INPUT_SOURCE handling that the V1 branch has",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "For SyncSwap V1 pools the code explicitly reverts on INTERNAL_INPUT_SOURCE, but the V2 branch only documents this case in a comment and silently falls through without a revert. The asymmetry leaves the V2 path open to unexpected source-routing values that aren't validated.",
+      "fix_summary": "Fixed in ad4b814 by adding the explicit revert for the V2 branch matching the V1 behavior.",
+      "recognition_signal": "Two sibling branches in the same function diverge in how they handle a sentinel/special-case input — one validates explicitly, the other only documents the case in a comment.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250630",
+          "source_label": "6.4.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit ad4b814"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.30_LiFiDexAggregator(v1.11.0).pdf",
+        "pages": [
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "branch-asymmetry"
+      ],
+      "id": "LF-077"
+    },
+    "LF-078": {
+      "source_id": "audit20250630::6.4.4",
+      "title": "swapIzumiV3 forwards decoded pool/recipient from the stream without zero-address or sentinel checks",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LiFiDEXAggregator"
+      ],
+      "root_cause": "swapIzumiV3 decodes pool, direction, and recipient from the raw stream and forwards them straight into the Izumi pool call. There is no check that pool is non-zero or not the IMPOSSIBLE_POOL_ADDRESS sentinel, and no check that recipient is non-zero, in contrast with sibling DEX handlers that validate these.",
+      "fix_summary": "Fixed in 36c3bbc by validating pool, the IMPOSSIBLE_POOL_ADDRESS sentinel, and recipient before forwarding the call.",
+      "recognition_signal": "Newly added DEX handler accepts critical addresses from packed calldata and forwards them to external calls without the zero-address/sentinel validations that exist in every neighboring handler.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250630",
+          "source_label": "6.4.4",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit 36c3bbc"
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.30_LiFiDexAggregator(v1.11.0).pdf",
+        "pages": [
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "zero-address",
+        "dex"
+      ],
+      "id": "LF-078"
+    },
+    "LF-079": {
+      "source_id": "audit20250718::6.1.1",
+      "title": "AllBridgeFacet does not cap _allBridgeData.fees, so any overpayment is permanently lost",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AllBridgeFacet"
+      ],
+      "root_cause": "The user-supplied _allBridgeData.fees parameter is forwarded to the AllBridge router without comparison against the on-chain quote (getTransactionCost + getMessageCost). The router itself does not refund overpayment, so any fees the user provides above the actual cost are absorbed by the router and unrecoverable.",
+      "fix_summary": "Acknowledged; team added documentation describing the behavior in commit d354cfa0129198d80d47f4ba6f70f05871a214a1 rather than capping at the on-chain quote.",
+      "recognition_signal": "Caller-supplied fee value is forwarded to a downstream bridge without an upper bound derived from the bridge's own on-chain quote, and the downstream does not refund overpayment.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250718",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Documentation-only; commit d354cfa0129198d80d47f4ba6f70f05871a214a1"
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.18_AllBridgeFacet(v2.1.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "fee-handling",
+        "no-refund",
+        "bridge"
+      ],
+      "id": "LF-079"
+    },
+    "LF-080": {
+      "source_id": "audit20250718::6.2.3",
+      "title": "AllBridgeFacet bridges to non-EVM chains without emitting the BridgeToNonEVMChain event",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "AllBridgeFacet"
+      ],
+      "root_cause": "_startBridge supports bridging to non-EVM destinations but, unlike sibling facets, never emits the BridgeToNonEVMChain event with the non-EVM receiver bytes. This breaks the convention that off-chain indexers and security tooling depend on to track non-EVM destination addresses.",
+      "fix_summary": "Fixed in 240e8072a23c400a7ca870b8500ed0fc61d2b0df by emitting BridgeToNonEVMChain on the non-EVM path.",
+      "recognition_signal": "Bridge facet supports a non-EVM destination path but is missing the project-wide BridgeToNonEVM* event that captures the non-EVM receiver bytes for indexers and monitoring.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250718",
+          "source_label": "6.2.3",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit 240e8072a23c400a7ca870b8500ed0fc61d2b0df"
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.18_AllBridgeFacet(v2.1.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "events",
+        "monitoring"
+      ],
+      "id": "LF-080"
+    },
+    "LF-081": {
+      "source_id": "audit20250718::6.2.5",
+      "title": "MayanFacet and DeBridgeDlnFacet constructors do not validate their address parameters",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "MayanFacet",
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "The constructors of MayanFacet and DeBridgeDlnFacet store immutable bridge/router addresses passed in at deploy time without checking that they are non-zero. A misconfigured deployment can permanently brick the facet because the addresses are immutable.",
+      "fix_summary": "Fixed in af2a8591fa2db65563dd02c353163450bdff79be by validating constructor params in both facets.",
+      "recognition_signal": "Facet constructor stores immutable external-protocol addresses without zero-address validation, diverging from the codebase's other facets that all validate.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250718",
+          "source_label": "6.2.5",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit af2a8591fa2db65563dd02c353163450bdff79be"
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.18_AllBridgeFacet(v2.1.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "constructor-validation",
+        "zero-address",
+        "immutable"
+      ],
+      "id": "LF-081"
+    },
+    "LF-082": {
+      "source_id": "audit20250730::6.1.1",
+      "title": "Front-running of Patcher depositAndExecute functions lets a malicious caller steal approved tokens",
+      "severity": "high",
+      "severity_native": "High",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "depositAndExecuteWithMultiplePatches / depositAndExecuteWithDynamicPatches accept arbitrary call targets and pull tokens from msg.sender via existing approvals. A second caller can use the user's outstanding Patcher approval to invoke transferFrom-style calldata against the original approver, draining funds.",
+      "fix_summary": "Acknowledged in 68b91b10: documented as accepted risk in Patcher NatSpec and Patcher.md; no on-chain guard added.",
+      "recognition_signal": "A periphery contract that pulls tokens via transferFrom from msg.sender while invoking caller-supplied call targets/data, with no per-call approval pattern or sender/owner pairing.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "High",
+          "notes": "Documented as accepted risk in 68b91b10."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "frontrunning",
+        "approvals",
+        "arbitrary-call"
+      ],
+      "id": "LF-082"
+    },
+    "LF-083": {
+      "source_id": "audit20250730::6.2.1",
+      "title": "_getDynamicValue blindly casts arbitrary return-types to uint256, allowing malformed patches",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "_getDynamicValue executes a low-level call against a target and reinterprets the entire returndata as uint256 without checking the called function's return type or length. Non-uint256 return values (bytes, address, bool, larger encodings) are silently coerced into nonsensical numbers used to patch downstream calldata, which can mis-size token amounts and lose user funds.",
+      "fix_summary": "Fixed in 68b91b10: partial mitigation via 32-byte length check; some 32-byte encoded types (bool, address) remain ambiguous and are documented as an accepted residual risk.",
+      "recognition_signal": "Reading a uint256 from a target via low-level call and abi.decode/bytes-cast without validating the target's function selector, return-type, or returndata length.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Partial fix 68b91b10; residual ambiguity acknowledged."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "abi-decoding",
+        "type-coercion",
+        "dynamic-call"
+      ],
+      "id": "LF-083"
+    },
+    "LF-084": {
+      "source_id": "audit20250730::6.4.1",
+      "title": "Unlimited token approvals to unknown external targets in Patcher",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "Patcher grants unlimited (type(uint256).max) ERC20 approvals to user-supplied execution targets and does not reset them after the call. Compromised or buggy target contracts can drain the residual allowance if any tokens are later held by Patcher.",
+      "fix_summary": "Fixed in 699218d7 by adjusting approval flow and documenting the behaviour.",
+      "recognition_signal": "Granting unbounded ERC20 approvals to caller-supplied external targets without resetting allowance after the external call.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.4.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fix commit 699218d7."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "approvals",
+        "approval-hygiene",
+        "arbitrary-target"
+      ],
+      "id": "LF-084"
+    },
+    "LF-085": {
+      "source_id": "audit20250730::6.4.3",
+      "title": "Patcher execution functions emit no events for off-chain tracking",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "All four functions that patch and execute external calldata complete without emitting any event, leaving indexers and monitoring with no on-chain trace of what was executed against which target.",
+      "fix_summary": "Fixed in 68f8b1c0 by adding events to the four execution functions.",
+      "recognition_signal": "Privileged or user-callable functions that execute arbitrary external calls without emitting an event capturing target, calldata, or amounts.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.4.3",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Events added in 68f8b1c0."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "events",
+        "observability"
+      ],
+      "id": "LF-085"
+    },
+    "LF-086": {
+      "source_id": "audit20250730::6.4.4",
+      "title": "Patcher silently transfers caller's entire approved balance regardless of requested amount",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "_depositAndApprove (used by depositAndExecuteWithMultiplePatches / depositAndExecuteWithDynamicPatches) transferFroms the caller's entire approved balance, ignoring the amount field in the calldata. Integrators expecting amount-bounded transfers can lose funds.",
+      "fix_summary": "Fixed in f25baadc by documenting the behaviour explicitly.",
+      "recognition_signal": "An entrypoint that takes a 'requested amount' parameter but actually pulls the caller's full pre-approved allowance, with the discrepancy undocumented.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.4.4",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Documentation added in f25baadc."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "documentation",
+        "transferFrom",
+        "amount-mismatch"
+      ],
+      "id": "LF-086"
+    },
+    "LF-087": {
+      "source_id": "audit20250730::6.4.5",
+      "title": "Patcher does not refund excess native/ERC20 sent or approved beyond what target consumes",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "Patcher"
+      ],
+      "root_cause": "If the dynamic patched value is less than deposited tokens, the target does not spend the full approval, or msg.value exceeds the value parameter, excess assets stay in Patcher and can be swept by anyone since execution targets are unconstrained.",
+      "fix_summary": "Fixed in f25baadc by documenting that any excess is locked / stealable and recommending msg.value == value as a sanity check.",
+      "recognition_signal": "A pass-through periphery that pulls native or tokens for downstream calls but does not refund unspent amounts back to the caller, leaving dust in a contract reachable by anyone.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250730",
+          "source_label": "6.4.5",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Documented in f25baadc."
+        }
+      ],
+      "source": {
+        "pdf": "2025.07.30_Patcher(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "refund",
+        "leftover-funds",
+        "documentation"
+      ],
+      "id": "LF-087"
+    },
+    "LF-088": {
+      "source_id": "audit20250825::6.1.1",
+      "title": "MayanFacet decodes the trader address as final receiver for Hypercore deposit/fastDeposit selectors instead of the receiver embedded in depositPayload",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "MayanFacet"
+      ],
+      "root_cause": "When MayanFacet added support for Hypercore routes, the receiver decoder for the new deposit(0xe27dce37) and fastDeposit(0x4d1ed73b) selectors treats the third parameter (trader) as the destination receiver. The real receiver is inside the encoded depositPayload struct, so the receiver assertion will fail (or silently mismatch) when the user's sender differs from their destination wallet, causing permanent DoS for those flows.",
+      "fix_summary": "Updated the decoder to extract the receiver address from depositPayload for both new selectors. Fixed in commits 2e9eeda, 74a57f9, b1f7ea4.",
+      "recognition_signal": "Receiver-extraction logic mapped per external selector that picks a positionally-convenient address parameter (e.g. trader/sender) as the receiver instead of decoding the destination from the protocol-specific payload struct.",
+      "status_history": [
+        {
+          "audit_id": "audit20250825",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed across commits 2e9eeda/74a57f9/b1f7ea4."
+        }
+      ],
+      "source": {
+        "pdf": "2025.08.25_MayanFacet(v1.2.2).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "selector-decoding",
+        "receiver-mismatch",
+        "non-evm-adjacent"
+      ],
+      "id": "LF-088"
+    },
+    "LF-089": {
+      "source_id": "audit20250825_1::I-02",
+      "title": "BridgeData receiver and destinationChain are emitted but not enforced by RelayDepositoryFacet, weakening event-based off-chain accounting",
+      "severity": "info",
+      "severity_native": "Info",
+      "area": "facets",
+      "contracts": [
+        "RelayDepositoryFacet"
+      ],
+      "root_cause": "The facet stores all real transfer details off-chain inside Relay's orderId; on-chain it only forwards the orderId and uses bridgeData.receiver/destinationChain solely to populate the LiFiTransferStarted event. A user can therefore submit bridgeData with arbitrary receiver/destinationChain values that do not match the actual off-chain order, and downstream consumers of the event have no way to detect the divergence. The facet also does not emit BridgeToNonEVMChainBytes32 when the off-chain destination is Solana.",
+      "fix_summary": "Acknowledged in commit 9d86e488b6f651205605dd65cb0086caed8507c3 with added contract and docs comments.",
+      "recognition_signal": "Facet that uses bridgeData fields only to populate emitted events while the authoritative bridge parameters live off-chain, allowing user-supplied event metadata to drift from the actual transfer.",
+      "status_history": [
+        {
+          "audit_id": "audit20250825_1",
+          "source_label": "I-02",
+          "status": "acknowledged",
+          "severity_native": "Info",
+          "notes": "Acknowledged; documented in contract and docs (commit 9d86e488)."
+        }
+      ],
+      "source": {
+        "pdf": "2025.08.25_RelayDepositoryFacet(v1.0.0).pdf",
+        "pages": [
+          6,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "events",
+        "off-chain-trust",
+        "non-evm"
+      ],
+      "id": "LF-089"
+    },
+    "LF-090": {
+      "source_id": "audit20250825_1::I-03",
+      "title": "RelayDepositoryFacet may forward more than the off-chain order specifies, relying on Relay solver to refund the difference",
+      "severity": "info",
+      "severity_native": "Info",
+      "area": "facets",
+      "contracts": [
+        "RelayDepositoryFacet"
+      ],
+      "root_cause": "When a preswap step produces positive slippage, the facet forwards the full swap output to RelayDepository even though the off-chain order specified a smaller input. Refund of the overpaid amount is entirely dependent on Relay's solver implementation, which is an off-chain trust assumption not enforced on-chain.",
+      "fix_summary": "Acknowledged in commit 898c77f65632565d1de12013e08dd61681335b32 with contract/docs comments and a recommendation to monitor for solver behavior changes.",
+      "recognition_signal": "Bridge integration that forwards full swap output (including positive slippage) instead of the off-chain-quoted input amount, relying on the external solver to refund the difference rather than returning excess to the user on-chain.",
+      "status_history": [
+        {
+          "audit_id": "audit20250825_1",
+          "source_label": "I-03",
+          "status": "acknowledged",
+          "severity_native": "Info",
+          "notes": "Acknowledged; documented in contract and docs (commit 898c77f6)."
+        }
+      ],
+      "source": {
+        "pdf": "2025.08.25_RelayDepositoryFacet(v1.0.0).pdf",
+        "pages": [
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "positive-slippage",
+        "external-trust",
+        "refund"
+      ],
+      "id": "LF-090"
+    },
+    "LF-091": {
+      "source_id": "audit20250901::6.1.1",
+      "title": "Lossy decode for non-EVM receiver address in AcrossFacetPackedV4 decoders",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV4"
+      ],
+      "root_cause": "The packed-calldata decoders set bridgeData.receiver = address(uint160(uint256(bytes32(...)))), discarding the upper 12 bytes of a 32-byte receiver. For non-EVM destinations (Solana etc.) the raw bytes32 receiver is not round-trippable and a 32-byte value with 12 leading zero bytes can be misclassified as an EVM address.",
+      "fix_summary": "Fixed in 5e797a1 by special-casing receivers with 12 leading zero bytes as EVM and keeping the full bytes32 receiver in acrossData.receiverAddress for non-EVM flows.",
+      "recognition_signal": "Truncating a 32-byte non-EVM receiver into a 20-byte address field during calldata decoding, losing data needed to identify the off-chain destination.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit 5e797a1; residual ambiguity for non-EVM values with 12 leading zero bytes acknowledged."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "encoding",
+        "calldata-decoding"
+      ],
+      "id": "LF-091"
+    },
+    "LF-092": {
+      "source_id": "audit20250901::6.1.2",
+      "title": "Missing zero-check for derived outputAmount after multiplier scaling in AcrossFacetV4",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetV4"
+      ],
+      "root_cause": "outputAmount is computed as (minAmount * outputAmountMultiplier) / 1e18 with no post-condition check. If outputAmountMultiplier is zero or the numerator is below 1e18, the result rounds to zero and an Across intent is created with zero output, locking user funds.",
+      "fix_summary": "Acknowledged in commit a265751: backend produces the multiplier so calldata is trusted; a disclaimer comment was added instead of an on-chain guard.",
+      "recognition_signal": "Computing a critical downstream amount via fixed-point multiplication and division without asserting the result is non-zero when the inputs are user/backend-controlled.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.1.2",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Backend-trusted; disclaimer added in a265751."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "math",
+        "rounding",
+        "trusted-input"
+      ],
+      "id": "LF-092"
+    },
+    "LF-093": {
+      "source_id": "audit20250901::6.1.3",
+      "title": "Missing non-zero validation for refundAddress passed to Across spoke pool",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetV4"
+      ],
+      "root_cause": "_startBridge forwards _acrossData.refundAddress to the spoke pool without checking != bytes32(0). A zero refundAddress means refunds for unfulfilled or expired intents cannot be received, leading to permanent fund loss.",
+      "fix_summary": "Fixed in ed698cc by adding an explicit revert when refundAddress is bytes32(0).",
+      "recognition_signal": "Forwarding a user-supplied refund/recovery address to an external bridge without validating it is non-zero, leaving no recovery path for stuck transfers.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.1.3",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit ed698cc; verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          4,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "validation",
+        "refund",
+        "zero-address"
+      ],
+      "id": "LF-093"
+    },
+    "LF-094": {
+      "source_id": "audit20250901::6.2.3",
+      "title": "Owner can execute arbitrary external calls via executeCallAndWithdraw on AcrossFacetPackedV4",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV4"
+      ],
+      "root_cause": "executeCallAndWithdraw lets onlyOwner call any _callTo with arbitrary _callData and no whitelist or timelock. A compromised or malicious owner can revoke approvals, drain partner contracts, or otherwise weaponize the contract.",
+      "fix_summary": "Acknowledged: function is not added to the diamond and only standalone packedFacet is affected, used by a small set of partners.",
+      "recognition_signal": "An onlyOwner function that performs an unrestricted low-level call to a caller-supplied target with caller-supplied calldata and no whitelist or timelock.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Standalone-facet-only; risk accepted."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          5,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "access-control",
+        "centralization",
+        "arbitrary-call"
+      ],
+      "id": "LF-094"
+    },
+    "LF-095": {
+      "source_id": "audit20250901::6.2.4",
+      "title": "Possible burn to zero address in ReceiverAcrossV4 swap-failure fallback",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverAcrossV4"
+      ],
+      "root_cause": "When a destination swap fails, tokens are forwarded to the receiver decoded from the Across message without checking receiver != address(0). A malformed or buggy upstream message can route funds to 0x0 irrecoverably.",
+      "fix_summary": "Acknowledged: LI.FI relies on backend-produced data correctness; no on-chain check added.",
+      "recognition_signal": "A fallback/error-path token transfer to an address taken directly from cross-chain payload without validating it is non-zero.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.2.4",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Trusts backend-produced message data."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          5,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "error-handling",
+        "cross-chain-message"
+      ],
+      "id": "LF-095"
+    },
+    "LF-096": {
+      "source_id": "audit20250901::6.2.6",
+      "title": "Incorrect calldata length validation in decode_startBridgeTokensViaAcrossV4NativePacked",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "AcrossFacetPackedV4"
+      ],
+      "root_cause": "Decoder validates data.length < 188 but then accesses data[216:220] for exclusivityDeadline and data[220:] for message, allowing inputs of length 188-219 to pass validation while producing out-of-bounds reads of packed fields.",
+      "fix_summary": "Fixed in 4bce2a1 (raising threshold to 220); later partially reverted as the related sendingAssetId parameter was removed in subsequent PRs.",
+      "recognition_signal": "Packed-calldata decoder whose declared minimum-length check is smaller than the highest byte index it indexes into.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20250901",
+          "source_label": "6.2.6",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fix 4bce2a1; later reverted due to struct reshape."
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.01_AcrossV4(v1.0.0).pdf",
+        "pages": [
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "calldata-decoding",
+        "bounds-check",
+        "packed-encoding"
+      ],
+      "id": "LF-096"
+    },
+    "LF-097": {
+      "source_id": "audit20250919::I-3",
+      "title": "Missing BridgeToNonEVMChain event when bridging to non-EVM destinations",
+      "severity": "info",
+      "severity_native": "Info",
+      "area": "facets",
+      "contracts": [
+        "GardenFacet"
+      ],
+      "root_cause": "GardenFacet's primary use-case is bridging to Bitcoin and BTC derivatives, but it does not emit the protocol-standard BridgeToNonEVMChain event and has no nonEvmReceiver field in GardenData. Off-chain indexers cannot reliably distinguish/track non-EVM transfers, and the bridgeData.receiver cannot fit a Bitcoin-format address.",
+      "fix_summary": "Added nonEvmReceiver field and BridgeToNonEVMChain event emission for non-EVM destinations. Fixed in 818de27b64a73879c91dbddc3195be03bafdc08f.",
+      "recognition_signal": "Cross-chain facet handling non-EVM destinations without emitting the standardized non-EVM bridging event or carrying a non-EVM-shaped receiver field — observability gap that also signals the address-encoding limitation.",
+      "status_history": [
+        {
+          "audit_id": "audit20250919",
+          "source_label": "I-3",
+          "status": "fixed",
+          "severity_native": "Info",
+          "notes": "Verified fix in 818de27b64a73879c91dbddc3195be03bafdc08f"
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.19_GardenFacet(v1.0.0).pdf",
+        "pages": [
+          10,
+          11
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "events",
+        "observability"
+      ],
+      "id": "LF-097"
+    },
+    "LF-098": {
+      "source_id": "audit20250919::M-1",
+      "title": "Destination receiver address reused as source-chain refund initiator can be stolen on source",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "GardenFacet"
+      ],
+      "root_cause": "GardenFacet passes _bridgeData.receiver as the initiator parameter to Garden's HTLC initiateOnBehalf, which grants refund rights on the source chain after timelock expiry. The same address can be controlled by different parties on different chains (Safe with different owners, predictable CREATE deployments not yet deployed on source), so when a solver fails to redeem, whoever controls that address on the source chain can claim the refund.",
+      "fix_summary": "GardenData extended with an explicit refundAddress field used as initiator, decoupling source-chain refund rights from the destination-chain receiver. Fixed in 7431c2d25d1106cc03542a9a29248c57f2e0f457.",
+      "recognition_signal": "Reusing the destination-chain receiver as the source-chain refund/initiator/owner in a cross-chain HTLC or escrow — same-address-different-chain control mismatches can let an unrelated party claim funds.",
+      "status_history": [
+        {
+          "audit_id": "audit20250919",
+          "source_label": "M-1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Verified fix in 7431c2d25d1106cc03542a9a29248c57f2e0f457"
+        }
+      ],
+      "source": {
+        "pdf": "2025.09.19_GardenFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6,
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "cross-chain",
+        "address-collision",
+        "htlc",
+        "refund"
+      ],
+      "id": "LF-098"
+    },
+    "LF-099": {
+      "source_id": "audit20251001::6.1.1",
+      "title": "EcoFacet accepts NON_EVM_ADDRESS receiver for non-Solana EVM chains without rejection",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "`_validateEcoData()` branches on `receiver == NON_EVM_ADDRESS` and applies Solana-specific validation only when `isSolanaDestination` is true; the non-Solana branch merely checks that `encodedRoute` is non-empty. A user can therefore submit a NON_EVM_ADDRESS receiver to a regular EVM-compatible chain (e.g., TRON) and pass validation, producing an inconsistent on-chain order.",
+      "fix_summary": "Reject NON_EVM_ADDRESS receiver unless `isSolanaDestination`. Fixed in commit ca999e8.",
+      "recognition_signal": "Receiver-validation logic that treats the NON_EVM sentinel as authorized for any destination unless another branch explicitly rejects it, instead of whitelisting only the chains that legitimately use NON_EVM_ADDRESS.",
+      "status_history": [
+        {
+          "audit_id": "audit20251001",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit ca999e8"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.01_EcoFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "input-validation",
+        "receiver"
+      ],
+      "id": "LF-099"
+    },
+    "LF-100": {
+      "source_id": "audit20251001::6.1.2",
+      "title": "Excess native tokens sent to EcoFacet bridging functions are permanently locked",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "`startBridgeTokensViaEco` is `payable` but the Eco portal is called with `value: 0` and no native asset is bridged or refunded, so any native sent stays in the diamond. `swapAndStartBridgeTokensViaEco` lacks the `refundExcessNative` modifier, so leftover msg.value after swaps is never returned to the user.",
+      "fix_summary": "Make `startBridgeTokensViaEco` non-payable and add `refundExcessNative` to `swapAndStartBridgeTokensViaEco`. Fixed in commit 8ee81f6.",
+      "recognition_signal": "`payable` bridging entrypoint whose underlying call uses `value: 0` and does not refund leftover msg.value (missing `refundExcessNative`-style modifier).",
+      "status_history": [
+        {
+          "audit_id": "audit20251001",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit 8ee81f6"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.01_EcoFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "eth-refund",
+        "stuck-funds",
+        "payable"
+      ],
+      "id": "LF-100"
+    },
+    "LF-101": {
+      "source_id": "audit20251001::6.1.3",
+      "title": "Solana receiver length lower-bound validation missing",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "`_validateSolanaReceiver()` checks only `length == 0` and `length > 44`, despite a code comment stating Solana addresses must be 32-44 chars. A `nonEVMReceiver` of length 1-31 passes validation and could result in funds bridged to an invalid Solana destination.",
+      "fix_summary": "Replace zero-length check with `length < 32 || length > 44`. Fixed in commit 94b00df.",
+      "recognition_signal": "Variable-length address validation that enforces only the upper bound or only a non-zero length, while the chain's address format mandates a specific length range.",
+      "status_history": [
+        {
+          "audit_id": "audit20251001",
+          "source_label": "6.1.3",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit 94b00df"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.01_EcoFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "solana",
+        "length-validation"
+      ],
+      "id": "LF-101"
+    },
+    "LF-102": {
+      "source_id": "audit20251001::6.1.4",
+      "title": "BridgeToNonEVMChain event emitted on EVM destinations when nonEVMReceiver is non-empty",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "`_startBridge` emits `BridgeToNonEVMChain` based on `_ecoData.nonEVMReceiver.length > 0` rather than the actual destination chain. Because validation never requires `nonEVMReceiver` to be empty on EVM destinations, a user can populate that field while bridging to a regular EVM chain and pollute event logs with a false non-EVM signal.",
+      "fix_summary": "Switch event guard to destination-chain-id based check (e.g., `destinationChainId == LIFI_CHAIN_ID_SOLANA`). Fixed in commit e3249ef.",
+      "recognition_signal": "Conditional event emission keyed on the length of an optional user-controlled field rather than the actual underlying state (destination chain, asset class, etc.) the event is meant to signal.",
+      "status_history": [
+        {
+          "audit_id": "audit20251001",
+          "source_label": "6.1.4",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit e3249ef"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.01_EcoFacet(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "events",
+        "non-evm"
+      ],
+      "id": "LF-102"
+    },
+    "LF-103": {
+      "source_id": "audit20251001::6.3.1",
+      "title": "_buildReward() does not validate prover address or rewardDeadline",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "`_buildReward()` passes user-supplied `prover` and `rewardDeadline` into the Eco Reward struct without checking that prover is non-zero or that the deadline is non-zero and in the future. Invalid configuration silently produces an unfundable or unprovable order.",
+      "fix_summary": "Validate `prover != address(0)` and `rewardDeadline > block.timestamp`. Fixed in commit 0c8f825.",
+      "recognition_signal": "Bridging facet that forwards user-supplied prover/relayer/deadline configuration into an external order without sanity-checking address-zero and timestamp-in-future invariants.",
+      "status_history": [
+        {
+          "audit_id": "audit20251001",
+          "source_label": "6.3.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed in commit 0c8f825"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.01_EcoFacet(v1.0.0).pdf",
+        "pages": [
+          8,
+          9
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "config"
+      ],
+      "id": "LF-103"
+    },
+    "LF-104": {
+      "source_id": "audit20251007::6.1.1",
+      "title": "UnitFacet unconditionally trusts the backend-signed depositAddress with no on-chain verification of its association with the Unit Protocol",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "The deposit address that user funds are routed to is delivered by an EIP-712 signature from a backend signer. There is no on-chain registry, whitelist, cooldown, or challenger gate that proves the destination is a legitimate Unit Protocol address. A compromised signer or backend can route every bridge to an attacker-controlled address.",
+      "fix_summary": "Acknowledged (mitigated off-chain). The backend re-signs P-256 MPC-verified guardian signatures into EIP-712; LI.FI agreed to relay the on-chain hardening recommendation to the Unit team.",
+      "recognition_signal": "Bridge or escrow facet that funnels user assets to a destination address authenticated only by a single off-chain signer, with no on-chain allow-list, cooldown, or challenge window.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.1.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Off-chain mitigation via P-256 MPC re-signing; no on-chain change"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "centralization",
+        "backend-signer",
+        "trust-assumption"
+      ],
+      "id": "LF-104"
+    },
+    "LF-105": {
+      "source_id": "audit20251007::6.1.2",
+      "title": "UnitFacet.swapAndStartBridgeTokensViaUnit does not verify that the post-swap token is native ETH before calling transferNativeAsset",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "The function performs an arbitrary swap then unconditionally treats the output as native ETH (passes the result amount to LibAsset.transferNativeAsset). If a misconfigured swap yields an ERC20, the transfer either reverts only when there is insufficient native balance or behaves incorrectly. There is no explicit check that swapData[length-1].receivingAssetId == NULL_ADDRESS.",
+      "fix_summary": "Acknowledged; LI.FI relies on the implicit revert from insufficient native balance to fail-stop instead of adding an explicit guard.",
+      "recognition_signal": "swap-then-bridge flow where the bridge step assumes a specific output asset (native or specific ERC20) but never asserts that the last swap's receivingAssetId matches that expected asset.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.1.2",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Relies on implicit revert via insufficient native balance"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "swap-validation",
+        "native-asset",
+        "asset-mismatch"
+      ],
+      "id": "LF-105"
+    },
+    "LF-106": {
+      "source_id": "audit20251007::6.1.3",
+      "title": "UnitFacet verifies backend signature against pre-swap minAmount but bridges the post-swap minAmount, weakening the signed authorization",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "_verifySignature reads bridgeData.minAmount before the swap mutates it; _depositAndSwap then overwrites minAmount with the swap output before _startBridge. The bridged amount is therefore not the one the backend signed for, so the signed authorization no longer binds the actual cross-chain transfer amount.",
+      "fix_summary": "Acknowledged; LI.FI treats the signature as authorizing initiation, not the post-swap amount.",
+      "recognition_signal": "Signature verified over input parameters that are subsequently mutated (e.g., by a swap, slippage adjustment, or fee deduction) before the authorized side-effect executes.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.1.3",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Treated as authorization of initiation, not post-swap result"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "signature-scope",
+        "amount-mismatch",
+        "authorization"
+      ],
+      "id": "LF-106"
+    },
+    "LF-107": {
+      "source_id": "audit20251007::6.2.1",
+      "title": "UnitFacet._startBridge enforces minimum amounts only on Ethereum and Plasma, silently accepting dust transfers on every other chain",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "The chain-id switch contains explicit minimum-amount branches for chain IDs 1 (Ethereum) and 9745 (Plasma) and falls through with no guard for every other chain. Users can therefore originate a bridge from an unsupported chain with arbitrarily small amounts; the off-chain Unit Protocol cannot process them and funds risk being stuck.",
+      "fix_summary": "Fixed in commit 40b6c94e by adding an UnsupportedChain revert in the else branch.",
+      "recognition_signal": "Chain-id switch with explicit cases for a subset of chains and an implicit fall-through that allows the same function to operate on any other chain with no validation.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit 40b6c94e"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          6,
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "chain-validation",
+        "stuck-funds",
+        "fail-fast"
+      ],
+      "id": "LF-107"
+    },
+    "LF-108": {
+      "source_id": "audit20251007::6.2.3",
+      "title": "UnitFacet checks the signature deadline after executing the signature-recovery work, wasting gas and surfacing failures late",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "The deadline comparison occurs after the expensive parts of _verifySignature complete. Stale signatures are still rejected, but the contract reaches that decision only after performing avoidable work.",
+      "fix_summary": "Fixed in commit e1648970 by moving the deadline check to the top of _verifySignature.",
+      "recognition_signal": "Signature verification that performs ecrecover/hashing before checking the cheap expiration timestamp, so expired signatures consume the full verification cost.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.2.3",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit e1648970"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          7,
+          8,
+          9
+        ]
+      },
+      "extraction_confidence": "medium",
+      "tags": [
+        "deadline",
+        "fail-fast",
+        "signature"
+      ],
+      "id": "LF-108"
+    },
+    "LF-109": {
+      "source_id": "audit20251007::6.2.5",
+      "title": "UnitFacet has no replay protection on backend signatures; the same signed message can be reused before deadline",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "UnitFacet"
+      ],
+      "root_cause": "_verifySignature checks only the signer and the deadline. There is no nonce, transactionId allowlist, or used-signature mapping. While Unit Protocol's deposit addresses are tied to receivers (limiting third-party theft), the signature can still be replayed by the same user (or anyone) before expiry.",
+      "fix_summary": "Fixed in commit 32a032515 by adding transactionId-based replay protection.",
+      "recognition_signal": "Backend-signed authorization with no nonce / no used-signature tracking, where uniqueness relies solely on a future deadline.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251007",
+          "source_label": "6.2.5",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Verified fix in commit 32a032515"
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.07_UnitFacet(v1.0.0).pdf",
+        "pages": [
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "replay-protection",
+        "signature",
+        "nonce"
+      ],
+      "id": "LF-109"
+    },
+    "LF-110": {
+      "source_id": "audit20251020::I-3",
+      "title": "Positive swap slippage in EcoFacet pre-bridge swap is silently captured by the solver instead of the user",
+      "severity": "info",
+      "severity_native": "Info",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "The intent's reward.tokens.amount encodes a totalAmount (intent + reward + any positive slippage). When swap output exceeds _bridgeData.minAmount, the surplus is included in the funded vault amount and ends up claimed by the solver upon fill, rather than refunded to the user. The pre-existing code comment understated this by claiming excess remains in the diamond.",
+      "fix_summary": "Updated swapAndStartBridgeTokensViaEco to detect actualAmountAfterSwap > minAmount and transfer the positive slippage back to msg.sender before bridging. Fixed in PR lifinance/contracts/pull/1421.",
+      "recognition_signal": "Bridge facet that funds a downstream vault using a totalAmount field encoding swap output, without skimming the delta between actual swap output and the intended minAmount back to the user.",
+      "status_history": [
+        {
+          "audit_id": "audit20251020",
+          "source_label": "I-3",
+          "status": "fixed",
+          "severity_native": "Info",
+          "notes": "Fixed in PR 1421; positive slippage now refunded to msg.sender."
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.20_EcoFacet(v1.1.0).pdf",
+        "pages": [
+          15,
+          16,
+          17
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "slippage",
+        "value-leak",
+        "swap-and-bridge"
+      ],
+      "id": "LF-110"
+    },
+    "LF-111": {
+      "source_id": "audit20251020::M-1",
+      "title": "Duplicate intent funding in EcoFacet traps user funds and lets attacker sweep them via swap leftovers refund",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "Eco Protocol's Portal silently no-ops a second publishAndFund call for an already-funded intent (the onlyFundable modifier returns early without reverting), so a duplicate call to startBridgeTokensViaEco still pulls tokens from the user but never deposits them, leaving them in the diamond. SwapperV2's _refundLeftovers then sweeps the entire input-token balance to the next caller of swapAndStartBridge*, enabling theft of the trapped funds.",
+      "fix_summary": "Added IEcoPortal.getRewardStatus() query and a precomputed intent hash check inside _startBridge that reverts with IntentAlreadyFunded() if the intent is not in Initial status. Fixed in PR lifinance/contracts/pull/1421.",
+      "recognition_signal": "Bridge facet integrating with an external protocol whose funding/deposit entrypoint silently no-ops on a duplicate-state input rather than reverting, combined with a downstream sweep/leftover-refund mechanism that distributes the contract's full balance to the current caller.",
+      "status_history": [
+        {
+          "audit_id": "audit20251020",
+          "source_label": "M-1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed in lifinance/contracts/pull/1421; Burra verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.20_EcoFacet(v1.1.0).pdf",
+        "pages": [
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "bridge-integration",
+        "external-state-assumption",
+        "leftovers-refund",
+        "fund-theft"
+      ],
+      "id": "LF-111"
+    },
+    "LF-112": {
+      "source_id": "audit20251020::M-2",
+      "title": "Eco intent refund on expiry sent to msg.sender (Permit2Proxy/integrator) instead of the real user, losing funds",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "EcoFacet"
+      ],
+      "root_cause": "EcoFacet hard-codes reward.creator to msg.sender when constructing the intent. When the caller is a relayer/proxy (Permit2Proxy) or an integrator contract rather than the end-user EOA, refunds for unfilled intents are delivered to that intermediate contract, where the actual user has no control over them.",
+      "fix_summary": "Added an explicit refundRecipient / intentCreator parameter to EcoData so the user can choose the address that receives refunds on intent expiry. Fixed in PR lifinance/contracts/pull/1421.",
+      "recognition_signal": "Bridge facet binding a downstream refund/cancellation beneficiary to msg.sender on the assumption the caller is the end user, ignoring legitimate intermediaries such as Permit2 proxies, batch routers, or integrator contracts.",
+      "status_history": [
+        {
+          "audit_id": "audit20251020",
+          "source_label": "M-2",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fixed in lifinance/contracts/pull/1421; Burra verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.10.20_EcoFacet(v1.1.0).pdf",
+        "pages": [
+          12,
+          13
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "refund-flow",
+        "msg.sender-trust",
+        "permit2",
+        "fund-loss"
+      ],
+      "id": "LF-112"
+    },
+    "LF-113": {
+      "source_id": "audit20251104::I-2",
+      "title": "Migration input list of selectors-to-remove can be incomplete, leaving stale whitelisted selectors after migration",
+      "severity": "info",
+      "severity_native": "Info",
+      "area": "facets",
+      "contracts": [
+        "WhitelistManagerFacet"
+      ],
+      "root_cause": "The off-chain-supplied _selectorsToRemove list for migration is assembled by parsing historical events across many chains, an error-prone process. Selectors absent from the list silently survive the migration with no on-chain detection, and one of the already-whitelisted contracts is a token (DEGENx on Base) for which an accidentally-whitelisted transferFrom selector would let any user drain outstanding approvals.",
+      "fix_summary": "Acknowledged; LI.FI aggregates the selector list from three sources (on-chain scan, sigs.json, whitelist.json) as defense in depth, and added a token-detection guard that rejects any contract whose decimals() returns 0-255. Reviewer verified.",
+      "recognition_signal": "Off-chain-derived input to an irreversible on-chain migration / state cleanup where missing entries leave dangerous residual state, with no on-chain consistency check to flag the gap.",
+      "status": "mitigated",
+      "status_history": [
+        {
+          "audit_id": "audit20251104",
+          "source_label": "I-2",
+          "status": "mitigated",
+          "severity_native": "Info",
+          "notes": "Multi-source aggregation + token-decimals filter; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.04_WhitelistManagerFacet(v1.0.0).pdf",
+        "pages": [
+          9,
+          10,
+          11
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "migration",
+        "off-chain-trust",
+        "whitelist",
+        "token-approval"
+      ],
+      "id": "LF-113"
+    },
+    "LF-114": {
+      "source_id": "audit20251104::L-1",
+      "title": "Whitelisting contracts and selectors in separate mappings allows any cross-combination to be permitted",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "libraries",
+      "contracts": [
+        "LibAllowList",
+        "WhitelistManagerFacet"
+      ],
+      "root_cause": "AllowListStorage keeps contractAllowList and selectorAllowList as two independent mappings, and external-call gates check each membership separately. As a result, every whitelisted address is implicitly callable with every whitelisted selector, so an unintended selector that happens to be whitelisted on a different protocol (e.g. transferFrom on a token contract) becomes a valid call target on every whitelisted contract.",
+      "fix_summary": "Acknowledged for already-deployed contracts; a new granular pair-based whitelist (isContractSelectorWhitelisted) was introduced for new contracts. Migration safety fix in PR#1441 commit e87f69019e59b8060f9c53e00acd4ed07ac4084a; verified.",
+      "recognition_signal": "Allow-list / access-control gate that checks two related dimensions (target + function-selector, or sender + role + scope) via independent mappings instead of a composite key, enabling cross-combinations the author never intended to authorize.",
+      "status": "mitigated",
+      "status_history": [
+        {
+          "audit_id": "audit20251104",
+          "source_label": "L-1",
+          "status": "mitigated",
+          "severity_native": "Low",
+          "notes": "New granular per-pair whitelist added for future contracts; legacy combos preserved for already-deployed contracts."
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.04_WhitelistManagerFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "access-control",
+        "whitelist",
+        "external-call"
+      ],
+      "id": "LF-114"
+    },
+    "LF-115": {
+      "source_id": "audit20251104::L-2",
+      "title": "Selector cleared from index but left true in allow-list mapping becomes permanently un-removable after migration",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "WhitelistManagerFacet",
+        "LibAllowList"
+      ],
+      "root_cause": "The DexManager-to-WhitelistManager migration relies on an off-chain list of selectors to clear; any selector missed by the off-chain list stays true in selectorAllowList but has no entry in selectorToIndex. The remove path in _removeAllowedSelector early-returns when oneBasedIndex == 0, so the leftover whitelisted selector can never be removed and stays callable.",
+      "fix_summary": "Fixed in PR#1376: _removeAllowedSelector now unconditionally deletes als.selectorAllowList[_selector] before checking the index, so imperfect off-chain cleanup cannot leave selectors stuck in the on/true state.",
+      "recognition_signal": "Two-mapping invariant (e.g. allow-list bool + reverse-index uint) where a remove/cleanup path early-returns based on one mapping and skips clearing the other, leaving an inconsistent state that cannot be undone through the normal admin path.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251104",
+          "source_label": "L-2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in PR#1376; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.04_WhitelistManagerFacet(v1.0.0).pdf",
+        "pages": [
+          7,
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "storage-migration",
+        "invariant",
+        "admin"
+      ],
+      "id": "LF-115"
+    },
+    "LF-116": {
+      "source_id": "audit20251104_1::6.2.1",
+      "title": "Unbounded contracts/selectors arrays in LibAllowList getters can exceed block gas and break whitelist visibility",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "libraries",
+      "contracts": [
+        "LibAllowList",
+        "WhitelistManagerFacet"
+      ],
+      "root_cause": "LibAllowList's contracts, selectors, and whitelistedSelectorsByContract arrays grow without bound. The view helpers (getAllowedContracts, getAllowedSelectors, getWhitelistedSelectorsForContract) iterate the full array; at large sizes the call exhausts block gas, making whitelist enumeration unusable by integrators.",
+      "fix_summary": "Acknowledged; LI.FI did not add pagination but documents the warning.",
+      "recognition_signal": "Storage helper exposing full-array view functions over an admin-grown unbounded list, with no pagination or cursor pattern.",
+      "status_history": [
+        {
+          "audit_id": "audit20251104_1",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Pagination deferred; warnings documented."
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.04_WhitelistManagerFacet(v1.0.0)_1.pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "unbounded-array",
+        "view-dos",
+        "gas-limit"
+      ],
+      "id": "LF-116"
+    },
+    "LF-117": {
+      "source_id": "audit20251104_1::6.2.4",
+      "title": "WhitelistManagerFacet v1->v2 migration lacks coverage that legacy state is fully cleared, risking corrupted state and data loss",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "WhitelistManagerFacet",
+        "LibAllowList"
+      ],
+      "root_cause": "The migration path from the legacy whitelist (V1) to the new granular system (V2) was not exercised by tests covering full state-clear-then-rebuild semantics. Without tests verifying mappings, arrays, reference counts, and indices are in sync after migration, latent bugs corrupting whitelist storage could pass unnoticed.",
+      "fix_summary": "Added migration-completeness and state-consistency tests covering legacy clearing, queryability via getters, and index integrity. Fixed in commit bb32542.",
+      "recognition_signal": "One-shot storage-migration function whose tests assert only the new structure's happy path, without verifying the legacy storage layout was zeroed and all derived indices remain consistent.",
+      "status_history": [
+        {
+          "audit_id": "audit20251104_1",
+          "source_label": "6.2.4",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Migration test coverage added in commit bb32542."
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.04_WhitelistManagerFacet(v1.0.0)_1.pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "storage-migration",
+        "test-coverage",
+        "state-consistency"
+      ],
+      "id": "LF-117"
+    },
+    "LF-118": {
+      "source_id": "audit20251119::6.1.1",
+      "title": "LiFiIntentEscrowFacet emits LiFiTransferStarted with hasDestinationCall=false even when OIF outputCall executes calldata on the destination",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "The facet applies the doesNotContainDestinationCalls modifier (forcing _bridgeData.hasDestinationCall = false) yet simultaneously forwards a non-empty _lifiIntentData.outputCall, which the OIF documentation defines as calldata executed after token delivery. Consumers of LiFiTransferStarted therefore see a flag that contradicts the actual on-destination behavior, breaking downstream monitoring and risk filters.",
+      "fix_summary": "Fixed in commit 67d51637 by removing the doesNotContainDestinationCalls modifier and synchronizing the flag with the actual outputCall presence.",
+      "recognition_signal": "Event/flag describing whether a destination call exists that is hardcoded false (or set independently of actual behavior) while another struct field carries calldata that is executed after delivery.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 67d51637"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "event-emission",
+        "destination-call",
+        "monitoring"
+      ],
+      "id": "LF-118"
+    },
+    "LF-119": {
+      "source_id": "audit20251119::6.1.2",
+      "title": "LiFiIntentEscrowFacet does not validate outputAmount, letting a solver settle with zero tokens and steal the entire deposit",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "The intent's outputAmount is forwarded to the OIF settler without a non-zero check. If outputAmount is 0, a solver can satisfy the intent by sending zero tokens to the user while collecting the entire deposit on the source chain.",
+      "fix_summary": "Fixed in commit e769f33 by reverting when outputAmount == 0.",
+      "recognition_signal": "Intent/escrow flow that accepts a user-specified output amount and forwards it to a solver/settler without validating it is non-zero.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.1.2",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit e769f33"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "intents",
+        "loss-of-funds"
+      ],
+      "id": "LF-119"
+    },
+    "LF-120": {
+      "source_id": "audit20251119::6.1.3",
+      "title": "LiFiIntentEscrowFacet does not validate depositAndRefundAddress, risking refund loss on a zero address",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "The user-supplied depositAndRefundAddress is forwarded to the settler without a non-zero check. A zero value (e.g., from a frontend bug) leaves refunds unreachable.",
+      "fix_summary": "Fixed in commit 7346115 by reverting with InvalidReceiver when depositAndRefundAddress is zero.",
+      "recognition_signal": "Refund/recovery address taken from user input and forwarded to an external settler without a zero-address guard.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.1.3",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 7346115"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "refund",
+        "input-validation"
+      ],
+      "id": "LF-120"
+    },
+    "LF-121": {
+      "source_id": "audit20251119::6.2.1",
+      "title": "LiFiIntentEscrowFacet does not handle non-EVM destinations; bridging to Solana/Bitcoin reverts or loses funds",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "Other LI.FI facets switch to a NON_EVM_ADDRESS sentinel and handle bridgeData.receiver specially for non-EVM destinations. The escrow facet has no such branch and the OIF settler call assumes an EVM receiver, so non-EVM intents either revert or send funds to a malformed receiver.",
+      "fix_summary": "Acknowledged; v1.0.0 ships EVM-only with a planned future update for non-EVM chains.",
+      "recognition_signal": "Bridge facet that interacts with non-EVM-aware downstream protocols but lacks the standard NON_EVM_ADDRESS / receiver-encoding branch present in sibling facets.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "EVM-only release; non-EVM support deferred"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "receiver-encoding",
+        "consistency"
+      ],
+      "id": "LF-121"
+    },
+    "LF-122": {
+      "source_id": "audit20251119::6.2.2",
+      "title": "LiFiIntentEscrowFacet does not validate MandateOutput's outputOracle and outputSettler, allowing zero values that yield unexpected refunds or behavior",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "outputOracle and outputSettler are bytes32 fields of MandateOutput passed through without validation. Zero or otherwise invalid values typically just trigger refunds, but malformed flows still degrade UX and could surface unexpected protocol-level outcomes.",
+      "fix_summary": "Status not recorded in the PDF (the LI.FI response line is empty).",
+      "recognition_signal": "Struct destined for a downstream settler containing bytes32 oracle/settler identifiers that are passed through without zero-or-invalid validation.",
+      "status": "raised",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.2.2",
+          "status": "raised",
+          "severity_native": "Informational",
+          "notes": "PDF shows empty LI.FI/Researcher response line"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "medium",
+      "tags": [
+        "input-validation",
+        "intents",
+        "mandate"
+      ],
+      "id": "LF-122"
+    },
+    "LF-123": {
+      "source_id": "audit20251119::6.2.3",
+      "title": "LiFiIntentEscrowFacet grants unbounded ERC20 allowance to the OIF settler via maxApproveERC20",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "maxApproveERC20 sets approval to type(uint256).max on the settler when allowance is insufficient. A bug or compromise in the settler can drain every token the diamond currently holds approval for, even across unrelated transactions.",
+      "fix_summary": "Acknowledged; the LI.FI team accepts the unbounded approval pattern.",
+      "recognition_signal": "ERC20 approval to a downstream integration set to type(uint256).max (or via a max-approval helper) when the caller could just as easily set the exact per-call amount.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251119",
+          "source_label": "6.2.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Max-approval pattern accepted by LI.FI"
+        }
+      ],
+      "source": {
+        "pdf": "2025.11.19_LiFiIntentEscrowFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "approval",
+        "supply-chain-risk",
+        "downstream-trust"
+      ],
+      "id": "LF-123"
+    },
+    "LF-124": {
+      "source_id": "audit20251201::6.1.2",
+      "title": "swapAndStartBridgeTokensViaPolymerCCTP missing validation that final swap output is USDC",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "PolymerCCTPFacet"
+      ],
+      "root_cause": "The facet only supports USDC, enforced on `sendingAssetId` via the `onlyAllowSourceToken` modifier. The post-swap output token is not asserted to match USDC, so an inconsistent swap reverts deep in the bridge call without a clear error.",
+      "fix_summary": "Acknowledged. Mismatched swap output would revert because the diamond lacks the required USDC, and the `onlyAllowSourceToken` modifier on `bridgeData.sendingAssetId` provides indirect protection; no contract change.",
+      "recognition_signal": "Single-asset bridging facet that enforces source-token whitelist on `bridgeData` but does not assert that `_swapData[last].receivingAssetId` matches the same whitelisted asset.",
+      "status_history": [
+        {
+          "audit_id": "audit20251201",
+          "source_label": "6.1.2",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Acknowledged - implicit revert via insufficient balance"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.01_PolymerCCTPFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "swap"
+      ],
+      "id": "LF-124"
+    },
+    "LF-125": {
+      "source_id": "audit20251201::6.1.4",
+      "title": "Insufficient bridgeAmount validation can underflow or trigger zero-amount bridging",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "PolymerCCTPFacet"
+      ],
+      "root_cause": "`bridgeAmount = _bridgeData.minAmount - _polymerData.polymerTokenFee` is computed without ordering checks. If `polymerTokenFee >= minAmount`, the subtraction underflows (revert) or yields a zero-amount bridge that is wasted work.",
+      "fix_summary": "Acknowledged - won't fix to save gas; LI.FI added documentation in commit e31eef9 instead.",
+      "recognition_signal": "Subtracting a user-supplied fee from a user-supplied total without validating fee ≤ total, leaving the protocol to rely on Solidity's checked subtraction to catch the case.",
+      "status_history": [
+        {
+          "audit_id": "audit20251201",
+          "source_label": "6.1.4",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Won't fix - documentation added in e31eef9"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.01_PolymerCCTPFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "math",
+        "underflow",
+        "input-validation"
+      ],
+      "id": "LF-125"
+    },
+    "LF-126": {
+      "source_id": "audit20251201::6.1.6",
+      "title": "Testnet chain IDs mapped to mainnet CCTP domains, mis-routing testnet inputs to mainnet",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "PolymerCCTPFacet"
+      ],
+      "root_cause": "`_chainIdToDomainId()` maps Sepolia / OP Sepolia / Base Sepolia chain IDs to the same CCTP domain IDs as their mainnet counterparts. A user mistakenly supplying a testnet chain ID on a mainnet deployment will have USDC bridged to the mainnet destination instead of reverting.",
+      "fix_summary": "Remove testnet chain ID mappings from the production `_chainIdToDomainId()` function. Fixed in commit 15bca15.",
+      "recognition_signal": "Chain-ID-to-domain mapping that includes both mainnet and testnet entries in the same production lookup, allowing a testnet chain ID on a mainnet deployment to silently resolve to a mainnet target.",
+      "status_history": [
+        {
+          "audit_id": "audit20251201",
+          "source_label": "6.1.6",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed in commit 15bca15"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.01_PolymerCCTPFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "chain-id",
+        "config",
+        "non-evm"
+      ],
+      "id": "LF-126"
+    },
+    "LF-127": {
+      "source_id": "audit20251203_1::6.2.3",
+      "title": "MegaETH bridge accepts unvalidated assetIdOnL2, allowing zero-address L2 token to reach depositERC20To",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "MegaETHBridgeFacet"
+      ],
+      "root_cause": "The MegaETHData.assetIdOnL2 field is forwarded directly into bridge.depositERC20To without a zero-address check on the non-requiresDepositTo branch. A user supplying address(0) (accidentally or maliciously) can drive a bridge call with a zero L2-token, which downstream may mint to an unusable token address or otherwise produce undefined behavior.",
+      "fix_summary": "Fixed in commit 740b0d9 by adding `if (LibUtil.isZeroAddress(_megaETHData.assetIdOnL2)) revert InvalidAssetIdOnL2();` before the depositERC20To call. Reviewer verified.",
+      "recognition_signal": "User-supplied address forwarded to an external bridge / vault deposit function without any zero-address guard, where the external contract's own validation is assumed but never confirmed.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251203_1",
+          "source_label": "6.2.3",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Zero-address revert added in commit 740b0d9; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.03_MegaETHBridgeFacet(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "validation",
+        "bridge-input"
+      ],
+      "id": "LF-127"
+    },
+    "LF-128": {
+      "source_id": "audit20251215::6.1.1",
+      "title": "ReceiverOIF.outputFilled decodes a receiver from executionData without zero-address validation",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverOIF"
+      ],
+      "root_cause": "outputFilled ABI-decodes (transactionId, swapData, receiver) from caller-supplied executionData and forwards receiver directly to the Executor without checking that it is non-zero. If the downstream Executor also does not validate, the tokens will be sent to address(0) and effectively burned.",
+      "fix_summary": "Fixed in 1ecae5a by validating that the decoded receiver is not the zero address in outputFilled.",
+      "recognition_signal": "Cross-chain receiver decodes a final-destination address from caller-controlled payload and forwards it without a zero-address check, relying on a downstream contract to catch the burn.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20251215",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Verified fix in commit 1ecae5a"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.15_ReceiverOIF(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "zero-address",
+        "receiver",
+        "input-validation"
+      ],
+      "id": "LF-128"
+    },
+    "LF-129": {
+      "source_id": "audit20251215::6.2.1",
+      "title": "ReceiverOIF has no slippage protection; users must embed minOut inside the swap calldata",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverOIF"
+      ],
+      "root_cause": "outputFilled does not enforce any minimum output amount or aggregate slippage threshold around the inner swap. The only protection is whatever the SwapData calldata itself encodes, which depends entirely on the swap target. If the user's encoded calldata lacks slippage protection, the swap can settle at extreme adverse prices without reverting.",
+      "fix_summary": "Documentation added in c6ead50 noting that slippage protection must be embedded in the SwapData by the caller.",
+      "recognition_signal": "Cross-chain receiver executes user-supplied swap calldata without any contract-level minOut check, delegating slippage protection entirely to the encoded calldata's target.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251215",
+          "source_label": "6.2.1",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Documentation-only fix in commit c6ead50"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.15_ReceiverOIF(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "slippage",
+        "receiver",
+        "documentation"
+      ],
+      "id": "LF-129"
+    },
+    "LF-130": {
+      "source_id": "audit20251215::6.2.2",
+      "title": "ReceiverOIF leaves residual ERC20 approval to the Executor after each swap completes",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "ReceiverOIF"
+      ],
+      "root_cause": "_swapAndCompleteBridgeTokens grants ERC20 approval to the Executor before the swap call but never resets the allowance to zero afterwards. Any residual allowance compounds across invocations and would be usable by a future-compromised or buggy Executor.",
+      "fix_summary": "Acknowledged; team argues ReceiverOIF cannot meaningfully hold tokens because anyone can craft a withdrawal call, so a residual Executor approval is treated as insignificant.",
+      "recognition_signal": "Helper contract that approves a trusted-but-upgradable downstream contract before each call does not zero the allowance afterwards, leaving accumulating standing approvals from non-zero-allowance approval flows.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20251215",
+          "source_label": "6.2.2",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Won't fix per LI.FI rationale (contract cannot hold tokens long-term)"
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.15_ReceiverOIF(v1.0.0).pdf",
+        "pages": [
+          6
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "approval",
+        "residual-allowance",
+        "receiver"
+      ],
+      "id": "LF-130"
+    },
+    "LF-131": {
+      "source_id": "audit20251216::6.2.2",
+      "title": "Fee-on-transfer tokens permanently burn the NEAR Intents quote ID while underfunding the bridge",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "NEARIntentsFacet"
+      ],
+      "root_cause": "The facet records the quote ID as consumed before validating that the actual delivered token balance matches the quoted amount. For fee-on-transfer tokens the received amount is strictly less than the supplied amount, so the bridge step fails (or underfunds), yet the quote ID has already been marked used and cannot be reused or refunded.",
+      "fix_summary": "Fixed in 4e5b2ec by documenting the limitation in the contract; protocol team will warn users off-chain not to use fee-on-transfer tokens with this facet.",
+      "recognition_signal": "Single-use off-chain quote/order identifier marked consumed before the actual on-chain transferred balance is validated, so a fee-on-transfer token (or any balance-shrinking transfer) silently wastes the quote.",
+      "status_history": [
+        {
+          "audit_id": "audit20251216",
+          "source_label": "6.2.2",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fixed via documentation in commit 4e5b2ec."
+        }
+      ],
+      "source": {
+        "pdf": "2025.12.16_NEARIntentsFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "fee-on-transfer",
+        "quote-id",
+        "single-use"
+      ],
+      "id": "LF-131"
+    },
+    "LF-132": {
+      "source_id": "audit20260130::6.1.1",
+      "title": "Inconsistent refund recipient: positive slippage goes to depositAndRefundAddress but excess native ETH and swap leftovers go to msg.sender",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "swapAndStartBridgeTokensViaLiFiIntentEscrow routes refund types differently: positive slippage to depositAndRefundAddress, but excess native ETH and swap leftovers via refundExcessNative(msg.sender). When msg.sender is a relayer/forwarder this misdirects user refunds to the relayer.",
+      "fix_summary": "Resolved in df0c3c2: aligned slippage refunds. Excess native flow kept on msg.sender across all facets to avoid implementation fragmentation; broader cross-facet fix deferred.",
+      "recognition_signal": "Multiple refund paths in one entrypoint that send leftover funds to two different recipients (depositor-supplied address vs. msg.sender), so a relayer-or-forwarder caller silently captures part of the refund.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260130",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Partial fix in df0c3c2; excessNative path unchanged repo-wide."
+        }
+      ],
+      "source": {
+        "pdf": "2026.01.30_LiFiIntentEscrowFacet(v1.1.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "refund",
+        "msg-sender",
+        "relayer",
+        "facets"
+      ],
+      "id": "LF-132"
+    },
+    "LF-133": {
+      "source_id": "audit20260130::6.2.1",
+      "title": "Misleading InvalidReceiver error used for zero depositAndRefundAddress validation",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "_startBridge reverts InvalidReceiver() when depositAndRefundAddress is zero, but that field is semantically the depositor / refund recipient, not the destination receiver, masking the real cause of the revert for integrators.",
+      "fix_summary": "Fixed in df0c3c (dedicated error for the depositAndRefundAddress zero check).",
+      "recognition_signal": "Reusing an unrelated semantic error (e.g. receiver-zero) for a different field's zero-address validation, hiding the real failure source from integrators.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260130",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Fix commit df0c3c."
+        }
+      ],
+      "source": {
+        "pdf": "2026.01.30_LiFiIntentEscrowFacet(v1.1.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "error-handling",
+        "validation",
+        "developer-ergonomics"
+      ],
+      "id": "LF-133"
+    },
+    "LF-134": {
+      "source_id": "audit20260216::6.1.1",
+      "title": "Polymer CCTP non-EVM path validates nonEVMReceiver but not solanaReceiverATA, leaving inconsistent zero-receiver coverage",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "PolymerCCTPFacet"
+      ],
+      "root_cause": "_startBridge explicitly reverts on nonEVMReceiver == bytes32(0) but leaves solanaReceiverATA unchecked, relying on the downstream TokenMessenger to enforce mintRecipient != 0. The two branches therefore fail with different errors at different call-stack depths, and the facet-level guarantee is incomplete and brittle to changes in the external CCTP contract.",
+      "fix_summary": "Fixed in commit 59d992d by adding an explicit zero-value check on solanaReceiverATA when destinationChainId == LIFI_CHAIN_ID_SOLANA, mirroring the EcoFacet pattern. Reviewer verified.",
+      "recognition_signal": "Parallel non-EVM-receiver fields where one is validated at the facet level and the sibling is delegated entirely to a downstream contract's check, creating inconsistent error surfaces and reliance on external invariants.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260216",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Informational",
+          "notes": "Explicit zero-value check added in commit 59d992d; reviewer verified."
+        }
+      ],
+      "source": {
+        "pdf": "2026.02.16_PolymerCCTPFacet(v2.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "non-evm",
+        "zero-address",
+        "validation",
+        "solana"
+      ],
+      "id": "LF-134"
+    },
+    "LF-135": {
+      "source_id": "audit20260409::6.1.1",
+      "title": "Incorrect LayerZero endpoint IDs for XDC and Plume in AcrossV4SwapFacet._chainIdToLzEid",
+      "severity": "high",
+      "severity_native": "High",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "Hard-coded chainId->LZ eid mappings used XDC eid 30136 (wrong; correct 30365) and Plume eid 30318 belonging to legacy Plume chainId 98865 rather than 98866 (correct 30370). The bad mapping mixes two distinct Plume deployments and would cause the OFT sponsored path's destination-chain validation either to reject valid quotes or accept ones targeting the wrong chain.",
+      "fix_summary": "Fixed in 8f46a81 by correcting both eids to 30365 (XDC) and 30370 (Plume).",
+      "recognition_signal": "A hard-coded chainId -> external-protocol-id table inside a facet without a corresponding exhaustive on-chain test, especially for less-popular chains or near-duplicate deployments.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "High",
+          "notes": "Fix commit 8f46a81."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "chain-id-mapping",
+        "layerzero",
+        "constants"
+      ],
+      "id": "LF-135"
+    },
+    "LF-136": {
+      "source_id": "audit20260409::6.2.1",
+      "title": "Router calldata not adjusted in SpokePoolPeriphery positive-slippage path creates inconsistent SwapAndDepositData",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "On positive slippage, _callSpokePoolPeripherySwapAndBridge scales outputAmount, minExpectedInputTokenAmount and swapTokenAmount, but forwards routerCalldata unchanged. The opaque router calldata was produced by the backend for the original (smaller) amount, so the periphery executes a swap whose parameters disagree with the upper-layer struct.",
+      "fix_summary": "Fixed in e6c6c82: switched to the sponsored-path strategy of bridging only the originally quoted amount and refunding the surplus to the user.",
+      "recognition_signal": "Patching individual numeric fields of a routing struct on positive slippage while leaving an opaque bytes routerCalldata blob (generated for the pre-slippage amount) unmodified.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.2.1",
+          "status": "fixed",
+          "severity_native": "Medium",
+          "notes": "Fix commit e6c6c82."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "positive-slippage",
+        "calldata-consistency",
+        "router"
+      ],
+      "id": "LF-136"
+    },
+    "LF-137": {
+      "source_id": "audit20260409::6.2.2",
+      "title": "Linear scaling of outputAmount on positive slippage may exceed relayer-fillable bounds",
+      "severity": "medium",
+      "severity_native": "Medium",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "SpokePool and SpokePoolPeriphery paths scale outputAmount linearly from the original quote ratio when positive slippage occurs. Across relayer fees and liquidity depth are not perfectly linear in input size, so the scaled outputAmount can exceed what any relayer is willing to fill, stranding funds until fillDeadline expires.",
+      "fix_summary": "Acknowledged: Across team confirmed proportional adjustment is their recommended approach; treated as approximately linear at these sizes. No change.",
+      "recognition_signal": "Scaling an external quote's output amount linearly with input size when the underlying fee/liquidity curve is not actually linear.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.2.2",
+          "status": "acknowledged",
+          "severity_native": "Medium",
+          "notes": "Confirmed acceptable by Across team."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "positive-slippage",
+        "math",
+        "external-quote"
+      ],
+      "id": "LF-137"
+    },
+    "LF-138": {
+      "source_id": "audit20260409::6.3.1",
+      "title": "Backend EIP-712 signature verification skipped for sponsored OFT/CCTP paths in AcrossV4SwapFacet",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "_verifySignatureIfRequired enforces the LI.FI backend EIP-712 signature only for SpokePool and SpokePoolPeriphery targets, returning early for SponsoredOFTSrcPeriphery and SponsoredCCTPSrcPeriphery. The two sponsored paths therefore accept any caller-crafted calldata as long as downstream periphery checks pass, breaking a uniform trust model.",
+      "fix_summary": "Acknowledged: sponsored paths are considered LI.FI-internal-only; risk accepted.",
+      "recognition_signal": "A facet that enforces a backend signature on some swap-API targets but selectively bypasses it for others, creating an asymmetric trust model across otherwise-similar entry paths.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.3.1",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Risk accepted."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          5,
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "signature-verification",
+        "defense-in-depth",
+        "backend-trust"
+      ],
+      "id": "LF-138"
+    },
+    "LF-139": {
+      "source_id": "audit20260409::6.3.3",
+      "title": "Full msg.value forwarded to sponsored OFT deposit can exceed available balance after native source swap",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "_callSponsoredOftDeposit forwards the original msg.value to the LayerZero deposit for messaging fees. When called via swapAndStartBridgeTokensViaAcrossV4Swap with a native-to-ERC20 source swap, the swap already consumed part of the contract's ETH, so forwarding msg.value reverts and the OFT path becomes unusable with native source swaps.",
+      "fix_summary": "Fixed in 5db76ea by tracking the native amount actually needed for LZ fees rather than blindly forwarding msg.value.",
+      "recognition_signal": "Forwarding the original msg.value to a downstream payable call inside a function that may have already consumed part of that ETH for an internal swap.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.3.3",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit 5db76ea."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "msg-value",
+        "native-swap",
+        "layerzero"
+      ],
+      "id": "LF-139"
+    },
+    "LF-140": {
+      "source_id": "audit20260409::6.3.4",
+      "title": "Native asset inputToken/swapToken not validated against WRAPPED_NATIVE in AcrossV4SwapFacet signature-gated paths",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "When isNative == true, both the SpokePool and SpokePoolPeriphery paths skip the token-address check that ERC20 flows perform against _bridgeData.sendingAssetId, leaving correctness of the native-token address entirely to the backend signature.",
+      "fix_summary": "Fixed in e36cd4a by enforcing that the decoded native token matches the expected wrapped-native constant.",
+      "recognition_signal": "Token-address validation branch that is performed for ERC20 inputs but silently skipped for the native-token case, deferring all correctness to an off-chain signature.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.3.4",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit e36cd4a."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          7
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "native-asset",
+        "validation",
+        "wrapped-native"
+      ],
+      "id": "LF-140"
+    },
+    "LF-141": {
+      "source_id": "audit20260409::6.3.5",
+      "title": "Positive-slippage refund executes before input validation in sponsored OFT and CCTP paths",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "In both _callSponsoredOftDeposit and _callSponsoredCctpDepositForBurn, the positive-slippage refund transfer happens before subsequent input checks (refundRecipient/receiver/amount/burnToken validations). This violates checks-effects-interactions and masks the real failure cause when later validations revert.",
+      "fix_summary": "Fixed in de6a839 by moving the refund block after all validation checks in both sponsored paths.",
+      "recognition_signal": "Performing a refund/transfer at the very top of a function before downstream parameter checks, so a failing check reverts an already-attempted state-changing transfer.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.3.5",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit de6a839."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          7,
+          9
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "checks-effects-interactions",
+        "refund-ordering"
+      ],
+      "id": "LF-141"
+    },
+    "LF-142": {
+      "source_id": "audit20260409::6.3.6",
+      "title": "Missing refundRecipient != address(0) validation in CCTP sponsored path",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "Three of four AcrossV4SwapFacet paths explicitly reject a zero depositor/refund address, but the SponsoredCCTP path does not, relying on a downstream LibAsset.transferERC20 NULL_ADDRESS check that only triggers when positive slippage occurs.",
+      "fix_summary": "Fixed in 93dda97 by adding an explicit refundRecipient != address(0) check before the positive-slippage block.",
+      "recognition_signal": "Inconsistent zero-address validation for an equivalent 'refund recipient' field across multiple sibling code paths in the same contract.",
+      "status": "fixed",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.3.6",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fix commit 93dda97."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          8
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "validation",
+        "zero-address",
+        "consistency"
+      ],
+      "id": "LF-142"
+    },
+    "LF-143": {
+      "source_id": "audit20260409::6.5.3",
+      "title": "hasDestinationCall flag always false even when forwarded Across calldata contains a destination message",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "AcrossV4SwapFacet"
+      ],
+      "root_cause": "AcrossV4SwapFacet enforces doesNotContainDestinationCalls on bridgeData but the inner SpokePool/Periphery calldata can carry a non-empty Across message that triggers destination-side execution. The LiFiTransferStarted event therefore emits hasDestinationCall = false even when a destination call effectively happens. AcrossFacetV4 cross-checks message length vs the flag; the swap facet does not.",
+      "fix_summary": "Acknowledged: LI.FI treats destinationCall=true as 'LI.FI-added destination calls only'; the Across swap API is treated as one opaque operation.",
+      "recognition_signal": "Emitting a 'has destination call' analytics flag based only on the outer wrapper while the inner cross-chain message field that triggers remote execution is not consulted.",
+      "status": "acknowledged",
+      "status_history": [
+        {
+          "audit_id": "audit20260409",
+          "source_label": "6.5.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "Semantic choice; documented behaviour."
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.09_AcrossV4SwapFacet(v1.0.0).pdf",
+        "pages": [
+          10,
+          12
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "events",
+        "destination-call",
+        "indexer-correctness"
+      ],
+      "id": "LF-143"
+    },
+    "LF-144": {
+      "source_id": "audit20260430::6.1.1",
+      "title": "Missing validation of orderAuthorityDst strands DLN cancel/refund flow",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "Because `allowedCancelBeneficiarySrc` is hardcoded to empty in `_startBridge`, all cancellation and refund authority resides exclusively with `orderAuthorityAddressDst`. The facet does not check that `_deBridgeData.orderAuthorityDst` is non-empty/non-zero, so a misconfigured order is uncancellable and unrefundable, permanently stranding funds if unfilled.",
+      "fix_summary": "Revert if `_deBridgeData.orderAuthorityDst.length == 0`. Fixed in commit 36a8922.",
+      "recognition_signal": "Bridging order configuration where the only path to cancel/refund flows through a single user-supplied destination authority field, while the facet performs no sanity check (zero/empty) on that field.",
+      "status_history": [
+        {
+          "audit_id": "audit20260430",
+          "source_label": "6.1.1",
+          "status": "fixed",
+          "severity_native": "Low",
+          "notes": "Fixed in commit 36a8922"
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.30_DeBridgeDlnFacet(v1.1.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "refund",
+        "cancel-flow"
+      ],
+      "id": "LF-144"
+    },
+    "LF-145": {
+      "source_id": "audit20260430::6.1.2",
+      "title": "givePatchAuthoritySrc = msg.sender assigns DLN patch authority to Permit2Proxy on permit flows",
+      "severity": "low",
+      "severity_native": "Low",
+      "area": "facets",
+      "contracts": [
+        "DeBridgeDlnFacet"
+      ],
+      "root_cause": "DLN's `givePatchAuthoritySrc` is set to `msg.sender`. When the facet is invoked indirectly via Permit2Proxy (`callDiamondWithEIP2612Signature`, `callDiamondWithPermit2*`), `msg.sender` inside the facet is the Permit2Proxy contract address, not the end user. Permit2Proxy exposes no patch endpoint, so the economic owner has no path to patch their own order.",
+      "fix_summary": "Acknowledged - LI.FI argues the destination authority gives sufficient control. No contract change.",
+      "recognition_signal": "Authority/permission field set to `msg.sender` inside a facet, where the same facet is reachable indirectly via a proxy/meta-tx contract that becomes msg.sender instead of the real user.",
+      "status_history": [
+        {
+          "audit_id": "audit20260430",
+          "source_label": "6.1.2",
+          "status": "acknowledged",
+          "severity_native": "Low",
+          "notes": "Acknowledged - dst authority considered sufficient"
+        }
+      ],
+      "source": {
+        "pdf": "2026.04.30_DeBridgeDlnFacet(v1.1.0).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "permit2",
+        "msg.sender",
+        "authority"
+      ],
+      "id": "LF-145"
+    }
+  }
+}

--- a/audit/knowledge/findings.json
+++ b/audit/knowledge/findings.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": "1.0",
-  "generated_at": "2026-05-19T14:56:58Z",
+  "schema_version": "1.1",
+  "generated_at": "2026-05-25T07:24:14Z",
   "findings": {
     "LF-001": {
       "source_id": "audit20240201::3.1.1",
@@ -5238,6 +5238,162 @@
         "authority"
       ],
       "id": "LF-145"
+    },
+    "LF-146": {
+      "source_id": "audit20250610::6.1.3",
+      "title": "wrapStETHToWstETH and unwrapWstETHToStETH lack a minimum-amount-out slippage parameter",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "periphery",
+      "contracts": [
+        "LidoWrapper"
+      ],
+      "root_cause": "Both wrap/unwrap entrypoints call ST_ETH.wrap / ST_ETH.unwrap with the user-supplied `_amount` and forward the resulting wstETH/stETH balance without comparing it to a caller-specified floor. Because stETH/wstETH share-to-token math depends on Lido's accounting state, the realized output amount can diverge from the caller's expectation between transaction construction and inclusion, with no on-chain check to abort the call.",
+      "fix_summary": "Acknowledged, not fixed. LI.FI argued no direct AMM-pool-style exploit exists and preferred to save gas; researcher accepted but flagged it as a defense-in-depth gap.",
+      "recognition_signal": "Token-conversion entrypoint that derives output from an external accounting contract (e.g. wrap/unwrap, deposit/redeem) and forwards the resulting balance to the caller without a `minAmountOut` floor.",
+      "status_history": [
+        {
+          "audit_id": "audit20250610",
+          "source_label": "6.1.3",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "LI.FI declined the fix citing no AMM exploit path; researcher acknowledged but recommended defensive check."
+        }
+      ],
+      "source": {
+        "pdf": "2025.06.10_LidoWrapper(v1.0.0).pdf",
+        "pages": [
+          4,
+          5
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "slippage",
+        "wrapper",
+        "lido",
+        "defense-in-depth"
+      ],
+      "id": "LF-146"
+    },
+    "LF-147": {
+      "source_id": "audit20260205::6.1.2",
+      "title": "validateBridgeDataLiFiIntentEscrow modifier omits zero-check on destinationChainId, allowing bridge calls with chainId 0",
+      "severity": "info",
+      "severity_native": "Informational",
+      "area": "facets",
+      "contracts": [
+        "LiFiIntentEscrowFacet"
+      ],
+      "root_cause": "The validateBridgeDataLiFiIntentEscrow() modifier only rejects a zero receiver and a zero minAmount, but does not check that _bridgeData.destinationChainId != 0. A malformed or misconfigured input can therefore pass facet-level validation with destinationChainId == 0, causing LiFiTransferStarted to be emitted with an invalid destination and any downstream off-chain routing to consume bad metadata.",
+      "fix_summary": "LI.FI acknowledged but declined to add the check to keep validateBridgeData modifiers consistent across facets (the check did not exist in the prior version). No code change landed.",
+      "recognition_signal": "Facet-specific validateBridgeData modifier that checks receiver and minAmount but skips destinationChainId != 0, leaving a single field of BridgeData unvalidated at the facet entry.",
+      "status_history": [
+        {
+          "audit_id": "audit20260205",
+          "source_label": "6.1.2",
+          "status": "acknowledged",
+          "severity_native": "Informational",
+          "notes": "LI.FI declined for cross-facet consistency; check did not exist prior to the change"
+        }
+      ],
+      "source": {
+        "pdf": "2026.02.05_LiFiIntentEscrowFacet(v1.0.1,v1.1.1).pdf",
+        "pages": [
+          4
+        ]
+      },
+      "extraction_confidence": "high",
+      "tags": [
+        "input-validation",
+        "bridge-data",
+        "modifier",
+        "destination-chain-id"
+      ],
+      "id": "LF-147"
     }
-  }
+  },
+  "processed_audits": [
+    "audit20240201",
+    "audit20240814",
+    "audit20240902",
+    "audit20240913",
+    "audit20241007",
+    "audit20241014",
+    "audit20241105",
+    "audit20241107",
+    "audit20241122",
+    "audit20241202",
+    "audit20241203",
+    "audit20241205",
+    "audit20241206",
+    "audit20250106",
+    "audit20250109_1",
+    "audit20250109_2",
+    "audit20250109_3",
+    "audit20250110_1",
+    "audit20250110_2",
+    "audit20250117_1",
+    "audit20250117_2",
+    "audit20250117_3",
+    "audit20250117_4",
+    "audit20250219",
+    "audit20250220",
+    "audit20250228",
+    "audit20250305",
+    "audit20250327",
+    "audit20250411",
+    "audit20250413",
+    "audit20250415",
+    "audit20250416",
+    "audit20250422",
+    "audit20250506",
+    "audit20250508",
+    "audit20250510",
+    "audit20250515",
+    "audit20250603",
+    "audit20250608",
+    "audit20250610",
+    "audit20250620",
+    "audit20250626",
+    "audit20250629",
+    "audit20250629_1",
+    "audit20250630",
+    "audit20250706",
+    "audit20250706_01",
+    "audit20250718",
+    "audit20250728",
+    "audit20250730",
+    "audit20250822",
+    "audit20250825",
+    "audit20250825_1",
+    "audit20250901",
+    "audit20250919",
+    "audit20250921",
+    "audit20251001",
+    "audit20251007",
+    "audit20251015",
+    "audit20251020",
+    "audit20251104",
+    "audit20251104_1",
+    "audit20251113",
+    "audit20251119",
+    "audit20251201",
+    "audit20251203_1",
+    "audit20251203_2",
+    "audit20251215",
+    "audit20251215_1",
+    "audit20251215_2",
+    "audit20251216",
+    "audit20251219",
+    "audit20251225",
+    "audit20251231",
+    "audit20260130",
+    "audit20260205",
+    "audit20260216",
+    "audit20260320",
+    "audit20260409",
+    "audit20260423",
+    "audit20260430"
+  ]
 }

--- a/audit/knowledge/lessons.md
+++ b/audit/knowledge/lessons.md
@@ -1,0 +1,189 @@
+# LI.FI audit knowledge — lessons
+
+Generated from `findings.json` by the `extract-audit-knowledge` skill. Do not hand-edit.
+
+## Totals
+
+- Findings: 145
+- Audits with at least one finding: 42
+- Audits processed (zero findings): 39
+- Audits processed total: 81
+- Audits unprocessable (PDF corrupt): 2
+
+## By severity
+
+| critical | high | medium | low | info |
+| --- | --- | --- | --- | --- |
+| 0 | 4 | 18 | 67 | 56 |
+
+## By area
+
+| facets | periphery | libraries | security | helpers | cross-cutting |
+| --- | --- | --- | --- | --- | --- |
+| 91 | 43 | 8 | 2 | 0 | 1 |
+
+## Coverage gaps
+
+**Unprocessable audits** — PDFs in `audit/reports/` that could not be read (corruption). Re-obtain from auditor and re-run extraction:
+- `audit20251208` — PDF file is permanently corrupted in the repository (and on github.com): xref/catalog destroyed, UTF-8 replacement bytes baked into binary stream — qpdf/pdftotext/pdfinfo all fail. Findings cannot be extracted from this report.
+- `audit20251229` — PDF file is corrupted (missing /Root dictionary, illegal characters, broken xref); not recoverable with qpdf/pdftotext. Both working tree and git-committed copy are damaged.
+
+**Zero-finding audits (39)** — read successfully but produced no in-scope findings (either 0 issues reported, or all issues were gas/style/code-quality with no security path):
+
+- `audit20240814`, `audit20241014`, `audit20241107`, `audit20241203`, `audit20250109_1`, `audit20250109_2`
+- `audit20250109_3`, `audit20250117_1`, `audit20250117_2`, `audit20250117_3`, `audit20250117_4`, `audit20250220`
+- `audit20250228`, `audit20250327`, `audit20250413`, `audit20250415`, `audit20250416`, `audit20250422`
+- `audit20250515`, `audit20250608`, `audit20250610`, `audit20250629`, `audit20250629_1`, `audit20250706`
+- `audit20250706_01`, `audit20250728`, `audit20250822`, `audit20250921`, `audit20251015`, `audit20251113`
+- `audit20251203_2`, `audit20251215_1`, `audit20251215_2`, `audit20251219`, `audit20251225`, `audit20251231`
+- `audit20260205`, `audit20260320`, `audit20260423`
+
+## Index
+
+| ID | Title | Severity | Area | Contracts | Status |
+| --- | --- | --- | --- | --- | --- |
+| LF-001 | wrapNative() drains entire native token balance instead of unwrapped amount | medium | periphery | RouteProcessor4 | fixed |
+| LF-002 | swapCurve() approve() reverts on tokens that return no bool (USDT) | medium | periphery | RouteProcessor4 | fixed |
+| LF-003 | swapCurve() uses .transfer() with 2300-gas stipend to send native tokens | medium | periphery | RouteProcessor4 | fixed |
+| LF-004 | exchange() reverts when swapping legacy Curve pool with native token | low | periphery | RouteProcessor4 | acknowledged |
+| LF-005 | swapUniV2 does not validate that tokenIn belongs to the pool | low | periphery | RouteProcessor4 | acknowledged |
+| LF-006 | distributeAndSwap() can call swap() with amount of 0, triggering bentoBridge full-balance flow | low | periphery | RouteProcessor4 | fixed |
+| LF-007 | Revert reason bubbled up incorrectly in transferValueAndprocessRoute() | low | periphery | RouteProcessor4 | fixed |
+| LF-008 | No events emitted when admin parameters bentoBox, priviledgedUsers, or paused are modified | info | periphery | RouteProcessor4 | acknowledged |
+| LF-009 | Per-leg slippage protection missing; intermediate swaps have minOut hardcoded to 0 | info | periphery | RouteProcessor4 | acknowledged |
+| LF-010 | swapCurve() approve() leaves non-zero allowance that bricks future swaps for USDT-like tokens | info | periphery | RouteProcessor4 | fixed |
+| LF-011 | extractGenericSwapParameters length check uses >= 484 instead of > 484, accepting calldata with empty SwapData | low | facets | CalldataVerificationFacet | fixed |
+| LF-012 | DiamondCutFacet can be accidentally permanently disabled by including it in the unpause blacklist | low | facets | EmergencyPauseFacet | fixed |
+| LF-013 | pauserWallet can brick the diamond by pausing then removing the EmergencyPauseFacet itself | low | facets | EmergencyPauseFacet | fixed |
+| LF-014 | pauseDiamond can run out of gas as the number of facets grows because there is no pagination | low | facets | EmergencyPauseFacet | acknowledged |
+| LF-015 | Across receiver address can be address(0) when destination call flag is enabled, bypassing zero-receiver validation | medium | facets | AcrossFacetV3 | acknowledged |
+| LF-016 | ERC20 bridging functions marked payable allow native ETH to be stuck in the contract | low | facets | AcrossFacetPackedV3 | fixed |
+| LF-017 | Packed Across calldata encoders silently drop trailing referrer bytes when used directly without out-of-band concatenation | low | facets | AcrossFacetPackedV3 | fixed |
+| LF-018 | transactionId truncated from bytes32 to bytes8 in packed Across encoders, producing 75% data loss in events | low | facets | AcrossFacetPackedV3 | acknowledged |
+| LF-019 | unpauseDiamond reverts with a panic when an unknown facet address is supplied in the blacklist array | low | facets | EmergencyPauseFacet | acknowledged |
+| LF-020 | EmergencyPauseFacet can be removed by the diamond owner during unpause, permanently disabling emergency-pause capability | info | facets | EmergencyPauseFacet | acknowledged |
+| LF-021 | Frontrunning callDiamondWithEIP2612Signature steals user funds via unsigned diamond calldata | high | periphery | Permit2Proxy | fixed |
+| LF-022 | Witness typehash includes fields not used in the newer Permit2 implementation | low | periphery | Permit2Proxy | fixed |
+| LF-023 | Permit2Proxy lacks receive() so native refunds from the Diamond revert | low | periphery | Permit2Proxy | fixed |
+| LF-024 | Dust left in Permit2Proxy after diamond calls is claimable by next caller | low | periphery | Permit2Proxy | acknowledged |
+| LF-025 | swapAndStartBridgeTokensViaRelay does not validate swap output token equals sendingAssetId | low | facets | RelayFacet | acknowledged |
+| LF-026 | Source-chain refunds from Relay are sent to the diamond contract rather than the user | low | facets | RelayFacet | acknowledged |
+| LF-027 | Redundant validateBridgeData receiver check while bridging to Solana/Bitcoin | low | facets | RelayFacet | fixed |
+| LF-028 | RelayFacet does not prevent requestId replay | info | facets | RelayFacet | fixed |
+| LF-029 | DeBridgeDlnFacet validates _bridgeData.receiver but bridges to _deBridgeData.receiver, allowing zero/invalid receiver | medium | facets | DeBridgeDlnFacet | fixed |
+| LF-030 | Non-EOA receiver becomes orderAuthorityAddressDst and cannot call sendEvmOrderCancel, permanently locking funds | medium | facets | DeBridgeDlnFacet | fixed |
+| LF-031 | allowedCancelBeneficiarySrc left empty allows orderAuthorityAddressDst to redirect refunds away from the original sender | low | facets | DeBridgeDlnFacet | fixed |
+| LF-032 | initDeBridgeDln does not gate on sm.initialized, allowing re-initialization of facet storage | low | facets | DeBridgeDlnFacet | acknowledged |
+| LF-033 | AcrossFacetPackedV3 hard-codes depositor=msg.sender in non-packed entries, blocking speedUpV3Deposit for contract callers | medium | facets | AcrossFacetPackedV3 | fixed |
+| LF-034 | AcrossFacetPackedV3 packed/min entrypoints lack zero-address, amount and timestamp validation, enabling fund loss on bad calldata | low | facets | AcrossFacetPackedV3 | acknowledged |
+| LF-035 | Failed/partial swapData in ReceiverAcrossV3.handleV3AcrossMessage leaves dust trapped in the receiver contract | low | periphery | ReceiverAcrossV3 | acknowledged |
+| LF-036 | ReceiverAcrossV3.handleV3AcrossMessage lacks nonReentrant modifier despite executing untrusted swap calldata | info | periphery | ReceiverAcrossV3 | acknowledged |
+| LF-037 | outputAmountPercent on AcrossFacetV3 swap-and-bridge has no bounds, allowing inflated or zero output amounts | info | facets | AcrossFacetV3 | acknowledged |
+| LF-038 | Griefing via frontrunning of callDiamondWithEIP2612Signature - attacker consumes user's permit signature before contract call | medium | periphery | Permit2Proxy | fixed |
+| LF-039 | Missing min/max bounds for Gas.zip deposit amounts in GasZipFacet/GasZipPeriphery | low | cross-cutting | GasZipFacet, GasZipPeriphery | acknowledged |
+| LF-040 | onlyRoleOrOpenRole exposes timelock-admin actions if role is granted to address(0) | low | security | LiFiTimelockController | fixed |
+| LF-041 | Emergency unpause function bypasses timelock delay | info | security | LiFiTimelockController | acknowledged |
+| LF-042 | GlacisFacet does not validate that GlacisData.refundAddress is non-zero, risking permanent loss of bridge refunds | low | facets | GlacisFacet | fixed |
+| LF-043 | GlacisFacet does not verify msg.value covers nativeFee, allowing callers to drain native balance the diamond may hold | info | facets | GlacisFacet | acknowledged |
+| LF-044 | GlacisFacet lacks noNativeAsset modifier, so native-asset bridges revert deep in the external call instead of failing fast with a clear error | info | facets | GlacisFacet | fixed |
+| LF-045 | GlacisFacet.swapAndStartBridgeTokensViaGlacis does not assert the last swap's output asset equals the bridge's sendingAssetId | info | facets | GlacisFacet | acknowledged |
+| LF-046 | Improper receiver address encoding for Bitcoin chain truncates non-EVM destination address | high | facets | ChainflipFacet | fixed |
+| LF-047 | Permanent loss of funds when refund receiver cannot accept native ETH in catch branch | low | periphery | ReceiverChainflip | acknowledged |
+| LF-048 | Destination-call message encoding assumes EVM SwapData when destination chain is non-EVM | low | facets | ChainflipFacet | acknowledged |
+| LF-049 | MEV exposure when Velodrome V2 callback recipient can boost its own balance during the swap | low | periphery | LiFiDEXAggregator | acknowledged |
+| LF-050 | Velodrome V2 callback flag accepts any non-zero byte instead of strict 1 | low | periphery | LiFiDEXAggregator | fixed |
+| LF-051 | swapVelodromeV2 can be used to invoke arbitrary recipient hooks without sender validation | info | periphery | LiFiDEXAggregator | mitigated |
+| LF-052 | swapVelodromeV2 missing zero-address validation for pool and recipient | info | periphery | LiFiDEXAggregator | fixed |
+| LF-053 | depositAssets does not aggregate msg.value across multiple native-asset swaps, allowing the same ETH to be counted multiple times | medium | libraries | LibAsset | acknowledged |
+| LF-054 | transferFromERC20 silently succeeds when called with the native asset placeholder address | medium | libraries | LibAsset | fixed |
+| LF-055 | approveERC20 reverts on native asset instead of no-op, breaking the prior LibAsset contract | low | libraries | LibAsset | fixed |
+| LF-056 | isContract is spoofable to true by EIP-7702 delegation to address(0) | low | libraries | LibAsset | fixed |
+| LF-057 | isContract uses only keccak256("") as the empty-codehash sentinel, misclassifying never-interacted addresses | info | libraries | LibAsset | fixed |
+| LF-058 | ReceiverStargateV2 does not verify lzCompose caller, enabling gas-griefing that forces fallback to source-token transfer | low | periphery | ReceiverStargateV2 | fixed |
+| LF-059 | DexManagerFacet.batchAddDex can enter an infinite loop when a dex is already allowed | low | facets | DexManagerFacet | fixed |
+| LF-060 | GasZipFacet's address-to-bytes32 conversion uses left-padding, breaking all bridges and silently directing funds to address(0) when caller compensates | low | facets | GasZipFacet | fixed |
+| LF-061 | Permit2Proxy sets allowedCancelBeneficiarySrc=msg.sender on DeBridge orders, causing canceled-order refunds to land in the proxy instead of the user | low | periphery | Permit2Proxy, DeBridgeDlnFacet | fixed |
+| LF-062 | Permit2Proxy catches only string Error reverts, leaving panic and custom-error reverts uncaught and exploitable for griefing | low | periphery | Permit2Proxy | fixed |
+| LF-063 | CelerIMFacetBase assumes RelayerCelerIM has the same address across chains, but CREATE-opcode-driven address derivation differs on zkSync, sending bridged funds to a non-existent address | low | facets | CelerIMFacetBase, RelayerCelerIM | fixed |
+| LF-064 | HopFacet forwards msg.value = minAmount + nativeFee, but Hop bridge requires value == amount, leaking nativeFee and double-charging ERC20 users | low | facets | HopFacet, HopFacetOptimized | fixed |
+| LF-065 | swapAlgebra falls back from swapSupportingFeeOnInputTokens to swap() on any error, masking unrelated failures | low | periphery | LiFiDEXAggregator | fixed |
+| LF-066 | swapAlgebra activates fee-on-transfer route on any non-zero flag value instead of strict equality with 1 | info | periphery | LiFiDEXAggregator | fixed |
+| LF-067 | swapAlgebra does not sanity-check pool and recipient addresses decoded from the stream | info | periphery | LiFiDEXAggregator | fixed |
+| LF-068 | GnosisBridgeFacet grants unlimited router approval every bridge call instead of approving exact amount | info | facets | GnosisBridgeFacet | acknowledged |
+| LF-069 | swapAndStartBridgeTokensViaGnosisBridge does not assert final swap output token equals bridgeData.sendingAssetId | info | facets | GnosisBridgeFacet | fixed |
+| LF-070 | LibAsset.isContract() classifies sub-23-byte contracts as EOAs | info | libraries | LibAsset | acknowledged |
+| LF-071 | PioneerFacet does not sanity-check refundAddress | low | facets | PioneerFacet | fixed |
+| LF-072 | PioneerFacet does not sanity-check transactionId | low | facets | PioneerFacet | fixed |
+| LF-073 | swapAndStartBridgeTokensViaPioneer does not validate swap output equals bridging asset | info | facets | PioneerFacet | acknowledged |
+| LF-074 | Unsafe uint256-to-uint128 cast of swap amount in swapIzumiV3 permanently locks excess funds | medium | periphery | LiFiDEXAggregator | fixed |
+| LF-075 | swapIzumiV3 uses out-of-range tick boundaries (-80000/80000) instead of the valid -79999/79999 | low | periphery | LiFiDEXAggregator | fixed |
+| LF-076 | Missing sanity check on withdrawMode in swapSyncSwap allows out-of-domain values | info | periphery | LiFiDEXAggregator | fixed |
+| LF-077 | swapSyncSwap V2 branch missing explicit INTERNAL_INPUT_SOURCE handling that the V1 branch has | info | periphery | LiFiDEXAggregator | fixed |
+| LF-078 | swapIzumiV3 forwards decoded pool/recipient from the stream without zero-address or sentinel checks | info | periphery | LiFiDEXAggregator | fixed |
+| LF-079 | AllBridgeFacet does not cap _allBridgeData.fees, so any overpayment is permanently lost | low | facets | AllBridgeFacet | acknowledged |
+| LF-080 | AllBridgeFacet bridges to non-EVM chains without emitting the BridgeToNonEVMChain event | info | facets | AllBridgeFacet | fixed |
+| LF-081 | MayanFacet and DeBridgeDlnFacet constructors do not validate their address parameters | info | facets | MayanFacet, DeBridgeDlnFacet | fixed |
+| LF-082 | Front-running of Patcher depositAndExecute functions lets a malicious caller steal approved tokens | high | periphery | Patcher | acknowledged |
+| LF-083 | _getDynamicValue blindly casts arbitrary return-types to uint256, allowing malformed patches | medium | periphery | Patcher | fixed |
+| LF-084 | Unlimited token approvals to unknown external targets in Patcher | info | periphery | Patcher | fixed |
+| LF-085 | Patcher execution functions emit no events for off-chain tracking | info | periphery | Patcher | fixed |
+| LF-086 | Patcher silently transfers caller's entire approved balance regardless of requested amount | info | periphery | Patcher | fixed |
+| LF-087 | Patcher does not refund excess native/ERC20 sent or approved beyond what target consumes | info | periphery | Patcher | fixed |
+| LF-088 | MayanFacet decodes the trader address as final receiver for Hypercore deposit/fastDeposit selectors instead of the receiver embedded in depositPayload | medium | facets | MayanFacet | fixed |
+| LF-089 | BridgeData receiver and destinationChain are emitted but not enforced by RelayDepositoryFacet, weakening event-based off-chain accounting | info | facets | RelayDepositoryFacet | acknowledged |
+| LF-090 | RelayDepositoryFacet may forward more than the off-chain order specifies, relying on Relay solver to refund the difference | info | facets | RelayDepositoryFacet | acknowledged |
+| LF-091 | Lossy decode for non-EVM receiver address in AcrossFacetPackedV4 decoders | low | facets | AcrossFacetPackedV4 | fixed |
+| LF-092 | Missing zero-check for derived outputAmount after multiplier scaling in AcrossFacetV4 | low | facets | AcrossFacetV4 | acknowledged |
+| LF-093 | Missing non-zero validation for refundAddress passed to Across spoke pool | low | facets | AcrossFacetV4 | fixed |
+| LF-094 | Owner can execute arbitrary external calls via executeCallAndWithdraw on AcrossFacetPackedV4 | info | facets | AcrossFacetPackedV4 | acknowledged |
+| LF-095 | Possible burn to zero address in ReceiverAcrossV4 swap-failure fallback | info | periphery | ReceiverAcrossV4 | acknowledged |
+| LF-096 | Incorrect calldata length validation in decode_startBridgeTokensViaAcrossV4NativePacked | info | facets | AcrossFacetPackedV4 | fixed |
+| LF-097 | Missing BridgeToNonEVMChain event when bridging to non-EVM destinations | info | facets | GardenFacet | fixed |
+| LF-098 | Destination receiver address reused as source-chain refund initiator can be stolen on source | medium | facets | GardenFacet | fixed |
+| LF-099 | EcoFacet accepts NON_EVM_ADDRESS receiver for non-Solana EVM chains without rejection | low | facets | EcoFacet | fixed |
+| LF-100 | Excess native tokens sent to EcoFacet bridging functions are permanently locked | low | facets | EcoFacet | fixed |
+| LF-101 | Solana receiver length lower-bound validation missing | low | facets | EcoFacet | fixed |
+| LF-102 | BridgeToNonEVMChain event emitted on EVM destinations when nonEVMReceiver is non-empty | low | facets | EcoFacet | fixed |
+| LF-103 | _buildReward() does not validate prover address or rewardDeadline | info | facets | EcoFacet | fixed |
+| LF-104 | UnitFacet unconditionally trusts the backend-signed depositAddress with no on-chain verification of its association with the Unit Protocol | low | facets | UnitFacet | acknowledged |
+| LF-105 | UnitFacet.swapAndStartBridgeTokensViaUnit does not verify that the post-swap token is native ETH before calling transferNativeAsset | low | facets | UnitFacet | acknowledged |
+| LF-106 | UnitFacet verifies backend signature against pre-swap minAmount but bridges the post-swap minAmount, weakening the signed authorization | low | facets | UnitFacet | acknowledged |
+| LF-107 | UnitFacet._startBridge enforces minimum amounts only on Ethereum and Plasma, silently accepting dust transfers on every other chain | info | facets | UnitFacet | fixed |
+| LF-108 | UnitFacet checks the signature deadline after executing the signature-recovery work, wasting gas and surfacing failures late | info | facets | UnitFacet | fixed |
+| LF-109 | UnitFacet has no replay protection on backend signatures; the same signed message can be reused before deadline | info | facets | UnitFacet | fixed |
+| LF-110 | Positive swap slippage in EcoFacet pre-bridge swap is silently captured by the solver instead of the user | info | facets | EcoFacet | fixed |
+| LF-111 | Duplicate intent funding in EcoFacet traps user funds and lets attacker sweep them via swap leftovers refund | medium | facets | EcoFacet | fixed |
+| LF-112 | Eco intent refund on expiry sent to msg.sender (Permit2Proxy/integrator) instead of the real user, losing funds | medium | facets | EcoFacet | fixed |
+| LF-113 | Migration input list of selectors-to-remove can be incomplete, leaving stale whitelisted selectors after migration | info | facets | WhitelistManagerFacet | mitigated |
+| LF-114 | Whitelisting contracts and selectors in separate mappings allows any cross-combination to be permitted | low | libraries | LibAllowList, WhitelistManagerFacet | mitigated |
+| LF-115 | Selector cleared from index but left true in allow-list mapping becomes permanently un-removable after migration | low | facets | WhitelistManagerFacet, LibAllowList | fixed |
+| LF-116 | Unbounded contracts/selectors arrays in LibAllowList getters can exceed block gas and break whitelist visibility | info | libraries | LibAllowList, WhitelistManagerFacet | acknowledged |
+| LF-117 | WhitelistManagerFacet v1->v2 migration lacks coverage that legacy state is fully cleared, risking corrupted state and data loss | info | facets | WhitelistManagerFacet, LibAllowList | fixed |
+| LF-118 | LiFiIntentEscrowFacet emits LiFiTransferStarted with hasDestinationCall=false even when OIF outputCall executes calldata on the destination | low | facets | LiFiIntentEscrowFacet | fixed |
+| LF-119 | LiFiIntentEscrowFacet does not validate outputAmount, letting a solver settle with zero tokens and steal the entire deposit | low | facets | LiFiIntentEscrowFacet | fixed |
+| LF-120 | LiFiIntentEscrowFacet does not validate depositAndRefundAddress, risking refund loss on a zero address | low | facets | LiFiIntentEscrowFacet | fixed |
+| LF-121 | LiFiIntentEscrowFacet does not handle non-EVM destinations; bridging to Solana/Bitcoin reverts or loses funds | info | facets | LiFiIntentEscrowFacet | acknowledged |
+| LF-122 | LiFiIntentEscrowFacet does not validate MandateOutput's outputOracle and outputSettler, allowing zero values that yield unexpected refunds or behavior | info | facets | LiFiIntentEscrowFacet | raised |
+| LF-123 | LiFiIntentEscrowFacet grants unbounded ERC20 allowance to the OIF settler via maxApproveERC20 | info | facets | LiFiIntentEscrowFacet | acknowledged |
+| LF-124 | swapAndStartBridgeTokensViaPolymerCCTP missing validation that final swap output is USDC | info | facets | PolymerCCTPFacet | acknowledged |
+| LF-125 | Insufficient bridgeAmount validation can underflow or trigger zero-amount bridging | info | facets | PolymerCCTPFacet | acknowledged |
+| LF-126 | Testnet chain IDs mapped to mainnet CCTP domains, mis-routing testnet inputs to mainnet | info | facets | PolymerCCTPFacet | fixed |
+| LF-127 | MegaETH bridge accepts unvalidated assetIdOnL2, allowing zero-address L2 token to reach depositERC20To | info | facets | MegaETHBridgeFacet | fixed |
+| LF-128 | ReceiverOIF.outputFilled decodes a receiver from executionData without zero-address validation | low | periphery | ReceiverOIF | fixed |
+| LF-129 | ReceiverOIF has no slippage protection; users must embed minOut inside the swap calldata | info | periphery | ReceiverOIF | acknowledged |
+| LF-130 | ReceiverOIF leaves residual ERC20 approval to the Executor after each swap completes | info | periphery | ReceiverOIF | acknowledged |
+| LF-131 | Fee-on-transfer tokens permanently burn the NEAR Intents quote ID while underfunding the bridge | info | facets | NEARIntentsFacet | fixed |
+| LF-132 | Inconsistent refund recipient: positive slippage goes to depositAndRefundAddress but excess native ETH and swap leftovers go to msg.sender | low | facets | LiFiIntentEscrowFacet | fixed |
+| LF-133 | Misleading InvalidReceiver error used for zero depositAndRefundAddress validation | info | facets | LiFiIntentEscrowFacet | fixed |
+| LF-134 | Polymer CCTP non-EVM path validates nonEVMReceiver but not solanaReceiverATA, leaving inconsistent zero-receiver coverage | info | facets | PolymerCCTPFacet | fixed |
+| LF-135 | Incorrect LayerZero endpoint IDs for XDC and Plume in AcrossV4SwapFacet._chainIdToLzEid | high | facets | AcrossV4SwapFacet | fixed |
+| LF-136 | Router calldata not adjusted in SpokePoolPeriphery positive-slippage path creates inconsistent SwapAndDepositData | medium | facets | AcrossV4SwapFacet | fixed |
+| LF-137 | Linear scaling of outputAmount on positive slippage may exceed relayer-fillable bounds | medium | facets | AcrossV4SwapFacet | acknowledged |
+| LF-138 | Backend EIP-712 signature verification skipped for sponsored OFT/CCTP paths in AcrossV4SwapFacet | low | facets | AcrossV4SwapFacet | acknowledged |
+| LF-139 | Full msg.value forwarded to sponsored OFT deposit can exceed available balance after native source swap | low | facets | AcrossV4SwapFacet | fixed |
+| LF-140 | Native asset inputToken/swapToken not validated against WRAPPED_NATIVE in AcrossV4SwapFacet signature-gated paths | low | facets | AcrossV4SwapFacet | fixed |
+| LF-141 | Positive-slippage refund executes before input validation in sponsored OFT and CCTP paths | low | facets | AcrossV4SwapFacet | fixed |
+| LF-142 | Missing refundRecipient != address(0) validation in CCTP sponsored path | low | facets | AcrossV4SwapFacet | fixed |
+| LF-143 | hasDestinationCall flag always false even when forwarded Across calldata contains a destination message | info | facets | AcrossV4SwapFacet | acknowledged |
+| LF-144 | Missing validation of orderAuthorityDst strands DLN cancel/refund flow | low | facets | DeBridgeDlnFacet | fixed |
+| LF-145 | givePatchAuthoritySrc = msg.sender assigns DLN patch authority to Permit2Proxy on permit flows | low | facets | DeBridgeDlnFacet | acknowledged |

--- a/audit/knowledge/lessons.md
+++ b/audit/knowledge/lessons.md
@@ -4,9 +4,9 @@ Generated from `findings.json` by the `extract-audit-knowledge` skill. Do not ha
 
 ## Totals
 
-- Findings: 145
-- Audits with at least one finding: 42
-- Audits processed (zero findings): 39
+- Findings: 147
+- Audits with at least one finding: 44
+- Audits processed (zero findings): 37
 - Audits processed total: 81
 - Audits unprocessable (PDF corrupt): 2
 
@@ -14,13 +14,13 @@ Generated from `findings.json` by the `extract-audit-knowledge` skill. Do not ha
 
 | critical | high | medium | low | info |
 | --- | --- | --- | --- | --- |
-| 0 | 4 | 18 | 67 | 56 |
+| 0 | 4 | 18 | 67 | 58 |
 
 ## By area
 
 | facets | periphery | libraries | security | helpers | cross-cutting |
 | --- | --- | --- | --- | --- | --- |
-| 91 | 43 | 8 | 2 | 0 | 1 |
+| 92 | 44 | 8 | 2 | 0 | 1 |
 
 ## Coverage gaps
 
@@ -28,15 +28,15 @@ Generated from `findings.json` by the `extract-audit-knowledge` skill. Do not ha
 - `audit20251208` — PDF file is permanently corrupted in the repository (and on github.com): xref/catalog destroyed, UTF-8 replacement bytes baked into binary stream — qpdf/pdftotext/pdfinfo all fail. Findings cannot be extracted from this report.
 - `audit20251229` — PDF file is corrupted (missing /Root dictionary, illegal characters, broken xref); not recoverable with qpdf/pdftotext. Both working tree and git-committed copy are damaged.
 
-**Zero-finding audits (39)** — read successfully but produced no in-scope findings (either 0 issues reported, or all issues were gas/style/code-quality with no security path):
+**Zero-finding audits (37)** — read successfully but produced no in-scope findings (either 0 issues reported, or all issues were gas/style/code-quality with no security path):
 
 - `audit20240814`, `audit20241014`, `audit20241107`, `audit20241203`, `audit20250109_1`, `audit20250109_2`
 - `audit20250109_3`, `audit20250117_1`, `audit20250117_2`, `audit20250117_3`, `audit20250117_4`, `audit20250220`
 - `audit20250228`, `audit20250327`, `audit20250413`, `audit20250415`, `audit20250416`, `audit20250422`
-- `audit20250515`, `audit20250608`, `audit20250610`, `audit20250629`, `audit20250629_1`, `audit20250706`
+- `audit20250515`, `audit20250608`, `audit20250629`, `audit20250629_1`, `audit20250706`
 - `audit20250706_01`, `audit20250728`, `audit20250822`, `audit20250921`, `audit20251015`, `audit20251113`
 - `audit20251203_2`, `audit20251215_1`, `audit20251215_2`, `audit20251219`, `audit20251225`, `audit20251231`
-- `audit20260205`, `audit20260320`, `audit20260423`
+- `audit20260320`, `audit20260423`
 
 ## Index
 
@@ -187,3 +187,5 @@ Generated from `findings.json` by the `extract-audit-knowledge` skill. Do not ha
 | LF-143 | hasDestinationCall flag always false even when forwarded Across calldata contains a destination message | info | facets | AcrossV4SwapFacet | acknowledged |
 | LF-144 | Missing validation of orderAuthorityDst strands DLN cancel/refund flow | low | facets | DeBridgeDlnFacet | fixed |
 | LF-145 | givePatchAuthoritySrc = msg.sender assigns DLN patch authority to Permit2Proxy on permit flows | low | facets | DeBridgeDlnFacet | acknowledged |
+| LF-146 | wrapStETHToWstETH and unwrapWstETHToStETH lack a minimum-amount-out slippage parameter | info | periphery | LidoWrapper | acknowledged |
+| LF-147 | validateBridgeDataLiFiIntentEscrow modifier omits zero-check on destinationChainId, allowing zero/uninitialized destination | info | facets | LiFiIntentEscrowFacet | acknowledged |

--- a/audit/knowledge/semgrep/README.md
+++ b/audit/knowledge/semgrep/README.md
@@ -1,0 +1,32 @@
+# LI.FI custom Semgrep rules
+
+Each rule encodes a structural pattern from a confirmed past finding in
+`audit/knowledge/findings.json`. The rule id includes the LF-NNN reference so
+findings and rules cross-link.
+
+Run locally:
+
+```bash
+semgrep --config=audit/knowledge/semgrep src/
+```
+
+In CI: Stage 1 of the security-review workflow includes these rules in the
+Semgrep invocation. See EXP-440 architecture diagram.
+
+## Conventions
+
+- One YAML file per rule (`lf-<NNN>-<short-name>.yml`)
+- `severity` (rule-level) reflects how confidently a hit is a real bug:
+  - `ERROR` → near-certain regression
+  - `WARNING` → strong signal, worth manual triage
+  - `INFO` → noisy / heuristic
+- Each rule's `message` cites the source finding (`LF-NNN`) and a one-line
+  description of the pattern
+- Rules are conservative by default — better to miss than to flood the PR
+  reviewer with false positives. Tune through EXP-484 baseline measurement.
+
+## Maintainership
+
+These are **seed rules**. EXP-487's auto-generation feedback loop will add
+rules over time as new findings are confirmed. Hand-authored rules here are
+versioned with the corpus.

--- a/audit/knowledge/semgrep/lf-001-balance-of-this-as-amount.yml
+++ b/audit/knowledge/semgrep/lf-001-balance-of-this-as-amount.yml
@@ -1,0 +1,42 @@
+rules:
+  - id: lf-001-balance-of-this-as-amount
+    languages: [solidity]
+    severity: WARNING
+    message: |
+      `address(this).balance` (or `IERC20(t).balanceOf(address(this))`) used as
+      the transfer amount in a function that should only forward a scoped
+      local amount. This drains the contract's entire balance — including
+      funds belonging to other in-flight users — instead of just the current
+      operation's amount.
+
+      If you genuinely need to sweep, do so behind explicit access control and
+      track the intent in the function name (e.g. `sweep…`). Otherwise pass
+      the operation's `amount` explicitly.
+
+      Source: LF-001 (audit20240201 — LiFiDexAggregator/RouteProcessor4 wrapNative).
+      Pattern: full-balance reads inside per-operation paths.
+    metadata:
+      lf-id: LF-001
+      audit: audit20240201
+      cwe: CWE-841
+    pattern-either:
+      - pattern: |
+          $X.transfer(address(this).balance)
+      - pattern: |
+          $X.send(address(this).balance)
+      - pattern: |
+          $X.call{value: address(this).balance}($Y)
+      - pattern: |
+          IWETH($W).deposit{value: address(this).balance}()
+      - pattern: |
+          IWETH($W).withdraw($T.balanceOf(address(this)))
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+        - "src/Helpers/**"
+      exclude:
+        - "**/*.t.sol"
+        # Allow under deliberate sweep / refund helpers — convention is to
+        # name them explicitly. Suppress matches inside such files:
+        - "src/Helpers/Withdrawable*.sol"

--- a/audit/knowledge/semgrep/lf-002-direct-ierc20-approve.yml
+++ b/audit/knowledge/semgrep/lf-002-direct-ierc20-approve.yml
@@ -1,0 +1,39 @@
+rules:
+  - id: lf-002-direct-ierc20-approve
+    languages: [solidity]
+    severity: WARNING
+    message: |
+      Direct `IERC20(...).approve(...)` / `.transfer(...)` / `.transferFrom(...)`
+      on user-supplied tokens breaks for non-standard ERC20 implementations
+      that don't return bool (USDT, BNB), revert on non-zero→non-zero allowance
+      change (USDT), or charge fee-on-transfer.
+
+      Use `SafeERC20.safeTransfer`/`safeTransferFrom`/`forceApprove`
+      (or solady's `SafeTransferLib`) — these handle the non-standard cases.
+
+      Source: LF-002 (audit20240201 — LiFiDexAggregator/RouteProcessor4).
+      Pattern: direct IERC20 call on arbitrary token without SafeERC20 wrap.
+    metadata:
+      lf-id: LF-002
+      audit: audit20240201
+      cwe: CWE-252
+    pattern-either:
+      - pattern: IERC20($T).approve($S, $A)
+      - pattern: IERC20($T).transfer($R, $A)
+      - pattern: IERC20($T).transferFrom($F, $R, $A)
+      - pattern: $TOKEN.approve($S, $A)
+      - pattern: $TOKEN.transfer($R, $A)
+      - pattern: $TOKEN.transferFrom($F, $R, $A)
+    metavariable-pattern:
+      metavariable: $TOKEN
+      patterns:
+        # Only flag when the receiver looks like a token variable
+        - pattern-regex: "(?i).*(token|asset|erc20|currency).*"
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+        - "src/Libraries/**"
+      exclude:
+        - "**/*.t.sol"
+        - "src/Interfaces/**"

--- a/audit/knowledge/semgrep/lf-003-eth-transfer-fixed-gas.yml
+++ b/audit/knowledge/semgrep/lf-003-eth-transfer-fixed-gas.yml
@@ -1,0 +1,37 @@
+rules:
+  - id: lf-003-eth-transfer-fixed-gas
+    languages: [solidity]
+    severity: WARNING
+    message: |
+      Use of `.transfer(...)` or `.send(...)` for ETH forwarding caps the gas
+      stipend at 2300, which breaks any receiver whose fallback/receive does
+      meaningful work (proxy patterns, multisigs with logic, hooks). Prefer
+      `(bool ok, ) = recipient.call{value: amount}("");` with a return-value
+      check, or `solady SafeTransferLib.safeTransferETH(...)`.
+
+      Source: LF-003 (audit20240201 — LiFiDexAggregator).
+      Pattern: payable.transfer / send for native-asset payout.
+    metadata:
+      lf-id: LF-003
+      audit: audit20240201
+      cwe: CWE-703
+    patterns:
+      - pattern-either:
+          - pattern: $X.transfer($AMT)
+          - pattern: $X.send($AMT)
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-either:
+                - pattern: payable($Y)
+                - pattern: $Y
+          # We don't want to flag IERC20.transfer(...) — only payable address
+          # variants. Tightening below.
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+        - "src/Helpers/**"
+      exclude:
+        - "src/Interfaces/**"
+        - "**/*.t.sol"

--- a/audit/knowledge/semgrep/lf-008-admin-fn-without-event.yml
+++ b/audit/knowledge/semgrep/lf-008-admin-fn-without-event.yml
@@ -1,0 +1,35 @@
+rules:
+  - id: lf-008-admin-fn-without-event
+    languages: [generic]
+    severity: INFO
+    message: |
+      State-mutating function appears to be gated by an admin-only modifier
+      (`onlyOwner` / `onlyRole` / `onlyAdmin`) but no `emit` is present in
+      the function body. Admin operations should be observable on-chain
+      for monitoring, governance UIs, and forensic timelines.
+
+      Add an event matching the change and emit it inside the function.
+
+      Source: LF-008 + recurrences. Pattern: admin-modifier function
+      without `emit`. Generic-language match — false positives expected
+      on tight functions; triage with diff context.
+    metadata:
+      lf-id: LF-008
+      audit: audit20240201
+      cwe: CWE-778
+    pattern: |
+      function $F (...) ... onlyOwner ... {
+        ...
+      }
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+        - "src/Security/**"
+      exclude:
+        - "**/*.t.sol"
+        - "src/Interfaces/**"
+    # Generic-mode caveat: Semgrep's experimental Solidity parser doesn't
+    # parse modifier-with-args reliably. This rule is intentionally
+    # lower-precision; treat hits as triage candidates, not confirmed bugs.
+    # EXP-484 (tune) should refine this once we have a baseline.

--- a/audit/knowledge/semgrep/lf-029-shared-modifier-parallel-fields.yml
+++ b/audit/knowledge/semgrep/lf-029-shared-modifier-parallel-fields.yml
@@ -1,0 +1,35 @@
+rules:
+  - id: lf-029-shared-modifier-parallel-fields
+    languages: [solidity]
+    severity: WARNING
+    message: |
+      Bridge-specific data struct exposes a `.receiver` field that is read
+      or written without an accompanying `require(bridgeData.receiver ==
+      <specific>.receiver, …)` check. Validation modifiers on the parent
+      `ILiFi.BridgeData` only cover the parent receiver; the bridge-specific
+      receiver — the one actually used by the external protocol — slips
+      through unchecked.
+
+      Either validate equality between the two receivers, or wrap the
+      specific receiver in `LibUtil.validateReceiver(...)` / equivalent.
+
+      Source: LF-029 (audit20241205 — DeBridgeDlnFacet) and recurrences.
+      Pattern: read of `<specific>.receiver` not paired with a guard.
+    metadata:
+      lf-id: LF-029
+      audit: audit20241205
+      cwe: CWE-20
+    patterns:
+      - pattern-either:
+          - pattern: $SD.receiver
+      - pattern-not: $SD.receiver = $X;
+    paths:
+      include:
+        - "src/Facets/**"
+      exclude:
+        - "**/*.t.sol"
+        - "src/Facets/Helpers/**"
+    # The narrow pattern (any read of `.receiver` on a struct named like
+    # the bridge-specific data) is intentionally noisy. EXP-484 tuning
+    # should add `pattern-inside` / `pattern-not-inside` constraints to
+    # exclude functions that already contain the equality check.

--- a/audit/knowledge/semgrep/lf-046-bytes32-nonevm-receiver.yml
+++ b/audit/knowledge/semgrep/lf-046-bytes32-nonevm-receiver.yml
@@ -1,0 +1,30 @@
+rules:
+  - id: lf-046-bytes32-nonevm-receiver
+    languages: [solidity]
+    severity: ERROR
+    message: |
+      Receiver field for a non-EVM destination is declared as fixed-size
+      `bytes32`. Non-EVM addresses (Bitcoin tb1q…, Solana base58, …) routinely
+      exceed 32 bytes after hex encoding; bytes32 silently truncates, sending
+      funds to an invalid address.
+
+      Use variable-length `bytes` for non-EVM receivers. If a fixed size is
+      truly required, validate the maximum encoded length explicitly.
+
+      Source: LF-046 (audit20250305 — ChainflipFacet).
+      Pattern: fixed-size receiver type for cross-chain non-EVM destinations.
+    metadata:
+      lf-id: LF-046
+      audit: audit20250305
+      cwe: CWE-130
+    pattern-either:
+      - pattern: bytes32 $RECEIVER;
+      - pattern: bytes32 $RECEIVER = $X;
+    metavariable-regex:
+      metavariable: $RECEIVER
+      regex: "(?i).*(non[_]?evm|nonEvm|destination|btc|bitcoin|solana|cosmos).*receiver.*|.*receiver.*(non[_]?evm|nonEvm|btc|bitcoin|solana|cosmos).*"
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+        - "src/Interfaces/**"

--- a/audit/knowledge/semgrep/lf-053-loop-msg-value.yml
+++ b/audit/knowledge/semgrep/lf-053-loop-msg-value.yml
@@ -1,0 +1,29 @@
+rules:
+  - id: lf-053-loop-msg-value
+    languages: [solidity]
+    severity: ERROR
+    message: |
+      `msg.value` referenced inside what appears to be a loop body or a
+      forwarded `{value: msg.value}` call inside an iterating context.
+      `msg.value` is constant for the whole transaction — using it as a
+      per-item budget lets a caller pay once and "spend" it N times.
+
+      Compute the cumulative requirement outside the loop, or distribute
+      the value explicitly and assert `sum == msg.value` after the loop.
+
+      Source: LF-053 (audit20251119 — LiFiIntentEscrowFacet batch-deposit).
+      Pattern: `{value: msg.value}` invocation pattern, likely inside a
+      loop (the loop context is checked manually during triage).
+    metadata:
+      lf-id: LF-053
+      audit: audit20251119
+      cwe: CWE-682
+    pattern-either:
+      - pattern: "$F{value: msg.value}(...)"
+      - pattern: "$C.$F{value: msg.value}(...)"
+    paths:
+      include:
+        - "src/Facets/**"
+        - "src/Periphery/**"
+      exclude:
+        - "**/*.t.sol"

--- a/audit/knowledge/semgrep/lf-054-native-sentinel-into-call.yml
+++ b/audit/knowledge/semgrep/lf-054-native-sentinel-into-call.yml
@@ -1,0 +1,30 @@
+rules:
+  - id: lf-054-native-sentinel-into-call
+    languages: [solidity]
+    severity: WARNING
+    message: |
+      Low-level `.call(abi.encodeWithSelector(IERC20.transfer.selector, …))`
+      (or `transferFrom`/`approve`) issued against an `address` variable
+      that may hold the native-asset sentinel (`address(0)` or
+      `0xEeee…EEeE`). On native flows the call resolves to a zero address
+      and silently no-ops or reverts confusingly.
+
+      Branch on `LibAsset.isNativeAsset(asset)` before any ERC20 op and
+      route native through the native code path.
+
+      Source: LF-054 (audit20240201 — LiFiDexAggregator).
+      Pattern: low-level ERC20 selector call on user-asset address.
+    metadata:
+      lf-id: LF-054
+      audit: audit20240201
+      cwe: CWE-754
+    pattern-either:
+      - pattern: $A.call(abi.encodeWithSelector(IERC20.transfer.selector, ...))
+      - pattern: $A.call(abi.encodeWithSelector(IERC20.transferFrom.selector, ...))
+      - pattern: $A.call(abi.encodeWithSelector(IERC20.approve.selector, ...))
+    paths:
+      include:
+        - "src/Libraries/**"
+        - "src/Helpers/**"
+        - "src/Facets/**"
+        - "src/Periphery/**"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXP-479](https://linear.app/lifi-linear/issue/EXP-479) — audit/knowledge/ corpus seed + 39-audit backfill.

# Why did I implement it this way?

PR 2 of 5 in the EXP-440 security-review stack. Builds on **PR #1883** (EXP-478 skill).

Two commits:

1. **Seed (c278ea19)** — initial corpus extracted from 42 historical audits via parallel sub-agents using the `/extract-audit-knowledge` skill. Produces:
   - `audit/knowledge/findings.json` — canonical LF-NNN store (145 entries at seed time)
   - `audit/knowledge/lessons.md` — totals + flat index
   - `audit/knowledge/by-area/*.md` — facets / periphery / libraries / security / cross-cutting projections
   - `audit/knowledge/semgrep/lf-*.yml` — 7 seed Semgrep rules derived from past findings

2. **Backfill (9fcc48d6)** — fans out 5 parallel sub-agents over the 39 audits the initial batch missed (out of 41 — 2 PDFs are corrupted in repo state). Adds 2 new findings: LF-146 (LidoWrapper slippage), LF-147 (LiFiIntentEscrow destinationChainId zero-check). Corpus now 147 findings, 81/83 audits tracked.

Schema bump 1.0 → 1.1 introduces a top-level `processed_audits: string[]` field, recording every audit_id we've considered — with or without findings — so downstream coverage checks distinguish "we looked and found nothing" from "we never looked." The 37 zero-finding audits are recorded here. Corresponding skill-doc updates in `extract-audit-knowledge.md` (Step 8 + schema example).

> Note: the original backfill commit (9fcc48d6) also modified `script/tasks/checkAuditKnowledgeCoverage.ts`. That file is created in PR 5 of this stack (EXP-481), so the script change is dropped here and PR 5 incorporates native `processed_audits` support in its own coverage script commit.

## Stack context (this is PR 2 of 5)

```
PR 1: EXP-478 — /extract-audit-knowledge skill          #1883
PR 2: EXP-479 — corpus seed + 39-audit backfill         #1884  ← this PR
PR 3: EXP-480 — Stage 1 static-analysis workflow        #1885
PR 4: EXP-483 — lifi-pr-review skill + Stages 2/3 (incl. EXP-484)  #1887
PR 5: EXP-481 — /add-audit chain + coverage check       #1889
(dropped: EXP-482 noise baseline #1886 · EXP-484 tuning #1888 merged into PR 4)

```

## /pr-ready notes

`coderabbit review --base origin/pr/exp-478-extract-audit-knowledge --type committed --plain` surfaced 2 deferred findings, both Semgrep rule precision concerns:

- **`audit/knowledge/semgrep/lf-002-direct-ierc20-approve.yml:20-31`** (critical / potential_issue) — `metavariable-pattern` constraint only filters `$TOKEN` while patterns 21-23 use `$T` (the address arg to `IERC20(...)`), causing the regex filter to never apply to `IERC20(...)` cast usages. Same structural class as the bug we fixed for lf-046 in PR 6 (EXP-484): top-level `metavariable-pattern` not anchored to the right metavariable. Defer to a follow-up EXP-484 commit (would extend PR 6 or land as a separate tuning PR).

- **`audit/knowledge/semgrep/lf-054-native-sentinel-into-call.yml:21-24`** (major / potential_issue) — `$A` (the address holding the potential native-asset sentinel) has no metavariable constraint, so the rule fires on every low-level ERC20-selector call regardless of whether the address is even plausibly user-supplied. Same EXP-484-class issue. Defer to follow-up.

Both findings are legitimate and worth fixing — they apply the same correctness lesson we already learned for the three rules tuned in PR 6. Leaving them out of this PR keeps the corpus shipment as a separable change from rule precision tuning. Will queue as EXP-484 follow-up after PR 6 lands.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug — n/a, this PR ships data + Semgrep rules; rule validation runs via `semgrep --validate --config audit/knowledge/semgrep` (passes)
- [ ] For new facets: n/a, no facets in this PR
- [x] I have updated any required documentation


