### PR TITLE
feat(EXSC-513): extract deploy-contract skill from multisig-rollout

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -65,9 +65,10 @@ Custom commands live in `.agents/commands/` (source of truth) and are symlinked 
 | `analyze-tx.md`   | `/analyze-tx <network> <tx_hash>` | Transaction trace/runbook analysis for a specific tx                                         |
 | `analyze-unverified-contract.md` | `/analyze-unverified-contract <address> <network>` | Investigate an unverified contract — resolve RPC, detect proxies, disassemble, enumerate selectors, emit a report |
 | `create-pr.md`    | `/create-pr`                      | Create a PR for the current branch (branch/commit/push) using the repo PR template          |
+| `deploy-contract.md` | `/deploy-contract <Contract> <network...> [--production]` | Deploy a facet/periphery to networks + register in each LiFiDiamond (verify, diamondCut/diamondUpdatePeriphery, periphery allowlist). Staging/test terminal path and the deploy primitive `multisig-rollout` calls; production rollouts go through `multisig-rollout` |
 | `deprecate-contract.md` | `/deprecate-contract <Name> ...` | Deprecate facet/periphery contracts by removing them from the codebase                  |
 | `deprecate-network.md`  | `/deprecate-network <net> ...`   | Deprecate networks — remove from networks.json, foundry.toml, deployment logs            |
-| `multisig-rollout.md` | `/multisig-rollout <Contract> \| --whitelist-pr <N>` | Orchestrate a production rollout: deploy/whitelist-sync across chains, Safe proposals, draft PR, signing hand-off, signature verification, `#dev-sc-multisig-proposals` thread |
+| `multisig-rollout.md` | `/multisig-rollout <Contract> \| --whitelist-pr <N>` | Orchestrate a production rollout: deploy (delegated to `deploy-contract`) or whitelist-sync across chains, Safe proposals, draft PR, signing hand-off, signature verification, `#dev-sc-multisig-proposals` thread |
 | `post-pr-for-review.md` | `/post-pr-for-review`            | Post a PR to `#dev-sc-review`, enable auto-merge (squash), tag `@smartcontract_core`     |
 | `pr-ready.md`     | `/pr-ready`                       | Run CodeRabbit locally against current branch and resolve findings — mandatory final step before opening/updating a PR |
 | `request-audit.md` | `/request-audit <PR_NUMBER_OR_URL> [--urgent]` | Prepare and send a smart contract audit request to Slack (Sujith or burrasec team)       |

--- a/.agents/commands/deploy-contract.md
+++ b/.agents/commands/deploy-contract.md
@@ -12,7 +12,7 @@ Non-interactive deploy of a single contract to N networks via `script/deploy/dep
 - **periphery** → `diamondUpdatePeriphery`
 - **diamond-called periphery** → the above **plus** an allowlist sync (a second proposal in production)
 
-It stops once the contract is deployed, verified, and registered (production: proposal created carrying the deployer's signature). It does **not** draft a PR, drive hardware-wallet signing, or post to Slack — those belong to `multisig-rollout`.
+It stops once the contract is deployed, verified, and registered (production: proposal created carrying the deployer's signature). In the standalone staging path it also lands the resulting deployment-log changes via a draft PR (Phase 4). It never drives hardware-wallet signing or posts to Slack — and in production it leaves the PR to `multisig-rollout`.
 
 ## When to use this vs multisig-rollout
 
@@ -22,6 +22,8 @@ It stops once the contract is deployed, verified, and registered (production: pr
 | Production rollout needing Safe proposals signed & shepherded | **`multisig-rollout`** (it calls this skill) |
 
 **Hard rail — don't strand production proposals.** A standalone production deploy creates Safe proposals carrying a single signature and then stops; with no PR, no signing hand-off, and no Slack thread, those proposals sit forgotten below threshold. So: if this is a production deploy (`--production`) and you are **not** running it as a step inside `multisig-rollout`, stop and route the user to `/multisig-rollout`. Only proceed with `--production` here when `multisig-rollout` is driving the full lifecycle around you.
+
+**PR ownership.** The staging path opens its own deployment-log PR (Phase 4). The production PR is **not** this skill's job — when `multisig-rollout` drives, skip Phase 4; it opens the single combined PR (logs + nonce table) after capturing proposals.
 
 ## Environment
 
@@ -100,6 +102,39 @@ The deploy framework attempts explorer verification inline, but it can fail, and
 ```
 
 It verifies the deployment's addresses on the explorer and writes `verified:true` to MongoDB (both must hold).
