### PR TITLE
ci: enforce LibAsset routing for ERC20 transfers

### DIFF
--- a/.github/workflows/enforceLibAssetRouting.yml
+++ b/.github/workflows/enforceLibAssetRouting.yml
@@ -1,0 +1,88 @@
+# Enforce LibAsset Routing
+# - enforces the architectural invariant that all ERC20 value-flow in src/ goes through LibAsset
+#   (audit follow-up: Sujith finding #4 on PR #1715 / Tron USDT routing migration, ticket EXSC-300)
+# - fails the build if any .sol file in src/ outside the allowlist calls .safeTransfer( or
+#   .safeTransferFrom( directly (Solmate / Solady / OZ SafeTransferLib-style calls)
+# - native-ETH transfers via safeTransferETH( remain allowed everywhere
+# - pre-existing offenders are grandfathered via an explicit allowlist in the check step;
+#   new files (or new call sites in previously clean files) are rejected
+# - known limitations: text-based grep, so a match inside a comment or string literal would
+#   also be flagged (acceptable as a backstop; remove the comment or route through LibAsset)
+
+name: Enforce LibAsset Routing
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read # required to fetch repository contents
+
+jobs:
+  enforce-libasset-routing:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout code
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Step 2: Scan src/ for direct ERC20 safeTransfer / safeTransferFrom calls
+      - name: Check for direct ERC20 transfers bypassing LibAsset
+        run: |
+          set -euo pipefail
+
+          ##### Files allowed to call .safeTransfer( / .safeTransferFrom( directly.
+          ##### Everything else in src/ must route ERC20 transfers through LibAsset.
+          ALLOWLIST=(
+            # canonical implementation - this is where ERC20 transfers are supposed to live
+            "src/Libraries/LibAsset.sol"
+            # gas-optimized packed facets bypass LibAsset by design (audit: Sujith #4, EXSC-300);
+            # migrating them is explicitly out of scope - see EXSC-300
+            "src/Facets/AcrossFacetPacked.sol"
+            "src/Facets/AcrossFacetPackedV3.sol"
+            "src/Facets/CBridgeFacetPacked.sol"
+            "src/Facets/HopFacetPacked.sol"
+            # pre-existing direct call sites grandfathered when this check was introduced (EXSC-300);
+            # do NOT add new files here without an explicit architectural decision
+            "src/Helpers/WithdrawablePeriphery.sol"
+            "src/Periphery/LiFiDEXAggregator.sol"
+            "src/Periphery/ReceiverAcrossV3.sol"
+            "src/Periphery/ReceiverChainflip.sol"
+            "src/Periphery/ReceiverStargateV2.sol"
+            "src/Periphery/TokenWrapper.sol"
+          )
+
+          ##### Matches .safeTransfer( and .safeTransferFrom( but NOT .safeTransferETH(
+          PATTERN='\.safeTransfer(From)?\('
+
+          ##### Initialize empty variables
+          VIOLATIONS=""
+
+          ##### collect every src/ Solidity file containing a direct ERC20 transfer call
+          ##### (grep exits 1 when nothing matches, which is fine - the loop body just never runs)
+          while IFS= read -r FILE; do
+            ##### skip allowlisted files
+            for ALLOWED in "${ALLOWLIST[@]}"; do
+              if [[ "$FILE" == "$ALLOWED" ]]; then
+                continue 2
+              fi
+            done
+            VIOLATIONS="${VIOLATIONS}${FILE}"$'\n'
+          done < <(grep -rlE "$PATTERN" src --include='*.sol' || true)
+
+          ##### fail with the offending lines if any non-allowlisted file matched
+          if [[ -n "$VIOLATIONS" ]]; then
+            echo -e "\033[31mError: direct ERC20 .safeTransfer/.safeTransferFrom calls found outside LibAsset:\033[0m"
+            while IFS= read -r FILE; do
+              if [[ -n "$FILE" ]]; then
+                echo -e "\033[31m  $FILE\033[0m"
+                grep -nE "$PATTERN" "$FILE" | sed 's/^/    /'
+              fi
+            done <<< "$VIOLATIONS"
+            echo -e "\033[31mAll ERC20 value-flow must go through LibAsset (src/Libraries/LibAsset.sol).\033[0m"
+            echo -e "\033[31mNative-ETH transfers via safeTransferETH are allowed. If this file is a deliberate,\033[0m"
+            echo -e "\033[31mreviewed exception, add it to the allowlist in .github/workflows/enforceLibAssetRouting.yml with a comment.\033[0m"
+            exit 1
+          fi
+
+          echo -e "\033[32mNo direct ERC20 safeTransfer/safeTransferFrom calls outside LibAsset and the allowlist. All good.\033[0m"

