### PR TITLE
feat(EXSC-331): static validation of touched TS scripts (pre-push hook + CI workflow)

### DIFF
--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -1,0 +1,130 @@
+# Validate Scripts (EXSC-331)
+# - Static validation (no script execution) of TS scripts under script/
+# - Type check: `tsc-files --noEmit` over changed TS files under script/ —
+#   removing a used import (TS2304) or a dependency a script imports (TS2307)
+#   fails fast instead of breaking at runtime
+# - Import resolution: when package.json / bun.lock / tsconfig.json change,
+#   every bare import in script TS files must resolve to a declared or
+#   installed package (catches "dependency removed while still imported"
+#   even when no .ts file was touched)
+# - Path-gated: the heavy job runs only when scripts or dependency manifests
+#   change. A `validate-scripts-required` aggregator job always reports a
+#   final status so this workflow can be registered as a required check on
+#   `main` branch protection (see .agents/rules/500-github-actions.md)
+# - TypeChain types are generated before the type check because several
+#   scripts import generated typechain/ types (requires foundry + forge build)
+# - Local counterpart: the .husky/pre-push hook runs the same validator for
+#   fast feedback; this workflow is the enforcement backstop since git hooks
+#   can be bypassed with --no-verify
+
+name: Validate Scripts
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read # required to fetch repository contents
+  pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+
+jobs:
+  detect-changes:
+    # Determines whether files that can influence script validity were touched.
+    # Always runs (cheap) so the downstream validate-scripts-required can report status.
+    runs-on: ubuntu-latest
+    outputs:
+      scripts: ${{ steps.filter.outputs.scripts }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            scripts:
+              - 'script/**/*.ts'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig.json'
+              - '.github/workflows/validateScripts.yml'
+
+  validate-scripts:
+    # Runs on PRs (once out of draft) and on workflow_dispatch.
+    # For non-PR events `github.event.pull_request` is null, so the draft check
+    # is gated behind an event-name guard.
+    needs: detect-changes
+    if: >-
+      ${{
+        needs.detect-changes.outputs.scripts == 'true' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.draft == false)
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Full history so the validator can compute the merge-base with the
+          # PR base branch; submodules for `forge build src` (TypeChain input)
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dev dependencies
+        run: bun install
+
+      - name: Install Foundry
+        uses: ./.github/actions/setup-foundry
+
+      - name: Install forge Dependencies
+        run: forge install
+
+      - name: Generate TypeChain types
+        # Several scripts (e.g. script/demoScripts/**, script/deploy/tron/**)
+        # import generated typechain/ types; without them the type check would
+        # fail with false TS2307 errors
+        run: bun typechain:incremental
+
+      - name: Validate scripts
+        shell: bash
+        run: |
+          ##### Diff against the PR base branch (merge-base is computed inside
+          ##### the validator); workflow_dispatch has no base ref, so the
+          ##### validator falls back to the merge-base with origin/main
+          if [[ -n "$BASE_REF" ]]; then
+            bunx tsx ./script/utils/validateScripts.ts --base "origin/$BASE_REF"
+          else
+            bunx tsx ./script/utils/validateScripts.ts
+          fi
+        env:
+          BASE_REF: ${{ github.base_ref }}
+
+  validate-scripts-required:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `validate-scripts`) as the required status check on `main`.
+    needs: [detect-changes, validate-scripts]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `validate-scripts`
+        # would be `skipped` due to the dependency failure — and treating that
+        # `skipped` as success would mask the infra failure from branch protection.
+        run: |
+          set -euo pipefail
+          detect_result="${{ needs.detect-changes.result }}"
+          validate_result="${{ needs.validate-scripts.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31mvalidate-scripts-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$validate_result" == "success" || "$validate_result" == "skipped" ]]; then
+            echo -e "\033[32mvalidate-scripts-required OK (validate-scripts=$validate_result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mvalidate-scripts-required FAILED (validate-scripts=$validate_result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -4,8 +4,8 @@
 #   removing a used import (TS2304) or a dependency a script imports (TS2307)
 #   fails fast instead of breaking at runtime
 # - Import resolution: when package.json / bun.lock / tsconfig.json change,
-#   every bare import in script TS files must resolve to a declared or
-#   installed package (catches "dependency removed while still imported"
+#   every bare import in script TS files must resolve to a package declared
+#   in package.json (catches "dependency removed while still imported"
 #   even when no .ts file was touched)
 # - Path-gated: the heavy job runs only when scripts or dependency manifests
 #   change. A `validate-scripts-required` aggregator job always reports a
