### PR TITLE
EXSC-528: Gate Types Bindings CI on requires-types label

### DIFF
--- a/.agents/rules/500-github-actions.md
+++ b/.agents/rules/500-github-actions.md
@@ -94,6 +94,10 @@ Example header format:
 
 #### Permissions
 
+- **Default-deny at the workflow level** with `permissions: {}`, then grant the minimal
+  scopes each job needs at the **job level**. A workflow-level grant is inherited by every
+  job, handing low-trust jobs more access than they need (flagged by Aikido as
+  "Overly Broad Permissions").
 - **Always document why each permission is needed** with inline comments
 - Use minimal permissions (principle of least privilege)
 - Common patterns:
@@ -106,10 +110,15 @@ Example header format:
 Example:
 
 ```yaml
-permissions:
-  contents: read # required to fetch repository contents
-  pull-requests: write # required to edit PR title and assign/remove labels
-  actions: write # required to upload/download artifacts between jobs
+# Default-deny at the workflow level; grant only what each job needs at the job level.
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: read # required to fetch repository contents
+      pull-requests: write # required to edit PR title and assign/remove labels
+      actions: write # required to upload/download artifacts between jobs
 ```
 
 #### Job Organization

--- a/.agents/rules/500-github-actions.md
+++ b/.agents/rules/500-github-actions.md
@@ -184,6 +184,17 @@ done <<< "${FILES}"
 - **Authorization**: Only allow specific bots (e.g., `lifi-action-bot`) to modify protected labels
 - **Verification**: Always verify label state after modification
 
+### Label-gated heavy workflows ([CONV:CI-LABEL-GATE])
+
+Use when a workflow is expensive (Foundry install, type generation, external repo publish) and most PRs do not need it:
+
+1. **Gate the heavy job** on a dedicated label (e.g. `requires-types`) for `pull_request` events; keep unconditional runs for `push` to `main` and `workflow_dispatch`.
+2. **Auto-assign the label** in a separate lightweight workflow using `dorny/paths-filter` on ABI-relevant paths so humans/agents do not need to remember the label for typical contract changes.
+3. **Include `labeled` in triggers** so the heavy workflow runs after the auto-label workflow adds the label (avoids race on the first `synchronize` event).
+4. **Document manual opt-in**: edge-case PRs (e.g. script-only changes needing fresh bindings) can add the label by hand.
+
+Reference: `assignRequiresTypesLabel.yml` + `types.yaml`.
+
 ### PR Comments
 
 - **Comment identification**: Use unique markers (e.g., "🤖 GitHub Action: Security Alerts Review 🔍")

--- a/.github/workflows/assignRequiresTypesLabel.yml
+++ b/.github/workflows/assignRequiresTypesLabel.yml
@@ -1,0 +1,50 @@
+# Assign Requires Types Label
+# - Auto-assigns the `requires-types` label when a PR touches ABI/type-relevant paths
+# - Triggers Types Bindings (types.yaml) via the `labeled` event on the next workflow run
+# - Skips draft PRs until marked ready for review
+# - Humans/agents can also add `requires-types` manually for edge cases (e.g. script-only PRs
+#   that need fresh bindings without a src/ diff)
+
+name: Assign Requires Types Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read # required to fetch repository contents
+  pull-requests: write # required to assign the requires-types label
+
+jobs:
+  assign-requires-types-label:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Detect ABI-relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            types:
+              - 'foundry.toml'
+              - 'remappings.txt'
+              - 'src/**'
+              - 'lib/**'
+              - 'tasks/generateDiamondABI.ts'
+              - 'package.json'
+              - '.gitmodules'
+
+      - name: Skip when no ABI-relevant changes
+        if: steps.filter.outputs.types != 'true'
+        run: echo "No ABI-relevant changes; requires-types label not needed."
+
+      - name: Add requires-types label
+        if: >-
+          steps.filter.outputs.types == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'requires-types')
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+        with:
+          labels: requires-types

