### PR TITLE
fix(EXSC-503): gate timelock queue 'executed' on on-chain confirmation

### DIFF
--- a/script/deploy/safe/confirm-timelock-execution.test.ts
+++ b/script/deploy/safe/confirm-timelock-execution.test.ts
@@ -1,0 +1,142 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { confirmTimelockExecution } from './confirm-timelock-execution'
+
+/** Builds an isOperationDone stub returning the given results in order (sticky last value). */
+function isOperationDoneStub(results: Array<boolean | Error>): {
+  isOperationDone: () => Promise<boolean>
+  calls: () => number
+} {
+  let callCount = 0
+  return {
+    isOperationDone: async () => {
+      const result =
+        results[Math.min(callCount, results.length - 1)] ?? new Error('empty')
+      callCount++
+      if (result instanceof Error) throw result
+      return result
+    },
+    calls: () => callCount,
+  }
+}
+
+const FAST_POLL = { attempts: 3, delayMs: 1 }
+
+describe('confirmTimelockExecution', () => {
+  it('returns reverted for a reverted receipt without checking on-chain state', async () => {
+    const stub = isOperationDoneStub([true])
+
+    const result = await confirmTimelockExecution({
+      receipt: { status: 'reverted' },
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('reverted')
+    expect(stub.calls()).toBe(0)
+  })
+
+  it('returns confirmed for a success receipt once isOperationDone is true', async () => {
+    const stub = isOperationDoneStub([true])
+
+    const result = await confirmTimelockExecution({
+      receipt: { status: 'success' },
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('confirmed')
+    expect(stub.calls()).toBe(1)
+  })
+
+  it('returns unconfirmed for a success receipt when isOperationDone stays false', async () => {
+    const stub = isOperationDoneStub([false])
+
+    const result = await confirmTimelockExecution({
+      receipt: { status: 'success' },
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('unconfirmed')
+    expect(stub.calls()).toBe(3)
+  })
+
+  it('returns confirmed without a receipt when isOperationDone is true on first poll', async () => {
+    const stub = isOperationDoneStub([true])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('confirmed')
+    expect(stub.calls()).toBe(1)
+  })
+
+  it('keeps polling without a receipt until isOperationDone turns true', async () => {
+    const stub = isOperationDoneStub([false, false, true])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('confirmed')
+    expect(stub.calls()).toBe(3)
+  })
+
+  it('returns unconfirmed without a receipt after exhausting all attempts', async () => {
+    const stub = isOperationDoneStub([false])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('unconfirmed')
+    expect(stub.calls()).toBe(3)
+  })
+
+  it('tolerates transient isOperationDone errors and still confirms', async () => {
+    const stub = isOperationDoneStub([new Error('rpc hiccup'), true])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('confirmed')
+    expect(stub.calls()).toBe(2)
+  })
+
+  it('returns unconfirmed when every isOperationDone check throws', async () => {
+    const stub = isOperationDoneStub([new Error('rpc down')])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      ...FAST_POLL,
+    })
+
+    expect(result).toBe('unconfirmed')
+    expect(stub.calls()).toBe(3)
+  })
+
+  it('returns unconfirmed without polling when attempts is zero', async () => {
+    const stub = isOperationDoneStub([true])
+
+    const result = await confirmTimelockExecution({
+      isOperationDone: stub.isOperationDone,
+      attempts: 0,
+      delayMs: 1,
+    })
+
+    expect(result).toBe('unconfirmed')
+    expect(stub.calls()).toBe(0)
+  })
+})

--- a/script/deploy/safe/confirm-timelock-execution.ts
+++ b/script/deploy/safe/confirm-timelock-execution.ts
@@ -1,0 +1,65 @@
+/**
+ * On-chain confirmation gate for timelock `executeBatch` submissions.
+ * Used by `execute-pending-timelock-tx.ts` to decide whether a queue row may
+ * be flipped to `executed` after broadcasting an execution transaction.
+ */
+
+import { consola } from 'consola'
+import type { TransactionReceipt } from 'viem'
+
+import { sleep } from '../../utils/delay'
+
+export type TimelockExecutionConfirmation =
+  | 'confirmed'
+  | 'reverted'
+  | 'unconfirmed'
+
+export interface IConfirmTimelockExecutionParams {
+  /** Receipt from the chain caller, when the chain confirmed synchronously. Absent on confirmation timeout and on chains without synchronous receipts (e.g. Tron). */
+  receipt?: Pick<TransactionReceipt, 'status'>
+  /** Reads `isOperationDone(operationId)` from the timelock controller. */
+  isOperationDone: () => Promise<boolean>
+  /** Maximum number of on-chain checks before giving up. */
+  attempts?: number
+  /** Delay between on-chain checks in milliseconds. */
+  delayMs?: number
+}
+
+const DEFAULT_ATTEMPTS = 10
+const DEFAULT_DELAY_MS = 5000 // 5 s between polls (~50 s total) — covers txs that outlive the caller's 30 s receipt wait
+
+/**
+ * Confirms whether a submitted `executeBatch` transaction actually executed
+ * the timelock operation on-chain.
+ *
+ * A missing receipt is never treated as success: the operation counts as
+ * executed only when `isOperationDone` reports true on-chain. Transient
+ * `isOperationDone` errors are retried until attempts are exhausted.
+ *
+ * @param params - Receipt (if any), the on-chain check, and poll tuning.
+ * @returns `reverted` for a failed receipt, `confirmed` once the operation is
+ *   done on-chain, otherwise `unconfirmed` (caller must keep the op retryable).
+ */
+export async function confirmTimelockExecution(
+  params: IConfirmTimelockExecutionParams
+): Promise<TimelockExecutionConfirmation> {
+  const { receipt, isOperationDone } = params
+  const attempts = params.attempts ?? DEFAULT_ATTEMPTS
+  const delayMs = params.delayMs ?? DEFAULT_DELAY_MS
+
+  if (receipt && receipt.status !== 'success') return 'reverted'
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) await sleep(delayMs)
+    try {
+      if (await isOperationDone()) return 'confirmed'
+    } catch (error) {
+      consola.warn(
+        `isOperationDone check failed (attempt ${attempt + 1}/${attempts}):`,
+        error
+      )
+    }
+  }
+
+  return 'unconfirmed'
+}

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -32,6 +32,7 @@ import {
   type IProcessingStats,
 } from '../../utils/slack-notifier'
 
+import { confirmTimelockExecution } from './confirm-timelock-execution'
 import { createChainCaller } from './executors/create-chain-caller'
 import { formatTimelockScheduleBatch } from './safe-decode-utils'
 import {
@@ -664,6 +665,7 @@ async function processNetwork(
 
         const result = await executeOperation(
           chainCaller,
+          publicClient,
           timelockAddress,
           operation,
           isDryRun,
@@ -1052,6 +1054,7 @@ async function getPendingOperations(
 
 async function executeOperation(
   chainCaller: IChainCaller,
+  publicClient: PublicClient,
   timelockAddress: Address,
   operation: ITimelockOperation,
   isDryRun: boolean,
@@ -1179,10 +1182,54 @@ async function executeOperation(
         `${networkPrefix}    Transaction hash: ${result.hash}${txExplorerSuffix}`
       )
 
-      if (result.receipt && result.receipt.status !== 'success') {
+      // A missing receipt (confirmation timeout, or chains without synchronous
+      // receipts like Tron) must not count as success — only flip the queue row
+      // once isOperationDone confirms the op on-chain (EXSC-503).
+      const confirmation = await confirmTimelockExecution({
+        receipt: result.receipt,
+        isOperationDone: () =>
+          publicClient.readContract({
+            address: timelockAddress,
+            abi: TIMELOCK_ABI,
+            functionName: 'isOperationDone',
+            args: [operation.id],
+          }),
+      })
+
+      if (confirmation === 'reverted') {
         consola.error(
           `${networkPrefix} ❌ Transaction failed for operation ${operation.id}`
         )
+        return 'failed'
+      }
+
+      if (confirmation === 'unconfirmed') {
+        consola.warn(
+          `${networkPrefix} ⚠️ Execution of operation ${operation.id} not confirmed on-chain (tx ${result.hash}); leaving queue row 'queued' for retry`
+        )
+        if (slackNotifier && networkName)
+          try {
+            await slackNotifier.notifyOperationFailed({
+              network: networkName,
+              operation: {
+                id: operation.id,
+                target: primaryTarget,
+                value: primaryValue,
+                data: primaryPayload,
+                functionName: operation.functionName,
+              },
+              status: 'failed',
+              error: new Error(
+                `executeBatch tx ${result.hash} not confirmed on-chain; operation left queued for retry`
+              ),
+            })
+          } catch (notifyError) {
+            consola.warn(
+              'Failed to send operation failure notification:',
+              notifyError
+            )
+          }
+
         return 'failed'
       }
 

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -1071,6 +1071,30 @@ async function executeOperation(
   const primaryPayload = operation.payloads[0]
   if (!primaryTarget || primaryValue === undefined || !primaryPayload)
     throw new Error('Invalid operation: missing target/value/payload')
+
+  const notifyFailure = async (error: unknown): Promise<void> => {
+    if (!slackNotifier || !networkName) return
+    try {
+      await slackNotifier.notifyOperationFailed({
+        network: networkName,
+        operation: {
+          id: operation.id,
+          target: primaryTarget,
+          value: primaryValue,
+          data: primaryPayload,
+          functionName: operation.functionName,
+        },
+        status: 'failed',
+        error,
+      })
+    } catch (notifyError) {
+      consola.warn(
+        'Failed to send operation failure notification:',
+        notifyError
+      )
+    }
+  }
+
   consola.info(
     `\n${networkPrefix} ⚡ Processing operation: ${operation.id} (batch of ${callCount} calls)`
   )
@@ -1200,6 +1224,9 @@ async function executeOperation(
         consola.error(
           `${networkPrefix} ❌ Transaction failed for operation ${operation.id}`
         )
+        await notifyFailure(
+          new Error(`executeBatch tx ${result.hash} reverted on-chain`)
+        )
         return 'failed'
       }
 
@@ -1207,29 +1234,11 @@ async function executeOperation(
         consola.warn(
           `${networkPrefix} ⚠️ Execution of operation ${operation.id} not confirmed on-chain (tx ${result.hash}); leaving queue row 'queued' for retry`
         )
-        if (slackNotifier && networkName)
-          try {
-            await slackNotifier.notifyOperationFailed({
-              network: networkName,
-              operation: {
-                id: operation.id,
-                target: primaryTarget,
-                value: primaryValue,
-                data: primaryPayload,
-                functionName: operation.functionName,
-              },
-              status: 'failed',
-              error: new Error(
-                `executeBatch tx ${result.hash} not confirmed on-chain; operation left queued for retry`
-              ),
-            })
-          } catch (notifyError) {
-            consola.warn(
-              'Failed to send operation failure notification:',
-              notifyError
-            )
-          }
-
+        await notifyFailure(
+          new Error(
+            `executeBatch tx ${result.hash} not confirmed on-chain; operation left queued for retry`
+          )
+        )
         return 'failed'
       }
 
@@ -1297,27 +1306,7 @@ async function executeOperation(
       error
     )
 
-    // Send Slack notification for failure if enabled
-    if (slackNotifier && networkName && !isDryRun)
-      try {
-        await slackNotifier.notifyOperationFailed({
-          network: networkName,
-          operation: {
-            id: operation.id,
-            target: primaryTarget,
-            value: primaryValue,
-            data: primaryPayload,
-            functionName: operation.functionName,
-          },
-          status: 'failed',
-          error,
-        })
-      } catch (notifyError) {
-        consola.warn(
-          'Failed to send operation failure notification:',
-          notifyError
-        )
-      }
+    if (!isDryRun) await notifyFailure(error)
 
     return 'failed'
   }

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -917,6 +917,38 @@ async function getPendingOperations(
           await timelockQueue.updateOne(byOperationId(networkName, opId), {
             $set: { status: 'executed', executedAt: now, updatedAt: now },
           })
+
+          // Close the alert loop: a row left 'queued' by an unconfirmed run
+          // already emitted a failure notification, so the retroactive
+          // discovery of its success must be announced too (EXSC-503).
+          const primaryTarget = targets[0]
+          const primaryValue = values[0]
+          const primaryPayload = payloads[0]
+          if (
+            slackNotifier &&
+            primaryTarget &&
+            primaryValue !== undefined &&
+            primaryPayload
+          )
+            try {
+              await slackNotifier.notifyOperationExecuted({
+                network: networkName,
+                operation: {
+                  id: opId,
+                  target: primaryTarget,
+                  value: primaryValue,
+                  data: primaryPayload,
+                  functionName: `batch (${targets.length} calls) — found already executed on-chain`,
+                },
+                status: 'success',
+                transactionHash: row.executionTxHash,
+              })
+            } catch (error) {
+              consola.warn(
+                'Failed to send reconciled-execution notification:',
+                error
+              )
+            }
           continue
         }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-503](https://linear.app/lifi-linear/issue/EXSC-503/timelock-executor-marks-ops-executed-without-confirming-on-chain)

# Why did I implement it this way?

`executeOperation` in `execute-pending-timelock-tx.ts` only treated an execution as failed when a receipt was present **and** reverted. But `EvmChainCaller.call()` returns `{ hash }` without a receipt when receipt confirmation times out after 30s, and the Tron caller never returns a receipt at all — so a dropped/unmined `executeBatch` fell through to the `status: 'executed'` Mongo update, orphaning the op (still ready on-chain, never retried). This is what stranded the Linea MayanFacet v1.3.0 diamondCut.

Because a receipt can legitimately be absent (Tron by design, EVM on timeout), "missing receipt = failure" would break Tron executions. The reliable signal is the timelock itself: the queue row is now flipped to `executed` only after `isOperationDone(opId)` reports true on-chain — even when a receipt claims success.

The confirmation gate lives in a new module `confirm-timelock-execution.ts` rather than inline because the runner script calls `runMain(cmd)` at module scope, making it untestable via import. The helper returns `'reverted' | 'confirmed' | 'unconfirmed'`:

- `reverted` (receipt present, status reverted) → fail fast, no polling
- `confirmed` (`isOperationDone` true, polled up to 10 × 5s, RPC-error tolerant) → mark row `executed`
- `unconfirmed` → row **stays `queued`** so the next run retries it; run reports failure and notifies Slack

Slack alert lifecycle is symmetric: all three failure paths in `executeOperation` (reverted, unconfirmed, thrown error) notify via a shared `notifyFailure` helper, and when a later run's reconcile path discovers a `queued` row is already done on-chain (the retry converging, or a manual execution), it sends a success notification so the earlier failure alert is visibly closed out.

Not included (flagged as follow-ups in the ticket): a reconcile sweep for already-`executed` rows, and the manual re-queue of the orphaned Linea row `0x64f1…d6db`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

