### PR TITLE
EXSC-526: Add scoped forge test commands for agents

### DIFF
--- a/.agents/commands/create-pr.md
+++ b/.agents/commands/create-pr.md
@@ -154,7 +154,7 @@ The one gap pre-commit deliberately leaves is **tests** (`forge build --skip tes
 `bun test:ts`). Per `.agents/rules/099-finish.md`, run them now — against the
 post-`/pr-ready` HEAD so any auto-fix commits are validated:
 
-- **Solidity changes**: `forge test` (or `forge test --match-path` if scope is clear).
+- **Solidity changes**: `bun test:scoped -- <path-or-match>` during iteration; full `bun test` (or `forge test --match-path` if scope is clear) before opening a PR.
 - **TypeScript / JS changes**: `bun test:ts`.
 - **Docs / markdown / skill files only**: skip; note `N/A` in the summary.
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "claude:install": "node script/claude/install.mjs",
     "remove-from-diamond": "bun script/tasks/cleanUpProdDiamond.ts",
     "test": "forge test --evm-version 'cancun'",
+    "test:scoped": "bun script/utils/runScopedForgeTests.ts",
     "test:fix": "npm run lint:fix; npm run format:fix; npm run test",
     "test:ts": "bun script/runTypescriptTests.ts",
     "troncast": "bun run script/troncast/index.ts",

--- a/script/utils/runScopedForgeTests.ts
+++ b/script/utils/runScopedForgeTests.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+/**
+ * Run a scoped forge test invocation for faster agent/human iteration.
+ *
+ * Usage:
+ *   bun test:scoped -- test/solidity/Facets/AccessManagerFacet.t.sol
+ *   bun test:scoped -- --match-contract AccessManagerFacetTest
+ *   bun test:scoped -- test/solidity/Libraries/
+ *
+ * All arguments after `--` are forwarded to `forge test`.
+ * When no args are given, prints usage and exits 1.
+ */
+import { spawnSync } from 'node:child_process'
+
+const sepIndex = process.argv.indexOf('--')
+const forgeArgs =
+  sepIndex === -1 ? process.argv.slice(2) : process.argv.slice(sepIndex + 1)
+
+if (forgeArgs.length === 0) {
+  console.error(`Usage: bun test:scoped -- <forge test args>
+
+Examples:
+  bun test:scoped -- test/solidity/Facets/AccessManagerFacet.t.sol
+  bun test:scoped -- --match-contract AccessManagerFacetTest
+  bun test:scoped -- test/solidity/Libraries/LibAllowList.t.sol -vvv`)
+  process.exit(1)
+}
+
+const result = spawnSync(
+  'forge',
+  ['test', '--evm-version', 'cancun', ...forgeArgs],
+  { stdio: 'inherit', env: process.env }
+)
+
+process.exit(result.status ?? 1)

--- a/script/utils/runScopedForgeTests.ts
+++ b/script/utils/runScopedForgeTests.ts
@@ -32,4 +32,9 @@ const result = spawnSync(
   { stdio: 'inherit', env: process.env }
 )
 
+if (result.error) {
+  console.error(`Error: Failed to spawn forge: ${result.error.message}`)
+  process.exit(1)
+}
+
 process.exit(result.status ?? 1)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-526

# Why did I implement it this way?

Adds bun test:scoped wrapping forge test --match-path/--match-contract so agents iterate on seconds-scale feedback instead of the full fork suite.

Manually verified (no automated test added — 35-line spawnSync wrapper):

- No args → prints usage, exits 1.
- Args after `--` → forwarded to forge.
- Args without `--` (the `slice(2)` fallback) → forwarded to forge.
- Real scoped run (`-- test/solidity/Libraries/LibAllowList.t.sol`) → 12 passed via `--evm-version cancun`, exit 0.
- Forge error (bad flag) → non-zero exit propagated (the property that matters for CI/agents, via `process.exit(result.status ?? 1)`).

CodeRabbit: /pr-ready run locally against the branch (full mode, counts toward lifinance plan). 1 minor finding (silent forge spawn failure) fixed in a9230e82; scoped re-run clean — no findings.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


