### PR TITLE
feat(EXSC-388): register Tron periphery via Safe/Timelock MongoDB proposal

### DIFF
--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -3,13 +3,10 @@
 import { resolve } from 'path'
 
 import {
-  DEFAULT_SAFETY_MARGIN,
-  REGISTRATION_RETRY_DELAY_MS,
   REGISTRATION_RPC_DELAY_MS,
   TRON_ZERO_ADDRESS,
   TronContractDeployer,
   createTronWeb,
-  estimateEnergyAndFeeLimit,
   loadForgeArtifact,
   promptEnergyRentalReminder,
   tronAddressLikeToBase58,
@@ -20,6 +17,7 @@ import {
 } from '@lifi/tron-devkit'
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
+import { encodeFunctionData } from 'viem'
 
 import type { SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
@@ -41,12 +39,21 @@ import { ZERO_ADDRESS } from '../shared/constants.js'
 import { getContractVersion } from '../shared/getContractVersion'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
-import {
-  REGISTER_PERIPHERY_FEE_LIMIT_MAX_SUN,
-  REGISTER_PERIPHERY_FEE_LIMIT_MIN_SUN,
-} from './constants.js'
 import { getTronCorePeriphery } from './helpers/tronContractLists.js'
 import { getTronWallet } from './tronUtils.js'
+
+const PERIPHERY_REGISTRY_ABI = [
+  {
+    name: 'registerPeripheryContract',
+    type: 'function' as const,
+    inputs: [
+      { name: '_name', type: 'string' },
+      { name: '_contractAddress', type: 'address' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const
 
 /**
  * Deploy and register periphery contracts to Tron
@@ -1052,197 +1059,96 @@ async function deployAndRegisterPeripheryImpl(options: {
       }
     }
 
-    // Register all periphery contracts with the diamond (LiFiTimelockController is not registered)
+    // Register all periphery contracts with the diamond via Safe proposals
+    // (LiFiTimelockController is a governance contract and is never registered)
     consola.info(
-      '\n Registering periphery contracts with PeripheryRegistryFacet...'
+      '\n Registering periphery contracts with PeripheryRegistryFacet (via Safe proposals)...'
     )
 
-    if (!dryRun) {
-      // Load the PeripheryRegistryFacet ABI to interact with the diamond
-      const peripheryRegistryArtifact = await loadForgeArtifact(
-        'PeripheryRegistryFacet'
-      )
-      const diamond = tronWeb.contract(
-        peripheryRegistryArtifact.abi,
-        diamondAddress
-      )
+    // Load PeripheryRegistryFacet artifact for read-only "already registered" checks
+    const peripheryRegistryArtifact = await loadForgeArtifact(
+      'PeripheryRegistryFacet'
+    )
+    const diamond = tronWeb.contract(
+      peripheryRegistryArtifact.abi,
+      diamondAddress
+    )
 
-      await sleep(REGISTRATION_RPC_DELAY_MS)
+    await sleep(REGISTRATION_RPC_DELAY_MS)
 
-      for (const [name, address] of Object.entries(deployedContracts)) {
-        if (name === 'LiFiTimelockController') continue // governance contract, not registered with PeripheryRegistryFacet (same as EVM)
-        if (address && address !== 'FAILED')
-          try {
-            consola.info(`\n Registering ${name}...`)
+    for (const [name, address] of Object.entries(deployedContracts)) {
+      if (name === 'LiFiTimelockController') continue // governance contract, not registered with PeripheryRegistryFacet (same as EVM)
+      if (!address || address === 'FAILED' || address === 'SKIPPED') continue
 
-            await sleep(REGISTRATION_RPC_DELAY_MS)
-            // Check if already registered (retry on 429)
-            const registered = await retryWithRateLimit(
-              () => diamond.getPeripheryContract(name).call(),
-              3,
-              REGISTRATION_RETRY_DELAY_MS,
-              (attempt, delay) =>
-                consola.warn(
-                  `Rate limit (429) or connection issue, retry ${attempt}/3 in ${
-                    delay / 1000
-                  }s...`
-                )
+      try {
+        consola.info(`\n Registering ${name}...`)
+
+        await sleep(REGISTRATION_RPC_DELAY_MS)
+        // Skip if already registered at the same address (retry on 429)
+        const registered = await retryWithRateLimit(
+          () => diamond.getPeripheryContract(name).call(),
+          3,
+          REGISTRATION_RPC_DELAY_MS,
+          (attempt, delay) =>
+            consola.warn(
+              `Rate limit (429) or connection issue, retry ${attempt}/3 in ${
+                delay / 1000
+              }s...`
             )
+        )
 
-            if (
-              registered &&
-              typeof registered === 'string' &&
-              registered !== TRON_ZERO_ADDRESS
-            ) {
-              const registeredBase58 = tronAddressLikeToBase58(
-                tronWeb,
-                registered
-              )
-              const currentBase58 = tronAddressLikeToBase58(tronWeb, address)
+        if (
+          registered &&
+          typeof registered === 'string' &&
+          registered !== TRON_ZERO_ADDRESS
+        ) {
+          const registeredBase58 = tronAddressLikeToBase58(tronWeb, registered)
+          const currentBase58 = tronAddressLikeToBase58(tronWeb, address)
 
-              if (registeredBase58 === currentBase58) {
-                consola.info(`${name} already correctly registered`)
-                continue
-              } else {
-                consola.warn(`  ${name} registered with different address:`)
-                consola.warn(`   Current: ${registeredBase58}`)
-                consola.warn(`   New: ${currentBase58}`)
-
-                const shouldUpdate = await consola.prompt(
-                  `Update registration for ${name}?`,
-                  {
-                    type: 'confirm',
-                    initial: true,
-                  }
-                )
-
-                if (!shouldUpdate) {
-                  consola.info(`Keeping existing registration for ${name}`)
-                  continue
-                }
-              }
-            }
-
-            // Estimate energy and set fee limit so delegated energy is used first
-            let feeLimitSun = REGISTER_PERIPHERY_FEE_LIMIT_MAX_SUN
-            try {
-              const addressHex = tronRegistrationAddressToEvmHex(
-                tronWeb,
-                address
-              )
-              const registerParamsHex = tronWeb.utils.abi.encodeParams(
-                ['string', 'address'],
-                [name, addressHex]
-              )
-              await sleep(REGISTRATION_RPC_DELAY_MS)
-              const result = await retryWithRateLimit<
-                Awaited<ReturnType<typeof estimateEnergyAndFeeLimit>>
-              >(
-                () =>
-                  estimateEnergyAndFeeLimit({
-                    fullHost: rpcUrl,
-                    tronWeb,
-                    contractAddressBase58: diamondAddress,
-                    functionSelector:
-                      'registerPeripheryContract(string,address)',
-                    parameterHex: registerParamsHex,
-                    safetyMargin: DEFAULT_SAFETY_MARGIN,
-                    minFeeLimitSun: REGISTER_PERIPHERY_FEE_LIMIT_MIN_SUN,
-                    maxFeeLimitSun: REGISTER_PERIPHERY_FEE_LIMIT_MAX_SUN,
-                    label: `  ${name}`,
-                  }),
-                3,
-                REGISTRATION_RETRY_DELAY_MS,
-                (attempt, delay) =>
-                  consola.warn(
-                    `Rate limit (429), retry ${attempt}/3 in ${
-                      delay / 1000
-                    }s...`
-                  )
-              )
-              feeLimitSun = result.feeLimitSun
-            } catch (err: unknown) {
-              consola.warn(
-                `  Energy estimate failed, using ${
-                  feeLimitSun / 1_000_000
-                } TRX limit:`,
-                err instanceof Error ? err.message : err
-              )
-            }
-
-            // Register the contract (retry on 429)
-            await sleep(REGISTRATION_RPC_DELAY_MS)
-            const tx = (await retryWithRateLimit(
-              () =>
-                diamond.registerPeripheryContract(name, address).send({
-                  feeLimit: feeLimitSun,
-                  shouldPollResponse: true,
-                }),
-              3,
-              REGISTRATION_RETRY_DELAY_MS,
-              (attempt, delay) =>
-                consola.warn(
-                  `Rate limit (429) or connection issue, retry ${attempt}/3 in ${
-                    delay / 1000
-                  }s...`
-                )
-            )) as string | { txid?: string; transaction?: { txID?: string } }
-
-            consola.success(`${name} registered successfully`)
-            // TronWeb returns the transaction ID directly when shouldPollResponse is true
-            const txId =
-              typeof tx === 'string'
-                ? tx
-                : tx.txid || tx.transaction?.txID || String(tx)
-            consola.info(`   Transaction: ${txId}`)
-          } catch (error: any) {
-            consola.error(` Failed to register ${name}:`, error.message)
+          if (registeredBase58 === currentBase58) {
+            consola.info(`${name} already correctly registered`)
+            continue
           }
-      }
 
-      // Verify registrations
-      consola.info('\n Verifying registrations...')
-
-      for (const name of getTronCorePeriphery())
-        try {
-          await sleep(REGISTRATION_RPC_DELAY_MS)
-          const registered = await retryWithRateLimit(
-            () => diamond.getPeripheryContract(name).call(),
-            3,
-            REGISTRATION_RETRY_DELAY_MS,
-            (attempt, delay) =>
-              consola.warn(
-                `Rate limit (429) verifying ${name}, retry ${attempt}/3 in ${
-                  delay / 1000
-                }s...`
-              )
-          )
-
-          if (
-            registered &&
-            typeof registered === 'string' &&
-            registered !== TRON_ZERO_ADDRESS
-          ) {
-            const registeredBase58 = tronAddressLikeToBase58(
-              tronWeb,
-              registered
-            )
-            consola.success(`${name}: ${registeredBase58}`)
-
-            // Update tron.diamond.json with successfully registered periphery contract
-            const deployedAddress = deployedContracts[name]
-            if (deployedAddress && deployedAddress !== 'FAILED') {
-              const addressToSave = tronAddressLikeToBase58(
-                tronWeb,
-                deployedAddress
-              )
-
-              await updateDiamondJsonPeriphery(addressToSave, name, network)
-            }
-          } else consola.warn(`  ${name}: Not registered`)
-        } catch (error: any) {
-          consola.error(` Failed to verify ${name}:`, error.message)
+          consola.warn(`  ${name} registered with different address:`)
+          consola.warn(`   Current: ${registeredBase58}`)
+          consola.warn(`   New: ${currentBase58}`)
         }
+
+        const addressHex = tronRegistrationAddressToEvmHex(
+          tronWeb,
+          address
+        ) as `0x${string}`
+        const calldata = encodeFunctionData({
+          abi: PERIPHERY_REGISTRY_ABI,
+          functionName: 'registerPeripheryContract',
+          args: [name, addressHex],
+        })
+
+        // Registration goes through the Safe → Timelock governance flow: this
+        // creates a pending proposal in MongoDB rather than sending a direct tx,
+        // so other Safe owners can co-sign before it executes on-chain.
+        const { runPropose } = await import('./propose-to-safe-tron.js')
+        await runPropose({
+          network: tvmKey,
+          to: diamondAddress,
+          calldata,
+          timelock: true,
+          dryRun,
+        })
+
+        // Record the pending registration in tron.diamond.json
+        await updateDiamondJsonPeriphery(
+          tronAddressLikeToBase58(tronWeb, address),
+          name,
+          network
+        )
+      } catch (err: unknown) {
+        consola.error(
+          ` Failed to propose registration for ${name}:`,
+          err instanceof Error ? err.message : err
+        )
+      }
     }
 
     // Print summary


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-388 (stacked on #1890). Small internal PR targeting the `feat/exsc-388-deploy-outputvalidator-all-chains` branch.

# Why did I implement it this way?

The OutputValidator restore commit on this branch (`4ce5a0f8` — *"restore Tron deploy script with OutputValidator"*) reverted Tron periphery **registration** from the Safe/Timelock proposal flow back to **direct** on-chain `registerPeripheryContract(name, address).send()` calls signed by the deployer key. This PR restores the governance flow that was lost in that revert.

What it does in `script/deploy/tron/deploy-and-register-periphery.ts`:

- For each deployed periphery contract, build the `registerPeripheryContract(string,address)` calldata (`viem` `encodeFunctionData` + a local `PERIPHERY_REGISTRY_ABI`) and route it through `runPropose` from `propose-to-safe-tron.ts`, which schedules `Timelock.scheduleBatch` via the Safe and **stores a pending proposal in MongoDB** for co-signers — instead of sending a direct deployer-signed tx.
- Record the pending registration in `tron.diamond.json` (`updateDiamondJsonPeriphery`) right after proposing.
- Keep the read-only "already registered at the same address?" short-circuit.

The **OutputValidator deploy step added on this branch is left untouched** — only the registration mechanism changes.

Cleanups that follow from the switch:
- Removed the now-unused direct-registration energy/fee-limit estimation and the post-registration on-chain verification loop (registrations are *pending* until the proposal executes, so an immediate on-chain read is meaningless).
- Dropped the now-unused imports (`estimateEnergyAndFeeLimit`, `DEFAULT_SAFETY_MARGIN`, `REGISTRATION_RETRY_DELAY_MS`, `REGISTER_PERIPHERY_FEE_LIMIT_MIN_SUN/MAX_SUN`); added `encodeFunctionData` and the local ABI.

Net: `+93 / −187` in one file. Aligns Tron periphery registration with the Safe/Timelock governance model used elsewhere rather than a direct deployer-key write.

Local checks: `bunx tsc-files --noEmit` → passes; `bunx eslint` → 0 errors (pre-existing `catch (error: any)` warnings only, none introduced here).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
