### PR TITLE
demo: scanner-blind bug for security-review pipeline (DO NOT MERGE)

### DIFF
--- a/docs/demo-diff-review-positive-slippage.md
+++ b/docs/demo-diff-review-positive-slippage.md
@@ -1,0 +1,90 @@
+# Demo fixture — a bug only `differential-review` catches
+
+> **This branch (`demo/diff-review-positive-slippage`) is a demonstration fixture.
+> It intentionally introduces a vulnerability and must never be merged.**
+
+## Purpose
+
+Show that the LI.FI security-review pipeline catches a class of bug that the
+static scanners in Stage 1 (Slither, Semgrep) structurally cannot — proving the
+ToB `differential-review` skill is the part doing the real bug-finding, not the
+scanners.
+
+## The planted bug
+
+In `AcrossFacetV4.sol`, `swapAndStartBridgeTokensViaAcrossV4` runs a swap before
+bridging. The swap changes the input amount (`_bridgeData.minAmount`), so the
+destination-side `outputAmount` — the amount the recipient is promised on the
+destination chain — must be rescaled proportionally. The production code does
+this (the `outputAmountMultiplier` block, lines 137-147 in the clean file; cited
+as the reference implementation in `.agents/rules/102-facets.md`).
+
+The fixture removes that rescaling, passing the caller-supplied `_acrossData`
+straight through:
+
+```solidity
+_bridgeData.minAmount = _depositAndSwap(
+    _bridgeData.transactionId,
+    _bridgeData.minAmount,
+    _swapData,
+    payable(msg.sender)
+);
+
+_startBridge(_bridgeData, _acrossData); // outputAmount no longer rescaled
+```
+
+It looks like a harmless simplification. It is a value-flow bug: after a swap the
+bridged `inputAmount` and the promised `outputAmount` diverge, so positive
+slippage from the swap is silently skimmed instead of reaching the user, and a
+relayer can fill the deposit for less than the input is worth.
+
+## Why the static scanners miss it
+
+The bug is the **absence** of a business-logic line. There is no dangerous
+pattern to match:
+
+- no reentrancy, no unchecked external call, no arbitrary send
+- `_depositAndSwap`'s return value is still assigned (no unused-return)
+- it compiles cleanly
+
+Slither matches dangerous code shapes; Semgrep matches code that *exists*.
+Neither can flag a missing rescale.
+
+### Reproduce the scanner silence (deterministic)
+
+Both scanners produce identical output on the clean and buggy file — same
+versions Stage 1 pins (Slither 0.11.3, Semgrep 1.117.0):
+
+```bash
+slither src/Facets/AcrossFacetV4.sol \
+  --sarif slither.sarif --exclude-informational --exclude-low --fail-none
+semgrep scan --config=audit/knowledge/semgrep src/Facets/AcrossFacetV4.sol \
+  --sarif --output=semgrep.sarif --metrics=off
+```
+
+| Scanner | clean | buggy | new findings |
+| ------- | ----- | ----- | ------------ |
+| Slither | 2 (both in `LibAsset` / `SwapperV2`) | 2 (identical) | **0** |
+| Semgrep | 0 | 0 | **0** |
+
+## What `differential-review` is expected to produce
+
+A Medium/High finding along these lines:
+
+> **Post-swap `outputAmount` not rescaled — positive slippage leaks.**
+> `swapAndStartBridgeTokensViaAcrossV4` updates `minAmount` from the swap output
+> but bridges with the caller-supplied `outputAmount`, which was sized for the
+> pre-swap amount. Input and output amounts diverge; slippage gain does not reach
+> the recipient. Echoes the `outputAmountMultiplier` requirement in rule 102 and
+> the post-swap-amount-adjustment finding class in the audit corpus.
+
+This comes from `differential-review`'s value-flow / blast-radius analysis (input
+amount vs. output amount across the swap), reinforced by the LF corpus loaded in
+the skill's Pre-Analysis step — none of which a pattern scanner performs.
+
+## Running the live pipeline against this fixture
+
+Open a PR from this branch against the branch carrying the pipeline
+(`feature/exp-440-security-review-pipeline`, or `main` once it merges). The
+`security-review` workflow runs: Stage 1 SARIF stays clean on this facet, and the
+Stage 2 sticky comment should carry the finding above.

--- a/src/Facets/AcrossFacetV4.sol
+++ b/src/Facets/AcrossFacetV4.sol
@@ -134,19 +134,7 @@ contract AcrossFacetV4 is
             payable(msg.sender)
         );
 
-        // Since the minAmount / inputAmount was updated, we also need to adjust the outputAmount.
-        // In case any of different decimals between input and output, we will adjust the outputAmount
-        // with the outputAmountMultiplier to account for the difference in decimals. We divide by 1e18
-        // to allow room for adjustment in both directions, i.e. from 6 > 18 decimals and vice versa.
-        // The multiplier should be calculated as:  multiplierPercentage * 1e18 * 10^(outputDecimals - inputDecimals)
-        // NOTE: please note that we intentionally do not verify the outputAmount any further. Only use LI.FI backend-
-        //       generated calldata to avoid potential loss of funds.
-        AcrossV4Data memory modifiedAcrossData = _acrossData;
-        modifiedAcrossData.outputAmount =
-            (_bridgeData.minAmount * _acrossData.outputAmountMultiplier) /
-            MULTIPLIER_BASE;
-
-        _startBridge(_bridgeData, modifiedAcrossData);
+        _startBridge(_bridgeData, _acrossData);
     }
 
     /// Internal Methods ///


### PR DESCRIPTION
> ⚠️ **DEMO — DO NOT MERGE.** This PR intentionally introduces a vulnerability
> to exercise the security-review pipeline. Base is the pipeline branch, not `main`.

## Purpose

Demonstrate that the security-review pipeline catches a bug class the Stage 1
static scanners structurally cannot.

## The planted bug

`AcrossFacetV4.swapAndStartBridgeTokensViaAcrossV4` no longer rescales the
destination `outputAmount` after the pre-bridge swap (the `outputAmountMultiplier`
block mandated by `.agents/rules/102-facets.md`). After a swap, the bridged
`inputAmount` and the promised `outputAmount` diverge — positive slippage is
silently skimmed instead of reaching the recipient.

## Why static scanners miss it (proven locally, CI-pinned versions)

The bug is the *absence* of a business-logic line — no dangerous pattern to match.

| Scanner | clean file | buggy file | new findings |
| --- | --- | --- | --- |
| Slither 0.11.3 (`--exclude-informational --exclude-low`) | 2 (both in `LibAsset`/`SwapperV2`) | 2 (identical set) | **0** |
| Semgrep 1.117.0 (LF rules) | 0 | 0 | **0** |

## What we expect from this run

Stage 1 SARIF stays clean on this facet; the Stage 2 sticky comment should carry
a Medium/High finding for the post-swap `outputAmount` divergence.

See `docs/demo-diff-review-positive-slippage.md` for full detail.
