### PR TITLE
chore: whitelist fly outlaw router

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4377,6 +4377,14 @@
               "0x46ec278a": "swapWithBackendSignature(bytes)"
             }
           }
+        ],
+        "outlaw": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
         ]
       }
     },


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXBE-399 — https://linear.app/lifi-linear/issue/EXBE-399/be-extend-fly-dex-support-with-outlaw-chain

# Why did I implement it this way?

Adds the **Outlaw** chain (chainId 4663) entry to the Fly DEX section of the calldata-validation whitelist, mirroring the backend allowlist.

Outlaw uses the same Fly `DexAggregator` router (`0x20f6ee51340adeed01a59b0e65cb3703f3dc860c`) that is already deployed and whitelisted across the other Fly chains, so the entry reuses the identical selector set (`0x46ec278a` → `swapWithBackendSignature(bytes)`).

Paired backend PR: https://github.com/lifinance/lifi-backend/pull/8481

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
