### PR TITLE
feat(safe): use openchain.xyz for selector lookup, drop anyabi.xyz

### DIFF
--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -34,8 +34,10 @@ import { decodeDiamondCut } from './safe-utils'
 
 /**
  * Signature-database lookup endpoints, tried in order. openchain.xyz is the
- * canonical source `cast 4byte` queries; the Sourcify mirror is a fallback for
- * when openchain is unreachable or has no match. Both share the same API shape.
+ * database Foundry's `cast 4byte` uses; since this repo is Foundry-native,
+ * aligning on it gives the most complete, consistent decoding. The Sourcify
+ * mirror is a fallback for when openchain is unreachable or has no match. Both
+ * share the same API shape.
  */
 const SIGNATURE_LOOKUP_ENDPOINTS = [
   {
@@ -632,10 +634,11 @@ export async function decodeTransactionData(
       consola.warn(`Error reading diamond ABI: ${error}`)
     }
 
-    // Fallback to external signature database. openchain.xyz is the canonical
-    // source `cast 4byte` queries; the Sourcify mirror is tried only when
-    // openchain is unreachable or has no match. Both expose the same response
-    // shape and filter=true suppresses spam/collision signatures.
+    // Fallback to external signature database. openchain.xyz is the database
+    // Foundry's `cast 4byte` uses; since this repo is Foundry-native, aligning
+    // on it gives the most complete, consistent decoding. The Sourcify mirror
+    // is tried only when openchain is unreachable or has no match. Both expose
+    // the same response shape and filter=true suppresses spam/collision sigs.
     for (const { label, base } of SIGNATURE_LOOKUP_ENDPOINTS) {
       consola.info(`${pre}No local ABI found, fetching from ${label}...`)
       try {

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -644,6 +644,7 @@ export async function decodeTransactionData(
       try {
         const url = `${base}?function=${selector}&filter=true`
         const response = await fetchWithTimeout(url)
+        if (!response.ok) continue
         const responseData = (await response.json()) as unknown
 
         const resultFn = (

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -32,6 +32,22 @@ import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import { decodeDiamondCut } from './safe-utils'
 
+/**
+ * Signature-database lookup endpoints, tried in order. openchain.xyz is the
+ * canonical source `cast 4byte` queries; the Sourcify mirror is a fallback for
+ * when openchain is unreachable or has no match. Both share the same API shape.
+ */
+const SIGNATURE_LOOKUP_ENDPOINTS = [
+  {
+    label: 'openchain.xyz',
+    base: 'https://api.openchain.xyz/signature-database/v1/lookup',
+  },
+  {
+    label: '4byte.sourcify.dev',
+    base: 'https://api.4byte.sourcify.dev/signature-database/v1/lookup',
+  },
+] as const
+
 export interface IFormatDecodedTxContext {
   chainId: number
   network: string
@@ -616,43 +632,37 @@ export async function decodeTransactionData(
       consola.warn(`Error reading diamond ABI: ${error}`)
     }
 
-    // Fallback to external API (Sourcify 4byte; same response shape as openchain.xyz)
-    consola.info(
-      `${pre}No local ABI found, fetching from 4byte.sourcify.dev...`
-    )
-    const url = `https://api.4byte.sourcify.dev/signature-database/v1/lookup?function=${selector}&filter=true`
-    const response = await fetchWithTimeout(url)
-    const responseData = (await response.json()) as unknown
-
-    const resultFn = (
-      responseData as {
-        result?: {
-          function?: Record<string, { name: string; args?: unknown }[]>
-        }
-      } | null
-    )?.result?.function?.[selector]
-    const fn = Array.isArray(resultFn) ? resultFn[0] : undefined
-    if (
-      typeof responseData === 'object' &&
-      responseData !== null &&
-      (responseData as { ok?: boolean }).ok &&
-      fn?.name
-    ) {
-      const functionName = fn.name
-
+    // Fallback to external signature database. openchain.xyz is the canonical
+    // source `cast 4byte` queries; the Sourcify mirror is tried only when
+    // openchain is unreachable or has no match. Both expose the same response
+    // shape and filter=true suppresses spam/collision signatures.
+    for (const { label, base } of SIGNATURE_LOOKUP_ENDPOINTS) {
+      consola.info(`${pre}No local ABI found, fetching from ${label}...`)
       try {
-        const decodedData = {
-          functionName,
-          args: fn.args,
-        }
+        const url = `${base}?function=${selector}&filter=true`
+        const response = await fetchWithTimeout(url)
+        const responseData = (await response.json()) as unknown
 
-        return {
-          functionName,
-          decodedData,
-        }
+        const resultFn = (
+          responseData as {
+            result?: {
+              function?: Record<string, { name: string; args?: unknown }[]>
+            }
+          } | null
+        )?.result?.function?.[selector]
+        const fn = Array.isArray(resultFn) ? resultFn[0] : undefined
+        if (
+          typeof responseData === 'object' &&
+          responseData !== null &&
+          (responseData as { ok?: boolean }).ok &&
+          fn?.name
+        )
+          return {
+            functionName: fn.name,
+            decodedData: { functionName: fn.name, args: fn.args },
+          }
       } catch (error) {
-        consola.warn(`Could not decode function data: ${error}`)
-        return { functionName }
+        consola.warn(`${pre}Lookup via ${label} failed: ${error}`)
       }
     }
 

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1792,16 +1792,22 @@ function getContractNameFromSelectorsInOut(
   }
 }
 
-/** Base URL for 4byte signature lookup (Sourcify; openchain.xyz-compatible API). */
-const FOURBYTE_LOOKUP_BASE =
-  'https://api.4byte.sourcify.dev/signature-database/v1/lookup'
+/**
+ * Signature-database lookup endpoints, tried in order. openchain.xyz is the
+ * canonical source `cast 4byte` queries; the Sourcify mirror is a fallback for
+ * when openchain is unreachable or has no match. Both share the same API shape.
+ */
+const FOURBYTE_LOOKUP_BASES = [
+  'https://api.openchain.xyz/signature-database/v1/lookup',
+  'https://api.4byte.sourcify.dev/signature-database/v1/lookup',
+] as const
 
-/** Item from 4byte/Sourcify signature lookup result (function name) */
+/** Item from openchain signature lookup result (function name) */
 interface IFourByteLookupResultItem {
   name: string
 }
 
-/** 4byte lookup API response shape for type-safe parsing (same as openchain.xyz) */
+/** openchain lookup API response shape for type-safe parsing */
 interface IFourByteLookupResponse {
   ok?: boolean
   result?: {
@@ -1821,30 +1827,33 @@ function isFourByteLookupResponse(
 }
 
 /**
- * Looks up a function selector via Sourcify 4byte signature database (api.4byte.sourcify.dev).
+ * Looks up a function selector via the openchain.xyz signature database, falling
+ * back to the Sourcify mirror when openchain is unreachable or has no match.
  * Use when the selector is not in diamond.json (e.g. different ABI encoding for same function).
  * @returns Function signature string if found, null otherwise
  */
 async function lookupSelectorFromFourByte(
   selector: string
 ): Promise<string | null> {
-  try {
-    const normalized = selector.startsWith('0x') ? selector : `0x${selector}`
-    const url = `${FOURBYTE_LOOKUP_BASE}?function=${normalized}&filter=true`
-    const response = await fetchWithTimeout(
-      url,
-      undefined,
-      DEFAULT_FETCH_TIMEOUT_MS
-    )
-    if (!response.ok) return null
-    const raw: unknown = await response.json()
-    if (!isFourByteLookupResponse(raw)) return null
-    const first = raw.result?.function?.[normalized]?.[0]
-    if (first?.name && typeof first.name === 'string') return first.name
-    return null
-  } catch {
-    return null
+  const normalized = selector.startsWith('0x') ? selector : `0x${selector}`
+  for (const base of FOURBYTE_LOOKUP_BASES) {
+    try {
+      const url = `${base}?function=${normalized}&filter=true`
+      const response = await fetchWithTimeout(
+        url,
+        undefined,
+        DEFAULT_FETCH_TIMEOUT_MS
+      )
+      if (!response.ok) continue
+      const raw: unknown = await response.json()
+      if (!isFourByteLookupResponse(raw)) continue
+      const first = raw.result?.function?.[normalized]?.[0]
+      if (first?.name && typeof first.name === 'string') return first.name
+    } catch {
+      continue
+    }
   }
+  return null
 }
 
 /**
@@ -2000,7 +2009,7 @@ export async function decodeDiamondCut(
             )
             if (fourByteName)
               consola.info(
-                `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(4byte.sourcify.dev)\u001b[0m`
+                `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(openchain.xyz)\u001b[0m`
               )
             else consola.warn(`${pre}Unknown function [${selector}]`)
           }

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1986,100 +1986,37 @@ export async function decodeDiamondCut(
       consola.info(`${pre}${facetLine}`)
       consola.info(`${pre}Action: ${actionMap[actionValue] ?? actionValue}`)
 
-      // Use selector map for efficient lookup
-      if (selectorMap) {
-        let contractName = network
-          ? getContractNameFromNetworkDeployments(network, facetAddress)
-          : 'Unknown'
-        // Remove (2): facet address is not a live deployable contract and the
-        // selector list may be a partial subset — superset matching is unsafe.
-        if (contractName === 'Unknown' && actionNum !== 2)
-          contractName = getContractNameFromSelectorsInOut(selectors)
-        consola.info(`${pre}Contract Name: \u001b[34m${contractName}\u001b[0m`)
+      let contractName = network
+        ? getContractNameFromNetworkDeployments(network, facetAddress)
+        : 'Unknown'
+      // Remove (2): facet address is the zero address (no live contract) and
+      // the selector list may be a partial subset — superset matching is unsafe.
+      if (contractName === 'Unknown' && actionNum !== 2)
+        contractName = getContractNameFromSelectorsInOut(selectors)
+      consola.info(`${pre}Contract Name: \u001b[34m${contractName}\u001b[0m`)
 
-        for (const selector of selectors) {
-          const normalizedSelector =
-            typeof selector === 'string' ? selector.toLowerCase() : selector
-          const functionInfo = selectorMap.get(normalizedSelector)
-          if (functionInfo) {
-            consola.info(
-              `${pre}Function: \u001b[34m${functionInfo.name}\u001b[0m [${selector}] - ${functionInfo.signature}`
-            )
-          } else {
-            const fourByteName = await lookupSelectorFromFourByte(
-              normalizedSelector
-            )
-            if (fourByteName)
-              consola.info(
-                `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(openchain.xyz)\u001b[0m`
-              )
-            else consola.warn(`${pre}Unknown function [${selector}]`)
-          }
-        }
-      } else {
-        // Fallback to external API if selector map not available
-        consola.info(`${pre}No diamond ABI found, fetching from anyabi.xyz...`)
-        const url = `https://anyabi.xyz/api/get-abi/${chainId}/${facetAddress}`
-        const response = await fetch(url)
-        const resData = await response.json()
-
-        if (resData && resData.abi) {
+      // Resolve each selector's name from the local diamond ABI first, then
+      // the openchain.xyz signature DB (Sourcify fallback). The facet ABI is
+      // never fetched by address: Remove uses the zero address, and per-selector
+      // lookup covers every action without depending on a live facet contract.
+      for (const selector of selectors) {
+        const normalizedSelector =
+          typeof selector === 'string' ? selector.toLowerCase() : selector
+        const functionInfo = selectorMap?.get(normalizedSelector)
+        if (functionInfo) {
           consola.info(
-            `${pre}Contract Name: \u001b[34m${
-              resData.name || 'unknown'
-            }\u001b[0m`
+            `${pre}Function: \u001b[34m${functionInfo.name}\u001b[0m [${selector}] - ${functionInfo.signature}`
           )
-
-          for (const selector of selectors)
-            try {
-              // Find matching function in ABI
-              const matchingFunction = resData.abi.find(
-                (abiItem: {
-                  type?: string
-                  name?: string
-                  inputs?: unknown[]
-                  outputs?: unknown[]
-                  stateMutability?: string
-                }) => {
-                  if (abiItem.type !== 'function' || !abiItem.name) return false
-                  try {
-                    // Create a proper ABI function for toFunctionSelector
-                    const abiFunction = {
-                      type: 'function' as const,
-                      name: abiItem.name,
-                      inputs: (abiItem.inputs || []) as Array<{
-                        type: string
-                        name?: string
-                      }>,
-                      outputs: (abiItem.outputs || []) as Array<{
-                        type: string
-                        name?: string
-                      }>,
-                      stateMutability:
-                        (abiItem.stateMutability as
-                          | 'pure'
-                          | 'view'
-                          | 'nonpayable'
-                          | 'payable') || 'nonpayable',
-                    }
-                    const calculatedSelector = toFunctionSelector(abiFunction)
-                    return calculatedSelector === selector
-                  } catch {
-                    return false
-                  }
-                }
-              )
-
-              if (matchingFunction)
-                consola.info(
-                  `${pre}Function: \u001b[34m${matchingFunction.name}\u001b[0m [${selector}]`
-                )
-              else consola.warn(`${pre}Unknown function [${selector}]`)
-            } catch (error) {
-              consola.warn(`${pre}Failed to decode selector: ${selector}`)
-            }
-        } else
-          consola.info(`${pre}Could not fetch ABI for facet ${facetAddress}`)
+          continue
+        }
+        const fourByteName = await lookupSelectorFromFourByte(
+          normalizedSelector
+        )
+        if (fourByteName)
+          consola.info(
+            `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(openchain.xyz)\u001b[0m`
+          )
+        else consola.warn(`${pre}Unknown function [${selector}]`)
       }
     } catch (error) {
       consola.error(`${pre}Error processing facet ${facetAddress}:`, error)

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1794,8 +1794,10 @@ function getContractNameFromSelectorsInOut(
 
 /**
  * Signature-database lookup endpoints, tried in order. openchain.xyz is the
- * canonical source `cast 4byte` queries; the Sourcify mirror is a fallback for
- * when openchain is unreachable or has no match. Both share the same API shape.
+ * database Foundry's `cast 4byte` uses; since this repo is Foundry-native,
+ * aligning on it gives the most complete, consistent decoding. The Sourcify
+ * mirror is a fallback for when openchain is unreachable or has no match. Both
+ * share the same API shape.
  */
 const FOURBYTE_LOOKUP_BASES = [
   'https://api.openchain.xyz/signature-database/v1/lookup',

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1800,8 +1800,14 @@ function getContractNameFromSelectorsInOut(
  * share the same API shape.
  */
 const FOURBYTE_LOOKUP_BASES = [
-  'https://api.openchain.xyz/signature-database/v1/lookup',
-  'https://api.4byte.sourcify.dev/signature-database/v1/lookup',
+  {
+    label: 'openchain.xyz',
+    base: 'https://api.openchain.xyz/signature-database/v1/lookup',
+  },
+  {
+    label: '4byte.sourcify.dev',
+    base: 'https://api.4byte.sourcify.dev/signature-database/v1/lookup',
+  },
 ] as const
 
 /** Item from openchain signature lookup result (function name) */
@@ -1832,13 +1838,13 @@ function isFourByteLookupResponse(
  * Looks up a function selector via the openchain.xyz signature database, falling
  * back to the Sourcify mirror when openchain is unreachable or has no match.
  * Use when the selector is not in diamond.json (e.g. different ABI encoding for same function).
- * @returns Function signature string if found, null otherwise
+ * @returns The resolved signature and the endpoint label that returned it, or null
  */
 async function lookupSelectorFromFourByte(
   selector: string
-): Promise<string | null> {
+): Promise<{ name: string; source: string } | null> {
   const normalized = selector.startsWith('0x') ? selector : `0x${selector}`
-  for (const base of FOURBYTE_LOOKUP_BASES) {
+  for (const { label, base } of FOURBYTE_LOOKUP_BASES) {
     try {
       const url = `${base}?function=${normalized}&filter=true`
       const response = await fetchWithTimeout(
@@ -1848,9 +1854,10 @@ async function lookupSelectorFromFourByte(
       )
       if (!response.ok) continue
       const raw: unknown = await response.json()
-      if (!isFourByteLookupResponse(raw)) continue
+      if (!isFourByteLookupResponse(raw) || !raw.ok) continue
       const first = raw.result?.function?.[normalized]?.[0]
-      if (first?.name && typeof first.name === 'string') return first.name
+      if (first?.name && typeof first.name === 'string')
+        return { name: first.name, source: label }
     } catch {
       continue
     }
@@ -2009,12 +2016,10 @@ export async function decodeDiamondCut(
           )
           continue
         }
-        const fourByteName = await lookupSelectorFromFourByte(
-          normalizedSelector
-        )
-        if (fourByteName)
+        const resolved = await lookupSelectorFromFourByte(normalizedSelector)
+        if (resolved)
           consola.info(
-            `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(openchain.xyz)\u001b[0m`
+            `${pre}Function: \u001b[34m${resolved.name}\u001b[0m [${selector}] \u001b[90m(${resolved.source})\u001b[0m`
           )
         else consola.warn(`${pre}Unknown function [${selector}]`)
       }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-491

# Why did I implement it this way?

The Safe transaction decoding flow resolves function selectors to signatures via an external signature database, used in two places:

- `safe-decode-utils.ts` → `decodeTransactionData` (drives `confirm-safe-tx.ts` calldata display)
- `safe-utils.ts` → `lookupSelectorFromFourByte` / `decodeDiamondCut` (drives diamondCut selector names)

**1. Prefer openchain.xyz, with Sourcify as fallback.** Both sites previously queried only the Sourcify mirror (`api.4byte.sourcify.dev`). That mirror was adopted (canceled ticket EXSC-175) on the premise that openchain.xyz would migrate away — but openchain.xyz is the signature database **Foundry's `cast 4byte` uses**, and since this repo is Foundry-native, aligning on it gives the most complete and consistent decoding. That is the main reason it's more complete, and the reason for migrating back to it. Now both query **openchain.xyz first** and fall back to the Sourcify mirror only when openchain is unreachable or has no match. The two endpoints share the same response shape (parsing unchanged) and both keep `filter=true` to suppress spam/collision signatures. The local `diamond.json` ABI remains the primary resolver before any remote lookup. Lookups stay HTTP via `fetchWithTimeout` (per `[CONV:FETCH-TIMEOUT]`) rather than shelling out to `cast`.

**2. Drop the anyabi.xyz facet-ABI fetch from `decodeDiamondCut`.** When the local `diamond.json` map was unavailable (it's generated/gitignored, so it's absent in fresh checkouts), the old code fetched the facet's full ABI from `anyabi.xyz` keyed by facet address. For Remove actions the facet address is the zero address, so that lookup always failed and spammed `Could not fetch ABI for facet 0x0…` once per cut entry. It also used a bare `fetch()` that bypassed `fetchWithTimeout`. Since selectors are already resolved individually (local diamond ABI → openchain → Sourcify), the facet-by-address fetch is redundant. Removed it; selector resolution is now a single map-optional loop that works for Add/Replace/Remove without depending on a live facet contract.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
