### PR TITLE
test: harmless workflow_dispatch ref-targeting canary (verifyRefDispatch.yml)

### DIFF
--- a/.github/workflows/verifyRefDispatch.yml
+++ b/.github/workflows/verifyRefDispatch.yml
@@ -1,0 +1,49 @@
+# TEST >> Verify workflow_dispatch ref targeting (HARMLESS)
+#
+# Purpose: prove that an API workflow_dispatch with {"ref": "<branch>"} runs THIS workflow file
+# FROM that branch (not from main) — so you can trust ref-targeting before pointing the real
+# emergency-pause HTTP call at a feature branch. This workflow pauses NOTHING: no secrets, no
+# cast/troncast, no diamonds — it only prints the ref/branch/commit the run came from.
+#
+# How to use:
+#   1. This file must exist on the DEFAULT branch (main) to be dispatchable. GitHub then runs the
+#      copy from whatever `ref` you dispatch. (A branch-only workflow cannot be dispatched.)
+#   2. Trigger it via the SAME Hexagate HTTP setup you'll use for the real workflow, e.g.:
+#        POST /repos/lifinance/contracts/actions/workflows/verifyRefDispatch.yml/dispatches
+#        { "ref": "feature/exsc-366-emergency-pause-hardening",
+#          "inputs": { "warning": "UNDERSTOOD" } }
+#   3. Open the run logs and read the printed `github.ref` / `github.ref_name` / `github.workflow_sha`:
+#        - ref_name == your feature branch  → ref-targeting works; the branch's file content ran.
+#        - ref_name == main                 → the HTTP call did NOT honor your ref; DO NOT run the
+#                                             real emergency-pause workflow against the branch yet.
+
+name: TEST >> Verify workflow_dispatch ref targeting (HARMLESS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      warning:
+        description: "Mirrors the real payload shape only; any value is fine — this workflow is harmless and pauses nothing."
+        required: false
+
+permissions:
+  contents: read # only needs to report context; nothing is changed
+
+jobs:
+  show-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report which ref/branch/commit this run came from
+        run: |
+          echo "============ workflow_dispatch ref check — HARMLESS, NOTHING IS PAUSED ============"
+          echo "github.ref          = ${{ github.ref }}"
+          echo "github.ref_name     = ${{ github.ref_name }}"
+          echo "github.sha          = ${{ github.sha }}"
+          echo "github.workflow_sha = ${{ github.workflow_sha }}"
+          echo "github.actor        = ${{ github.actor }}"
+          echo "input.warning       = ${{ inputs.warning }}"
+          echo "==================================================================================="
+          echo "If you dispatched with ref=<feature branch>, github.ref_name above MUST show that"
+          echo "branch (and github.workflow_sha must equal that branch's HEAD commit) — proving the"
+          echo "dispatch ran the branch's workflow file. If it shows 'main', the ref was not honored:"
+          echo "resolve the HTTP payload before pointing the real emergency-pause workflow at a branch."


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-368](https://linear.app/lifi-linear/issue/EXSC-368) — test infrastructure for the emergency-pause work.

# Why did I implement it this way?

Adds **`verifyRefDispatch.yml`**, a harmless workflow that prints the ref / branch / commit a `workflow_dispatch` actually ran from (`github.ref`, `github.ref_name`, `github.workflow_sha`). **It pauses nothing** — no secrets, no `cast`/`troncast`, no diamonds.

Purpose: a workflow can only be `workflow_dispatch`-triggered if it exists on the **default branch**, and GitHub then runs the file from whatever `ref` is dispatched. Before pointing the Hexagate HTTP emergency-pause call at a feature branch, we want to **prove the `ref` in the payload is honored** — without any chance of accidentally pausing production. This canary lets us dispatch with `{"ref":"<branch>","inputs":{"warning":"UNDERSTOOD"}}` and confirm from the logs that the branch's file ran.

Once merged to `main` it becomes dispatchable; it can stay as a permanent test helper or be removed afterwards.

> Note: this touches `.github/workflows/`, so `protectSecurityRelevantCode.yml` requires an **Information Security Manager** approval to merge.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
