### PR TITLE
ci(EXSC-498): address CodeRabbit findings on QA review trigger workflow

### DIFF
--- a/.github/workflows/qa-review-trigger.yml
+++ b/.github/workflows/qa-review-trigger.yml
@@ -1,3 +1,13 @@
+# Trigger Zeus QA Review
+# - Purpose: plugs the contracts repo into the lifinance/QA Zeus QA pipeline. Applying the
+#   "Agent Review Request" label swaps it for "QA AI Reviewing" and dispatches qa-run.yml in
+#   lifinance/QA (agent=zeus, scenario=QAReviewContracts.md, ticket=PR URL).
+# - Triggers: pull_request [labeled]; the job runs only when the applied label is
+#   "Agent Review Request".
+# - Key behaviors: label swap, cross-repo workflow_dispatch via a least-privilege GitHub App
+#   token, and label restore on dispatch failure so the trigger can simply be re-applied.
+# - Known limitations: requires the QA_APP_ID / QA_APP_PRIVATE_KEY secrets and the App
+#   installation to grant Actions:write on lifinance/QA; never touches protected audit labels.
 name: Trigger Zeus QA Review
 
 on:
@@ -14,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write
+      pull-requests: write # required to swap/restore the QA review labels on the PR
 
     steps:
       - name: Create GitHub App token
@@ -25,6 +35,7 @@ jobs:
           private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
           owner: lifinance
           repositories: QA
+          permission-actions: write # least privilege: token only dispatches qa-run.yml
 
       - name: Swap labels
         env:


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Relates to https://linear.app/lifi-linear/issue/EXSC-498/add-zeus-qa-agent-review-trigger-to-lifinancecontracts-agent-review

This PR targets `feat/exsc-498-add-zeus-qa-review-trigger` (PR #1916), not `main`. It addresses the two CodeRabbit findings on that PR so they can be merged into the branch.

# Why did I implement it this way?

CodeRabbit raised two Major findings on `.github/workflows/qa-review-trigger.yml`, both backed by `.agents/rules/500-github-actions.md`:

1. **Missing workflow header + permission rationale** — rule 500 mandates a top-of-file header block (Purpose / Triggers / Key behaviors / Known limitations) and an inline "why" on every permission. Added both.
2. **Unscoped GitHub App token** (also flagged by zizmor) — `actions/create-github-app-token` inherited the full installation permission set, but the token only dispatches `qa-run.yml`. Scoped it to `permission-actions: write` (least privilege). Per the action's docs, the dispatch API needs the **Actions** permission; the QA App installation must grant `Actions: write` on `lifinance/QA` for the intersection to resolve.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch — result: **No findings**. (The PR was created via the documented `PR_READY_OK=1` bypass because the pre-PR gate misfires on git-worktree cwd; the clean run was performed in the worktree.)
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
