### PR TITLE
chore(config): replace offboarded core dev's shared wallets + Safe signer (EXSC-565)

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -2,9 +2,9 @@
   "refundWallet": "0x156CeBba59DEB2cB23742F70dCb0a11cC775591F",
   "feeCollectorOwner": "0xC06ebbefD94032B85424D51906e2A335EFAe264B",
   "withdrawWallet": "0x08647cc950813966142A416D40C382e2c5DB73bB",
-  "pauserWallet": "0xd38743b48d26743C0Ec6898d699394FBc94657Ee",
-  "deployerWallet": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
-  "devWallet": "0x85A8F3cf6d255BD497Bd1Dd83a338Cce0B14C3B3",
+  "pauserWallet": "0xf9D8BA34a51750cf6abFA9De7aCD37f182081A4A",
+  "deployerWallet": "0xb05E63458A51731Aad26BdcD6E12246330E6095F",
+  "devWallet": "0xcf1A07FEd1b622B1d9B80D86DE06D8c43E4fBDdB",
   "backendSigner": {
     "staging": "0x981CCF8c09633F6F2AF3fe661C285ca1DB09caE1",
     "production": "0xAF4B7A83591a6c4c8B9d1341C3F08BBc3b800fc5"
@@ -13,9 +13,9 @@
     "refundWallet": "TBvVg3Aam5QP2XE3XCatgatjefXvsYf6yD",
     "feeCollectorOwner": "TTWhPqF38FneGGN1smz3m5LsNJQYx4mgQy",
     "withdrawWallet": "TAjanapKoCE1ky3L4Qzndnv3YAUmDwCLdZ",
-    "pauserWallet": "TVFfcsjqBskfjZV6gMSsqqgvtUG4cz5Jjx",
-    "deployerWallet": "TS8EymUNucdNwseZMcLZRzTLy7Yz768yeD",
-    "devWallet": "TN9wGbAaoHUmh2u6GQSZq7LCPbquoY3FvU"
+    "pauserWallet": "TYkGtJi7iQqMvtyeMhhHUCiGfsRExKnAkd",
+    "deployerWallet": "TS3kzzu8BVn6q5T8pskbhpEftZzk2nUkps",
+    "devWallet": "TUrG4T2iYVzHikATZtoGoy1xPxdyKA8M8J"
   },
   "approvedSelectorsForRefundWallet": [
     {
@@ -28,9 +28,9 @@
     }
   ],
   "safeOwners": [
-    "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+    "0xb05E63458A51731Aad26BdcD6E12246330E6095F",
     "0x518ee3D0F8AC59deDAc278859A7B8bc13dA360Dc",
-    "0xb4557653119Dd49F7433fef4aE270665Be2cbf4F",
+    "0x042727b75C80326F3488a6CEd46775EDCe8f1940",
     "0xFF0cC7DdcE415293c5dE85b8737bC487eff176cF",
     "0xe5552E1a40cBcB95b4905d92907336C06681280c",
     "0x9740A8E0197689d144B19DA4bDc9eF65fEf11Cda"

--- a/config/global.json
+++ b/config/global.json
@@ -2,7 +2,7 @@
   "refundWallet": "0x156CeBba59DEB2cB23742F70dCb0a11cC775591F",
   "feeCollectorOwner": "0xC06ebbefD94032B85424D51906e2A335EFAe264B",
   "withdrawWallet": "0x08647cc950813966142A416D40C382e2c5DB73bB",
-  "pauserWallet": "0xf9D8BA34a51750cf6abFA9De7aCD37f182081A4A",
+  "pauserWallet": "0xd38743b48d26743C0Ec6898d699394FBc94657Ee",
   "deployerWallet": "0xb05E63458A51731Aad26BdcD6E12246330E6095F",
   "devWallet": "0xcf1A07FEd1b622B1d9B80D86DE06D8c43E4fBDdB",
   "backendSigner": {
@@ -13,7 +13,7 @@
     "refundWallet": "TBvVg3Aam5QP2XE3XCatgatjefXvsYf6yD",
     "feeCollectorOwner": "TTWhPqF38FneGGN1smz3m5LsNJQYx4mgQy",
     "withdrawWallet": "TAjanapKoCE1ky3L4Qzndnv3YAUmDwCLdZ",
-    "pauserWallet": "TYkGtJi7iQqMvtyeMhhHUCiGfsRExKnAkd",
+    "pauserWallet": "TVFfcsjqBskfjZV6gMSsqqgvtUG4cz5Jjx",
     "deployerWallet": "TS3kzzu8BVn6q5T8pskbhpEftZzk2nUkps",
     "devWallet": "TUrG4T2iYVzHikATZtoGoy1xPxdyKA8M8J"
   },

--- a/config/global.json
+++ b/config/global.json
@@ -2,7 +2,7 @@
   "refundWallet": "0x156CeBba59DEB2cB23742F70dCb0a11cC775591F",
   "feeCollectorOwner": "0xC06ebbefD94032B85424D51906e2A335EFAe264B",
   "withdrawWallet": "0x08647cc950813966142A416D40C382e2c5DB73bB",
-  "pauserWallet": "0xd38743b48d26743C0Ec6898d699394FBc94657Ee",
+  "pauserWallet": "0xf9D8BA34a51750cf6abFA9De7aCD37f182081A4A",
   "deployerWallet": "0xb05E63458A51731Aad26BdcD6E12246330E6095F",
   "devWallet": "0xcf1A07FEd1b622B1d9B80D86DE06D8c43E4fBDdB",
   "backendSigner": {
@@ -13,7 +13,7 @@
     "refundWallet": "TBvVg3Aam5QP2XE3XCatgatjefXvsYf6yD",
     "feeCollectorOwner": "TTWhPqF38FneGGN1smz3m5LsNJQYx4mgQy",
     "withdrawWallet": "TAjanapKoCE1ky3L4Qzndnv3YAUmDwCLdZ",
-    "pauserWallet": "TVFfcsjqBskfjZV6gMSsqqgvtUG4cz5Jjx",
+    "pauserWallet": "TYkGtJi7iQqMvtyeMhhHUCiGfsRExKnAkd",
     "deployerWallet": "TS3kzzu8BVn6q5T8pskbhpEftZzk2nUkps",
     "devWallet": "TUrG4T2iYVzHikATZtoGoy1xPxdyKA8M8J"
   },

--- a/docs/LiFiTimelockController.md
+++ b/docs/LiFiTimelockController.md
@@ -26,7 +26,7 @@ The timelock uses the following roles from OpenZeppelin's TimelockController:
 
 ```solidity
 constructor(
-    uint256 _minDelay,           // Minimum delay for operations (e.g., 1 day)
+    uint256 _minDelay,           // Minimum delay for operations (production: 3 hours / 10800s, see config/timelockController.json)
     address[] memory _proposers, // Addresses that can propose operations
     address[] memory _executors, // Addresses that can execute operations
     address _cancellerWallet,    // Address that can cancel operations
@@ -107,7 +107,7 @@ function setDiamondAddress(
 
 The timelock requires the following configuration parameters:
 
-- **minDelay**: Minimum delay for operations (typically 1 day for production)
+- **minDelay**: Minimum delay for operations (production: 3 hours / 10800 seconds, as set in `config/timelockController.json`)
 - **proposers**: Array of addresses that can propose operations (usually the LiFi MultiSig)
 - **executors**: Array of addresses that can execute operations (can be address(0) for anyone)
 - **cancellerWallet**: Address that can cancel operations (usually the deployer wallet)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-565](https://linear.app/lifi-linear/issue/EXSC-565)

# Why did I implement it this way?

Offboarding a core smart-contract dev. This swaps his shared `deployer`/`dev`
wallets and his Safe-signer slot in `config/global.json` for the replacement
wallets, and nothing else in that scope.

**`config/global.json` changes (this scope only):**

| Role | Old → New (EVM) | Old → New (TRON) |
|---|---|---|
| `deployerWallet` | `0xb137…4E269` → `0xb05E…6095F` | `TS8Eym…68yeD` → `TS3kzz…nUkps` |
| `devWallet` | `0x85A8…C3B3` → `0xcf1A…BDdB` | `TN9wGb…Y3FvU` → `TUrG4T…KA8M8J` |
| `pauserWallet` | `0xd387…4657Ee` → `0xf9D8…081A4A` | `TVFfcs…z5Jjx` → `TYkGtJ…KnAkd` |
| `safeOwners` | removed offboarded signer `0xb455…bf4F`, added `0x0427…1940`; also swapped the old deployer `0xb137…4E269` → new deployer `0xb05E…6095F` (slot 0) | n/a |

`safeOwners` stays at **6 entries** (one removal + one addition, plus the
deployer-slot swap). `withdrawWallet`, `refundWallet`, and `feeCollectorOwner`
are intentionally **out of scope** (separate offboarding step / pending
confirmation).

### `pauserWallet` — rotated ahead of the on-chain role move (accepted risk)

⚠️ **This PR rotates the `pauserWallet` config value (EVM + TRON) to the new
address `0xf9D8BA34a51750cf6abFA9De7aCD37f182081A4A` / `TYkGtJi7iQqMvtyeMhhHUCiGfsRExKnAkd`
before the on-chain pauser role has been moved to it.** This reverses the
original plan documented below and in the initial commit for this file
(`8d7f0c2b1`).

As previously noted, rotating the config value before the on-chain pauser role
moves means emergency-pause tooling now points at a key that **cannot yet
pause the diamonds** — i.e. the diamonds are effectively un-pausable via this
config entry until the corresponding multisig proposals against the new
`EmergencyPauseFacet` (which must be deployed first) are signed and executed
on every chain. Daniel Blaecker confirmed rotating now regardless of on-chain
state; the on-chain proposals to actually move the pauser role remain a
separate, outstanding follow-up and should be prioritized to close this gap.

**TRON addresses are derived, not hand-entered.** A TRON base58 address is a
deterministic `Base58Check(0x41 ‖ <20-byte EVM address body>)` — no private key
needed. They were generated from the new EVM addresses via the repo's own
`script/troncast` codec (`bunx tsx script/troncast/index.ts address to-base58`).
The derivation was validated by round-tripping both the **old** and **new**
`pauserWallet` EVM addresses — the old one reproduces the exact TRON value
previously in config byte-for-byte, and the new one round-trips cleanly.

## ⚠️ Flagged for decision — timelock `minDelay` discrepancy (NOT changed here)

The Security Policy states a **72h** timelock delay, but
`config/timelockController.json` has `minDelay: 10800` (**3h**). I investigated
rather than silently "fixing" it, because `minDelay` feeds the
`LiFiTimelockController` constructor at deploy time (via
`deployRequirements.json` → `_minDelay`) and changing it affects on-chain
timelock deployments.

Findings:

- `minDelay` has been `10800` (3h) since the file was introduced in #1254
  (2025-07-07) and has **never** changed.
- All currently-deployed `LiFiTimelockController` instances were therefore
  deployed with a 3h delay (propose scripts read the live `getMinDelay()`).
- **No "72h" reference exists anywhere in the repo.** The doc string previously
  said a vague "typically 1 day" — also wrong.

So repo + on-chain reality is **3h**; the **72h lives only in the external
Security Policy**. This PR does **not** touch `minDelay`. It only corrects the
doc (`docs/LiFiTimelockController.md`) to state the actual on-chain 3h value,
treating on-chain as authoritative for documentation purposes.

**Decision needed (out of band):** if the Security Policy's 72h is the intended
production value, raising it is a governance change (re-deploy / re-config of
the timelock across all chains) and is out of scope here — please confirm which
value is authoritative.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