--- a/.github/workflows/enforceLibAssetRouting.yml
+++ b/.github/workflows/enforceLibAssetRouting.yml
@@ -27,6 +27,8 @@ jobs:
       # Step 1: Checkout code
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       # Step 2: Scan src/ for direct ERC20 safeTransfer / safeTransferFrom calls
       - name: Check for direct ERC20 transfers bypassing LibAsset

--- a/.github/workflows/enforceLibAssetRouting.yml
+++ b/.github/workflows/enforceLibAssetRouting.yml
@@ -1,8 +1,10 @@
 # Enforce LibAsset Routing
 # - enforces the architectural invariant that all ERC20 value-flow in src/ goes through LibAsset
 #   (audit follow-up: Sujith finding #4 on PR #1715 / Tron USDT routing migration, ticket EXSC-300)
-# - fails the build if any .sol file in src/ outside the allowlist calls .safeTransfer( or
-#   .safeTransferFrom( directly (Solmate / Solady / OZ SafeTransferLib-style calls)
+# - fails the build if any .sol file in src/ outside the allowlist calls .safeTransfer(,
+#   .safeTransferFrom( (Solmate / Solady / OZ SafeTransferLib-style calls) or raw .transfer( /
+#   .transferFrom( directly (the original Tron USDT bug class: raw transfer with unchecked or
+#   non-standard return data)
 # - native-ETH transfers via safeTransferETH( remain allowed everywhere
 # - pre-existing offenders are grandfathered via an explicit allowlist in the check step;
 #   new files (or new call sites in previously clean files) are rejected
@@ -31,7 +33,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          ##### Files allowed to call .safeTransfer( / .safeTransferFrom( directly.
+          ##### Files allowed to call .safeTransfer( / .safeTransferFrom( / .transfer( / .transferFrom( directly.
           ##### Everything else in src/ must route ERC20 transfers through LibAsset.
           ALLOWLIST=(
             # canonical implementation - this is where ERC20 transfers are supposed to live
@@ -50,10 +52,18 @@ jobs:
             "src/Periphery/ReceiverChainflip.sol"
             "src/Periphery/ReceiverStargateV2.sol"
             "src/Periphery/TokenWrapper.sol"
+            # pre-existing raw IERC20.transfer/transferFrom call sites on stETH/wstETH,
+            # explicitly named in audit finding Sujith #4 (EXSC-300); grandfathered, not endorsed
+            "src/Periphery/LidoWrapper.sol"
+            # false positive: calls transferFrom on our own ERC20Proxy contract (which itself
+            # routes through LibAsset.transferFromERC20), not on a token - text-based grep
+            # cannot tell these apart
+            "src/Periphery/Executor.sol"
           )
 
-          ##### Matches .safeTransfer( and .safeTransferFrom( but NOT .safeTransferETH(
-          PATTERN='\.safeTransfer(From)?\('
+          ##### Matches .safeTransfer(, .safeTransferFrom( and raw .transfer(, .transferFrom(
+          ##### but NOT .safeTransferETH(
+          PATTERN='\.(safeT|t)ransfer(From)?\('
 
           ##### Initialize empty variables
           VIOLATIONS=""
@@ -72,7 +82,7 @@ jobs:
 
           ##### fail with the offending lines if any non-allowlisted file matched
           if [[ -n "$VIOLATIONS" ]]; then
