### PR TITLE
ci-after (DO NOT MERGE): contract — EXSC-519

### DIFF
--- a/src/Interfaces/IERC165.sol
+++ b/src/Interfaces/IERC165.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
+// EXSC-519 CI-after timing fixture — DO NOT MERGE
 pragma solidity ^0.8.17;
 
 /// @title Interface for ERC165


### PR DESCRIPTION
**DO NOT MERGE / DO NOT REVIEW.**

Throwaway CI-timing fixture for the EXSC-519 AFTER measurement (base = `main` + EXSC-520 = all CI-speedup work). Single-file diff mirrors the BEFORE baseline cohort. Will be closed once timings are captured.

PR_READY_OK=1: throwaway measurement PR, not subject to review.