### PR TITLE
fix: surface failing-job link + real error in timelock executor Slack alerts

### DIFF
--- a/.github/workflows/runPendingTimelockTXs.yml
+++ b/.github/workflows/runPendingTimelockTXs.yml
@@ -98,7 +98,19 @@ jobs:
           PRIVATE_KEY_PRODUCTION: ${{ secrets.TIMELOCK_EXECUTOR_PRIVATE_KEY }}
           SLACK_WEBHOOK_URL: ${{ secrets.TIMELOCK_SLACK_WEBHOOK_URL }}
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          GH_TOKEN: ${{ github.token }} # required by `gh api` to resolve the job's html_url
+          # Fallback link (run overview); upgraded to a deep job link below when the jobs API is reachable.
+          RUN_OVERVIEW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          ##### Resolve a deep-link to THIS job so the executor's own Slack notifications
+          # (which fire on the happy path AND on per-operation failures) point straight at
+          # the failing job and its logs. github.job is the job key, not the numeric id the
+          # URL needs, so resolve the job's html_url via the jobs API; fall back to the run
+          # overview if it can't be read.
+          RESOLVED_URL=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.name == "${{ github.job }}") | .html_url][0] // .jobs[0].html_url' 2>/dev/null || true)
+          export TIMELOCK_RUN_URL="${RESOLVED_URL:-$RUN_OVERVIEW_URL}"
+
           ##### Run the executor and tee stdout+stderr to execution.log on disk.
           # The log file is read by the Slack failure step and uploaded as an artifact,
           # so we deliberately do NOT push it through $GITHUB_OUTPUT (1 MB cap, template-injection risk).

--- a/.github/workflows/runPendingTimelockTXs.yml
+++ b/.github/workflows/runPendingTimelockTXs.yml
@@ -49,6 +49,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read # required to checkout the repository
+      actions: read # required to resolve this job's URL (jobs API) for the Slack deep-link
 
     steps:
       - name: Checkout repository
@@ -113,7 +114,10 @@ jobs:
         env:
           # All values flow via env to avoid ${{ }} expansion inside shell/Python (template-injection risk).
           SLACK_WEBHOOK_URL: ${{ secrets.TIMELOCK_SLACK_WEBHOOK_URL }}
+          # Fallback link (run overview); the bash body below upgrades this to a deep
+          # link to THIS job (and its failing step) when the jobs API is reachable.
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ github.token }} # required by `gh api` to resolve the job's html_url
           TRIGGER: ${{ github.event_name }}
         run: |
           ##### Fallback notification for when the script crashes before its own SlackNotifier can fire.
@@ -126,6 +130,17 @@ jobs:
           if [ -f execution.log ] && grep -q "Parallel execution summary" execution.log; then
             echo "Executor already sent its own Slack summary; skipping fallback."
             exit 0
