### PR TITLE
feat(EXSC-514): yield adapter abstraction in vault wrapper factory

### DIFF
--- a/script/deploy/facets/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/facets/DeployLiFiVaultWrapperFactory.s.sol
@@ -5,13 +5,19 @@ import { Script } from "forge-std/Script.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { MockVaultWrapper } from "lifi/VaultWrapper/mocks/MockVaultWrapper.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 
 /// @title DeployLiFiVaultWrapperFactory
 /// @author LI.FI (https://li.fi)
-/// @notice Deploys the mock wrapper implementation, its upgradeable beacon, and
-///         the vault wrapper factory (mock impl is a temporary stand-in until S1).
-/// @dev Deploy order: MockVaultWrapper → UpgradeableBeacon(impl) → LiFiVaultWrapperFactory(beacon, …)
+/// @notice Deploys the mock wrapper implementation, its upgradeable beacon, the
+///         vault wrapper factory (mock impl is a temporary stand-in until S1), and
+///         the ERC-4626 yield adapter.
+/// @dev Deploy order: MockVaultWrapper → UpgradeableBeacon(impl) → LiFiVaultWrapperFactory(beacon, …) → ERC4626Adapter
 ///      Reads OWNER, EMERGENCY_PAUSER, and ONBOARDING_MANAGER from environment.
+///      The deployer key (PRIVATE_KEY) is not the governance owner, so this script
+///      cannot approve the adapter or allowlist underlyings. After deployment,
+///      governance must call setAdapterApproved(adapter) and setUnderlyingAllowed(underlying)
+///      on the factory before any wrapper can be deployed.
 /// @custom:version 1.0.0
 contract DeployScript is Script {
     error ZeroOwner();
@@ -23,7 +29,8 @@ contract DeployScript is Script {
         returns (
             LiFiVaultWrapperFactory factory,
             UpgradeableBeacon beacon,
-            MockVaultWrapper impl
+            MockVaultWrapper impl,
+            ERC4626Adapter erc4626Adapter
         )
     {
         uint256 deployerPrivateKey = uint256(vm.envBytes32("PRIVATE_KEY"));
@@ -46,6 +53,7 @@ contract DeployScript is Script {
             emergencyPauser,
             onboardingManager
         );
+        erc4626Adapter = new ERC4626Adapter();
 
         vm.stopBroadcast();
     }

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 import { TransferrableOwnership } from "../Helpers/TransferrableOwnership.sol";
 import { InvalidConfig, InvalidContract, UnAuthorized } from "../Errors/GenericErrors.sol";
 import { FeeType, FeeBounds, FeeConfig, DeployParams } from "./LiFiVaultWrapperTypes.sol";
-import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IYieldAdapter } from "./interfaces/IYieldAdapter.sol";
 import { ILiFiVaultWrapper } from "./interfaces/ILiFiVaultWrapper.sol";
 import { LibClone } from "solady/utils/LibClone.sol";
 
@@ -41,6 +41,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
 
     mapping(address => bool) public allowedUnderlying;
     mapping(address => bool) public approvedIntegrator;
+    mapping(address => bool) public approvedAdapter;
     mapping(FeeType => FeeBounds) public feeBounds;
     mapping(FeeType => uint16) public defaultLifiShareBps;
 
@@ -51,6 +52,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
     /// Errors ///
 
     error UnderlyingNotAllowed();
+    error AdapterNotApproved();
     error UnderlyingProbeFailed();
     error ChainLockMismatch();
     error FeeRateAboveBound();
@@ -65,11 +67,13 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
         address indexed instance,
         address indexed integrator,
         address indexed underlying,
+        address adapter,
         uint256 chainLockId,
         uint256 nonce,
         bytes32 salt
     );
     event UnderlyingAllowedSet(address indexed underlying, bool allowed);
+    event AdapterApprovedSet(address indexed adapter, bool approved);
     event FeeBoundsSet(FeeType indexed feeType, uint16 minBps, uint16 maxBps);
     event DefaultSplitSet(FeeType indexed feeType, uint16 lifiBps);
     event IntegratorApprovedSet(address indexed integrator, bool approved);
@@ -128,6 +132,16 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
         if (_underlying == address(0)) revert InvalidConfig();
         allowedUnderlying[_underlying] = _allowed;
         emit UnderlyingAllowedSet(_underlying, _allowed);
