### PR TITLE
chore(EXSC-72): upgrade forge-std to v1.16.1 and clean up legacy DSTest usage in tests

### DIFF
--- a/test/solidity/Facets/CBridge/CBridgeRefund.t.sol
+++ b/test/solidity/Facets/CBridge/CBridgeRefund.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
 import { DiamondTest, LiFiDiamond } from "../../utils/DiamondTest.sol";
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 import { WithdrawFacet } from "lifi/Facets/WithdrawFacet.sol";
@@ -11,7 +10,7 @@ import { UnAuthorized, NotAContract } from "lifi/Errors/GenericErrors.sol";
 // Actual refund was processed at 25085299(Feb-18-2022 03:24:09 PM +UTC)
 // Run `forge test --match-path test\solidity\Facets\CBridgeRefund.t.sol --fork-url POLYGON_RPC_URL --fork-block-number 25085298`
 // or `forge test --match-contract CBridgeRefundTest --fork-url POLYGON_RPC_URL --fork-block-number 25085298`
-contract CBridgeRefundTestPolygon is DSTest, DiamondTest {
+contract CBridgeRefundTestPolygon is DiamondTest {
     address internal constant CBRIDGE_ADDRESS =
         0x88DCDC47D2f83a99CF0000FDF667A468bB958a78;
     address internal constant LIFI_ADDRESS =

--- a/test/solidity/Facets/WhitelistManagerFacet.t.sol
+++ b/test/solidity/Facets/WhitelistManagerFacet.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
 import { DiamondTest, LiFiDiamond } from "../utils/DiamondTest.sol";
 import { WhitelistManagerFacet } from "lifi/Facets/WhitelistManagerFacet.sol";
 import { AccessManagerFacet } from "lifi/Facets/AccessManagerFacet.sol";
@@ -36,7 +35,7 @@ contract MockSwapperFacet {
     }
 }
 
-contract WhitelistManagerFacetTest is DSTest, DiamondTest {
+contract WhitelistManagerFacetTest is DiamondTest {
     address internal constant USER_PAUSER = address(0xdeadbeef);
     address internal constant USER_DIAMOND_OWNER = address(0x123456);
     address internal constant NOT_DIAMOND_OWNER = address(0xabc123456);

--- a/test/solidity/Helpers/TransferrableOwnership.t.sol
+++ b/test/solidity/Helpers/TransferrableOwnership.t.sol
@@ -7,7 +7,6 @@ import { UnAuthorized } from "lifi/Errors/GenericErrors.sol";
 
 contract TransferrableOwnershipTest is Test {
     TransferrableOwnership internal ownable;
-    // solhint-disable immutable-vars-naming
 
     error NoNullOwner();
     error NewOwnerMustNotBeSelf();

--- a/test/solidity/Helpers/TransferrableOwnership.t.sol
+++ b/test/solidity/Helpers/TransferrableOwnership.t.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
-import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
 import { UnAuthorized } from "lifi/Errors/GenericErrors.sol";
 
-contract TransferrableOwnershipTest is DSTest {
+contract TransferrableOwnershipTest is Test {
     TransferrableOwnership internal ownable;
     // solhint-disable immutable-vars-naming
-    Vm internal immutable vm = Vm(HEVM_ADDRESS);
 
     error NoNullOwner();
     error NewOwnerMustNotBeSelf();

--- a/test/solidity/LiFiDiamond.t.sol
+++ b/test/solidity/LiFiDiamond.t.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.17;
 
+import { Test } from "forge-std/Test.sol";
 import { LiFiDiamond } from "lifi/LiFiDiamond.sol";
 import { LibDiamond } from "lifi/Libraries/LibDiamond.sol";
 import { DiamondCutFacet } from "lifi/Facets/DiamondCutFacet.sol";
 import { DiamondLoupeFacet } from "lifi/Facets/DiamondLoupeFacet.sol";
 import { OwnershipFacet } from "lifi/Facets/OwnershipFacet.sol";
-import { DSTest } from "ds-test/test.sol";
-import { Vm } from "forge-std/Vm.sol";
 
-contract LiFiDiamondTest is DSTest {
+contract LiFiDiamondTest is Test {
     // solhint-disable immutable-vars-naming
-    Vm internal immutable vm = Vm(HEVM_ADDRESS);
     LiFiDiamond public diamond;
     DiamondCutFacet public diamondCutFacet;
     OwnershipFacet public ownershipFacet;

--- a/test/solidity/LiFiDiamond.t.sol
+++ b/test/solidity/LiFiDiamond.t.sol
@@ -9,7 +9,6 @@ import { DiamondLoupeFacet } from "lifi/Facets/DiamondLoupeFacet.sol";
 import { OwnershipFacet } from "lifi/Facets/OwnershipFacet.sol";
 
 contract LiFiDiamondTest is Test {
-    // solhint-disable immutable-vars-naming
     LiFiDiamond public diamond;
     DiamondCutFacet public diamondCutFacet;
     OwnershipFacet public ownershipFacet;

--- a/test/solidity/Libraries/LibAsset.t.sol
+++ b/test/solidity/Libraries/LibAsset.t.sol
@@ -125,18 +125,16 @@ contract LibAssetTest is TestBase {
     }
 
     function test_isContractWithDelegationDesignator() public {
-        // 0xef0100 is the delegation designator
-        // build a 23‑byte blob: 0xef0100 ‖ <20‑byte delegate address>
-        // here we just point back at the test contract itself,
-        // but you can put any 20‑byte address
-        bytes memory aaCode = abi.encodePacked(
-            hex"ef0100",
-            bytes20(address(this))
+        // use a real EIP-7702 delegation (designator 0xef0100 ++ delegate
+        // address, attached via cheatcode) instead of hand-etching the code
+        (address delegatedEoa, uint256 delegatedEoaKey) = makeAddrAndKey(
+            "delegatedEoa"
         );
 
-        vm.etch(USER_SENDER, aaCode); // inject the delegation designator into the USER_SENDER address
+        vm.signAndAttachDelegation(address(implementer), delegatedEoaKey);
 
-        bool result = implementer.isContract(USER_SENDER);
+        bool result = implementer.isContract(delegatedEoa);
+
         assertFalse(result, "Delegated EOA is not a contract");
     }
 }

--- a/test/solidity/Periphery/ERC20Proxy.t.sol
+++ b/test/solidity/Periphery/ERC20Proxy.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.17;
 
+import { Test } from "forge-std/Test.sol";
 import { ERC20Proxy } from "lifi/Periphery/ERC20Proxy.sol";
-import { DSTest } from "ds-test/test.sol";
 
-contract ERC20ProxyTest is DSTest {
+contract ERC20ProxyTest is Test {
     ERC20Proxy public erc20Proxy;
     address public proxyOwner;
 

--- a/test/solidity/Periphery/Executor.t.sol
+++ b/test/solidity/Periphery/Executor.t.sol
@@ -57,7 +57,6 @@ contract MockGateway {
 }
 
 contract ExecutorTest is Test {
-    // solhint-disable immutable-vars-naming
     Executor internal executor;
     TestAMM internal amm;
     Vault internal vault;

--- a/test/solidity/Periphery/Executor.t.sol
+++ b/test/solidity/Periphery/Executor.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
-import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import { Executor } from "lifi/Periphery/Executor.sol";
 import { ERC20Proxy } from "lifi/Periphery/ERC20Proxy.sol";
 import { TestAMM } from "../utils/TestAMM.sol";
@@ -57,9 +56,8 @@ contract MockGateway {
     }
 }
 
-contract ExecutorTest is DSTest {
+contract ExecutorTest is Test {
     // solhint-disable immutable-vars-naming
-    Vm internal immutable vm = Vm(HEVM_ADDRESS);
     Executor internal executor;
     TestAMM internal amm;
     Vault internal vault;

--- a/test/solidity/Periphery/FeeCollector.t.sol
+++ b/test/solidity/Periphery/FeeCollector.t.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
-import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import { FeeCollector } from "lifi/Periphery/FeeCollector.sol";
 import { TestToken as ERC20 } from "../utils/TestToken.sol";
 import { UnAuthorized } from "lifi/Errors/GenericErrors.sol";
 
-contract FeeCollectorTest is DSTest {
+contract FeeCollectorTest is Test {
     // solhint-disable immutable-vars-naming
-    Vm internal immutable vm = Vm(HEVM_ADDRESS);
     FeeCollector private feeCollector;
     ERC20 private feeToken;
 

--- a/test/solidity/Periphery/FeeCollector.t.sol
+++ b/test/solidity/Periphery/FeeCollector.t.sol
@@ -7,7 +7,6 @@ import { TestToken as ERC20 } from "../utils/TestToken.sol";
 import { UnAuthorized } from "lifi/Errors/GenericErrors.sol";
 
 contract FeeCollectorTest is Test {
-    // solhint-disable immutable-vars-naming
     FeeCollector private feeCollector;
     ERC20 private feeToken;
 

--- a/test/solidity/Periphery/TokenWrapper.t.sol
+++ b/test/solidity/Periphery/TokenWrapper.t.sol
@@ -10,7 +10,6 @@ import { TestBasicToken } from "../utils/TestBasicToken.sol";
 import { TestConverterWithDecimals } from "../utils/TestConverterWithDecimals.sol";
 
 contract TokenWrapperTest is Test {
-    // solhint-disable immutable-vars-naming
     TokenWrapper private tokenWrapper;
     ERC20 private wrappedToken;
 

--- a/test/solidity/Periphery/TokenWrapper.t.sol
+++ b/test/solidity/Periphery/TokenWrapper.t.sol
@@ -2,17 +2,15 @@
 
 pragma solidity ^0.8.17;
 
-import { DSTest } from "ds-test/test.sol";
-import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
 import { TokenWrapper } from "lifi/Periphery/TokenWrapper.sol";
 import { TestWrappedToken as ERC20 } from "../utils/TestWrappedToken.sol";
 import { TestWrappedConverter } from "../utils/TestWrappedConverter.sol";
 import { TestBasicToken } from "../utils/TestBasicToken.sol";
 import { TestConverterWithDecimals } from "../utils/TestConverterWithDecimals.sol";
 
-contract TokenWrapperTest is DSTest {
+contract TokenWrapperTest is Test {
     // solhint-disable immutable-vars-naming
-    Vm internal immutable vm = Vm(HEVM_ADDRESS);
     TokenWrapper private tokenWrapper;
     ERC20 private wrappedToken;
 

--- a/test/solidity/utils/TestBase.sol
+++ b/test/solidity/utils/TestBase.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.17;
 
 import { Test } from "forge-std/Test.sol";
-import { DSTest } from "ds-test/test.sol";
 import { ILiFi } from "lifi/Interfaces/ILiFi.sol";
 import { LibSwap } from "lifi/Libraries/LibSwap.sol";
 import { UniswapV2Router02 } from "../utils/Interfaces.sol";
@@ -20,7 +19,7 @@ contract TestFacet is TestWhitelistManagerBase {
     constructor() {}
 }
 
-contract ReentrancyChecker is DSTest {
+contract ReentrancyChecker {
     address private _facetAddress;
     bytes private _callData;
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-72](https://linear.app/lifi-linear/issue/EXSC-72/upgrade-forge-std-lib-and-clean-up-tests-by-removing-redundant-code)

# Why did I implement it this way?

This follows the 7-step plan in the ticket. The ~3-year forge-std jump (`7f7cb06` / v1.5.5 → `620536f` / v1.16.1) was treated as a behavioral migration, not a mechanical bump:

1. **Submodule bumps** — `lib/forge-std` → v1.16.1. `lib/ds-test` already tracks the latest upstream `master` (`e282159`), so no change there. ds-test itself stays: the deploy `ScriptBase` contracts intentionally keep `Script, DSTest` because scripts use DSTest's `log`/`log_*` events and forge-std's `Script` does not bundle assertions/log events — no conflict there, minimal diff.
2. **`forge build` on both profiles** — passes on default (`solc 0.8.29`, cancun) and `zksync` (`zksolc 1.5.15` via foundry-zksync v0.0.32, `--zksync`), warnings only.
   All compile errors came from one root cause: forge-std's `Test` no longer inherits `DSTest` but embeds the same members via `StdAssertions`, so test contracts inheriting BOTH (`is DSTest, DiamondTest`) hit duplicate-member errors. Fix: drop the redundant `DSTest` base everywhere in `test/` and migrate the DSTest-only test contracts to forge-std `Test`, removing the manual `Vm internal immutable vm = Vm(HEVM_ADDRESS)` declarations that `Test` provides.
3. **`forge test`** — 1577 passed, 0 deterministic failures. The only failures across three full runs were transient drpc RPC timeouts/DNS on fork tests (different test each run, each passes on rerun; CI's 10× `--rerun` covers this class).
4. **Coverage gate** — `forge coverage --report lcov --force --ir-minimum` + `filter_lcov.ts` (same as `enforceTestCoverage.yml`): **89.99% line coverage for `src/`** (3255/3617). No tests were removed, only base-class scaffolding.
5. **StdJson script dry-run validation** (highest-blast-radius step):
   - Real dry-run of `DeployExecutor.s.sol` against a mainnet fork (no broadcast): parsed `ERC20Proxy` (`0x68E1...18f0`) and `refundWallet` (`0x156C...591F`) byte-identical to `jq` ground truth; CREATE3 prediction + simulation succeed.
   - A throwaway harness (not committed) exercised every stdJson pattern the deploy scripts use — `readAddress`, `readUint`, `readStringArray`, `readBytes32`-style reads, `vm.parseJsonAddress`, and `parseRaw` + `abi.decode` into struct arrays (`FunctionSelector[]` from `global.json`, `ChainIdConfig[]` from `debridgedln.json`) — against the real config files. All values matched `jq` exactly (incl. array lengths, first/last elements, non-trivial uint `1151111081099710`).
6. **EIP-7702 rework** — `LibAsset.t.sol` now uses `vm.signAndAttachDelegation` with a `makeAddrAndKey` wallet instead of hand-etching `0xef0100 ++ address`. **EVM-version approach: none needed** — verified empirically that the 7702 cheatcodes work under the repo's `evm_version = cancun` (the cheatcode writes the delegation designator into state directly; `extcodesize` returns 23 as expected), so no global bump and no per-test override. The other `vm.etch` call sites (`CBridgeFacetPacked.t.sol`, `GasZipPeriphery.t.sol` ×2) are legitimate contract-mocking (replacing a router with mock code / giving an address >23-byte code) — not 7702 fakes — and were left as-is.
7. **Redundant-code cleanup** — removed: direct `DSTest` imports/bases in 10 test files, manual `vm = Vm(HEVM_ADDRESS)` declarations (5 files), and the `solhint-disable immutable-vars-naming` comments orphaned by that removal. No test logic or assertions removed, so no coverage regression.

`/pr-ready` (local CodeRabbit) ran clean: **No findings**.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)