### PR TITLE
chore: invoke TS scripts via bunx tsx in helperFunctions.sh (EXSC-502)

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -110,7 +110,7 @@ function logContractDeploymentInfo {
 
   # Build MongoDB command as array for safe execution
   local MONGO_CMD=(
-    bun script/deploy/update-deployment-logs.ts add
+    bunx tsx script/deploy/update-deployment-logs.ts add
     --env "$ENVIRONMENT"
     --contract "$CONTRACT"
     --network "$NETWORK"
@@ -317,12 +317,12 @@ function findContractInMasterLogByAddress() {
       fi
 
       if [[ "$USE_CACHE" == "true" ]]; then
-        MONGO_RESULT=$(bun script/deploy/query-deployment-logs.ts find \
+        MONGO_RESULT=$(bunx tsx script/deploy/query-deployment-logs.ts find \
           --env "$ENV_TRY" \
           --network "$NETWORK" \
           --address "$TARGET_ADDRESS" 2>/dev/null)
       else
-        MONGO_RESULT=$(bun script/deploy/query-deployment-logs.ts find \
+        MONGO_RESULT=$(bunx tsx script/deploy/query-deployment-logs.ts find \
           --env "$ENV_TRY" \
           --network "$NETWORK" \
           --address "$TARGET_ADDRESS" \
@@ -384,7 +384,7 @@ function getContractVersionFromMasterLog() {
     echoDebug "Querying MongoDB for getContractVersionFromMasterLog: $CONTRACT $TARGET_ADDRESS (attempt $attempt/$MONGO_MAX_RETRIES)"
     local MONGO_RESULT
     local EXIT_CODE
-    MONGO_RESULT=$(bun script/deploy/query-deployment-logs.ts find \
+    MONGO_RESULT=$(bunx tsx script/deploy/query-deployment-logs.ts find \
       --env="$ENVIRONMENT" \
       --network="$NETWORK" \
       --address="$TARGET_ADDRESS" 2>/dev/null)
@@ -434,7 +434,7 @@ function getHighestDeployedContractVersionFromMasterLog() {
     echoDebug "Querying MongoDB for getHighestDeployedContractVersionFromMasterLog: $CONTRACT (attempt $attempt/$MONGO_MAX_RETRIES)"
     local MONGO_RESULT
     local EXIT_CODE
-    MONGO_RESULT=$(bun script/deploy/query-deployment-logs.ts filter \
+    MONGO_RESULT=$(bunx tsx script/deploy/query-deployment-logs.ts filter \
       --env="$ENVIRONMENT" \
       --contract="$CONTRACT" \
       --network="$NETWORK" \
@@ -484,7 +484,7 @@ function queryMongoDeployment() {
   local ENVIRONMENT="$3"
   local VERSION="$4"
 
-  bun script/deploy/query-deployment-logs.ts get \
+  bunx tsx script/deploy/query-deployment-logs.ts get \
     --env "$ENVIRONMENT" \
     --contract "$CONTRACT" \
     --network "$NETWORK" \
@@ -498,7 +498,7 @@ function checkMongoDeploymentExists() {
   local ENVIRONMENT="$3"
   local VERSION="$4"
 
-  bun script/deploy/query-deployment-logs.ts exists \
+  bunx tsx script/deploy/query-deployment-logs.ts exists \
     --env="$ENVIRONMENT" \
     --contract="$CONTRACT" \
     --network="$NETWORK" \
@@ -511,7 +511,7 @@ function getLatestMongoDeployment() {
   local NETWORK="$2"
   local ENVIRONMENT="$3"
 
-  bun script/deploy/query-deployment-logs.ts latest \
+  bunx tsx script/deploy/query-deployment-logs.ts latest \
     --env="$ENVIRONMENT" \
     --contract="$CONTRACT" \
     --network="$NETWORK" 2>/dev/null
@@ -523,7 +523,7 @@ function getUnverifiedContractsFromMongo() {
 
   echoDebug "Getting unverified contracts from MongoDB"
 
-  bun script/deploy/query-deployment-logs.ts filter \
+  bunx tsx script/deploy/query-deployment-logs.ts filter \
     --env="$ENVIRONMENT" \
     --verified=false \
     --limit=1000 2>/dev/null
@@ -803,7 +803,7 @@ function getConstructorArgsFromMasterLog() {
     echoDebug "Querying MongoDB for getConstructorArgsFromMasterLog: $CONTRACT $NETWORK $VERSION (attempt $attempt/$MONGO_MAX_RETRIES)"
     local MONGO_RESULT
     local EXIT_CODE
-    MONGO_RESULT=$(bun script/deploy/query-deployment-logs.ts get \
+    MONGO_RESULT=$(bunx tsx script/deploy/query-deployment-logs.ts get \
       --env "$ENVIRONMENT" \
       --contract "$CONTRACT" \
       --network "$NETWORK" \


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-502](https://linear.app/lifi-linear/issue/EXSC-502/replace-bare-bun-ts-invocations-with-bunx-tsx-in-helperfunctionssh)

# Why did I implement it this way?

Rule `.agents/rules/200-typescript.md` mandates invoking TS scripts via `bunx tsx ./script/path.ts` — bare `bun ./script/path.ts` bypasses the pinned local `tsx` and the project's `node_modules` resolution for bare-specifier imports. `script/helperFunctions.sh` predates the rule and carried 10 bare-`bun` call sites (`query-deployment-logs.ts`, `update-deployment-logs.ts`), flagged as pre-existing debt during review of #1896. This is the mechanical sweep: 10 lines, invocation form only, no behavior change.

Verified: `bash -n` clean; `bunx tsx script/deploy/query-deployment-logs.ts latest --contract LiFiDiamond --network mainnet --environment production` performs a real MongoDB round-trip successfully from the rewritten invocation form.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug (n/a — mechanical invocation-form change, covered by existing CI usage of these helpers)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e (n/a)
- [ ] I have updated any required documentation (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)