### PR TITLE
ci: reenable audit commit hash validation for non-revert PRs

### DIFF
--- a/.agents/commands/create-pr.md
+++ b/.agents/commands/create-pr.md
@@ -118,6 +118,13 @@ Read `.github/pull_request_template.md` verbatim. Fill in:
 
 Short imperative title (≤70 chars). Match existing commit style in `git log`.
 
+**Revert PRs**: the title must start with `Revert` or contain `[Revert]`.
+`versionControlAndAuditCheck.yml` uses the title to exempt revert PRs from the
+audit-commit-hash check (the audited commit lives in the reverted PR's history,
+never in the revert PR's commit list) — a non-conforming title (e.g.
+`fix: undo facet change`) blocks the merge of a genuine revert that touches
+audited contracts.
+
 ### 7. Run `/pr-ready`
 
 Run this **before** the test suite. `/pr-ready` (local CodeRabbit) can land

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -17,6 +17,9 @@
 # - checks include:
 #   - ensuring the audit log contains an entry for all added/modified contracts in their latest version
 #   - ensuring that an audit report has been added at the logged path
+#   - ensuring that the logged audit commit hash is part of the PR's commit list (skipped for revert PRs,
+#     i.e. titles starting with "Revert" or containing "[Revert]", since the audited commit lives in the
+#     reverted PR's history, not the revert PR's)
 # - assigns label "AuditCompleted" if the audit for each relevant modified contract passed all checks
 # - KNOWN LIMITATIONS
 #   - multiple audits can be registered per contract (in a specific version)
@@ -451,6 +454,8 @@ jobs:
       - name: Check Audit Log
         id: check-audit-log
         if: ${{ always() && env.AUDIT_REQUIRED == 'true' }} # always() ensures that validation is always executed, even if env variable is not set
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }} # passed via env (not inline interpolation) to prevent shell injection through PR titles
         run: |
 
           echo "This step will make sure that an audit is logged for each contract modified/added by this PR."
@@ -588,22 +593,25 @@ jobs:
               fi
               echo -e "\033[32mA user with handle '$AUDITOR_GIT_HANDLE' exists on GitHub.\033[0m"
 
-            # NOTE: This check is disabled because it can cause issues when reverting PRs.
-            # For example, if a PR is mistakenly merged and needs to be reverted,
-            # the revert PR would fail this check since the audit commit hash would not be
-            # part of the revert PR's commit history. This would make it impossible to
-            # revert changes through the normal PR process. - WAS USED FOR SINGLE AUDIT CHECK
-            # echo "now checking if audit commit hash $AUDIT_COMMIT_HASH is associated with PR $PR_NUMBER"
-            # ##### Fetch the list of commits associated with the PR
-            # COMMIT_LIST=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
+              ##### make sure that the audited commit is part of this PR's commit list
+              ##### skipped for revert PRs (title starts with "Revert" or contains "[Revert]"):
+              ##### a revert PR cannot contain the originally audited commit, and the check
+              ##### would otherwise make it impossible to revert through the normal PR process
+              if [[ "$PR_TITLE" == Revert* || "$PR_TITLE" == *"[Revert]"* ]]; then
+                echo "PR title indicates a revert PR. Skipping audit commit hash verification for audit $AUDIT_ID."
+              else
+                echo "now checking if audit commit hash $AUDIT_COMMIT_HASH is associated with PR $PR_NUMBER"
+                ##### Fetch the list of commits associated with the PR
+                COMMIT_LIST=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
 
-            # ##### Check if the target commit is in the list
-            # if echo "$COMMIT_LIST" | grep -q "$AUDIT_COMMIT_HASH"; then
-            #   echo -e "\033[32mCommit $AUDIT_COMMIT_HASH is associated with PR #$PR_NUMBER.\033[0m"
-            # else
-            #   echo -e "\033[31mCommit $AUDIT_COMMIT_HASH is NOT associated with PR #$PR_NUMBER.\033[0m"
-            #   exit 1
-            # fi
+                ##### Check if the target commit is in the list
+                if echo "$COMMIT_LIST" | grep -q "$AUDIT_COMMIT_HASH"; then
+                  echo -e "\033[32mCommit $AUDIT_COMMIT_HASH is associated with PR #$PR_NUMBER.\033[0m"
+                else
+                  echo -e "\033[31mCommit $AUDIT_COMMIT_HASH is NOT associated with PR #$PR_NUMBER.\033[0m"
+                  exit 1
+                fi
+              fi
 
             ##### Check if the auditor git handle exists on github
             echo "now checking if the auditor git handle ($AUDITOR_GIT_HANDLE) actually exists"

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -605,7 +605,7 @@ jobs:
                 COMMIT_LIST=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
 
                 ##### Check if the target commit is in the list
-                if echo "$COMMIT_LIST" | grep -q "$AUDIT_COMMIT_HASH"; then
+                if echo "$COMMIT_LIST" | grep -Fxq -- "$AUDIT_COMMIT_HASH"; then
                   echo -e "\033[32mCommit $AUDIT_COMMIT_HASH is associated with PR #$PR_NUMBER.\033[0m"
                 else
                   echo -e "\033[31mCommit $AUDIT_COMMIT_HASH is NOT associated with PR #$PR_NUMBER.\033[0m"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-50](https://linear.app/lifi-linear/issue/EXSC-50/reenable-audit-commit-hash-validation-for-non-revert-prs)

# Why did I implement it this way?

The audit-commit-hash check in `.github/workflows/versionControlAndAuditCheck.yml` had been fully commented out because it made revert PRs impossible to merge (the audited commit lives in the reverted PR's history, never in the revert PR's commit list). This re-enables the check exactly as proposed by CodeRabbit in [PR #1187](https://github.com/lifinance/contracts/pull/1187#discussion_r2128596159), with the skip scoped to genuine reverts only:

- Revert PRs are detected by title: starts with `Revert` (GitHub's auto-generated revert title format) or contains `[Revert]`.
- For all other PRs, the workflow now fails if `auditCommitHash` from `audit/auditLog.json` is not in the PR's commit list (`gh pr view --json commits`).
- The check lives inside the existing per-audit-ID loop in the "Check Audit Log" step rather than a separate workflow step, because `AUDIT_COMMIT_HASH` is only available inside that loop (multiple audits can be registered per contract/version).
- The PR title is passed into the script via a step-level `env` var (`PR_TITLE`) instead of inline `${{ }}` interpolation, to prevent shell injection through attacker-controlled PR titles.
- Workflow header comment updated to document the new check and its revert exception.

Verification evidence:

- YAML parsed successfully (`yaml` package) and the extracted `run` script passes `bash -n`.
- Revert-detection logic dry-run against representative titles: `Revert "feat: add facet"` → skip, `fix: something [Revert] cleanup` → skip, `feat: new facet` → enforce, `fix revert handling` → enforce.
- `bunx prettier --check` clean on the workflow file.
- `/pr-ready` (local CodeRabbit, base `origin/main`): **No findings.**

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug (n/a — GitHub Actions workflow change; validated via YAML parse, `bash -n`, and logic dry-run)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)