--- a/.github/workflows/assignRequiresTypesLabel.yml
+++ b/.github/workflows/assignRequiresTypesLabel.yml
@@ -11,12 +11,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-permissions:
-  contents: read # required to fetch repository contents
-  pull-requests: write # required to assign the requires-types label
+# Default-deny at the workflow level; grant only what the job needs at the job level.
+permissions: {}
 
 jobs:
   assign-requires-types-label:
+    permissions:
+      contents: read # required to fetch repository contents
+      pull-requests: write # required to assign the requires-types label
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -17,15 +17,17 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write # Needed to push new tags to lifi-contract-types
-  pull-requests: read # required to read PR labels when gating the job
+# Default-deny at the workflow level; grant only what generate-tag needs at the job level.
+permissions: {}
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   generate-tag:
+    permissions:
+      contents: write # Needed to push new tags to lifi-contract-types
+      pull-requests: read # required to read PR labels when gating the job
     if: >-
       ${{
         github.event_name == 'push' ||

--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -26,7 +26,7 @@ env:
 jobs:
   generate-tag:
     permissions:
-      contents: write # Needed to push new tags to lifi-contract-types
+      contents: read # required to fetch repository contents (tags are pushed to lifi-contract-types via SSH key, not GITHUB_TOKEN)
       pull-requests: read # required to read PR labels when gating the job
     if: >-
       ${{

--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -1,16 +1,39 @@
+# Types Bindings
+# - Generates ABI + TypeScript bindings and publishes to lifinance/lifi-contract-types
+# - On PRs: runs only when the `requires-types` label is present (assignRequiresTypesLabel.yml
+#   auto-adds it for ABI-relevant path changes; add the label manually for edge cases)
+# - On push to main: always runs (production type release)
+# - workflow_dispatch: manual trigger
+# - Known limitation: a PR synchronize event may skip until assignRequiresTypesLabel adds the
+#   label and re-triggers this workflow via `labeled`
+
 name: Types Bindings
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
   push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
-  contents: write # Needed to push new tags
+  contents: write # Needed to push new tags to lifi-contract-types
+  pull-requests: read # required to read PR labels when gating the job
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   generate-tag:
+    if: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.draft == false &&
+         contains(github.event.pull_request.labels.*.name, 'requires-types'))
+      }}
     runs-on: ubuntu-latest
 
     steps:
@@ -116,7 +139,7 @@ jobs:
         env:
           LATEST_TAG: ${{ env.LATEST_TAG }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
-          MESSAGE: ${{ github.event.head_commit.message }}
+          MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title || 'workflow dispatch' }}
         id: bump_version
         run: |
           # Remove leading "v" from LATEST_TAG for semver parsing
@@ -166,7 +189,7 @@ jobs:
         env:
           NEW_VERSION: ${{ env.NEW_VERSION }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
-          MESSAGE: ${{ github.event.head_commit.message }}
+          MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title || 'workflow dispatch' }}
         run: |
           cd lifi-contract-types
           TMP=$(mktemp)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-528/gate-types-bindings-ci-on-requires-types-label

Parent: [EXSC-519](https://linear.app/lifi-linear/issue/EXSC-519/speed-up-contracts-test-and-agent-feedback-loop)

# Why did I implement it this way?

`types.yaml` previously ran on **every push** to any branch — installing Foundry, running `forge install`, generating ABI + TypeChain, and publishing beta tags to `lifinance/lifi-contract-types`. Most PRs (test-only, docs, CI-only, script-only) never need that.

This change:

1. **Gates** the heavy `generate-tag` job on PRs behind a `requires-types` label (created in the repo).
2. **Auto-assigns** `requires-types` via `assignRequiresTypesLabel.yml` when the PR diff touches ABI-relevant paths (`src/**`, `lib/**`, `foundry.toml`, etc.).
3. **Keeps unconditional runs** on `push` to `main` and `workflow_dispatch` (production release path).
4. **Documents** the label-gate pattern in `.agents/rules/500-github-actions.md` for future heavy workflows.

Manual opt-in: add `requires-types` by hand when a PR needs fresh bindings without touching `src/` (e.g. script-only changes consuming new selectors).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

Made with [Cursor](https://cursor.com)