+          fi
+
+          ##### Deep-link straight to THIS job (…/runs/<run>/job/<job_id>) so the Slack
+          # link lands on the failing job (and its failing step) rather than the run
+          # overview. github.job is the job key, not the numeric id the URL needs, so
+          # resolve the job's html_url via the jobs API; keep the run-overview WORKFLOW_URL
+          # as the fallback if it can't be read.
+          RESOLVED_URL=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '[.jobs[] | select(.name == "${{ github.job }}") | .html_url][0] // .jobs[0].html_url' 2>/dev/null || true)
+          if [ -n "${RESOLVED_URL}" ]; then
+            export WORKFLOW_URL="${RESOLVED_URL}"
           fi
 
           ##### Extract errors from the on-disk log. The log may not exist if an earlier step

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -169,7 +169,13 @@ const cmd = defineCommand({
     if (notifyWebhook)
       try {
         new URL(notifyWebhook) // Validate webhook URL format
-        slackNotifier = new SlackNotifier(notifyWebhook)
+        // In CI the workflow exports a deep-link to the running job; when present
+        // it is surfaced in failure/summary notifications so on-call can jump
+        // straight to the failing logs. Absent for local runs.
+        slackNotifier = new SlackNotifier(
+          notifyWebhook,
+          process.env.TIMELOCK_RUN_URL
+        )
         consola.info('📢 Slack notifications enabled')
       } catch (error) {
         consola.error('❌ Invalid Slack webhook URL provided')

--- a/script/utils/slack-notifier.test.ts
+++ b/script/utils/slack-notifier.test.ts
@@ -108,4 +108,21 @@ describe('SlackNotifier payload safety', () => {
     expect(errorBlock).toBeDefined()
     expect(errorBlock?.text?.text.length ?? 0).toBeLessThanOrEqual(3000)
   })
+
+  it('does not throw when the error is a circular, non-serializable object', async () => {
+    const getPayload = mockFetchCapturing()
+    const circular: Record<string, unknown> = {}
+    circular.self = circular // JSON.stringify would throw on this
+
+    await new SlackNotifier(WEBHOOK).notifyOperationFailed({
+      network: 'tron',
+      operation: baseOp,
+      status: 'failed',
+      error: circular,
+    })
+
+    const blocks = (getPayload().blocks ?? []) as unknown as ICapturedBlock[]
+    const errorBlock = blocks.find((b) => b.text?.text?.includes('*Error:*'))
+    expect(errorBlock).toBeDefined()
+  })
 })

--- a/script/utils/slack-notifier.test.ts
+++ b/script/utils/slack-notifier.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for SlackNotifier's CI-link and payload-safety behavior: the optional
+ * run URL must surface as a deep-link on failure/summary messages, and
+ * oversized error text must be clamped so Slack never rejects the blocks.
+ */
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  mock,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { SlackNotifier } from './slack-notifier'
+import type { ISlackMessage } from './slack-notifier'
+
+const WEBHOOK = 'https://hooks.slack.com/services/T000/B000/xxx'
+const RUN_URL = 'https://github.com/lifinance/contracts/actions/runs/1/job/2'
+
+interface ICapturedBlock {
+  type: string
+  text?: { type: string; text: string }
+  elements?: { type: string; text: string }[]
+}
+
+/**
+ * Stub global fetch so notifications are captured instead of sent. Returns the
+ * parsed Slack payload from the most recent call.
+ */
+function mockFetchCapturing(): () => ISlackMessage {
+  let lastBody = ''
+  global.fetch = mock(async (_url: string, init?: { body?: string }) => {
+    lastBody = init?.body ?? ''
+    return new Response('ok', { status: 200 })
+  }) as unknown as typeof fetch
+  return () => JSON.parse(lastBody) as ISlackMessage
+}
+
+const baseOp = {
+  id: '0xabc123' as `0x${string}`,
+  target: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+  value: 0n,
+  data: '0x' as `0x${string}`,
+  functionName: 'batch',
+}
+
+const originalFetch = global.fetch
+
+afterEach(() => {
+  global.fetch = originalFetch
+  mock.restore()
+})
+
+describe('SlackNotifier run-link', () => {
+  it('appends a "View workflow run" context block to failures when runUrl is set', async () => {
+    const getPayload = mockFetchCapturing()
+    await new SlackNotifier(WEBHOOK, RUN_URL).notifyOperationFailed({
+      network: 'tron',
+      operation: baseOp,
+      status: 'failed',
+      error: new Error('boom'),
+    })
+
+    const blocks = (getPayload().blocks ?? []) as unknown as ICapturedBlock[]
+    const ctx = blocks.find((b) => b.type === 'context')
+    expect(ctx).toBeDefined()
+    expect(ctx?.elements?.[0]?.text).toBe(`<${RUN_URL}|View workflow run>`)
+  })
+
+  it('omits the run-link block when no runUrl is configured', async () => {
+    const getPayload = mockFetchCapturing()
+    await new SlackNotifier(WEBHOOK).notifyOperationFailed({
+      network: 'tron',
+      operation: baseOp,
+      status: 'failed',
+      error: new Error('boom'),
+    })
+
+    const blocks = (getPayload().blocks ?? []) as unknown as ICapturedBlock[]
+    expect(blocks.some((b) => b.type === 'context')).toBe(false)
+  })
+
+  it('adds the run-link to batch summaries as well', async () => {
+    const getPayload = mockFetchCapturing()
+    await new SlackNotifier(WEBHOOK, RUN_URL).notifyBatchSummary([
+      { network: 'tron', success: false, error: new Error('nope') },
+    ])
+
+    const blocks = (getPayload().blocks ?? []) as unknown as ICapturedBlock[]
+    expect(blocks.some((b) => b.type === 'context')).toBe(true)
+  })
+})
+
+describe('SlackNotifier payload safety', () => {
+  it('clamps an oversized error message below the Slack 3000-char block limit', async () => {
+    const getPayload = mockFetchCapturing()
+    const huge = 'x'.repeat(8000)
+    await new SlackNotifier(WEBHOOK).notifyOperationFailed({
+      network: 'tron',
+      operation: baseOp,
+      status: 'failed',
+      error: new Error(huge),
+    })
+
+    const blocks = (getPayload().blocks ?? []) as unknown as ICapturedBlock[]
+    const errorBlock = blocks.find((b) => b.text?.text?.includes('*Error:*'))
+    expect(errorBlock).toBeDefined()
+    expect(errorBlock?.text?.text.length ?? 0).toBeLessThanOrEqual(3000)
+  })
+})

--- a/script/utils/slack-notifier.ts
+++ b/script/utils/slack-notifier.ts
@@ -50,13 +50,27 @@ interface IProcessingStats {
   duration?: number
 }
 
+// Slack rejects any single block text element longer than 3000 chars with
+// `invalid_blocks`. Cap error/detail text below that so an oversized RPC error
+// (e.g. a Tron broadcast failure that echoes the whole raw transaction) still
+// posts instead of being dropped.
+const SLACK_TEXT_LIMIT = 2900
+
 export class SlackNotifier {
   private webhookUrl: string
   private startTime: Date
+  private runUrl?: string
 
-  public constructor(webhookUrl: string) {
+  /**
+   * @param webhookUrl - Slack incoming-webhook URL to post to.
+   * @param runUrl - Optional CI run/job URL; when set, failure and summary
+   *   notifications include a "View workflow run" deep-link so an on-call
+   *   engineer can jump straight to the failing job and its logs.
+   */
+  public constructor(webhookUrl: string, runUrl?: string) {
     this.webhookUrl = webhookUrl
     this.startTime = new Date()
+    this.runUrl = runUrl
   }
 
   /**
@@ -269,6 +283,8 @@ export class SlackNotifier {
       ],
     }
 
+    this.appendRunLink(message)
+
     await this.sendNotificationWithRetry(message)
   }
 
@@ -442,10 +458,12 @@ export class SlackNotifier {
           type: 'section',
           text: {
             type: 'mrkdwn',
-            text: `*Failed Networks:*\n${failureDetails}`,
+            text: `*Failed Networks:*\n${this.truncateText(failureDetails)}`,
           },
         })
     }
+
+    this.appendRunLink(message)
 
     await this.sendNotificationWithRetry(message)
   }
@@ -517,6 +535,8 @@ export class SlackNotifier {
         },
       })
 
+    this.appendRunLink(message)
+
     await this.sendNotificationWithRetry(message)
   }
 
@@ -565,6 +585,33 @@ export class SlackNotifier {
   }
 
   /**
+   * Append a compact "View workflow run" deep-link to the message when a run
+   * URL was configured. No-op otherwise, so local/manual runs stay link-free.
+   */
+  private appendRunLink(message: ISlackMessage): void {
+    if (!this.runUrl || !message.blocks) return
+
+    message.blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `<${this.runUrl}|View workflow run>`,
+        },
+      ],
+    })
+  }
+
+  /**
+   * Clamp arbitrary text to Slack's per-block limit so an oversized payload
+   * cannot trigger an `invalid_blocks` rejection.
+   */
+  private truncateText(text: string, max = SLACK_TEXT_LIMIT): string {
+    if (text.length <= max) return text
+    return `${text.slice(0, max - 1)}…`
+  }
+
+  /**
    * Helper to truncate hash for display
    */
   private truncateHash(hash: string): string {
@@ -586,21 +633,21 @@ export class SlackNotifier {
   private extractErrorMessage(error: unknown): string {
     if (!error) return 'Unknown error'
 
-    if (typeof error === 'string') return error
+    if (typeof error === 'string') return this.truncateText(error)
 
     const errorObj = error as Record<string, unknown>
 
     if (errorObj.message && typeof errorObj.message === 'string')
-      return errorObj.message
+      return this.truncateText(errorObj.message)
 
     if (errorObj.reason && typeof errorObj.reason === 'string')
-      return errorObj.reason
+      return this.truncateText(errorObj.reason)
 
     if (errorObj.shortMessage && typeof errorObj.shortMessage === 'string')
-      return errorObj.shortMessage
+      return this.truncateText(errorObj.shortMessage)
 
     if (errorObj.details && typeof errorObj.details === 'string')
-      return errorObj.details
+      return this.truncateText(errorObj.details)
 
     return JSON.stringify(error).slice(0, 500)
   }

--- a/script/utils/slack-notifier.ts
+++ b/script/utils/slack-notifier.ts
@@ -649,7 +649,14 @@ export class SlackNotifier {
     if (errorObj.details && typeof errorObj.details === 'string')
       return this.truncateText(errorObj.details)
 
-    return JSON.stringify(error).slice(0, 500)
+    // JSON.stringify throws on circular/non-serializable payloads (e.g. some
+    // viem error objects); fall back to String() so the failure notification
+    // still assembles instead of throwing on the error path.
+    try {
+      return this.truncateText(JSON.stringify(error), 500)
+    } catch {
+      return this.truncateText(String(error), 500)
+    }
   }
 
   /**


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-505](https://linear.app/lifi-linear/issue/EXSC-505/timelock-auto-exec-slack-alerts-surface-the-real-error-and-deep-link)

# Why did I implement it this way?

The `Timelock Auto Execution` workflow (`runPendingTimelockTXs.yml`) posts execution results to `#dev-sc-timelock-executions` through the executor's `SlackNotifier`. Two operational problems made those alerts much less useful than intended, and this PR fixes both.

**Problem 1 — the actual error never showed up.** On a per-operation failure (e.g. the recurring Tron `Account resource insufficient` broadcast failure), the `❌ Timelock Operation Failed` message — the only one that carries the real error — was silently rejected by Slack. The Tron broadcast error string is the entire raw transaction JSON (~3.5k chars); it was dropped verbatim into one Slack section block, and Slack rejects any block whose text exceeds 3000 chars with `400 - invalid_blocks`. So the whole message was dropped and the channel only ever showed the batch summary with a misleading `• tron: Unknown error`.

- Fix: clamp error/detail text below the Slack per-block limit (`SLACK_TEXT_LIMIT = 2900`) in `extractErrorMessage`/`notifyBatchSummary`, so the per-operation failure (with the real error) actually posts. Verified live: the error now renders, truncated with a trailing `…`.

**Problem 2 — hard to reach the workflow logs from Slack.** To investigate a failure you had to leave Slack, open GitHub Actions, find the right workflow, then the right run, then the right job — many clicks and searching. The notification had no link.

- Fix: add a `View workflow run` deep-link to failure / summary / not-scheduled notifications, resolved to the specific failing job (and its failing step) via the jobs API, so a dev can jump straight to the logs in **one click**. The workflow resolves the job URL (needs `actions: read` + `gh api`) and passes it to the executor via `TIMELOCK_RUN_URL`; the failure-fallback step deep-links the same way. The link is opt-in: absent locally (`process.env.TIMELOCK_RUN_URL` unset), so manual/local runs are unchanged.

Files:
- `script/utils/slack-notifier.ts` — optional `runUrl`, `appendRunLink()` context block on failure/summary/not-scheduled messages, `truncateText()` + `SLACK_TEXT_LIMIT`.
- `script/deploy/safe/execute-pending-timelock-tx.ts` — pass `process.env.TIMELOCK_RUN_URL` into the notifier.
- `.github/workflows/runPendingTimelockTXs.yml` — `actions: read`; resolve the deep job URL via the jobs API in both the execute step (→ `TIMELOCK_RUN_URL`) and the failure-fallback step.
- `script/utils/slack-notifier.test.ts` — new colocated tests (link present/absent, batch-summary link, oversized-error clamp).

Out of scope: the unfunded Tron timelock executor wallet (the root cause of the failing ops themselves) is a separate operational issue.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
