### PR TITLE
EXSC-525: Verify fast archive mainnet RPC for CI

### DIFF
--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -76,6 +76,8 @@ jobs:
         run: forge install
 
       - name: Fetch RPC endpoints from MongoDB
+        # ETH_NODE_URI_MAINNET must be a fast archive node: fork tests pin old blocks
+        # and cold RPC cache misses require historical state (see EXSC-525).
         run: |
           # Run the fetch-rpcs.ts script to update .env with RPC endpoint variables
           # This will fetch prioritized RPCs from MongoDB, or fall back to public RPCs from networks.json if MongoDB is unavailable


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-525

# Why did I implement it this way?

Documents that ETH_NODE_URI_MAINNET from fetch-rpcs must be archive-capable for pinned historical blocks. MongoDB RPC verification remains a DevOps follow-up.

CodeRabbit: not run (CLI rate limit).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
