### PR TITLE
EXSC-523: Add profile.ci with reduced fuzz runs for CI

### DIFF
--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -93,6 +93,8 @@ jobs:
         run: forge install
 
       - name: Generate Coverage Report
+        env:
+          FOUNDRY_PROFILE: ci
         run: |
           forge coverage --report lcov --force --ir-minimum
 

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Run forge tests
         # retry failed tests up to 10 times (RPC flakiness)
         shell: bash
+        env:
+          FOUNDRY_PROFILE: ci
         run: |
           forge test && exit 0
           for i in $(seq 1 10); do

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,16 @@ ffi = true
 libs = ["node_modules", "lib"]
 cache = true
 
+# CI profile: lower fuzz runs for faster PR feedback. Local default keeps 256 runs.
+[profile.default.fuzz]
+runs = 256
+
+[profile.ci]
+# Inherits [profile.default]; only fuzz runs differ for faster CI.
+
+[profile.ci.fuzz]
+runs = 32
+
 [profile.zksync]
 solc_version = '0.8.29'
 evm_version = 'cancun'


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-523

# Why did I implement it this way?

CI sets FOUNDRY_PROFILE=ci (32 fuzz runs) while local default stays at 256, cutting facet fuzz overhead without weakening nightly/local runs.

CodeRabbit: clean (local /pr-ready).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