@@ -38,6 +38,9 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Read-only job — no authenticated git operations after checkout
+          persist-credentials: false
       - name: Detect relevant changes
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-push hook: static validation of TS scripts about to be pushed (EXSC-331).
+#
+# Runs script/utils/validateScripts.ts over each pushed ref:
+# - tsc-files --noEmit type check on changed TS files under script/
+# - bare-import resolution over all script TS files when dependency manifests
+#   (package.json / bun.lock / tsconfig.json) changed
+#
+# Fast local feedback only — the validateScripts.yml CI workflow is the
+# enforcement backstop, since hooks can be bypassed with --no-verify.
+#
+# Same husky v8 re-exec workaround as .husky/pre-commit: husky.sh re-execs
+# hooks under `sh -e`, so we replicate the init bits we need (HUSKY=0 skip,
+# ~/.huskyrc) and re-exec under `bash -e` ourselves.
+[ "$HUSKY" = "0" ] && exit 0
+if [ -z "$husky_skip_init" ]; then
+  readonly husky_skip_init=1
+  export husky_skip_init
+  [ -f ~/.huskyrc ] && . ~/.huskyrc
+  exec bash -e "$0" "$@"
+fi
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+cd "$GIT_ROOT" || exit 1
+
+ZERO_SHA=0000000000000000000000000000000000000000
+STATUS=0
+
+# stdin: one line per pushed ref: <local-ref> <local-sha> <remote-ref> <remote-sha>
+while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+  if [ -z "$LOCAL_SHA" ] || [ "$LOCAL_SHA" = "$ZERO_SHA" ]; then
+    # Branch deletion — nothing to validate
+    continue
+  fi
+
+  if [ "$REMOTE_SHA" != "$ZERO_SHA" ] && git cat-file -e "$REMOTE_SHA" 2>/dev/null; then
+    # Updating an existing remote ref — validate only the commits being pushed
+    BASE="$REMOTE_SHA"
+  else
+    # New remote branch (or remote sha not fetched locally) — let the script
+    # fall back to the merge-base with origin/main
+    BASE=""
+  fi
+
+  # </dev/null so the validator cannot consume the remaining ref lines on stdin
+  if [ -n "$BASE" ]; then
+    if ! bunx tsx ./script/utils/validateScripts.ts --base "$BASE" --head "$LOCAL_SHA" </dev/null; then
+      STATUS=1
+    fi
+  else
+    if ! bunx tsx ./script/utils/validateScripts.ts --head "$LOCAL_SHA" </dev/null; then
+      STATUS=1
+    fi
+  fi
+done
+
+exit $STATUS

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@types/pino": "^7.0.5",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^7.10.0",
+        "bs58": "^4.0.1",
         "cross-env": "^7.0.2",
         "dotenv": "^16.0.0",
         "eslint": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "typechain": "forge clean && rm -rf typechain/* && forge build src && bun abi:removeDuplicateEvents && typechain --target ethers-v5 'out/!(*.t).sol/*.json' --out-dir typechain",
     "typechain:incremental": "forge build src && bun abi:removeDuplicateEvents && typechain --target ethers-v5 'out/!(*.t).sol/*.json' --out-dir typechain",
     "unpause-all-diamonds": "bunx tsx ./script/tasks/unpauseAllDiamonds.ts",
+    "validate-scripts": "bunx tsx ./script/utils/validateScripts.ts",
     "balances": "bunx tsx ./script/balances.ts",
     "update-whitelist-periphery": "bunx tsx ./script/tasks/updateWhitelistPeriphery.ts"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/pino": "^7.0.5",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^7.10.0",
+    "bs58": "^4.0.1",
     "cross-env": "^7.0.2",
     "dotenv": "^16.0.0",
     "eslint": "^8.11.0",

--- a/script/demoScripts/utils/demoScriptHelpers.ts
+++ b/script/demoScripts/utils/demoScriptHelpers.ts
@@ -5,7 +5,6 @@ import { isTronNetworkKey } from '@lifi/tron-devkit'
 import { getAssociatedTokenAddressSync } from '@solana/spl-token'
 import { Keypair, PublicKey } from '@solana/web3.js'
 // @ts-expect-error - bs58 types not available
-// eslint-disable-next-line import/no-extraneous-dependencies -- bs58 is available via @layerzerolabs/lz-v2-utilities
 import bs58 from 'bs58'
 import { consola } from 'consola'
 import { config } from 'dotenv'