-            echo -e "\033[31mError: direct ERC20 .safeTransfer/.safeTransferFrom calls found outside LibAsset:\033[0m"
+            echo -e "\033[31mError: direct ERC20 transfer/transferFrom/safeTransfer/safeTransferFrom calls found outside LibAsset:\033[0m"
             while IFS= read -r FILE; do
               if [[ -n "$FILE" ]]; then
                 echo -e "\033[31m  $FILE\033[0m"
@@ -85,4 +95,4 @@ jobs:
             exit 1
           fi
 
-          echo -e "\033[32mNo direct ERC20 safeTransfer/safeTransferFrom calls outside LibAsset and the allowlist. All good.\033[0m"
+          echo -e "\033[32mNo direct ERC20 transfer/transferFrom/safeTransfer/safeTransferFrom calls outside LibAsset and the allowlist. All good.\033[0m"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-300](https://linear.app/lifi-linear/issue/EXSC-300/add-solhint-rule-or-ci-grep-enforcing-libasset-routing-for-erc20) — Add solhint rule (or CI grep) enforcing LibAsset routing for ERC20 transfers

Audit follow-up to PR #1715 (Sujith, informational finding #4).

# Why did I implement it this way?

The ticket offered two options: a custom solhint rule or a CI grep step. I went with the **CI grep step** (a new workflow, `enforceLibAssetRouting.yml`):

- A custom solhint rule would require shipping a local JS solhint plugin package (`solhint-plugin-*`), which conflicts with the repo's TypeScript/Bash-only scripting rule and adds dependency surface for a single rule.
- The grep backstop is explicitly sanctioned by the ticket as "adequate", is trivially auditable, and follows the established house pattern of inline-bash checker workflows (`jsonChecker.yml`, `protectSecurityRelevantCode.yml`).

Behavior:

- Fails CI if any `.sol` file in `src/` outside the allowlist contains `.safeTransfer(` or `.safeTransferFrom(`.
- `safeTransferETH(` is not matched and remains allowed everywhere (the regex requires `(` directly after `safeTransfer`/`safeTransferFrom`).
- The four packed facets (`HopFacetPacked`, `AcrossFacetPacked`, `CBridgeFacetPacked`, `AcrossFacetPackedV3`) are explicitly allowlisted with a comment, per the AC.
- Beyond the four facets named in the AC, six more pre-existing offenders exist on `main` (`TokenWrapper`, `LiFiDEXAggregator`, `ReceiverStargateV2`, `ReceiverAcrossV3`, `ReceiverChainflip`, `WithdrawablePeriphery` — consistent with the audit finding "Out-of-scope facets and LidoWrapper bypass LibAsset"). They are grandfathered in a separately-commented allowlist section so the check is green on `main` from day one while still rejecting any NEW file or any new call site in a currently-clean file.

Verification evidence (run locally against this branch):

- `bash -n` on the extracted check script: pass
- Clean tree (current `src/`): exit 0
- Injected `src/EvilFacet.sol` with `IERC20(t).safeTransfer(...)`: exit 1, offending file + line printed
- Injected `src/EthOnlyFacet.sol` with only `safeTransferETH` calls (both method-style and library-style): exit 0
- `bunx prettier --check` on the workflow file: pass

## DRAFT status / pr-ready note

`/pr-ready` (local CodeRabbit) could not be run to a clean state: the CLI returned "Review limit reached" (org usage credits exhausted), twice. Per the pre-PR workflow this PR is therefore opened as a **draft**; cloud CodeRabbit will review on this PR as the safety net. A `self-review-pass` sweep (mechanical/semantic/executable) was completed with no findings.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md` (attempted; rate-limited — documented above)
- [x] I have added tests that cover the functionality / test the bug (manual positive/negative/exemption runs of the check script, evidence above; no Solidity changes)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e (N/A — no facets touched)
- [x] I have updated any required documentation (workflow header documents purpose, triggers, behavior, limitations)

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
