### PR TITLE
feat(EXSC-96): fall back to Safe tx-hash signing when EIP-712 signing fails

### DIFF
--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -43,7 +43,6 @@ import {
   fetchWithTimeout,
 } from '../../utils/fetchWithTimeout'
 import { normalizeAddressForNetwork } from '../../utils/normalizeAddressStringForViem'
-import { getEnvVar } from '../../utils/utils'
 import {
   buildExplorerContractPageUrl,
   getTransportConfigFromRpcUrl,
@@ -579,9 +578,7 @@ export class SafeClient {
     try {
       // 1) Compute the Safe transaction hash on-chain (via viem client)
       const hash = await this.getTransactionHash(safeTx)
-      consola.info(
-        `[safe-utils] Signing Safe tx hash (ENABLE_SAFE_TX_HASH_SIGNING=true): ${hash}`
-      )
+      consola.info(`[safe-utils] Signing Safe tx hash via eth_sign: ${hash}`)
 
       // 2) Sign the hash using eth_sign-compatible flow
       const sig = await this.signHash(hash)
@@ -601,10 +598,11 @@ export class SafeClient {
   public async signTransaction(
     safeTx: ISafeTransaction
   ): Promise<ISafeTransaction> {
-    // Optional feature flag to switch between EIP-712 signing and hash signing.
-    // If ENABLE_SAFE_TX_HASH_SIGNING === 'true', we sign the Safe tx hash
-    // using eth_sign instead of constructing a large EIP-712 payload.
-    if (getEnvVar('ENABLE_SAFE_TX_HASH_SIGNING') === 'true') {
+    // Optional flag to force tx-hash signing from the start instead of EIP-712
+    // typed data. Read directly from process.env so an unset flag does not
+    // throw — tx-hash signing also runs automatically as a fallback whenever
+    // the EIP-712 path fails.
+    if (process.env.ENABLE_SAFE_TX_HASH_SIGNING === 'true') {
       return this.signTransactionWithHash(safeTx)
     }
 
@@ -668,8 +666,10 @@ export class SafeClient {
       return safeTx
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
-      console.error('Error signing transaction:', error)
-      throw new Error(`Failed to sign transaction: ${errorMsg}`)
+      consola.warn(
+        `[safe-utils] EIP-712 signing failed, falling back to tx-hash signing. Caught error: ${errorMsg}`
+      )
+      return this.signTransactionWithHash(safeTx)
     }
   }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-96](https://linear.app/lifi-linear/issue/EXSC-96/make-transaction-hash-signing-as-fallback-instead-of-activation-via) — Make transaction hash signing as fallback (instead of activation via .env variable)

# Why did I implement it this way?

`SafeClient.signTransaction` previously threw when the EIP-712 typed-data signing path failed, and tx-hash (eth_sign) signing was only reachable by setting `ENABLE_SAFE_TX_HASH_SIGNING=true` up front. Per the ticket's decided behavior (broad fallback):

- The EIP-712 path still runs first (no behavior change on the happy path).
- If it throws for any reason, `signTransaction` now logs a `consola.warn` recording that the fallback was taken plus the caught error, and retries via the existing `signTransactionWithHash` path.
- `ENABLE_SAFE_TX_HASH_SIGNING=true` is kept as a manual override to force tx-hash signing from the start. It is now read directly from `process.env` instead of `getEnvVar()` so an *unset* flag no longer throws — required for "fallback works with no `.env` flag" to hold.
- The log line inside `signTransactionWithHash` hardcoded `(ENABLE_SAFE_TX_HASH_SIGNING=true)`, which would be false when reached via the fallback; it now states the signing method instead.

Error semantics for callers are preserved: `signTransaction` only rejects if the fallback also fails (existing `Failed to sign transaction hash: …` error), so call-site try/catch wrappers (e.g. `confirm-safe-tx.ts`) keep working unchanged.

Note: a doc-comment refresh for the flag in `.env.example` was intentionally left out — the repo's pre-commit secret scanner flags any commit touching `.env.example` when a placeholder value matches the local `.env` (false positive on `DO_NOT_VERIFY_IN_THESE_NETWORKS`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug (no existing test harness for `SafeClient` signing; verified via `bunx eslint` + `bunx tsc-files --noEmit`)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e (n/a)
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