--- a/script/utils/validateScripts.ts
+++ b/script/utils/validateScripts.ts
@@ -208,13 +208,11 @@ const runImportResolutionCheck = (repoRoot: string): boolean => {
     for (const specifier of collectBareImportSpecifiers(join(repoRoot, file))) {
       if (isBuiltinSpecifier(specifier)) continue
       const packageName = getPackageName(specifier)
-      // A package installed transitively via the lockfile (e.g. bs58 through
-      // @layerzerolabs/lz-v2-utilities) still resolves at runtime, so only
-      // flag packages that are neither declared nor installed.
-      if (
-        !declared.has(packageName) &&
-        !existsSync(join(repoRoot, 'node_modules', packageName))
-      )
+      // Strict declared-only policy: relying on a transitively installed
+      // package (present in node_modules via another dependency's lockfile
+      // entry) breaks silently when that dependency drops it, so every
+      // runtime import must be declared in package.json itself.
+      if (!declared.has(packageName))
         missing.push({ file, specifier, packageName })
     }
 

--- a/script/utils/validateScripts.ts
+++ b/script/utils/validateScripts.ts
@@ -3,7 +3,8 @@
  *
  * Guards against changes that silently break TS scripts (EXSC-331):
  * 1. Type check: runs `tsc-files --noEmit` over the TS files under `script/`
- *    changed between a base ref and HEAD. Removing a used import (TS2304) or
+ *    changed between a base and a head ref (default HEAD). Removing a used
+ *    import (TS2304) or
  *    a dependency a script imports (TS2307) fails the check — no execution,
  *    no fixtures.
  * 2. Import resolution: when dependency manifests (package.json / bun.lock /

--- a/script/utils/validateScripts.ts
+++ b/script/utils/validateScripts.ts
@@ -1,0 +1,281 @@
+/**
+ * Script Validation (static check, no execution)
+ *
+ * Guards against changes that silently break TS scripts (EXSC-331):
+ * 1. Type check: runs `tsc-files --noEmit` over the TS files under `script/`
+ *    changed between a base ref and HEAD. Removing a used import (TS2304) or
+ *    a dependency a script imports (TS2307) fails the check — no execution,
+ *    no fixtures.
+ * 2. Import resolution: when dependency manifests (package.json / bun.lock /
+ *    tsconfig.json) changed, every bare import specifier in ALL TS files
+ *    under `script/` must resolve to a package declared in
+ *    package.json (or a node/bun builtin). This catches "dependency removed
+ *    from package.json while a script still imports it" even when no .ts
+ *    file was touched.
+ *
+ * Used by the `.husky/pre-push` hook (fast local feedback) and the
+ * `validateScripts.yml` CI workflow (enforcement backstop).
+ *
+ * Usage:
+ *   bunx tsx ./script/utils/validateScripts.ts [--base <ref>] [--head <ref>]
+ *
+ *   --base  ref to diff against (default: merge-base of HEAD and origin/main)
+ *   --head  ref whose changes are validated (default: HEAD)
+ *
+ * Package.json shortcut:
+ *   bun validate-scripts
+ */
+
+import { spawnSync } from 'child_process'
+import { existsSync, readFileSync, readdirSync } from 'fs'
+import { builtinModules } from 'module'
+import { join } from 'path'
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isExportDeclaration,
+  isIdentifier,
+  isImportDeclaration,
+  isStringLiteralLike,
+  ScriptTarget,
+  SyntaxKind,
+} from 'typescript'
+import type { Expression, Node } from 'typescript'
+
+const SCRIPT_FILE_PATTERN = /^script\/.*\.ts$/u
+const DEPENDENCY_MANIFESTS = ['package.json', 'bun.lock', 'tsconfig.json']
+
+interface IMissingImport {
+  file: string
+  specifier: string
+  packageName: string
+}
+
+const git = (args: string[], cwd: string): string => {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' })
+  if (result.status !== 0)
+    throw new Error(
+      `git ${args.join(' ')} failed: ${
+        result.stderr?.trim() ?? 'unknown error'
+      }`
+    )
+  return result.stdout.trim()
+}
+
+/**
+ * Diffing directly against a base branch ref would also pick up files changed
+ * on the base branch since this branch forked, so resolve to the merge-base.
+ */
+const resolveBaseRef = (
+  repoRoot: string,
+  head: string,
+  base?: string
+): string => {
+  const baseRef = base ?? 'origin/main'
+  try {
+    return git(['merge-base', baseRef, head], repoRoot)
+  } catch {
+    consola.warn(
+      `Could not compute merge-base of ${baseRef} and ${head}, diffing against ${baseRef} directly`
+    )
+    return baseRef
+  }
+}
+
+const getChangedFiles = (
+  repoRoot: string,
+  base: string,
+  head: string
+): string[] => {
+  const output = git(
+    ['diff', '--name-only', '--diff-filter=ACMR', base, head],
+    repoRoot
+  )
+  return output ? output.split('\n').filter(Boolean) : []
+}
+
+const listScriptFiles = (repoRoot: string): string[] => {
+  const result: string[] = []
+  const walk = (relativeDir: string): void => {
+    for (const entry of readdirSync(join(repoRoot, relativeDir), {
+      withFileTypes: true,
+    })) {
+      const relativePath = `${relativeDir}/${entry.name}`
+      if (entry.isDirectory()) walk(relativePath)
+      else if (entry.isFile() && entry.name.endsWith('.ts'))
+        result.push(relativePath)
+    }
+  }
+  walk('script')
+  return result
+}
+
+/**
+ * Extracts the npm package name from a bare import specifier
+ * (e.g. "@scope/pkg/sub/path" -> "@scope/pkg", "mongodb/lib" -> "mongodb").
+ */
+const getPackageName = (specifier: string): string => {
+  const segments = specifier.split('/')
+  if (specifier.startsWith('@') && segments.length >= 2)
+    return `${segments[0]}/${segments[1]}`
+  return segments[0] ?? specifier
+}
+
+const isBuiltinSpecifier = (specifier: string): boolean =>
+  specifier.startsWith('node:') ||
+  specifier === 'bun' ||
+  specifier.startsWith('bun:') ||
+  builtinModules.includes(getPackageName(specifier))
+
+const collectBareImportSpecifiers = (filePath: string): string[] => {
+  const sourceFile = createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ScriptTarget.Latest,
+    true
+  )
+  const specifiers: string[] = []
+  const visit = (node: Node): void => {
+    let moduleSpecifier: Expression | undefined
+    // Type-only imports are erased at runtime (tsx strips them), so a missing
+    // package behind one cannot break script execution.
+    if (isImportDeclaration(node) && !node.importClause?.isTypeOnly)
+      moduleSpecifier = node.moduleSpecifier
+    else if (isExportDeclaration(node) && !node.isTypeOnly)
+      moduleSpecifier = node.moduleSpecifier
+    else if (
+      isCallExpression(node) &&
+      (node.expression.kind === SyntaxKind.ImportKeyword ||
+        (isIdentifier(node.expression) && node.expression.text === 'require'))
+    )
+      moduleSpecifier = node.arguments[0]
+
+    if (moduleSpecifier && isStringLiteralLike(moduleSpecifier)) {
+      const specifier = moduleSpecifier.text
+      // Relative/absolute imports are covered by the type check on changed
+      // files; a package.json change cannot break them.
+      if (!specifier.startsWith('.') && !specifier.startsWith('/'))
+        specifiers.push(specifier)
+    }
+    forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return specifiers
+}
+
+const getDeclaredPackages = (repoRoot: string): Set<string> => {
+  const packageJson = JSON.parse(
+    readFileSync(join(repoRoot, 'package.json'), 'utf8')
+  ) as Record<string, Record<string, string> | undefined>
+  const declared = new Set<string>()
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ])
+    for (const name of Object.keys(packageJson[field] ?? {})) declared.add(name)
+  return declared
+}
+
+const runTypeCheck = (repoRoot: string, files: string[]): boolean => {
+  consola.info(`Type-checking ${files.length} changed script file(s):`)
+  for (const file of files) consola.info(`  ${file}`)
+  const result = spawnSync('bunx', ['tsc-files', '--noEmit', ...files], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  })
+  if (result.status !== 0 && !existsSync(join(repoRoot, 'typechain')))
+    consola.warn(
+      'typechain/ is missing — if errors above mention typechain imports, run `bun typechain` first'
+    )
+  return result.status === 0
+}
+
+const runImportResolutionCheck = (repoRoot: string): boolean => {
+  const declared = getDeclaredPackages(repoRoot)
+  const missing: IMissingImport[] = []
+  const allScriptFiles = listScriptFiles(repoRoot)
+  consola.info(
+    `Dependency manifest changed — verifying bare imports of ${allScriptFiles.length} script file(s) against package.json`
+  )
+  for (const file of allScriptFiles)
+    for (const specifier of collectBareImportSpecifiers(join(repoRoot, file))) {
+      if (isBuiltinSpecifier(specifier)) continue
+      const packageName = getPackageName(specifier)
+      // A package installed transitively via the lockfile (e.g. bs58 through
+      // @layerzerolabs/lz-v2-utilities) still resolves at runtime, so only
+      // flag packages that are neither declared nor installed.
+      if (
+        !declared.has(packageName) &&
+        !existsSync(join(repoRoot, 'node_modules', packageName))
+      )
+        missing.push({ file, specifier, packageName })
+    }
+
+  if (missing.length > 0) {
+    consola.error('Imports without a matching package.json dependency:')
+    for (const entry of missing)
+      consola.error(
+        `  ${entry.file} imports '${entry.specifier}' but '${entry.packageName}' is not declared in package.json`
+      )
+    return false
+  }
+  return true
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'validateScripts',
+    description:
+      'Static validation (type check + import resolution) of changed TS files under script/',
+  },
+  args: {
+    base: {
+      type: 'string',
+      description:
+        'Git ref to diff against (default: merge-base of HEAD and origin/main)',
+    },
+    head: {
+      type: 'string',
+      description: 'Git ref whose changes are validated (default: HEAD)',
+    },
+  },
+  async run({ args }) {
+    const repoRoot = git(['rev-parse', '--show-toplevel'], process.cwd())
+    const head = args.head ?? 'HEAD'
+    const base = resolveBaseRef(repoRoot, head, args.base)
+    const changedFiles = getChangedFiles(repoRoot, base, head)
+
+    const changedScriptFiles = changedFiles.filter((file) =>
+      SCRIPT_FILE_PATTERN.test(file)
+    )
+    const manifestsChanged = changedFiles.some((file) =>
+      DEPENDENCY_MANIFESTS.includes(file)
+    )
+
+    if (changedScriptFiles.length === 0 && !manifestsChanged) {
+      consola.success(
+        `No script/**/*.ts or dependency manifest changes between ${base} and ${head} — nothing to validate`
+      )
+      return
+    }
+
+    let passed = true
+    if (changedScriptFiles.length > 0)
+      passed = runTypeCheck(repoRoot, changedScriptFiles) && passed
+    if (manifestsChanged) passed = runImportResolutionCheck(repoRoot) && passed
+
+    if (!passed) {
+      consola.error('Script validation failed')
+      process.exit(1)
+    }
+    consola.success('Script validation passed')
+  },
+})
+
+runMain(main)

