### PR TITLE
ci(EXSC-498): add Zeus QA review trigger workflow

### DIFF
--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -1,0 +1,66 @@
+name: Trigger Zeus QA Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: qa-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    if: github.event.label.name == 'Agent Review Request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.QA_APP_ID }}
+          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
+          owner: lifinance
+          repositories: QA
+
+      - name: Swap labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/Agent%20Review%20Request" || true
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Approved" || true
+          if ! gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=QA AI Reviewing"; then
+            echo "❌ Failed to apply QA AI Reviewing label — aborting"
+            exit 1
+          fi
+
+      - name: Dispatch to QA repo
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh api repos/lifinance/QA/actions/workflows/qa-run.yml/dispatches \
+            --method POST \
+            --field ref=main \
+            --field "inputs[scenario]=QAReviewContracts.md" \
+            --field "inputs[agent]=zeus" \
+            --field "inputs[ticket]=$PR_URL"
+
+      - name: Restore labels on dispatch failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Reviewing" || true
+          gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=Agent Review Request" || true
+          echo "⚠️ Dispatch failed — restored Agent Review Request label"

--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -1,3 +1,13 @@
+# Trigger Zeus QA Review
+# - Purpose: plugs the contracts repo into the lifinance/QA Zeus QA pipeline. Applying the
+#   "Agent Review Request" label swaps it for "QA AI Reviewing" and dispatches qa-run.yml in
+#   lifinance/QA (agent=zeus, scenario=QAReviewContracts.md, ticket=PR URL).
+# - Triggers: pull_request [labeled]; the job runs only when the applied label is
+#   "Agent Review Request".
+# - Key behaviors: label swap, cross-repo workflow_dispatch via a least-privilege GitHub App
+#   token, and label restore on dispatch failure so the trigger can simply be re-applied.
+# - Known limitations: requires the QA_APP_ID / QA_APP_PRIVATE_KEY secrets and the App
+#   installation to grant Actions:write on lifinance/QA; never touches protected audit labels.
 name: Trigger Zeus QA Review
 
 on:
@@ -14,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write
+      pull-requests: write # required to swap/restore the QA review labels on the PR
 
     steps:
       - name: Create GitHub App token
@@ -25,6 +35,7 @@ jobs:
           private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
           owner: lifinance
           repositories: QA
+          permission-actions: write # least privilege: token only dispatches qa-run.yml
 
       - name: Swap labels
         env:


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Closes https://linear.app/lifi-linear/issue/EXSC-498/add-zeus-qa-agent-review-trigger-to-lifinancecontracts-agent-review

# Why did I implement it this way?

This mirrors the trigger workflow already live in `lifinance/widget` so the contracts repo plugs into the existing Zeus QA pipeline with no new infrastructure: applying the **Agent Review Request** label swaps it for **QA AI Reviewing** and dispatches `qa-run.yml` in `lifinance/QA` with `agent=zeus`, `scenario=QAReviewContracts.md`, and the PR URL. On dispatch failure the original label is restored so the trigger can simply be re-applied. All actions are pinned to full commit SHAs per repo convention, and the workflow never touches the protected audit labels.

The repo-specific review logic (Solidity/Foundry/Diamond conventions, version + audit-log coherence, facet requirements, test conventions) lives in the new `qa-review-contracts` skill in `lifinance/QA` — companion PR there. Required GitHub labels (`Agent Review Request`, `QA AI Reviewing`, `QA AI Approved`) and the SmartContract-team Linear labels already exist. The workflow needs `QA_APP_ID` / `QA_APP_PRIVATE_KEY` secrets (same GitHub App the widget trigger uses).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
