### PR TITLE
chore(offboarding): retarget owner-swap status check for Michał cycle (EXSC-561)

### DIFF
--- a/script/tasks/temp/checkOffboardingStatusPerNetwork.ts
+++ b/script/tasks/temp/checkOffboardingStatusPerNetwork.ts
@@ -21,12 +21,18 @@ import { getDeployments } from '../../utils/deploymentHelpers'
 import { getRPCEnvVarName } from '../../utils/utils'
 import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
 
-// Outgoing addresses for this offboarding cycle (should be removed)
-const MICHAL_SAFE_SIGNER =
-  '0xb4557653119Dd49F7433fef4aE270665Be2cbf4F' as Address
-const OLD_DEPLOYER = '0xb137683965ADC470f140df1a1D05B0D25C14E269' as Address
-const OLD_SC_DEV_WALLET =
-  '0x2b2c52B1b63c4BfC7F1A310a1734641D8e34De62' as Address
+// Outgoing addresses for this offboarding cycle (should be removed).
+// Wrapped in getAddress() so a mistyped literal fails fast at module load
+// rather than silently flipping an owner/role check.
+const MICHAL_SAFE_SIGNER = getAddress(
+  '0xb4557653119Dd49F7433fef4aE270665Be2cbf4F'
+) as Address
+const OLD_DEPLOYER = getAddress(
+  '0xb137683965ADC470f140df1a1D05B0D25C14E269'
+) as Address
+const OLD_SC_DEV_WALLET = getAddress(
+  '0x2b2c52B1b63c4BfC7F1A310a1734641D8e34De62'
+) as Address
 
 // Incoming addresses for this offboarding cycle.
 // NEW_DEPLOYER is hardcoded rather than read from global.json: deployerWallet