+    }
+
+    /// @notice Approve or revoke a yield adapter usable in deployments.
+    function setAdapterApproved(
+        address _adapter,
+        bool _approved
+    ) external onlyOwner {
+        if (_adapter == address(0)) revert InvalidConfig();
+        approvedAdapter[_adapter] = _approved;
+        emit AdapterApprovedSet(_adapter, _approved);
     }
 
     /// @notice Set adjustable min/max bps bounds for a fee type (within the immutable cap).
@@ -228,13 +242,14 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
     /// @notice The deterministic address a clone will have for the given key.
     function predictAddress(
         address _integrator,
+        address _adapter,
         address _underlying,
         uint256 _nonce
     ) external view returns (address) {
         return
             LibClone.predictDeterministicAddressERC1967BeaconProxy(
                 beacon,
-                _salt(_integrator, _underlying, _nonce),
+                _salt(_integrator, _adapter, _underlying, _nonce),
                 address(this)
             );
     }
@@ -243,10 +258,12 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
 
     function _salt(
         address _integrator,
+        address _adapter,
         address _underlying,
         uint256 _nonce
     ) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_integrator, _underlying, _nonce));
+        return
+            keccak256(abi.encode(_integrator, _adapter, _underlying, _nonce));
     }
 
     function _cap(FeeType _feeType) internal pure returns (uint16) {
@@ -269,10 +286,11 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
             if (_params.integrator != msg.sender) revert IntegratorMismatch();
         }
         if (_params.integrator == address(0)) revert InvalidConfig();
+        if (!approvedAdapter[_params.adapter]) revert AdapterNotApproved();
         if (!allowedUnderlying[_params.underlying])
             revert UnderlyingNotAllowed();
 
-        address asset = _probeUnderlying(_params.underlying);
+        address asset = _probeViaAdapter(_params.adapter, _params.underlying);
 
         if (_params.chainLockId != 0 && _params.chainLockId != block.chainid)
             revert ChainLockMismatch();
@@ -281,6 +299,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
 
         bytes32 salt = _salt(
             _params.integrator,
+            _params.adapter,
             _params.underlying,
             _params.nonce
         );
@@ -299,6 +318,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
             instance,
             _params.integrator,
             _params.underlying,
+            _params.adapter,
             _params.chainLockId,
             _params.nonce,
             salt
@@ -307,6 +327,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
         ILiFiVaultWrapper(instance).initialize(
             asset,
             _params.underlying,
+            _params.adapter,
             _params.integrator,
             _params.chainLockId,
             _params.fees,
@@ -314,17 +335,14 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
         );
     }
 
