### PR TITLE
ci: scope concurrency cancel-in-progress on heavy required checks (EXSC-552)

### DIFF
--- a/.github/workflows/enforceTestCoverage.yml
+++ b/.github/workflows/enforceTestCoverage.yml
@@ -16,6 +16,15 @@ permissions:
   contents: read # required to fetch repository contents
   pull-requests: write # required to post the coverage summary as a PR comment
 
+# Cancel superseded in-progress runs on the same PR (force-push / rapid commits)
+# so the slow forge-coverage run stops burning runner minutes on stale commits.
+# Keyed per workflow and per PR (falling back to ref) so unrelated branches never
+# cancel each other. cancel-in-progress is scoped to pull_request events; this
+# workflow only runs on PRs, so non-PR events are unaffected.
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-changes:
     # Determines whether files that can influence `forge coverage` outcomes were touched.

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -22,11 +22,14 @@ permissions:
 
 # Cancel superseded in-progress runs on the same PR (force-push / rapid commits)
 # so stale, expensive forge-test runs stop burning runner minutes. Keyed per
-# workflow and per PR (falling back to ref) so unrelated branches never cancel
-# each other. cancel-in-progress is scoped to pull_request events so post-merge
-# runs on main and manual workflow_dispatch runs always complete and keep their signal.
+# workflow, per event type, and per PR (falling back to ref). Scoping by
+# event_name keeps unrelated branches and event types in separate groups, so a
+# manual workflow_dispatch run on main is never queued behind (and cancelled by)
+# a stream of push runs sharing the same ref. cancel-in-progress is scoped to
+# pull_request events so post-merge runs on main and manual workflow_dispatch
+# runs always complete and keep their signal.
 concurrency:
-  group: unit-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: unit-tests-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -20,6 +20,15 @@ permissions:
   contents: read # required to fetch repository contents
   pull-requests: read # required by dorny/paths-filter to read changed files on PRs
 
+# Cancel superseded in-progress runs on the same PR (force-push / rapid commits)
+# so stale, expensive forge-test runs stop burning runner minutes. Keyed per
+# workflow and per PR (falling back to ref) so unrelated branches never cancel
+# each other. cancel-in-progress is scoped to pull_request events so post-merge
+# runs on main and manual workflow_dispatch runs always complete and keep their signal.
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-changes:
     # Determines whether files that can influence `forge test` outcomes were touched.

--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -31,11 +31,14 @@ permissions:
 
 # Cancel superseded in-progress runs on the same PR (force-push / rapid commits)
 # so stale script-validation runs (which build forge + typechain) stop burning
-# runner minutes. Keyed per workflow and per PR (falling back to ref) so unrelated
-# branches never cancel each other. cancel-in-progress is scoped to pull_request
-# events so manual workflow_dispatch runs always complete and keep their signal.
+# runner minutes. Keyed per workflow, per event type, and per PR (falling back to
+# ref). Scoping by event_name keeps unrelated branches and event types in
+# separate groups, so a manual workflow_dispatch run keeps its own concurrency
+# lane instead of competing with PR runs. cancel-in-progress is scoped to
+# pull_request events so manual workflow_dispatch runs always complete and keep
+# their signal.
 concurrency:
-  group: validate-scripts-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: validate-scripts-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -29,6 +29,15 @@ permissions:
   contents: read # required to fetch repository contents
   pull-requests: read # required by dorny/paths-filter to read changed files on PRs
 
+# Cancel superseded in-progress runs on the same PR (force-push / rapid commits)
+# so stale script-validation runs (which build forge + typechain) stop burning
+# runner minutes. Keyed per workflow and per PR (falling back to ref) so unrelated
+# branches never cancel each other. cancel-in-progress is scoped to pull_request
+# events so manual workflow_dispatch runs always complete and keep their signal.
+concurrency:
+  group: validate-scripts-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-changes:
     # Determines whether files that can influence script validity were touched.


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-552](https://linear.app/lifi-linear/issue/EXSC-552/ci-add-concurrency-cancel-in-progress-to-the-3-heavy-required-checks)

# Why did I implement it this way?

CI/CD optimization pass on this repo. The pipeline is already heavily optimized (path-gating via the `detect-changes → *-required` aggregator pattern, the `setup-foundry` composite with layered caching, `forge test --rerun`, secret masking, and **all active workflows already 100% SHA-pinned**). The one remaining structural win:

The three heaviest **required** checks had **no `concurrency` group**, so a force-push or rapid commits left stale, expensive runs burning to completion:

| Workflow | Heavy job |
|---|---|
| `forge-unit-tests.yml` | `forge test` + RPC fetch + 10× retry |
| `enforceTestCoverage.yml` | `forge coverage --ir-minimum` (~10 min) |
| `validateScripts.yml` | forge + typechain build |

Each gets the same block, matching the existing `deploy-smoke-test.yml` house style:

```yaml
concurrency:
  group: <name>-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**`cancel-in-progress` is scoped to `pull_request` events** (not bare `true`): superseded PR runs are cancelled (the win), but post-merge runs on `main` and manual `workflow_dispatch` runs always complete and keep their signal — so we never lose CI signal on what actually landed on `main`.

**Impact:** cuts wasted runner-minutes on the most expensive jobs whenever a PR is force-pushed or pushed to repeatedly. No change to what runs on a final commit. The aggregator `*-required` jobs still report status, so branch protection is unaffected.

**Out of scope (deliberately):** an action-pinning sweep — all *active* workflows are already SHA-pinned; the only tag refs are in `workflows_deactivated/` files that don't run. That's a separate hygiene PR if we want the `[CONV:ACTIONS-IMMUTABLE]` invariant to hold across dead files too.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug — n/a (CI workflow config only)
- [ ] For new facets — n/a
- [x] I have updated any required documentation — n/a (workflow comments document the behavior inline)

> **CodeRabbit note:** the local pre-flight returned 2 minor findings, both on untracked `.playwright-mcp/*.yml` scratch files unrelated to this PR (not staged, not part of the diff). The actual 3-file change is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