+
+## Phase 4 — Commit logs & draft PR (staging path only)
+
+Skip this phase entirely when `multisig-rollout` is driving (production): the
+orchestrator opens one combined PR after capturing proposals, because that body
+needs the per-network Safe nonce table that doesn't exist until then. In the
+standalone staging path the deploy's only leftover is the deployment-log diff,
+and landing it shouldn't be a manual afterthought.
+
+1. Collect exactly what the deploy touched — **never `git add -A`**:
+
+   ```bash
+   git status --porcelain -- deployments/ 'config/whitelist*.json'
+   ```
+
+   The contract type need not be special-cased: a facet writes the diamond log's
+   Facets section + address map, periphery writes the Periphery section, a
+   diamond-called periphery also rewrites `config/whitelist.json` /
+   `config/whitelist.staging.json` (Phase 3b) — staging whatever changed covers
+   all of them. If the output is empty (idempotent re-deploy — same CREATE3
+   address, version already registered), there's nothing to land; skip.
+
+2. Delegate the branch / commit / template / `/pr-ready` / push / create mechanic
+   to `/create-pr`, passing:
+   - **files to stage**: exactly the paths from step 1.
+   - **body** (the "Why"): contract, version (old → new per network), network
+     list, environment (staging), and the registration note for the type —
+     `diamondCut` (facet) / `diamondUpdatePeriphery` (periphery) / `+ allowlist
+     sync, whitelist.json updated` (diamond-called periphery).
+
+`/create-pr` stages only the named files and has a confirm gate, so a routine
+staging deploy isn't force-PR'd — you approve before it pushes. Don't reimplement
+branching/commit/PR plumbing here; `/create-pr` owns it.
 
 ## Output
 

