### PR TITLE
fix(safe): drop dead anyabi.xyz facet-ABI fetch from decodeDiamondCut

### DIFF
--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1975,100 +1975,37 @@ export async function decodeDiamondCut(
       consola.info(`${pre}${facetLine}`)
       consola.info(`${pre}Action: ${actionMap[actionValue] ?? actionValue}`)
 
-      // Use selector map for efficient lookup
-      if (selectorMap) {
-        let contractName = network
-          ? getContractNameFromNetworkDeployments(network, facetAddress)
-          : 'Unknown'
-        // Remove (2): facet address is not a live deployable contract and the
-        // selector list may be a partial subset — superset matching is unsafe.
-        if (contractName === 'Unknown' && actionNum !== 2)
-          contractName = getContractNameFromSelectorsInOut(selectors)
-        consola.info(`${pre}Contract Name: \u001b[34m${contractName}\u001b[0m`)
+      let contractName = network
+        ? getContractNameFromNetworkDeployments(network, facetAddress)
+        : 'Unknown'
+      // Remove (2): facet address is the zero address (no live contract) and
+      // the selector list may be a partial subset — superset matching is unsafe.
+      if (contractName === 'Unknown' && actionNum !== 2)
+        contractName = getContractNameFromSelectorsInOut(selectors)
+      consola.info(`${pre}Contract Name: \u001b[34m${contractName}\u001b[0m`)
 
-        for (const selector of selectors) {
-          const normalizedSelector =
-            typeof selector === 'string' ? selector.toLowerCase() : selector
-          const functionInfo = selectorMap.get(normalizedSelector)
-          if (functionInfo) {
-            consola.info(
-              `${pre}Function: \u001b[34m${functionInfo.name}\u001b[0m [${selector}] - ${functionInfo.signature}`
-            )
-          } else {
-            const fourByteName = await lookupSelectorFromFourByte(
-              normalizedSelector
-            )
-            if (fourByteName)
-              consola.info(
-                `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(4byte.sourcify.dev)\u001b[0m`
-              )
-            else consola.warn(`${pre}Unknown function [${selector}]`)
-          }
-        }
-      } else {
-        // Fallback to external API if selector map not available
-        consola.info(`${pre}No diamond ABI found, fetching from anyabi.xyz...`)
-        const url = `https://anyabi.xyz/api/get-abi/${chainId}/${facetAddress}`
-        const response = await fetch(url)
-        const resData = await response.json()
-
-        if (resData && resData.abi) {
+      // Resolve each selector's name from the local diamond ABI first, then the
+      // 4byte/Sourcify signature DB. The facet ABI is never fetched by address:
+      // Remove uses the zero address, and per-selector lookup covers every action
+      // without depending on a live facet contract.
+      for (const selector of selectors) {
+        const normalizedSelector =
+          typeof selector === 'string' ? selector.toLowerCase() : selector
+        const functionInfo = selectorMap?.get(normalizedSelector)
+        if (functionInfo) {
           consola.info(
-            `${pre}Contract Name: \u001b[34m${
-              resData.name || 'unknown'
-            }\u001b[0m`
+            `${pre}Function: \u001b[34m${functionInfo.name}\u001b[0m [${selector}] - ${functionInfo.signature}`
           )
-
-          for (const selector of selectors)
-            try {
-              // Find matching function in ABI
-              const matchingFunction = resData.abi.find(
-                (abiItem: {
-                  type?: string
-                  name?: string
-                  inputs?: unknown[]
-                  outputs?: unknown[]
-                  stateMutability?: string
-                }) => {
-                  if (abiItem.type !== 'function' || !abiItem.name) return false
-                  try {
-                    // Create a proper ABI function for toFunctionSelector
-                    const abiFunction = {
-                      type: 'function' as const,
-                      name: abiItem.name,
-                      inputs: (abiItem.inputs || []) as Array<{
-                        type: string
-                        name?: string
-                      }>,
-                      outputs: (abiItem.outputs || []) as Array<{
-                        type: string
-                        name?: string
-                      }>,
-                      stateMutability:
-                        (abiItem.stateMutability as
-                          | 'pure'
-                          | 'view'
-                          | 'nonpayable'
-                          | 'payable') || 'nonpayable',
-                    }
-                    const calculatedSelector = toFunctionSelector(abiFunction)
-                    return calculatedSelector === selector
-                  } catch {
-                    return false
-                  }
-                }
-              )
-
-              if (matchingFunction)
-                consola.info(
-                  `${pre}Function: \u001b[34m${matchingFunction.name}\u001b[0m [${selector}]`
-                )
-              else consola.warn(`${pre}Unknown function [${selector}]`)
-            } catch (error) {
-              consola.warn(`${pre}Failed to decode selector: ${selector}`)
-            }
-        } else
-          consola.info(`${pre}Could not fetch ABI for facet ${facetAddress}`)
+          continue
+        }
+        const fourByteName = await lookupSelectorFromFourByte(
+          normalizedSelector
+        )
+        if (fourByteName)
+          consola.info(
+            `${pre}Function: \u001b[34m${fourByteName}\u001b[0m [${selector}] \u001b[90m(4byte.sourcify.dev)\u001b[0m`
+          )
+        else consola.warn(`${pre}Unknown function [${selector}]`)
       }
     } catch (error) {
       consola.error(`${pre}Error processing facet ${facetAddress}:`, error)

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1990,7 +1990,12 @@ export async function decodeDiamondCut(
       // without depending on a live facet contract.
       for (const selector of selectors) {
         const normalizedSelector =
-          typeof selector === 'string' ? selector.toLowerCase() : selector
+          typeof selector === 'string'
+            ? (selector.startsWith('0x')
+                ? selector
+                : `0x${selector}`
+              ).toLowerCase()
+            : `0x${Buffer.from(selector).toString('hex')}`.toLowerCase()
         const functionInfo = selectorMap?.get(normalizedSelector)
         if (functionInfo) {
           consola.info(


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-492

# Why did I implement it this way?

When displaying a pending Safe/timelock `diamondCut` (e.g. in `confirm-safe-tx.ts`), `decodeDiamondCut` names each selector. When the local `diamond.json` selector map is unavailable — the normal case, since `diamond.json` is generated and gitignored, so absent in fresh checkouts — it fell back to fetching the **facet's full ABI from `anyabi.xyz`**, keyed by facet address. For **Remove** actions the facet address is the zero address, so that lookup always failed and spammed `Could not fetch ABI for facet 0x0…` once per cut entry. It also used a bare `fetch()` that bypassed `fetchWithTimeout` (`[CONV:FETCH-TIMEOUT]`).

Selectors are already resolved individually — local diamond ABI first, then the 4byte/Sourcify signature DB via `lookupSelectorFromFourByte` — so the facet-by-address fetch is redundant. This replaces the `if (selectorMap) {…} else {anyabi}` split with a single map-optional loop that works for Add / Replace / Remove without depending on a live facet contract. Selector normalization now also handles `Uint8Array` and non-`0x` strings (mirroring `getContractNameFromSelectorsInOut`) so every selector reaches the map/lookup as a `0x`-prefixed lowercase hex string.

Scope is `script/deploy/safe/safe-utils.ts` only — no signature-DB endpoint change; the existing Sourcify endpoint is unchanged.

> Note: local `/pr-ready` (CodeRabbit CLI) ran and surfaced one finding (selector normalization), fixed in `ff50be67`. The confirming clean re-run was blocked by the CodeRabbit usage rate limit, so cloud CodeRabbit on this PR is relied upon for the final pass.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>