### PR TITLE
fix(tasks): target LiFiTimelockController in unpause Safe proposals

### DIFF
--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -150,9 +150,10 @@ const main = defineCommand({
         try {
           consola.info(`[${network.name}] Processing network now`)
 
-          // get the diamond address for this network
-          const diamondAddress = await getContractAddressForNetwork(
-            'LiFiDiamond',
+          // get the timelock address for this network — unpauseDiamond on the
+          // timelock bypasses minDelay and is callable directly by the Safe admin
+          const timelockAddress = await getContractAddressForNetwork(
+            'LiFiTimelockController',
             network.name as SupportedChain,
             environment
           )
@@ -193,7 +194,7 @@ const main = defineCommand({
           const safeTransaction = await safe.createTransaction({
             transactions: [
               {
-                to: diamondAddress as Address,
+                to: timelockAddress as Address,
                 value: 0n,
                 data: calldata,
                 operation: OperationTypeEnum.Call,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-529/fix-unpause-safe-proposals-targeting-diamond-instead-of

# Why did I implement it this way?

The production mainnet path of `unpauseAllDiamonds` was resolving the `to` address for the Safe proposal from `LiFiDiamond` instead of `LiFiTimelockController`. On mainnets the diamond is owned by the timelock, not by the Safe directly. The Safe is the timelock's admin and can call `unpauseDiamond` on it (which bypasses `minDelay`), but the Safe has no direct authority over the diamond. Every proposal generated by the old code would revert on execution.

The fix is a one-line change: look up `LiFiTimelockController` instead of `LiFiDiamond` when constructing the Safe transaction target in the mainnet pass. The testnet / staging direct-send path is unaffected — those diamonds are EOA-owned and receive calldata directly.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>