### PR TITLE
docs(OptimismBridgeFacet): fix 404 link to L1StandardBridge

### DIFF
--- a/docs/OptimismBridgeFacet.md
+++ b/docs/OptimismBridgeFacet.md
@@ -2,7 +2,7 @@
 
 ## How it works
 
-The Optimism Bridge Facet works by forwarding Optimism Bridge specific calls to Optimism Bridge [contract](https://github.com/ethereum-optimism/optimism/blob/master/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol). The standard bridge functionality provides a method for an ERC20 token to be deposited and locked on L1 in exchange of the same amount of an equivalent token on L2.
+The Optimism Bridge Facet works by forwarding Optimism Bridge specific calls to Optimism Bridge [contract](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L1/L1StandardBridge.sol). The standard bridge functionality provides a method for an ERC20 token to be deposited and locked on L1 in exchange of the same amount of an equivalent token on L2.
 
 ```mermaid
 graph LR;


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None — doc-only single-line fix (labelled `trivial`). Recreates an external community PR (#1128) internally per our contribution policy.

# Why did I implement it this way?

The `docs/OptimismBridgeFacet.md` "How it works" section linked to the Optimism `L1StandardBridge.sol` contract at a `master`-branch path that has since been removed, returning a 404. Updated the link to the current Bedrock location on the `develop` branch (`packages/contracts-bedrock/src/L1/L1StandardBridge.sol`), which I verified resolves to the live contract.

The change was originally reported by @gap-editor in #1128. Since we cannot merge pull requests from outside the organization, that PR was closed and the fix recreated here, crediting the find to the original reporter.

CodeRabbit / `/pr-ready` skipped intentionally for this doc-only one-line link fix (`PR_READY_OK=1` bypass).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
