### PR TITLE
EXSC-548: Fix poisoned forge build cache key in CI

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -9,6 +9,19 @@
 name: Setup Foundry
 description: Install pinned foundry from .foundry-version, restore solc + forge build caches, and verify the installed binary matches.
 
+inputs:
+  cache-key-suffix:
+    description: >-
+      Extra segment folded into the forge-build cache key. Required whenever a
+      single workflow runs more than one build SCOPE in parallel — e.g. matrix
+      shards that each `forge test --match-path <subset>` and therefore compile
+      a different partial out/. Pass the shard id (e.g. matrix.shard) so each
+      scope owns its own cache; otherwise the shards share one key and the first
+      to finish poisons the rest with its partial out/. Leave empty for
+      workflows that produce a single, consistent out/.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -53,16 +66,19 @@ runs:
       # workflow: the stale entry was restored forever and forced a full
       # recompile despite a "cache hit". Namespacing makes each workflow own a
       # cache it always populates with a complete out/ from its own build/test.
-      # The vN prefix is a manual eviction lever — bump it to discard all
-      # existing entries at once.
+      # cache-key-suffix further splits workflows that build more than one scope
+      # in parallel (matrix shards with different --match-path globs); without it
+      # those shards would re-introduce first-writer-wins poisoning within the
+      # one workflow namespace. The vN prefix is a manual eviction lever — bump
+      # it to discard all existing entries at once.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           cache
           out
