### PR TITLE
fix(config): point avalanche explorerUrl to snowscan.xyz (EXSC-500)

### DIFF
--- a/config/networks.json
+++ b/config/networks.json
@@ -192,7 +192,7 @@
     "type": "mainnet",
     "rpcUrl": "https://api.avax.network/ext/bc/C/rpc",
     "verificationType": "etherscan",
-    "explorerUrl": "https://snowtrace.io",
+    "explorerUrl": "https://snowscan.xyz",
     "explorerApiUrl": "https://api.etherscan.io/v2/api?chainid=43114",
     "multicallAddress": "0xca11bde05977b3631167028862be2a173976ca11",
     "safeAddress": "0x5CC4321e1fd413Db3Ac7EBB3097c1DF7878e0D17",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-500](https://linear.app/lifi-linear/issue/EXSC-500/avalanche-explorer-link-doesnt-match-verification-target-snowtraceio)

# Why did I implement it this way?

Avalanche linked users to a different explorer than the one the deploy flow verifies against:

- `config/networks.json` → `avalanche.explorerUrl` was `https://snowtrace.io` (Routescan). This is the URL the Safe/deploy scripts link to via `buildExplorerAddressUrl` / `buildExplorerContractPageUrl` (`confirm-safe-tx.ts`, `safe-decode-utils.ts`, `safe-utils.ts`).
- The deploy flow submits verification to Etherscan-v2 (`foundry.toml` verifier `url = "https://api.etherscan.io/v2/api?chainid=43114"`, matching `avalanche.explorerApiUrl`).

Routescan and Etherscan maintain independent verification databases, so a contract verified by the deploy flow showed as **unverified** on the linked `snowtrace.io` page. This surfaced during the MayanFacet v1.3.0 rollout (`0xaC5Ad28A8FA95ABD6eA3D9c82c931C87ae413e6A`), which verified fine on Etherscan-v2 but read as unverified on snowtrace and had to be manually re-verified on Routescan.

Chose **option A** (config fix): point `explorerUrl` at `https://snowscan.xyz`, Etherscan's official Avalanche explorer, which is backed by the same Etherscan-v2 database the deploy flow uses. `verificationType: "etherscan"` keeps the default `/address/<addr>` URL pattern, so links resolve to `https://snowscan.xyz/address/0x…` — confirmed showing the MayanFacet as "Source Code Verified — Exact Match".

This is one line and fixes every `explorerUrl` consumer for avalanche consistently, with no hardcoded per-network branch. Rejected option C (special-case avalanche in `confirm-safe-tx.ts`) because the mismatch affects all Safe-flow explorer-link helpers, not just one script.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