--- a/script/utils/validateScripts.ts
+++ b/script/utils/validateScripts.ts
@@ -7,12 +7,15 @@
  *    import (TS2304) or
  *    a dependency a script imports (TS2307) fails the check — no execution,
  *    no fixtures.
- * 2. Import resolution: when dependency manifests (package.json / bun.lock /
- *    tsconfig.json) changed, every bare import specifier in ALL TS files
- *    under `script/` must resolve to a package declared in
- *    package.json (or a node/bun builtin). This catches "dependency removed
- *    from package.json while a script still imports it" even when no .ts
- *    file was touched.
+ * 2. Import resolution: when script files OR dependency manifests
+ *    (package.json / bun.lock / tsconfig.json) changed, every bare import
+ *    specifier in ALL TS files under `script/` must resolve to a package
+ *    declared in package.json (or a node/bun builtin). Running it on script
+ *    changes catches an undeclared import at introduction (the package is
+ *    physically present via a transitive dependency, so the type check passes);
+ *    running it on manifest changes catches "dependency removed from
+ *    package.json while a script still imports it" even when no .ts file was
+ *    touched.
  *
  * Used by the `.husky/pre-push` hook (fast local feedback) and the
  * `validateScripts.yml` CI workflow (enforcement backstop).
@@ -202,7 +205,7 @@ const runImportResolutionCheck = (repoRoot: string): boolean => {
   const missing: IMissingImport[] = []
   const allScriptFiles = listScriptFiles(repoRoot)
   consola.info(
-    `Dependency manifest changed — verifying bare imports of ${allScriptFiles.length} script file(s) against package.json`
+    `Verifying bare imports of ${allScriptFiles.length} script file(s) against package.json`
   )
   for (const file of allScriptFiles)
     for (const specifier of collectBareImportSpecifiers(join(repoRoot, file))) {
@@ -267,7 +270,12 @@ const main = defineCommand({
     let passed = true
     if (changedScriptFiles.length > 0)
       passed = runTypeCheck(repoRoot, changedScriptFiles) && passed
-    if (manifestsChanged) passed = runImportResolutionCheck(repoRoot) && passed
+    // Sweep on script changes too (not just manifest changes): an undeclared
+    // import added in a script resolves fine for the type check (the package is
+    // installed transitively) but must be caught now, not deferred to whenever
+    // an unrelated manifest edit next trips the sweep.
+    if (manifestsChanged || changedScriptFiles.length > 0)
+      passed = runImportResolutionCheck(repoRoot) && passed
 
     if (!passed) {
       consola.error('Script validation failed')


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-331 — CI: dedicated workflow to validate scripts when they are touched](https://linear.app/lifi-linear/issue/EXSC-331/ci-dedicated-workflow-to-validate-scripts-when-they-are-touched)

# Why did I implement it this way?

Per the approach decided on the ticket: scripts are **not executed** (flaky/slow). Instead a deterministic static check, delivered as both a local pre-push hook (fast feedback) and a path-gated CI workflow (enforcement backstop, since hooks are bypassable with `--no-verify`):

- **`script/utils/validateScripts.ts`** (also exposed as `bun validate-scripts`) does two things:
  1. **Type check** — `tsc-files --noEmit` over the TS files under `script/` changed between a base ref and head. Removing a used import fails with TS2304; removing a dependency a script imports fails with TS2307. A full-repo `tsc` gate was not feasible: `tsc --noEmit -p tsconfig.json` is currently red (missing generated `typechain/` plus pre-existing errors in a handful of legacy scripts), so the check is scoped to changed files — same fix-on-touch semantics the pre-commit hook already applies via lint-staged.
  2. **Import resolution sweep** — when dependency manifests (`package.json` / `bun.lock` / `tsconfig.json`) change, every bare import specifier across ALL `script/**` TS files must be declared in `package.json` (**strict declared-only**, per review decision — relying on transitively installed packages breaks silently when the parent dependency drops them; `bs58`, previously relied on via `@layerzerolabs/lz-v2-utilities`, is now declared explicitly and its eslint suppression removed). Type-only imports are exempt (erased at runtime by `tsx`). This catches the exact scenario from the PR #1791 discussion — dependency removed while `script/mongoDb/fetch-rpcs.ts` still imports it — even when no `.ts` file was touched.
- **`.husky/pre-push`** — runs the validator per pushed ref (base = remote sha when it exists locally, otherwise merge-base with `origin/main`). Uses the same husky-v8 `bash -e` re-exec workaround as `.husky/pre-commit`.
- **`.github/workflows/validateScripts.yml`** — follows the `forge-unit-tests.yml` house pattern: cheap `detect-changes` (dorny/paths-filter) + path-gated heavy job + an always-reporting `validate-scripts-required` aggregator so it can be registered as a required check on `main`. TypeChain types are generated in the job because several scripts (demoScripts, tron deploy scripts via `demoScriptHelpers`) import generated `typechain/` types. `forge-unit-tests.yml` stays solidity-only (untouched).

Coordination with EXSC-368: no overlap — EXSC-368 guards the *bash* `universalCast`/`sendOrPropose` routing behaviourally (Anvil smoke tests / testnet dry-runs); this PR is a *TypeScript static* check only and does not touch `.sh` scripts.

**Verification evidence (local dry-runs):**

- removed `MongoClient` import from `fetch-rpcs.ts` → type check fails (TS2304), exit 1 ✅
- removed `mongodb` from `package.json` (+ simulated fresh install) → sweep flags 10 importing files, exit 1 ✅
- manifest touched with deps intact → sweep passes over 138 script files, exit 0 ✅
- no relevant changes → "nothing to validate", exit 0 ✅
- strict-mode negative test: with `bs58` undeclared, the sweep flags `demoScriptHelpers.ts`, exit 1 ✅; declared → sweep passes over 138 files, exit 0 ✅
- pre-push hook stdin simulation (new-branch ref line) → exit 0 ✅ and the hook ran live on the actual push of this branch
- `bash -n .husky/pre-push`, `bunx eslint` + `bunx tsc-files --noEmit` + prettier on `validateScripts.ts`: clean ✅

**For the reviewer / follow-up:** after merge, register `validate-scripts-required` as a required status check on `main` branch protection (repo settings — needs admin).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md` (zero findings)
- [x] I have added tests that cover the functionality / test the bug (deterministic dry-run evidence above; the validator is itself a static check harness)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e (N/A — no contracts touched)
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