-        key: forge-build-v2-${{ github.workflow }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
+        key: forge-build-v2-${{ github.workflow }}-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
         restore-keys: |
-          forge-build-v2-${{ github.workflow }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-
+          forge-build-v2-${{ github.workflow }}-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-
 
     - name: Verify foundry version
       shell: bash

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -57,25 +57,21 @@ runs:
         version: ${{ steps.pin.outputs.version }}
 
     - name: Cache forge build artifacts (cache/, out/)
-      # Key on every input that influences compilation. A cache miss falls back to
-      # a clean build with no behavior change.
-      #
-      # The key is namespaced per workflow (github.workflow). actions/cache is
-      # first-writer-wins and never overwrites an existing key on a hit, so a
-      # SHARED key let any job that saved a partial out/ poison every other
-      # workflow: the stale entry was restored forever and forced a full
-      # recompile despite a "cache hit". Namespacing makes each workflow own a
-      # cache it always populates with a complete out/ from its own build/test.
-      # cache-key-suffix further splits workflows that build more than one scope
-      # in parallel (matrix shards with different --match-path globs); without it
-      # those shards would re-introduce first-writer-wins poisoning within the
-      # one workflow namespace. The vN prefix is a manual eviction lever — bump
-      # it to discard all existing entries at once.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           cache
           out
+        # Key on every input that influences compilation; a miss falls back to a
+        # clean build with no behavior change. Namespaced per workflow
+        # (github.workflow): actions/cache is first-writer-wins and never
+        # overwrites an existing key on a hit, so a SHARED key let any job that
+        # saved a partial out/ poison every other workflow — the stale entry was
+        # restored forever and forced a full recompile despite a "cache hit".
+        # cache-key-suffix further splits a workflow that builds more than one
+        # scope in parallel (matrix shards with different --match-path globs).
+        # The vN prefix is a manual eviction lever — bump it to discard all
+        # existing entries at once.
         key: forge-build-v2-${{ github.workflow }}-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
         restore-keys: |
           forge-build-v2-${{ github.workflow }}-${{ inputs.cache-key-suffix }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -46,14 +46,23 @@ runs:
     - name: Cache forge build artifacts (cache/, out/)
       # Key on every input that influences compilation. A cache miss falls back to
       # a clean build with no behavior change.
+      #
+      # The key is namespaced per workflow (github.workflow). actions/cache is
+      # first-writer-wins and never overwrites an existing key on a hit, so a
+      # SHARED key let any job that saved a partial out/ poison every other
+      # workflow: the stale entry was restored forever and forced a full
+      # recompile despite a "cache hit". Namespacing makes each workflow own a
+      # cache it always populates with a complete out/ from its own build/test.
+      # The vN prefix is a manual eviction lever — bump it to discard all
+      # existing entries at once.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           cache
           out
-        key: forge-build-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
+        key: forge-build-v2-${{ github.workflow }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml', 'remappings.txt', 'src/**', 'test/**', 'lib/**') }}
         restore-keys: |
-          forge-build-${{ runner.os }}-${{ steps.pin.outputs.version }}-
+          forge-build-v2-${{ github.workflow }}-${{ runner.os }}-${{ steps.pin.outputs.version }}-
 
     - name: Verify foundry version
       shell: bash

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -154,7 +154,9 @@ jobs:
           exit 1
 
       - name: Build contracts
-        run: forge build
+        # Skip .t.sol test contracts: the smoke deploy compiles src/ and the
+        # script/deploy/*.s.sol scripts but never deploys test contracts.
+        run: forge build --skip test
 
       - name: Run deploy smoke test
         run: bash script/deploy/smokeDeploy.sh 2>&1 | tee smoke-deploy.log

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -76,6 +76,11 @@ jobs:
 
       - name: Install Foundry
         uses: ./.github/actions/setup-foundry
+        with:
+          # Each shard runs `forge test --match-path <subset>` and so compiles a
+          # different partial out/; key the build cache per shard so they do not
+          # poison one another's cache.
+          cache-key-suffix: ${{ matrix.shard }}
 
       - name: Install forge Dependencies
         run: forge install


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-548](https://linear.app/lifi-linear/issue/EXSC-548/fix-poisoned-forge-build-cache-in-ci-shared-key-across-workflows) (sub-task of EXSC-519; sibling to EXSC-520).

# Why did I implement it this way?

The `forge-build` cache in `setup-foundry` delivered zero benefit: every run did a full cold recompile despite an exact cache hit.

Observed in the Deploy Smoke Test (run 28152451203, job 83373073810):

- `Cache hit for: forge-build-Linux-1.7.1-29f412b…` → `Cache restored successfully`, `Cache Size: ~1 MB`
- then `Compiling 289 files with Solc 0.8.29 … finished in 121.68s`
- post-job: `Cache hit occurred on the primary key forge-build-… , not saving cache.`

**Root cause:** a single `forge-build-*` key was shared by all 8 workflows that call `setup-foundry`. `actions/cache` is first-writer-wins and never overwrites on a hit, so once any job saved a partial `out/` (~1 MB) under that hash, every later job restored that stale entry forever and recompiled from scratch — and the broken entry was never refreshed because the hit suppresses the save.

(It is not a profile mismatch: `profile.ci` only lowers `fuzz.runs` 256→32, which does not affect compiled bytecode, so ci and default share identical artifacts.)

**Fix:**

- Namespace the key per workflow (`forge-build-v2-${{ github.workflow }}-…`) so a partial build in one workflow can no longer be restored by another. The `v2` prefix evicts every existing (poisoned) entry in one shot.
- Namespace per build scope *within* a workflow via a new `cache-key-suffix` input. The `Run Unit Tests` workflow shards into 5 parallel jobs that each `forge test --match-path <subset>`, which sparse-compiles only that subset (measured on foundry 1.7.1: one shard produces 239 `out/` artifacts vs 647 for a full build). All shards share one `github.workflow`, so without a per-shard suffix they would re-introduce the same first-writer-wins poisoning inside the one namespace. Composite actions cannot read the `matrix` context, so the suffix is passed in as `cache-key-suffix: ${{ matrix.shard }}`.
- Scope the smoke-test build with `forge build --skip test` (`test` is forge's alias for `.t.sol`): the smoke deploy compiles `src/` and the `script/deploy/*.s.sol` scripts but never deploys test contracts (drops the build from 647 to 432 artifacts).

After this, the smoke build drops from ~122s to ~5–15s on a warm cache; first run after merge does one full build per workflow to repopulate. Independent of EXSC-520 (#1943), which adds RPC-state caching in the same file but does not touch this block.

Follow-ups (out of scope here): cache `lib/` to skip the ~37s recursive submodule clone in checkout; bump action SHAs for Node 20→24 deprecation.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
