### PR TITLE
fix(tron): update OutputValidator address to redeployed instance

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -11049,7 +11049,7 @@
       },
       {
         "name": "OutputValidator",
-        "address": "TTumBQrmwWGacj7LEybnnxgHVxamJqFAWq",
+        "address": "TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR",
         "selectors": [
           {
             "selector": "0x27444dab",

--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -78,7 +78,7 @@
       "GasZipPeriphery": "",
       "LiFiDEXAggregator": "",
       "LidoWrapper": "",
-      "OutputValidator": "TTumBQrmwWGacj7LEybnnxgHVxamJqFAWq",
+      "OutputValidator": "TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR",
       "Patcher": "",
       "Permit2Proxy": "",
       "ReceiverAcrossV3": "",

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -22,5 +22,5 @@
   "ERC20Proxy": "TDCo8wrqwRVC7HaRAAsuCdbnS4AdAdtcn9",
   "Executor": "TUJnqSDodwaDo2HFX2Ct2JsVEzWFpkAbht",
   "FeeForwarder": "TBiwoFZpHoSG1NkdpTvgSi7bDm1W8DdAF8",
-  "OutputValidator": "TTumBQrmwWGacj7LEybnnxgHVxamJqFAWq"
+  "OutputValidator": "TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR"
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-388 (follow-up). Trivial deploy-log/whitelist address correction — suggest labelling `trivial`.

# Why did I implement it this way?

`OutputValidator` on Tron was redeployed; its live address is `TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR`, but the deploy logs and whitelist still pointed at the previous instance `TTumBQrmwWGacj7LEybnnxgHVxamJqFAWq`. This updates the three places that reference it:

- `deployments/tron.json` → `OutputValidator`
- `deployments/tron.diamond.json` → `LiFiDiamond.Periphery.OutputValidator`
- `config/whitelist.json` → `PERIPHERY.tron[]` entry named `OutputValidator` (selectors unchanged: `validateERC20Output` / `validateNativeOutput`)

The diff is exactly **3 files, 1 line each** — only the address value changes, nothing else. This PR targets `main` (the required base for whitelist changes per the repo's whitelist-branching policy).

The on-chain re-registration (PeripheryRegistry: `TTumBQ… → TGYGf6…`) is handled separately via a pending Safe/Timelock proposal on Tron; this PR only brings the repo's recorded addresses in line with the deployed contract.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
