### PR TITLE
EXSC-524: Shard forge test CI across runner matrix

### DIFF
--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -96,7 +96,24 @@ jobs:
         env:
           FOUNDRY_PROFILE: ci
         run: |
-          forge coverage --report lcov --force --ir-minimum
+          set -euo pipefail
+          # forge coverage hits live RPCs for fork tests and has no built-in
+          # retry, so a single transient RPC blip sinks the whole report. Retry
+          # the full command (--rerun can't be used — coverage needs the complete
+          # run). Kept low: --ir-minimum coverage is slow (~8 min/run).
+          for i in 1 2 3; do
+            echo "::group::forge coverage (attempt $i/3)"
+            if forge coverage --report lcov --force --ir-minimum; then
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
+            if [[ "$i" -eq 3 ]]; then
+              echo "forge coverage failed after 3 attempts" >&2
+              exit 1
+            fi
+            sleep 15
+          done
 
           echo "Filtering coverage report to only contain coverage info for 'src/'' folder now"
 

--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -93,6 +93,8 @@ jobs:
         run: forge install
 
       - name: Generate Coverage Report
+        env:
+          FOUNDRY_PROFILE: ci
         run: |
           forge coverage --report lcov --force --ir-minimum
 

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Run forge tests
         # retry failed tests up to 10 times (RPC flakiness)
         shell: bash
+        env:
+          FOUNDRY_PROFILE: ci
         run: |
           forge test && exit 0
           for i in $(seq 1 10); do

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -108,29 +108,24 @@ jobs:
           FOUNDRY_PROFILE: ci
         run: |
           set -euo pipefail
-          MATCH_PATHS=()
+          # forge accepts only a single --match-path/--no-match-path argument, so
+          # each shard maps to exactly one glob. `misc` is a catch-all by
+          # exclusion: any new top-level dir under test/solidity/ auto-runs there
+          # instead of silently dropping out of CI with all checks green.
           case "${{ matrix.shard }}" in
-            libraries) MATCH_PATHS+=("test/solidity/Libraries/**") ;;
-            facets) MATCH_PATHS+=("test/solidity/Facets/**") ;;
-            periphery) MATCH_PATHS+=("test/solidity/Periphery/**") ;;
-            gas) MATCH_PATHS+=("test/solidity/Gas/**") ;;
-            misc)
-              MATCH_PATHS+=("test/solidity/Helpers/**")
-              MATCH_PATHS+=("test/solidity/Security/**")
-              MATCH_PATHS+=("test/solidity/LiFiDiamond.t.sol")
-              ;;
+            libraries) FORGE_ARGS=(--match-path "test/solidity/Libraries/**") ;;
+            facets)    FORGE_ARGS=(--match-path "test/solidity/Facets/**") ;;
+            periphery) FORGE_ARGS=(--match-path "test/solidity/Periphery/**") ;;
+            gas)       FORGE_ARGS=(--match-path "test/solidity/Gas/**") ;;
+            misc)      FORGE_ARGS=(--no-match-path "test/solidity/{Libraries,Facets,Periphery,Gas}/**") ;;
+            *) echo "Unknown shard: ${{ matrix.shard }}" >&2; exit 1 ;;
           esac
 
-          FORGE_ARGS=(test)
-          for path in "${MATCH_PATHS[@]}"; do
-            FORGE_ARGS+=(--match-path "$path")
-          done
-
-          forge "${FORGE_ARGS[@]}" && exit 0
+          forge test "${FORGE_ARGS[@]}" && exit 0
           for i in $(seq 1 10); do
-            echo "::group::Retry $i/10: forge ${FORGE_ARGS[*]} --rerun"
+            echo "::group::Retry $i/10: forge test ${FORGE_ARGS[*]} --rerun"
             sleep 15
-            forge "${FORGE_ARGS[@]}" --rerun && exit 0
+            forge test "${FORGE_ARGS[@]}" --rerun && exit 0
             echo "::endgroup::"
           done
           exit 1

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -1,5 +1,6 @@
 # - Run (Foundry) Unit Test Suite
 # - will make sure that all tests pass
+# - Sharded across five parallel runners (Libraries, Facets, Periphery, Gas, misc)
 # - Path-gated: heavy job runs only when files that can affect test outcome change.
 #   A `unit-tests-required` aggregator job always reports a final status so this
 #   workflow can remain a required check on `main` branch protection even when
@@ -56,6 +57,10 @@ jobs:
          github.event.pull_request.draft == false)
       }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [libraries, facets, periphery, gas, misc]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -96,17 +101,36 @@ jobs:
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
 
-      - name: Run forge tests
+      - name: Run forge tests (${{ matrix.shard }})
         # retry failed tests up to 10 times (RPC flakiness)
         shell: bash
         env:
           FOUNDRY_PROFILE: ci
         run: |
-          forge test && exit 0
+          set -euo pipefail
+          MATCH_PATHS=()
+          case "${{ matrix.shard }}" in
+            libraries) MATCH_PATHS+=("test/solidity/Libraries/**") ;;
+            facets) MATCH_PATHS+=("test/solidity/Facets/**") ;;
+            periphery) MATCH_PATHS+=("test/solidity/Periphery/**") ;;
+            gas) MATCH_PATHS+=("test/solidity/Gas/**") ;;
+            misc)
+              MATCH_PATHS+=("test/solidity/Helpers/**")
+              MATCH_PATHS+=("test/solidity/Security/**")
+              MATCH_PATHS+=("test/solidity/LiFiDiamond.t.sol")
+              ;;
+          esac
+
+          FORGE_ARGS=(test)
+          for path in "${MATCH_PATHS[@]}"; do
+            FORGE_ARGS+=(--match-path "$path")
+          done
+
+          forge "${FORGE_ARGS[@]}" && exit 0
           for i in $(seq 1 10); do
-            echo "::group::Retry $i/10: forge test --rerun"
+            echo "::group::Retry $i/10: forge ${FORGE_ARGS[*]} --rerun"
             sleep 15
-            forge test --rerun && exit 0
+            forge "${FORGE_ARGS[@]}" --rerun && exit 0
             echo "::endgroup::"
           done
           exit 1

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,16 @@ ffi = true
 libs = ["node_modules", "lib"]
 cache = true
 
+# CI profile: lower fuzz runs for faster PR feedback. Local default keeps 256 runs.
+[profile.default.fuzz]
+runs = 256
+
+[profile.ci]
+# Inherits [profile.default]; only fuzz runs differ for faster CI.
+
+[profile.ci.fuzz]
+runs = 32
+
 [profile.zksync]
 solc_version = '0.8.29'
 evm_version = 'cancun'


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-524

# Why did I implement it this way?

Parallel matrix over Libraries/Facets/Periphery/Gas/misc reduces wall-clock CI time. Rebased on EXSC-523 — merge EXSC-523 first (includes FOUNDRY_PROFILE=ci + matrix).

Depends on EXSC-523. CodeRabbit: not run (CLI rate limit after 523).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
