### PR TITLE
EXSC-488: feat(safe): add --nonce override to propose-to-safe

### DIFF
--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -236,6 +236,7 @@ export interface IProposeToSafeOptions {
   derivationPath?: string
   safeAddress?: string
   calldataFile?: string
+  nonce?: bigint
 }
 
 /** Strategy interface for chain-specific generic contract call broadcasting. */

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -10,6 +10,17 @@
  *
  * Or run directly from the CLI:
  *   bun run propose-to-safe.ts --network mainnet --to 0x... --calldata 0x... --timelock --privateKey 0x...
+ *
+ * Recovering a skipped Safe nonce:
+ *   The nonce is auto-derived by default (on-chain nonce + pending proposals).
+ *   If a nonce gap appears in the queue — e.g. the queue holds 58/59/60 but the
+ *   Safe's on-chain nonce is stuck at 57 with no proposal for it — every
+ *   higher-nonce proposal is blocked because the Safe executes strictly in
+ *   order. Use --nonce to mint a proposal at the missing slot (a 0x self-call
+ *   is a harmless filler), then run confirm-safe-tx to execute the queue:
+ *     bunx tsx propose-to-safe.ts --network base --to <SAFE> --calldata 0x --nonce 57
+ *   The override is rejected if the nonce is below the on-chain nonce or already
+ *   occupied by a pending/submitted proposal.
  */
 
 import 'dotenv/config'
@@ -150,14 +161,37 @@ export async function runPropose(options: IProposeToSafeOptions) {
   const { client: mongoClient, pendingTransactions } =
     await getSafeMongoCollection()
 
-  // Get the next nonce
-  const nextNonce = await getNextNonce(
-    pendingTransactions,
-    safeAddress,
-    options.network,
-    chain.id,
-    await safe.getNonce()
-  )
+  // Resolve the nonce: an explicit --nonce override (e.g. to fill a gap that
+  // blocks higher-nonce proposals) bypasses the auto-increment; otherwise pick
+  // the next free nonce from the on-chain value and pending proposals.
+  let nextNonce: bigint
+  if (options.nonce !== undefined) {
+    const onChainNonce = await safe.getNonce()
+    if (options.nonce < onChainNonce)
+      throw new Error(
+        `--nonce ${options.nonce} is below the on-chain nonce ${onChainNonce}; it can never execute`
+      )
+    const collision = await pendingTransactions.findOne({
+      safeAddress,
+      network: options.network.toLowerCase(),
+      chainId: chain.id,
+      status: { $in: ['pending', 'submitted'] },
+      'safeTx.data.nonce': Number(options.nonce),
+    })
+    if (collision)
+      throw new Error(
+        `A ${collision.status} proposal already occupies nonce ${options.nonce} (safeTxHash ${collision.safeTxHash})`
+      )
+    nextNonce = options.nonce
+    consola.warn(`Using explicit nonce override: ${nextNonce}`)
+  } else
+    nextNonce = await getNextNonce(
+      pendingTransactions,
+      safeAddress,
+      options.network,
+      chain.id,
+      await safe.getNonce()
+    )
 
   // Create and sign the Safe transaction
   const safeTransaction = await safe.createTransaction({
@@ -286,6 +320,12 @@ const main = defineCommand({
         'Override Safe address (default: from config for network). Use to propose to a different Safe (e.g. old Safe for admin transfer).',
       required: false,
     },
+    nonce: {
+      type: 'string',
+      description:
+        'Override the Safe nonce (default: auto-derived). Use to fill a gap that blocks higher-nonce proposals. Rejected if below the on-chain nonce or already occupied by a pending/submitted proposal.',
+      required: false,
+    },
   },
   async run({ args }) {
     if (!args.calldata && !args.calldataFile)
@@ -304,6 +344,7 @@ const main = defineCommand({
       accountIndex: args.accountIndex ? Number(args.accountIndex) : undefined,
       derivationPath: args.derivationPath,
       safeAddress: args.safeAddress,
+      nonce: args.nonce !== undefined ? BigInt(args.nonce) : undefined,
     })
   },
 })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-488](https://linear.app/lifi-linear/issue/EXSC-488/add-nonce-override-to-propose-to-safe-recover-skipped-safe-nonces)

# Why did I implement it this way?

`propose-to-safe` always auto-derived the Safe nonce (on-chain nonce + highest
pending/submitted proposal), and `confirm-safe-tx` only signs/executes rows that
already exist. There was no way to mint a proposal at a *specific* nonce, so a
gap in the queue could not be filled from the existing scripts — every
higher-nonce proposal stays blocked because the Safe executes strictly in order.

This adds an optional `--nonce` override that bypasses the auto-increment when
set, leaving the default path untouched. It's guarded: the override is rejected
if the nonce is below the current on-chain nonce (can never execute) or already
occupied by a pending/submitted proposal (avoids creating a duplicate-nonce
collision).

## Example: recovering a skipped nonce

If the queue holds 58/59/60 but the Safe's on-chain nonce is stuck at 57 with no
proposal for it, mint a filler at the missing slot (a `0x` self-call is
harmless), then run `confirm-safe-tx` to drain the queue in order:

```bash
SAFE=0x<safe-address>

# pre-flight: confirm the chain is stuck on the missing nonce
cast call -r $ETH_NODE_URI_BASE $SAFE "nonce()(uint256)"   # -> 57

# mint a proposal at the missing slot
bunx tsx script/deploy/safe/propose-to-safe.ts \
  --network base --to $SAFE --calldata 0x --nonce 57

# sign to threshold + execute 57 -> 58 -> 59 -> 60
bunx tsx script/deploy/safe/confirm-safe-tx.ts --network base
```

Same in-script doc comment is included at the top of `propose-to-safe.ts`.

Note: this unblocks the *symptom*. A follow-up should address the root cause of
skipped nonces (the unconditional `nextNonce++` in
`add-safe-owners-and-threshold.ts` after a dedup-`null` store, combined with a
nonce-independent intent hash).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