--- a/.agents/commands/deploy-contract.md
+++ b/.agents/commands/deploy-contract.md
@@ -1,0 +1,124 @@
+---
+name: deploy-contract
+description: Deploys a facet/periphery contract (the version currently in the repo) to one or more networks and registers it in each network's LiFiDiamond — deploy, explorer-verify, diamondCut (facets) or diamondUpdatePeriphery (periphery), plus the diamond allowlist sync for diamond-called periphery. Use whenever the user wants to "deploy <Contract> to <networks>", "redeploy <Facet> on staging", "push <Periphery> to base/optimism", or otherwise get a contract on-chain and into the diamond WITHOUT the Safe-proposal lifecycle. This is the staging/test deploy path and is the deploy primitive that `multisig-rollout` calls. For a PRODUCTION rollout — anything that needs Safe proposals shepherded to signing ("roll out vX.Y.Z to all chains", "upgrade <Facet> in production", "create the diamond cut proposals") — use `multisig-rollout` instead; it calls this skill and then drives the proposal → PR → signing → Slack tail. Requires Foundry, gh, and (production only) VPN for MongoDB.
+usage: /deploy-contract <ContractName> <network...> [--production]
+---
+
+# Deploy Contract (LI.FI Contracts)
+
+Non-interactive deploy of a single contract to N networks via `script/deploy/deployContractToNetworks.sh` (scriptMaster use case 1, repeated). Per network it deploys (CREATE3), verifies on the explorer, and registers in the LiFiDiamond:
+
+- **facet** → `diamondCut` (a Safe proposal in production, direct cut in staging)
+- **periphery** → `diamondUpdatePeriphery`
+- **diamond-called periphery** → the above **plus** an allowlist sync (a second proposal in production)
+
+It stops once the contract is deployed, verified, and registered (production: proposal created carrying the deployer's signature). It does **not** draft a PR, drive hardware-wallet signing, or post to Slack — those belong to `multisig-rollout`.
+
+## When to use this vs multisig-rollout
+
+| Situation | Skill |
+|---|---|
+| Staging / testnet / non-governed deploy (terminal) | **this skill** |
+| Production rollout needing Safe proposals signed & shepherded | **`multisig-rollout`** (it calls this skill) |
+
+**Hard rail — don't strand production proposals.** A standalone production deploy creates Safe proposals carrying a single signature and then stops; with no PR, no signing hand-off, and no Slack thread, those proposals sit forgotten below threshold. So: if this is a production deploy (`--production`) and you are **not** running it as a step inside `multisig-rollout`, stop and route the user to `/multisig-rollout`. Only proceed with `--production` here when `multisig-rollout` is driving the full lifecycle around you.
+
+## Environment
+
+The target environment is a double opt-in enforced by the script: staging unless **both** `--production` is passed *and* `PRODUCTION=true` is in `.env`. Default standalone use is staging. Never edit `.env` to flip this — if `--production` and `.env` disagree, the script aborts; relay that to the user.
+
+## Phase 0 — Preflight
+
+Run from the repo root. Check and report (don't fix silently):
+
+- `.env` exists; `PRODUCTION` matches the intended environment (`true` only for a production run); `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND` not `true` for production (it bypasses the Safe — legitimate only when bootstrapping a new production network before ownership transfers to the Safe; abort otherwise); `MAX_CONCURRENT_JOBS` set.
+- Foundry available (`forge --version`); `gh auth status` OK.
+- Working tree state noted — the deploy writes `deployments/<net>.json` (and, for diamond-called periphery, `config/whitelist.json`), which the caller commits later.
+
+## Phase 1 — Resolve targets
+
+The target list comes from one of two sources:
+
+- **Explicit** — the user names the networks ("deploy MayanFacet to arbitrum, base, sei"). Use exactly those, in the order given. This is how a contract reaches a **new** network it isn't live on yet. The only requirement is that each named network already hosts a LiFiDiamond (this flow adds the contract to an existing diamond; it does **not** stand up a brand-new network — that's `/add-network` + a full deploy). If a named network has no diamond, flag it and drop it.
+- **Discovery** (when the user says "all chains where it's running" or names none) — networks where the contract is already live in the production diamond, plus its deployed version:
+
+```bash
+for F in deployments/*.diamond.json; do
+  NET=$(basename "$F" .diamond.json)
+  V=$(jq -r --arg N "<Contract>" '(.LiFiDiamond.Facets // {}) | to_entries[] | select(.value.Name == $N) | .value.Version' "$F" 2>/dev/null | head -1)
+  [ -n "$V" ] && echo "$NET $V"
+done
+```
+
+For periphery contracts check `.LiFiDiamond.Periphery | has($N)` instead. The glob matches only production logs (`*.diamond.staging.json` and `*.diamond.immutable.json` do not end in `.diamond.json`).
+
+Repo version: `grep -m1 "@custom:version" src/Facets/<Contract>.sol` (or `src/Periphery/...`). Report old → new version per network (a new network shows no current version — expected). Networks already on the repo version are re-deployed only if the user asked — surface them and ask.
+
+**Diamond-called periphery needs a second proposal.** A periphery contract the diamond invokes during swaps (e.g. `GasZipPeriphery`, `FeeCollector`, `LiFiDEXAggregator`) must be **both** registered in the diamond *and* added to the diamond's allowlist — registration alone (`PeripheryRegistry`) does not let the diamond call it. Detect deterministically:
+
+```bash
+jq -e --arg N "<Contract>" '.whitelistPeripheryFunctions | has($N)' config/global.json >/dev/null && echo "needs whitelist sync"
+```
+
+If it matches, Phase 3b runs an allowlist sync afterwards (a second production proposal). No manual `whitelist.json` editing: the sync derives the address + selectors from `global.json.whitelistPeripheryFunctions` automatically. Facets and non-diamond-called periphery skip Phase 3b.
+
+## Phase 2 — Confirm plan
+
+Present: contract + version (old → new per network), the full network list, environment, and what will be created (per network: one registration; **two** for a diamond-called periphery — registration + allowlist; in production each is a timelock-wrapped Safe proposal). Wait for explicit go-ahead — deployments cost gas and, in production, mint Safe proposals on many chains.
+
+## Phase 3 — Execute
+
+Run in the background (long-running; deploys retry and verify inline), monitor output, report per-network results:
+
+```bash
+# staging (default)
+./script/deploy/deployContractToNetworks.sh <Contract> <network...>
+
+# production (only inside multisig-rollout — see hard rail)
+./script/deploy/deployContractToNetworks.sh <Contract> <network...> --production
+```
+
+Ends with a per-network summary and exits `1` if any network failed. Failures don't block survivors: continue with the succeeded networks, report the failed ones, and offer to retry them individually with the same command. In production each proposal is created already carrying one signature (`signatureCount: 1`).
+
+## Phase 3b — Whitelist a diamond-called periphery
+
+Run only when Phase 1 flagged the contract as diamond-called. After the deploy registered it, sync the allowlist on the same networks:
+
+```bash
+# staging sends directly; production proposes (and re-syncs staging afterwards — expected)
+./script/tasks/syncWhitelistToNetworks.sh <network...> [--production]
+```
+
+This re-derives `whitelist.json` from `global.json.whitelistPeripheryFunctions` (picking up the just-deployed address) and applies a `batchSetContractSelectorWhitelist` cut — the second proposal per network in production. Skip entirely for facets and non-diamond-called periphery.
+
+## Phase 3c — Verify deployed contracts
+
+The deploy framework attempts explorer verification inline, but it can fail, and the MongoDB `verified` flag is written separately from on-chain verification. Confirm every freshly deployed contract is verified by invoking the `verify-contracts` skill for each target network:
+
+```text
+/verify-contracts <network>
+```
+
+It verifies the deployment's addresses on the explorer and writes `verified:true` to MongoDB (both must hold).
+
+## Output
+
+Report a per-network result table the caller (or user) can act on:
+
+| Field | Source |
+|---|---|
+| `contract`, `version` | Phase 1 (repo `@custom:version`) |
+| `network`, `chainId` | target list / `config/networks.json` |
+| `address` | deploy summary / `deployments/<net>.json` |
+| `registration` | `diamondCut` (facet) or `diamondUpdatePeriphery` (periphery); `+ allowlist` if Phase 3b ran |
+| `proposalCreated` | production only — one per registration (sig 1); two for diamond-called periphery |
+| `verified` | Phase 3c result |
+
+In production, note the files changed on disk (`deployments/<net>.json`, and `config/whitelist.json` / `config/whitelist.staging.json` if Phase 3b ran) so the caller commits them, and that proposals carry a single signature awaiting the signing lifecycle. When run inside `multisig-rollout`, hand this table back so it can capture proposal nonces, draft the PR, and run the signing tail.
+
+## Failure modes
+
+- `--production` / `.env` mismatch → script aborts with a clear message; do not edit `.env`, relay it.
+- Deploy succeeded but production proposal missing → the propose step failed; check the network's deploy log and re-run that single network.
+- A network has no diamond → drop it from the list (this skill adds to existing diamonds only).
+- Explorer verification flaky → re-run `/verify-contracts <network>`; the MongoDB `verified` flag and on-chain verification must both hold.

--- a/.agents/commands/multisig-rollout.md
+++ b/.agents/commands/multisig-rollout.md
@@ -1,6 +1,6 @@
 ---
 name: multisig-rollout
-description: Orchestrates a production multisig rollout end-to-end — facet/periphery re-deployment or whitelist sync across many chains, Safe proposal creation, draft PR with deployed addresses, hardware-wallet signing hand-off, signature verification in MongoDB, and the #dev-sc-multisig-proposals Slack thread. Use whenever the user asks to "re-deploy <Contract> to all chains where it is running", "roll out <Facet> vX.Y.Z", "create diamond cut proposals", "sync the whitelist for PR <N> and propose", or otherwise wants Safe multisig proposals produced and shepherded to signing. Requires VPN (MongoDB), gh, and the Slack MCP server.
+description: Orchestrates a PRODUCTION multisig rollout end-to-end — drives a facet/periphery deployment (by delegating to the `deploy-contract` skill) or a whitelist sync across many chains, then captures the Safe proposals, drafts a PR with the deployed addresses, hands hardware-wallet signing to the user, verifies signatures in MongoDB, and posts the #dev-sc-multisig-proposals Slack thread. Use whenever the user wants Safe multisig proposals produced and shepherded to signing: "roll out <Facet> vX.Y.Z to all chains", "upgrade <Contract> in production", "re-deploy <Contract> to every chain where it is running", "create the diamond cut proposals", or "sync the whitelist for PR <N> and propose". For a staging/test deploy with no proposal lifecycle, use `deploy-contract` directly instead. Requires VPN (MongoDB), gh, and the Slack MCP server.
 usage: /multisig-rollout <ContractName> | /multisig-rollout --whitelist-pr <PR number or URL>
 ---
 
@@ -8,10 +8,10 @@ usage: /multisig-rollout <ContractName> | /multisig-rollout --whitelist-pr <PR n
 
 Drives the production rollout lifecycle in two modes:
 
-- **deploy mode** — deploy a facet/periphery contract (version currently in the repo) to a set of production chains — either the chains the user names (including a chain it isn't live on yet) or, by default, every chain where it's already live — and propose the diamond cuts to each chain's Safe.
+- **deploy mode** — get a facet/periphery contract (version currently in the repo) on-chain across production networks and proposed to each Safe. The deploy itself (preflight, target resolution, the deploy, diamond-called-periphery allowlist sync, explorer verification) is delegated to the **`deploy-contract`** skill; this skill owns the proposal lifecycle around it.
 - **whitelist mode** — given a merged whitelist PR, sync `config/whitelist.json` onto the affected chains' diamonds, proposing the changes to each chain's Safe.
 
-Both modes converge on the same tail: (deploy mode only) verify the deployed contracts on their explorers via the `verify-contracts` skill → capture proposals → (deploy mode only) draft PR with addresses → hand off hardware-wallet signing to the user → verify signatures in MongoDB → post the `#dev-sc-multisig-proposals` Slack thread.
+Both modes converge on the same tail: capture proposals → (deploy mode only) draft PR with addresses → hand off hardware-wallet signing → verify signatures in MongoDB → post the `#dev-sc-multisig-proposals` Slack thread.
 
 **Signing model** (Safe threshold is 3): a freshly created proposal already carries one signature. The user running this skill adds a second via `confirm-safe-tx.ts`. The Slack thread then recruits the remaining signer(s) to reach the threshold, the last of whom executes. So the verification gate before posting is "the runner has signed" — `signatureCount >= 2` — deliberately short of the threshold; recruiting the rest is the whole point of the Slack ask.
 
@@ -19,49 +19,36 @@ Both modes converge on the same tail: (deploy mode only) verify the deployed con
 
 - **Never run `confirm-safe-tx.ts` yourself.** Signing uses the user's hardware wallet; only the human can do it. Your job ends at giving the exact command.
 - **Never post to Slack before the signature verification gate passes.** The Slack message asks the team to spend their time signing — it must be accurate.
-- **Production double opt-in**: both entry scripts require `--production` on the CLI *and* `PRODUCTION=true` in `.env`. Do not edit `.env` to satisfy this — if it mismatches, stop and tell the user.
+- **Production double opt-in**: the entry scripts (`deployContractToNetworks.sh` via `deploy-contract`, and `syncWhitelistToNetworks.sh`) require `--production` on the CLI *and* `PRODUCTION=true` in `.env`. Do not edit `.env` to satisfy this — if it mismatches, stop and tell the user.
 - `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND` must NOT be `true` (it would bypass the Safe). Abort if set.
 - Confirm the resolved plan (contract/version/networks or PR/networks) with the user before executing — deployments cost gas and mint Safe proposals on many chains.
 
 ## Phase 0 — Preflight
 
-Run from the repo root. Check and report (don't fix silently):
+Run from the repo root. Check and report (don't fix silently) the lifecycle prerequisites:
 
 - `.env` exists, `PRODUCTION=true`, `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND` not `true`, `MAX_CONCURRENT_JOBS` set.
-- `gh auth status` OK; Slack MCP connected (needed in Phase 6 — warn early if missing, posting falls to the user).
+- `gh auth status` OK; Slack MCP connected (needed in Phase 8 — warn early if missing, posting falls to the user).
 - Working tree clean enough to branch later (deploy mode creates a PR from deployment-log changes).
 - VPN: verified implicitly later — `list-pending-proposals.ts` exits `2` with a clear message when the VPN is down; relay that to the user when it happens.
 
-## Phase 1 — Resolve targets
+In deploy mode, `deploy-contract` re-checks the deploy-side prerequisites (Foundry, deployer balances, the `.env`/`--production` agreement) before touching any network — don't duplicate that here.
 
-### deploy mode
+## Phase 1 — Deploy (deploy mode) / Resolve sync targets (whitelist mode)
 
-The target list comes from one of two sources:
+### deploy mode — delegate to `deploy-contract`
 
-- **Explicit** — the user names the chains ("deploy MayanFacet to arbitrum, base, and sei"). Use exactly those, in the order given. This is how a facet reaches a **new** chain it isn't live on yet — discovery would never surface it. The only requirement is that each named chain already hosts a LiFiDiamond (`deployContractToNetworks.sh` adds the facet to an existing diamond; it does **not** stand up a brand-new network — that's `/add-network` + a full deploy). If a named chain has no diamond, flag it and drop it from the list.
-- **Discovery** (default when the user says "all chains where it's running" or names none) — chains where the contract is already live in the production diamond, plus its deployed version (verified recipe):
+Invoke the `deploy-contract` skill in production:
 
-```bash
-for F in deployments/*.diamond.json; do
-  NET=$(basename "$F" .diamond.json)
-  V=$(jq -r --arg N "<Contract>" '(.LiFiDiamond.Facets // {}) | to_entries[] | select(.value.Name == $N) | .value.Version' "$F" 2>/dev/null | head -1)
-  [ -n "$V" ] && echo "$NET $V"
-done
+```text
+/deploy-contract <Contract> <network...> --production
 ```
 
-For periphery contracts check `.LiFiDiamond.Periphery | has($N)` instead. The glob matches only production logs (`*.diamond.staging.json` and `*.diamond.immutable.json` do not end in `.diamond.json`).
+If the user named explicit chains, pass them through; otherwise let `deploy-contract` discover every chain where the contract is already live (`deployments/*.diamond.json`). It resolves old → new version per network, deploys + verifies + registers (`diamondCut` for facets, `diamondUpdatePeriphery` for periphery), runs the allowlist sync for diamond-called periphery (a **second** proposal per network), and hands back a per-network table: contract, version, network, chainId, address, registration type, whether a proposal was created, and verification status. Confirm the plan with the user (Phase 2 below) **before** letting `deploy-contract` execute against production.
 
-Repo version: `grep -m1 "@custom:version" src/Facets/<Contract>.sol` (or `src/Periphery/...`). Report old → new version per chain (a new chain shows no current version — that's expected). Chains already on the repo version are re-deployed only if the user asked — surface them and ask.
+Carry forward from its output: the deployed addresses (for the PR table), which networks succeeded/failed, and whether the periphery allowlist sync ran (two proposals per network if so). Files it changed on disk — `deployments/<net>.json`, plus `config/whitelist.json` / `config/whitelist.staging.json` when the allowlist synced — are committed in Phase 5.
 
-**Diamond-called periphery needs a second proposal.** A periphery contract that the diamond invokes during swaps (e.g. `GasZipPeriphery`, `FeeCollector`, `LiFiDEXAggregator`) must be **both** registered in the diamond *and* added to the diamond's allowlist — registration alone (`PeripheryRegistry`) does not let the diamond call it. The deploy prints a reminder for these (`script/deploy/resources/contractSpecificReminders.sh`, "do not forget to add … to whitelisted DEXs"); **don't filter it out of the log.** Detect the case deterministically:
-
-```bash
-jq -e --arg N "<Contract>" '.whitelistPeripheryFunctions | has($N)' config/global.json >/dev/null && echo "needs whitelist sync"
-```
-
-If it matches, the rollout produces **two** proposals per network — the registration cut (Phase 3) and a whitelist update (Phase 3b). No manual `whitelist.json` editing: the sync derives the address + selectors from `global.json.whitelistPeripheryFunctions` automatically. Facets and non-diamond-called periphery skip Phase 3b.
-
-### whitelist mode
+### whitelist mode — resolve targets
 
 If the user didn't supply a whitelist PR (number or URL), ask for it — don't guess from recent merges or the working tree. The PR defines exactly which whitelist change is being rolled out and is the link the Slack post references.
 
@@ -80,43 +67,17 @@ The sync itself is on-chain-diff-driven, so a too-wide network list is harmless 
 
 ## Phase 2 — Confirm plan
 
-Present: mode, contract + version (or PR + summary), full network list, and what will be created (one timelock-wrapped Safe proposal per chain — **two** for a diamond-called periphery: registration + whitelist). Wait for explicit go-ahead.
+Present: mode, contract + version (or PR + summary), full network list, and what will be created (one timelock-wrapped Safe proposal per chain — **two** for a diamond-called periphery: registration + whitelist). Wait for explicit go-ahead. In deploy mode this is the gate before `deploy-contract` executes.
 
-## Phase 3 — Execute
+## Phase 3 — Execute sync (whitelist mode only)
 
-Run in the background (long-running; deploys retry and verify), monitor output, report per-network results:
-
-```bash
-# deploy mode
-./script/deploy/deployContractToNetworks.sh <Contract> <network...> --production
-
-# whitelist mode
-./script/tasks/syncWhitelistToNetworks.sh <network...> --production
-```
-
-Both end with a per-network summary and exit `1` if any network failed. Failures don't block the survivors: continue the flow with the succeeded networks, report the failed ones, and offer to retry them individually with the same command. Each proposal is created already carrying one signature, so every fresh proposal starts at `signatureCount: 1`.
-
-Whitelist note: a production sync automatically re-syncs staging on the same networks afterwards (staging sends directly, no proposals) — expected, not an error.
-
-## Phase 3b — Whitelist a diamond-called periphery (deploy mode only)
-
-Run only when Phase 1 flagged the contract as a diamond-called periphery. After the deploy registered it, sync the allowlist on the same networks to propose the whitelist change:
+deploy mode already executed via `deploy-contract` in Phase 1. For whitelist mode, run in the background, monitor output, report per-network results:
 
 ```bash
 ./script/tasks/syncWhitelistToNetworks.sh <network...> --production
 ```
 
-This re-derives `whitelist.json` from `global.json.whitelistPeripheryFunctions` (picking up the just-deployed address) and proposes a `batchSetContractSelectorWhitelist` cut — the second proposal per network. It's the same `confirm-safe-tx` / verify / Slack tail; just expect two proposals per network from here on. Skip entirely for facets and non-diamond-called periphery.
-
-## Phase 3c — Verify deployed contracts (deploy mode only)
-
-The deploy framework attempts explorer verification inline, but it can fail, and the MongoDB `verified` flag is written separately from on-chain verification. Before moving on, confirm every freshly deployed contract is verified on its network's block explorer by invoking the `verify-contracts` skill for each target network:
-
-```text
-/verify-contracts <network>
-```
-
-It verifies the deployment's addresses on the explorer and writes `verified:true` back to MongoDB (both must hold). Whitelist mode deploys nothing, so it skips this phase.
+Ends with a per-network summary and exits `1` if any network failed. Failures don't block survivors: continue with the succeeded networks, report the failed ones, and offer to retry them individually. Each proposal is created already carrying one signature (`signatureCount: 1`). A production sync automatically re-syncs staging on the same networks afterwards (staging sends directly, no proposals) — expected, not an error.
 
 ## Phase 4 — Capture proposals
 
@@ -124,14 +85,14 @@ It verifies the deployment's addresses on the explorer and writes `verified:true
 bunx tsx script/deploy/safe/list-pending-proposals.ts --network <csv> --maxAgeHours 2 --json
 ```
 
-Expect one `pending` proposal per succeeded network with `signatureCount: 1` (the signature added at creation) — **two** per network when Phase 3b ran (registration + whitelist). Targets are the chain's `LiFiTimelockController` (proposals wrap in a timelock `scheduleBatch`). Keep `nonce` per network — the PR table needs it. Missing networks here mean the propose step failed even though the deploy succeeded — investigate before continuing; a periphery network showing only one proposal means Phase 3b's whitelist sync didn't land.
+Expect one `pending` proposal per succeeded network with `signatureCount: 1` (the signature added at creation) — **two** per network when a diamond-called periphery's allowlist synced (registration + whitelist). Targets are the chain's `LiFiTimelockController` (proposals wrap in a timelock `scheduleBatch`). Keep `nonce` per network — the PR table needs it. Missing networks here mean the propose step failed even though the deploy succeeded — investigate before continuing; a periphery network showing only one proposal means its allowlist sync didn't land.
 
 ## Phase 5 — Draft PR (deploy mode only)
 
-The deploy updated `deployments/<net>.json` (and staging logs if staging was deployed). If Phase 3b ran, `updateWhitelistPeriphery.ts` also rewrote `config/whitelist.json` (and `config/whitelist.staging.json`) on disk — that diff must ship in this PR too, or the repo's allowlist won't reflect the on-chain proposal. Model the PR on #1917:
+The deploy updated `deployments/<net>.json` (and staging logs if staging was deployed). If a diamond-called periphery's allowlist synced, `updateWhitelistPeriphery.ts` also rewrote `config/whitelist.json` (and `config/whitelist.staging.json`) on disk — that diff must ship in this PR too, or the repo's allowlist won't reflect the on-chain proposal. Model the PR on #1917:
 
-1. Branch (never commit to main), commit the deployment-log changes **and** any `config/whitelist.json` / `config/whitelist.staging.json` diff from Phase 3b, push. (`git status` after Phase 3b shows exactly what to stage.) The whitelist diff is allowed here because this PR targets `main` (rule 502).
-2. Body from `.github/pull_request_template.md` (see project instructions for the `gh api` PATCH pattern). "Why" section: staging bullet list (if any) + production table `| Chain | Facet address | Safe nonce |` from Phase 4, plus the note that production `<chain>.diamond.json` registries update only when the cuts execute. For a periphery rollout, note the whitelist proposal and the `whitelist.json` update too.
+1. Branch (never commit to main), commit the deployment-log changes **and** any `config/whitelist.json` / `config/whitelist.staging.json` diff from Phase 1's allowlist sync, push. (`git status` after the deploy shows exactly what to stage.) The whitelist diff is allowed here because this PR targets `main` (rule 502).
+2. Body from `.github/pull_request_template.md` (see project instructions for the `gh api` PATCH pattern). "Why" section: staging bullet list (if any) + production table `| Chain | Facet address | Safe nonce |` from Phases 1 and 4, plus the note that production `<chain>.diamond.json` registries update only when the cuts execute. For a periphery rollout, note the whitelist proposal and the `whitelist.json` update too.
 3. Run `/pr-ready` before `gh pr create --draft` (the pre-PR gate enforces it).
 
 Whitelist mode changes no files — skip this phase; the input PR plays the PR role in the Slack post.
@@ -188,6 +149,6 @@ Summarize: networks rolled out (+ failures and their state), proposal nonces, PR
 ## Failure modes
 
 - `list-pending-proposals.ts` exits `2` → VPN down or `SC_MONGODB_URI` missing — tell the user, retry after they fix it.
-- Deploy succeeded but no proposal row → propose step failed; check the deploy log for the network, re-run that single network.
+- Deploy succeeded but no proposal row → propose step failed; check the deploy log for the network, re-run that single network via `deploy-contract`.
 - Stale/future nonce warnings during signing → `confirm-safe-tx.ts` explains them inline; relay its guidance (usually: delete + re-propose, or execute the blocking nonce first).
 - Slack MCP missing → give the user both message texts verbatim to post manually; do not fall back to webhooks (wrong identity).

--- a/.claude/skills/deploy-contract/SKILL.md
+++ b/.claude/skills/deploy-contract/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agents/commands/deploy-contract.md

--- a/.cursor/commands/deploy-contract.md
+++ b/.cursor/commands/deploy-contract.md
@@ -1,0 +1,1 @@
+../../.agents/commands/deploy-contract.md


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-513](https://linear.app/lifi-linear/issue/EXSC-513/extract-deploy-contract-skill-from-multisig-rollout)

# Why did I implement it this way?

Stacked on top of #1926 (EXSC-405). Extracts the deploy-to-networks flow out of `/multisig-rollout` into a standalone `/deploy-contract` skill, and refactors `multisig-rollout` to delegate to it. This is a skill-layer refactor — the underlying scripts (`deployContractToNetworks.sh`, `syncWhitelistToNetworks.sh`) are unchanged and net rollout behavior is identical.

**`/deploy-contract`** (`.agents/commands/deploy-contract.md`, symlinked into `.cursor/` and `.claude/`) deploys a facet/periphery to N networks, verifies on the explorer, and registers it in each `LiFiDiamond` (`diamondCut` for facets, `diamondUpdatePeriphery` for periphery, plus the allowlist sync for diamond-called periphery). It stops at the proposal — no PR, signing, or Slack. It lifts the deploy-side phases that previously lived inside `multisig-rollout` (preflight, target resolution, execute, periphery whitelist, verify).

**Routing boundary** is the load-bearing part, encoded in both skills' `description` fields:
- staging / testnet / non-governed deploy → `/deploy-contract` is terminal;
- production rollout needing Safe proposals → `/multisig-rollout`, which calls `/deploy-contract` as its deploy phase.

A standalone production deploy would create Safe proposals carrying a single signature and then stop — no PR, no signing hand-off, no Slack thread — stranding them below threshold. To prevent that, `/deploy-contract` carries a hard rail: if it's a production deploy and it is *not* running inside `multisig-rollout`, it stops and routes the user to `/multisig-rollout`.

**`multisig-rollout`** deploy mode now delegates the deploy to `/deploy-contract` and keeps the proposal lifecycle (capture proposals → draft PR with addresses → hardware-wallet signing hand-off → signature verification → `#dev-sc-multisig-proposals` Slack thread). Whitelist mode is unchanged.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