-    function _probeUnderlying(
+    function _probeViaAdapter(
+        address _adapter,
         address _underlying
     ) internal view returns (address asset) {
-        if (_underlying.code.length == 0) revert UnderlyingProbeFailed();
-        try IERC4626(_underlying).asset() returns (address a) {
+        try IYieldAdapter(_adapter).probe(_underlying) returns (address a) {
             if (a == address(0)) revert UnderlyingProbeFailed();
             asset = a;
         } catch {
-            revert UnderlyingProbeFailed();
-        }
-        try IERC4626(_underlying).totalAssets() returns (uint256) {} catch {
             revert UnderlyingProbeFailed();
         }
     }

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -124,7 +124,7 @@ contract LiFiVaultWrapperFactory is TransferrableOwnership {
 
     /// Config (owner / timelock) ///
 
-    /// @notice Add or remove an ERC4626 vault from the deploy allowlist.
+    /// @notice Add or remove a yield source from the deploy allowlist.
     function setUnderlyingAllowed(
         address _underlying,
         bool _allowed

--- a/src/VaultWrapper/LiFiVaultWrapperTypes.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperTypes.sol
@@ -27,7 +27,8 @@ struct FeeBounds {
 /// @notice Parameters for a single wrapper deployment.
 struct DeployParams {
     address integrator;
-    address underlying; // The ERC4626 vault to wrap; its asset() is derived by the factory.
+    address adapter; // Approved yield adapter; validates `underlying` and derives its asset.
+    address underlying; // Protocol-specific yield source (e.g. an ERC-4626 vault).
     uint256 chainLockId;
     uint256 nonce;
     FeeConfig fees;

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
+
+/// @title ERC4626Adapter
+/// @author LI.FI (https://li.fi)
+/// @notice Yield adapter for standard ERC-4626 vaults. Validates the vault and
+///         derives its asset via the ERC-4626 introspection methods.
+/// @custom:version 1.0.0
+contract ERC4626Adapter is IYieldAdapter {
+    error UnderlyingProbeFailed();
+
+    /// @inheritdoc IYieldAdapter
+    function probe(address _underlying) external view returns (address asset) {
+        if (_underlying.code.length == 0) revert UnderlyingProbeFailed();
+        try IERC4626(_underlying).asset() returns (address a) {
+            if (a == address(0)) revert UnderlyingProbeFailed();
+            asset = a;
+        } catch {
+            revert UnderlyingProbeFailed();
+        }
+        try IERC4626(_underlying).totalAssets() returns (uint256) {} catch {
+            revert UnderlyingProbeFailed();
+        }
+    }
+}

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -9,8 +9,9 @@ import { FeeConfig } from "../LiFiVaultWrapperTypes.sol";
 /// @notice Minimal interface the factory calls on a freshly deployed clone.
 interface ILiFiVaultWrapper {
     /// @notice One-time setup of a wrapper clone immediately after deployment.
-    /// @param _asset The ERC20 asset of the underlying vault.
-    /// @param _underlying The wrapped ERC4626 vault.
+    /// @param _asset The ERC20 asset of the underlying yield source.
+    /// @param _underlying The protocol-specific yield source (e.g. an ERC-4626 vault).
+    /// @param _adapter The approved yield adapter the clone routes through at runtime.
     /// @param _integrator The address granted the instance admin role.
     /// @param _chainLockId 0 if unlocked, else the only chain id where deposits are allowed.
     /// @param _fees The per-fee-type rates and enabled flags (already validated by the factory).
@@ -18,6 +19,7 @@ interface ILiFiVaultWrapper {
     function initialize(
         address _asset,
         address _underlying,
+        address _adapter,
         address _integrator,
         uint256 _chainLockId,
         FeeConfig calldata _fees,

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+/// @title IYieldAdapter
+/// @author LI.FI (https://li.fi)
+/// @notice Adapter abstraction over a yield source (ERC-4626 vault, Aave market, ...).
+///         The factory depends only on `probe`; the wrapper implementation extends
+///         this interface with runtime methods (deposit/withdraw/totalAssets/
+///         convertToShares) in S1.
+/// @custom:version 1.0.0
+interface IYieldAdapter {
+    /// @notice Validates that `_underlying` is a usable yield source for this
+    ///         adapter's protocol and returns its ERC20 asset.
+    /// @dev MUST revert if `_underlying` is unusable (wrong protocol, not a
+    ///      contract, zero asset, broken introspection).
+    /// @param _underlying The protocol-specific yield source identifier.
+    /// @return asset The ERC20 token deposited into the yield source.
+    function probe(address _underlying) external view returns (address asset);
+}

--- a/src/VaultWrapper/mocks/MockVaultWrapper.sol
+++ b/src/VaultWrapper/mocks/MockVaultWrapper.sol
@@ -15,6 +15,7 @@ contract MockVaultWrapper is ILiFiVaultWrapper {
     bool public initialized;
     address public asset;
     address public underlying;
+    address public adapter;
     address public integrator;
     uint256 public chainLockId;
     bytes public initData;
@@ -25,6 +26,7 @@ contract MockVaultWrapper is ILiFiVaultWrapper {
     function initialize(
         address _asset,
         address _underlying,
+        address _adapter,
         address _integrator,
         uint256 _chainLockId,
         FeeConfig calldata _fees,
@@ -34,6 +36,7 @@ contract MockVaultWrapper is ILiFiVaultWrapper {
         initialized = true;
         asset = _asset;
         underlying = _underlying;
+        adapter = _adapter;
         integrator = _integrator;
         chainLockId = _chainLockId;
         _feeConfig = _fees;

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -5,6 +5,7 @@ import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { MockVaultWrapper } from "lifi/VaultWrapper/mocks/MockVaultWrapper.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeType, DeployParams, FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { UnAuthorized, InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 import { MockERC4626Underlying } from "./mocks/MockERC4626Underlying.sol";
@@ -13,6 +14,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     LiFiVaultWrapperFactory internal factory;
     UpgradeableBeacon internal beacon;
     MockVaultWrapper internal impl;
+    ERC4626Adapter internal adapter;
 
     address internal owner = makeAddr("owner");
     address internal pauser = makeAddr("pauser");
@@ -30,6 +32,9 @@ contract LiFiVaultWrapperFactoryTest is Test {
             pauser,
             onboarder
         );
+        adapter = new ERC4626Adapter();
+        vm.prank(owner);
+        factory.setAdapterApproved(address(adapter), true);
     }
 
     function test_ConstructorSetsRolesBeaconAndDefaultSplit() public view {
@@ -141,9 +146,9 @@ contract LiFiVaultWrapperFactoryTest is Test {
 
     function test_PredictAddressIsDeterministicAndNonceVaries() public {
         address u = makeAddr("underlying");
-        address a = factory.predictAddress(integrator, u, 0);
-        address b = factory.predictAddress(integrator, u, 0);
-        address c = factory.predictAddress(integrator, u, 1);
+        address a = factory.predictAddress(integrator, address(adapter), u, 0);
+        address b = factory.predictAddress(integrator, address(adapter), u, 0);
+        address c = factory.predictAddress(integrator, address(adapter), u, 1);
         assertEq(a, b);
         assertTrue(a != c);
         assertTrue(a != address(0));
@@ -165,6 +170,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         bool[4] memory enabled = [true, false, false, false];
         p = DeployParams({
             integrator: integrator_,
+            adapter: address(adapter),
             underlying: address(underlying),
             chainLockId: 0,
             nonce: nonce_,
@@ -179,6 +185,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
 
         address predicted = factory.predictAddress(
             integrator,
+            address(adapter),
             address(underlying),
             0
         );
@@ -193,6 +200,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertTrue(w.initialized());
         assertEq(w.asset(), assetToken);
         assertEq(w.underlying(), address(underlying));
+        assertEq(w.adapter(), address(adapter));
         assertEq(w.integrator(), integrator);
         assertEq(w.chainLockId(), 0);
         assertEq(w.feeRate(uint8(FeeType.Performance)), 1000);
@@ -247,6 +255,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.stopPrank();
         DeployParams memory p;
         p.integrator = integrator;
+        p.adapter = address(adapter);
         p.underlying = notAVault;
         uint16[4] memory rates = [uint16(0), 0, 0, 0];
         bool[4] memory enabled = [false, false, false, false];
@@ -294,6 +303,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.stopPrank();
         DeployParams memory p;
         p.integrator = integrator;
+        p.adapter = address(adapter);
         p.underlying = address(underlying);
         uint16[4] memory rates = [uint16(0), 1500, 0, 0]; // 15% > 10% cap
         bool[4] memory enabled = [false, true, false, false];
@@ -377,5 +387,53 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(page.length, 2);
         assertEq(page[0], i0);
         assertEq(page[1], i1);
+    }
+
+    function test_DeployRevertsOnUnapprovedAdapter() public {
+        _enableUnderlyingAndBounds();
+        ERC4626Adapter rogue = new ERC4626Adapter();
+        DeployParams memory p = _params(integrator, 0);
+        p.adapter = address(rogue); // never approved
+        vm.prank(onboarder);
+        vm.expectRevert(LiFiVaultWrapperFactory.AdapterNotApproved.selector);
+        factory.deploy(p);
+    }
+
+    function test_PredictAddressVariesByAdapter() public {
+        ERC4626Adapter other = new ERC4626Adapter();
+        address u = makeAddr("underlying");
+        address withA = factory.predictAddress(
+            integrator,
+            address(adapter),
+            u,
+            0
+        );
+        address withB = factory.predictAddress(
+            integrator,
+            address(other),
+            u,
+            0
+        );
+        assertTrue(withA != withB);
+    }
+
+    function test_OwnerSetsAdapterApproved() public {
+        address a = makeAddr("adapter2");
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit LiFiVaultWrapperFactory.AdapterApprovedSet(a, true);
+        vm.prank(owner);
+        factory.setAdapterApproved(a, true);
+        assertTrue(factory.approvedAdapter(a));
+    }
+
+    function test_NonOwnerCannotSetAdapterApproved() public {
+        vm.expectRevert(UnAuthorized.selector);
+        factory.setAdapterApproved(makeAddr("adapter2"), true);
+    }
+
+    function test_SetAdapterApprovedRevertsOnZero() public {
+        vm.prank(owner);
+        vm.expectRevert(InvalidConfig.selector);
+        factory.setAdapterApproved(address(0), true);
     }
 }

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
+
+contract ERC4626AdapterTest is Test {
+    ERC4626Adapter internal adapter;
+    address internal assetToken = makeAddr("asset");
+
+    function setUp() public {
+        adapter = new ERC4626Adapter();
+    }
+
+    function test_ProbeReturnsAssetForValidVault() public {
+        MockERC4626Underlying vault = new MockERC4626Underlying(assetToken);
+        assertEq(adapter.probe(address(vault)), assetToken);
+    }
+
+    function test_ProbeRevertsOnNoCode() public {
+        vm.expectRevert(ERC4626Adapter.UnderlyingProbeFailed.selector);
+        adapter.probe(makeAddr("eoa"));
+    }
+
+    function test_ProbeRevertsOnZeroAsset() public {
+        MockERC4626Underlying vault = new MockERC4626Underlying(address(0));
+        vm.expectRevert(ERC4626Adapter.UnderlyingProbeFailed.selector);
+        adapter.probe(address(vault));
+    }
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-514 — Yield adapter abstraction in vault wrapper factory](https://linear.app/lifi-linear/issue/EXSC-514/yield-adapter-abstraction-in-vault-wrapper-factory)

> **Stacked PR.** Base branch is `feature/exsc-417-s8-factory` (#1936), not `main`. Review only the delta in this PR; the factory itself is reviewed in #1936.

# Why did I implement it this way?

Makes `LiFiVaultWrapperFactory` protocol-agnostic so future yield sources (Aave v3, Compound, Morpho) can be supported without changing the factory or deploying a second beacon. The factory previously hardcoded an ERC-4626 probe (`IERC4626(underlying).asset()` / `totalAssets()`) and derived the asset from the underlying — which does not generalize to Aave (rebasing aTokens, `pool.supply`/`withdraw`, no ERC-4626 introspection).

Approach (Option A — single beacon, heterogeneity in adapters):

- **`IYieldAdapter` seam.** The factory depends only on `probe(underlying) → asset`, which validates the underlying for its protocol and returns the ERC20 asset (reverts if unusable). The wrapper implementation extends the *same* interface with runtime methods (deposit/withdraw/totalAssets/convertToShares) in S1 — out of scope here.
- **`ERC4626Adapter` as the first adapter.** The ERC-4626 validation/asset-derivation that used to be inlined in the factory now lives in this adapter. The factory contains zero ERC-4626 references afterward.
- **Governance adapter registry.** `approvedAdapter` + `setAdapterApproved` (owner-only, mirrors the existing underlying allowlist). `deploy()` requires both the adapter approved and the underlying allowlisted, then calls `adapter.probe()`.
- **Adapter recorded per clone.** Folded into the CREATE2 salt (`keccak256(integrator, adapter, underlying, nonce)`), the `WrapperDeployed` event (non-indexed; the event already uses its 3 indexed topics), `predictAddress`, and `initialize()` so each clone knows which adapter to call at runtime. Same `(integrator, underlying)` under a different adapter is a distinct instance.
- **Deploy script** deploys + returns the `ERC4626Adapter`. The deployer key is not the governance owner, so approval/allowlisting is a post-deploy governance step (documented in the script NatSpec).

Net result: adding Aave later is `AaveV3Adapter` + `setAdapterApproved` + `setUnderlyingAllowed` — no factory edit, no second beacon.

**Scope boundaries / follow-ups:**
- Wrapper runtime methods and the concrete `AaveV3Adapter` are **S1 (EXSC-409) / wrapper-team** scope. This PR ships only the adapter seam + the ERC-4626 adapter.
- `MockVaultWrapper` remains the temporary beacon implementation until S1 (unchanged here except recording the new `adapter` init arg).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
