### PR TITLE
fix(utils): introduce NetworkKey for Tron-outside-networks.json compat

### DIFF
--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -15,6 +15,12 @@ export type TTronWalletName = keyof TGlobalConfig['tronWallets']
 
 export type SupportedChain = keyof typeof networks
 
+/** Tron network keys — hardcoded because they are never in networks.json (Tron is non-EVM). */
+export type TronNetworkKey = 'tron' | 'tronshasta'
+
+/** Any network key accepted by deployment scripts: EVM chains from config plus Tron. */
+export type NetworkKey = SupportedChain | TronNetworkKey
+
 type NetworkRow = (typeof networks)[keyof typeof networks]
 
 /**

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -21,6 +21,7 @@ import type {
   INetwork,
   INetworkInfo,
   INetworksObject,
+  NetworkKey,
   SupportedChain,
 } from '../common/types'
 import { EnvironmentEnum } from '../common/types'
@@ -351,7 +352,7 @@ export async function saveContractAddress(
  * Tries env-specific file first, then base network file; also tries alternate roots (e.g. cwd vs cwd/contracts).
  */
 export async function getContractAddress(
-  network: SupportedChain,
+  network: NetworkKey,
   contract: string
 ): Promise<string | null> {
   const environment = getEnvironment()
@@ -535,7 +536,7 @@ export async function updateDiamondJson(
   facetAddress: string,
   facetName: string,
   version?: string,
-  network: SupportedChain = 'tron'
+  network: NetworkKey = 'tron'
 ): Promise<void> {
   try {
     const diamondJsonPath = resolve(
@@ -626,7 +627,7 @@ export async function updateDiamondJsonBatch(
     name: string
     version?: string
   }>,
-  network: SupportedChain = 'tron'
+  network: NetworkKey = 'tron'
 ): Promise<void> {
   try {
     const diamondJsonPath = resolve(
@@ -730,7 +731,7 @@ export async function updateDiamondJsonBatch(
 export async function updateDiamondJsonPeriphery(
   contractAddress: string,
   contractName: string,
-  network: SupportedChain = 'tron'
+  network: NetworkKey = 'tron'
 ): Promise<void> {
   try {
     const diamondJsonPath = resolve(
@@ -937,4 +938,3 @@ Selectors: ${selectors.length} functions
     },
   })
 }
-


### PR DESCRIPTION
## Which Linear task belongs to this PR?

Ref EXSC-366

## Why did I implement it this way?

`SupportedChain` is derived from `config/networks.json` via `keyof typeof networks`. When `networks.json` is temporarily narrowed to a subset of chains (e.g. for emergency-pause retesting), Tron literal strings `'tron'` and `'tronshasta'` fall outside the union and cause TS errors in four `utils.ts` functions.

Rather than widening those parameters to `string` (which loses type information), this PR adds two new types to `script/common/types.ts`:
- `TronNetworkKey = 'tron' | 'tronshasta'` — explicit Tron literals that are intentionally non-EVM and will never appear in `networks.json`
- `NetworkKey = SupportedChain | TronNetworkKey` — used in deployment helpers that must accept both EVM and Tron networks

`SupportedChain` stays clean and config-derived. When Tron is restored to `networks.json`, `NetworkKey` becomes slightly redundant but continues to work correctly.

## Author checklist

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run /pr-ready (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings
- [ ] I have added tests that cover the functionality
- [ ] For new facets: I have created an audit log entry and informed the auditors about this addition
- [ ] I have updated any required documentation

## Reviewer checklist

- [ ] The code works as expected
- [ ] The code is easy to understand
- [ ] I have checked for potential security issues
- [ ] I have checked for potential performance issues