--- a/script/tasks/temp/checkOffboardingStatusPerNetwork.ts
+++ b/script/tasks/temp/checkOffboardingStatusPerNetwork.ts
@@ -9,7 +9,6 @@ import {
 
 import 'dotenv/config'
 
-import globalConfig from '../../../config/global.json'
 import networksConfig from '../../../config/networks.json'
 import {
   EnvironmentEnum,
@@ -22,15 +21,19 @@ import { getDeployments } from '../../utils/deploymentHelpers'
 import { getRPCEnvVarName } from '../../utils/utils'
 import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
 
-// Old addresses (hardcoded - these should be removed)
-const EDMUND_SAFE_SIGNER =
-  '0x1cEC0F949D04b809ab26c1001C9aEf75b1a28eeb' as Address
-const OLD_DEPLOYER = '0x11F1022cA6AdEF6400e5677528a80d49a069C00c' as Address
+// Outgoing addresses for this offboarding cycle (should be removed)
+const MICHAL_SAFE_SIGNER =
+  '0xb4557653119Dd49F7433fef4aE270665Be2cbf4F' as Address
+const OLD_DEPLOYER = '0xb137683965ADC470f140df1a1D05B0D25C14E269' as Address
 const OLD_SC_DEV_WALLET =
   '0x2b2c52B1b63c4BfC7F1A310a1734641D8e34De62' as Address
 
-// New addresses (from global.json)
-const NEW_DEPLOYER = getAddress(globalConfig.deployerWallet) as Address
+// Incoming addresses for this offboarding cycle.
+// NEW_DEPLOYER is hardcoded rather than read from global.json: deployerWallet
+// still points at the outgoing deployer until the owner-swap proposals execute.
+const NEW_DEPLOYER = getAddress(
+  '0xb05E63458A51731Aad26BdcD6E12246330E6095F'
+) as Address
 const NEW_SC_DEV_WALLET = getAddress(DEV_WALLET_ADDRESS) as Address
 
 // Function selector for batchSetContractSelectorWhitelist
@@ -55,7 +58,7 @@ const OWNERSHIP_FACET_ABI = parseAbi([
 
 interface INetworkStatus {
   network: string
-  edmundRemoved: boolean | null
+  michalRemoved: boolean | null
   oldDeployerRemoved: boolean | null
   newDeployerAdded: boolean | null
   oldDeployerCancellerRemoved: boolean | null
@@ -73,7 +76,7 @@ async function checkNetworkStatus(
 ): Promise<INetworkStatus> {
   const status: INetworkStatus = {
     network: networkName,
-    edmundRemoved: null,
+    michalRemoved: null,
     oldDeployerRemoved: null,
     newDeployerAdded: null,
     oldDeployerCancellerRemoved: null,
@@ -126,8 +129,8 @@ async function checkNetworkStatus(
       })) as Address[]
 
       const ownersLower = owners.map((o) => o.toLowerCase())
-      status.edmundRemoved = !ownersLower.includes(
-        EDMUND_SAFE_SIGNER.toLowerCase()
+      status.michalRemoved = !ownersLower.includes(
+        MICHAL_SAFE_SIGNER.toLowerCase()
       )
       status.oldDeployerRemoved = !ownersLower.includes(
         OLD_DEPLOYER.toLowerCase()
@@ -331,7 +334,7 @@ function printTable(results: INetworkStatus[]) {
   console.log('\n')
   console.log('Legend:')
   console.log(
-    `  1: Edmund safe signer (${EDMUND_SAFE_SIGNER}) removed from multisig`
+    `  1: Michał safe signer (${MICHAL_SAFE_SIGNER}) removed from multisig`
   )
   console.log(`  2: Old deployer (${OLD_DEPLOYER}) removed from multisig`)
   console.log(`  3: New deployer (${NEW_DEPLOYER}) added to multisig`)
@@ -390,7 +393,7 @@ function printTable(results: INetworkStatus[]) {
     const isExcluded = result.excluded === true
     const baseChecksDone =
       !isExcluded &&
-      result.edmundRemoved === true &&
+      result.michalRemoved === true &&
       result.oldDeployerRemoved === true &&
       result.newDeployerAdded === true &&
       result.oldDeployerCancellerRemoved === true &&
@@ -411,8 +414,8 @@ function printTable(results: INetworkStatus[]) {
     const networkName = result.network.padEnd(networkWidth)
 
     // Center-align the status emojis in their columns (emojis have visual width 2)
-    const edmund = centerInColumn(
-      formatStatus(result.edmundRemoved, isExcluded),
+    const michal = centerInColumn(
+      formatStatus(result.michalRemoved, isExcluded),
       colWidth,
       !isExcluded
     )
@@ -455,7 +458,7 @@ function printTable(results: INetworkStatus[]) {
     // Print network name in color - only one line per network
     const line = `${getColorCode(networkColor)}${networkName}${getColorCode(
       'reset'
-    )} | ${edmund} | ${oldDep} | ${newDep} | ${oldCan} | ${newCan} | ${oldWht} | ${newWht} | ${stagingOwnership}`
+    )} | ${michal} | ${oldDep} | ${newDep} | ${oldCan} | ${newCan} | ${oldWht} | ${newWht} | ${stagingOwnership}`
 
     console.log(line)
   }
@@ -464,7 +467,7 @@ function printTable(results: INetworkStatus[]) {
   const allDoneCount = results.filter((r) => {
     if (r.excluded === true) return false // Don't count excluded networks
     const baseChecksDone =
-      r.edmundRemoved === true &&
+      r.michalRemoved === true &&
       r.oldDeployerRemoved === true &&
       r.newDeployerAdded === true &&
       r.oldDeployerCancellerRemoved === true &&
@@ -485,7 +488,7 @@ function printTable(results: INetworkStatus[]) {
   console.log('')
   console.log('Legend:')
   console.log(
-    `  1: Edmund safe signer (${EDMUND_SAFE_SIGNER}) removed from multisig`
+    `  1: Michał safe signer (${MICHAL_SAFE_SIGNER}) removed from multisig`
   )
   console.log(`  2: Old deployer (${OLD_DEPLOYER}) removed from multisig`)
   console.log(`  3: New deployer (${NEW_DEPLOYER}) added to multisig`)
@@ -586,7 +589,7 @@ async function main() {
   for (const excludedNetwork of excludedNetworks) {
     results.push({
       network: excludedNetwork,
-      edmundRemoved: null,
+      michalRemoved: null,
       oldDeployerRemoved: null,
       newDeployerAdded: null,
       oldDeployerCancellerRemoved: null,
@@ -606,7 +609,7 @@ async function main() {
       if (!networkConfig) {
         const errorStatus: INetworkStatus = {
           network: networkName,
-          edmundRemoved: null,
+          michalRemoved: null,
           oldDeployerRemoved: null,
           newDeployerAdded: null,
           oldDeployerCancellerRemoved: null,
@@ -641,7 +644,7 @@ async function main() {
 
     // For non-excluded networks, sort by completion status, then by name
     const aBaseDone =
-      a.edmundRemoved === true &&
+      a.michalRemoved === true &&
       a.oldDeployerRemoved === true &&
       a.newDeployerAdded === true &&
       a.oldDeployerCancellerRemoved === true &&
@@ -654,7 +657,7 @@ async function main() {
     const aDone = aBaseDone && aStagingDone
 
     const bBaseDone =
-      b.edmundRemoved === true &&
+      b.michalRemoved === true &&
       b.oldDeployerRemoved === true &&
       b.newDeployerAdded === true &&
       b.oldDeployerCancellerRemoved === true &&


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-561](https://linear.app/lifi-linear/issue/EXSC-561) — Offboarding Michał (SC core dev): EVM production owner-swap.

# Why did I implement it this way?

Retargets the per-cycle offboarding status checker
(`script/tasks/temp/checkOffboardingStatusPerNetwork.ts`) from last cycle's
Edmund addresses to this cycle's swap, so the human-supervised proposal step has
an accurate per-chain progress view. Mirrors the structure used in prior cycles
(PRs #1562 / #1568):

- Outgoing safe signer: Edmund → **Michał** (`0xb455…cbf4F`)
- Old deployer: `0x11F1…` → `0xb137…4E269`
- New deployer: hardcoded `0xb05E…6095F`

The new deployer is **hardcoded** rather than read from `global.json.deployerWallet`
because that field still points at the outgoing deployer (`0xb137…`) until the
owner-swap proposals execute; deriving it from config would make columns 2 and 3
reference the same address and report a misleading status.

Verified before opening:

- Baseline `add-safe-owners-and-threshold.ts --check --all-networks`: all 71 active
  EVM mainnets `OK`, threshold=3, owners=6/6 (clean before-state).
- Updated script run confirms the expected pre-swap picture (Michał + old deployer
  still present everywhere) and that the deployer whitelist-update permission
  remains removed on every prod diamond (col 6 ✅, col 7 ✅ — whitelist stays
  multisig-only, per #1558 / #1559).

No on-chain transaction is created or broadcast by this change — the script is
read-only.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
