### PR TITLE
ci-after (DO NOT MERGE): config — EXSC-519

### DIFF
--- a/config/ci-baseline-fixture.json
+++ b/config/ci-baseline-fixture.json
@@ -1,0 +1,3 @@
+{
+  "exsc519CiAfterFixture": true
+}


### PR DESCRIPTION
**DO NOT MERGE / DO NOT REVIEW.**

Throwaway CI-timing fixture for the EXSC-519 AFTER measurement (base = `main` + EXSC-520 = all CI-speedup work). Single-file diff mirrors the BEFORE baseline cohort. Will be closed once timings are captured.

PR_READY_OK=1: throwaway measurement PR, not subject to review.