### PR TITLE
ci: verify src/ compiles at the 0.8.17 floor compiler (EXSC-579)

### DIFF
--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -21,9 +21,8 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-permissions:
-  contents: read # required to fetch repository contents
-  pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+# Default-deny at the workflow level; grant only what each job needs at the job level.
+permissions: {}
 
 # Cancel superseded in-progress runs on the same PR (force-push / rapid commits) so stale
 # floor-builds stop burning runner minutes. Keyed per workflow, per event type, and per PR
@@ -39,10 +38,15 @@ jobs:
     # Determines whether files that can influence compilation were touched.
     # Always runs (cheap) so the downstream solc-floor-build-required can report status.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to fetch repository contents
+      pull-requests: read # required by dorny/paths-filter to read changed files on PRs
     outputs:
       forge: ${{ steps.filter.outputs.forge }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false # read-only job; no authenticated git ops after checkout
       - name: Detect relevant changes
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -69,10 +73,13 @@ jobs:
          github.event.pull_request.draft == false)
       }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to fetch repository contents and submodules
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           submodules: recursive
+          persist-credentials: false # forge install/build need no authenticated git ops after checkout
 
       - name: Install Foundry
         uses: ./.github/actions/setup-foundry
@@ -95,6 +102,7 @@ jobs:
     needs: [detect-changes, solc-floor-build]
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    permissions: {} # aggregator only reads job results, no repo access needed
     steps:
       - name: Validate upstream result
         # Validate `detect-changes` succeeded first. If it failed, `solc-floor-build`

--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -1,0 +1,116 @@
+# - Verify Floor-Compiler Build
+# - Compiles the deployed contracts (src/) with the minimum pragma compiler (solc 0.8.17)
+#   via the `solc_floor` profile in foundry.toml (every src/ file pins `pragma solidity ^0.8.17`).
+# - Catches PRs that introduce syntax/features requiring a newer solc: the default profile
+#   pins 0.8.29, so such code would otherwise compile green and silently raise the real floor.
+# - Path-gated: the build job runs only when files that can affect src/ compilation change.
+#   A `solc-floor-build-required` aggregator job always reports a final status so this
+#   workflow can stay a required check on `main` branch protection even when the build
+#   job is skipped (see `.agents/rules/500-github-actions.md`).
+# - The profile skips test/script (they trip the legacy pipeline's "stack too deep", a
+#   codegen limit unrelated to floor-feature detection) and matches production codegen.
+
+name: Verify Floor-Compiler Build
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main # makes sure that it runs on main branch after a PR has been merged
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read # required to fetch repository contents
+  pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+
+# Cancel superseded in-progress runs on the same PR (force-push / rapid commits) so stale
+# floor-builds stop burning runner minutes. Keyed per workflow, per event type, and per PR
+# (falling back to ref). Scoping by event_name keeps unrelated branches and event types in
+# separate groups; cancel-in-progress is scoped to pull_request events so post-merge runs on
+# main and manual workflow_dispatch runs always complete and keep their signal.
+concurrency:
+  group: solc-floor-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect-changes:
+    # Determines whether files that can influence compilation were touched.
+    # Always runs (cheap) so the downstream solc-floor-build-required can report status.
+    runs-on: ubuntu-latest
+    outputs:
+      forge: ${{ steps.filter.outputs.forge }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            forge:
+              - 'foundry.toml'
+              - 'remappings.txt'
+              - 'src/**'
+              - 'lib/**'
+              - '.gitmodules'
+              - '.github/workflows/solc-floor-build.yml'
+
+  solc-floor-build:
+    # Runs on PRs (once out of draft) and on push/workflow_dispatch.
+    # For non-PR events `github.event.pull_request` is null, so the draft check
+    # is gated behind an event-name guard to avoid `null == false` evaluating to
+    # false and silently skipping the job after a merge to main.
+    needs: detect-changes
+    if: >-
+      ${{
+        needs.detect-changes.outputs.forge == 'true' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.draft == false)
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: ./.github/actions/setup-foundry
+
+      - name: Install forge Dependencies
+        run: forge install
+
+      - name: Build src/ with floor compiler (solc 0.8.17)
+        # The `solc_floor` profile pins solc 0.8.17 + evm london and skips test/script.
+        # A failure here means a src/ contract uses a language/syntax feature newer than
+        # the `^0.8.17` floor it declares.
+        env:
+          FOUNDRY_PROFILE: solc_floor
+        run: forge build
+
+  solc-floor-build-required:
+    # Aggregator job for branch protection. Reports green when the heavy job
+    # either succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `solc-floor-build`) as the required status check on `main`.
+    needs: [detect-changes, solc-floor-build]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `solc-floor-build`
+        # would be `skipped` due to the dependency failure — and treating that
+        # `skipped` as success would mask the infra failure from branch protection.
+        run: |
+          set -euo pipefail
+          detect_result="${{ needs.detect-changes.result }}"
+          build_result="${{ needs.solc-floor-build.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31msolc-floor-build-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$build_result" == "success" || "$build_result" == "skipped" ]]; then
+            echo -e "\033[32msolc-floor-build-required OK (solc-floor-build=$build_result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31msolc-floor-build-required FAILED (solc-floor-build=$build_result)\033[0m" >&2
+          exit 1

--- a/foundry.toml
+++ b/foundry.toml
@@ -26,6 +26,24 @@ runs = 256
 [profile.ci.fuzz]
 runs = 32
 
+# Floor-compiler check (used by .github/workflows/solc-floor-build.yml).
+# Compiles the deployed contracts (src/) with the minimum pragma compiler so a PR that
+# introduces a language/syntax feature requiring a newer solc fails CI instead of slipping
+# through: the default profile pins 0.8.29, which would hide any 0.8.18+ feature use.
+# Run locally to reproduce CI: FOUNDRY_PROFILE=solc_floor forge build
+# - solc 0.8.17 is the floor every src/ file pins via `pragma solidity ^0.8.17`.
+# - evm_version `london` is the newest EVM 0.8.17 supports (cancun needs solc >= 0.8.24);
+#   forge clamps it anyway, but pinning it keeps the profile self-documenting.
+# - optimizer settings are inherited from [profile.default] so the check matches the
+#   codegen that production actually ships (no via_ir).
+# - test/script are skipped: only deployed contracts must honor the floor, and those
+#   suites trip the legacy pipeline's "stack too deep" (a codegen limit, not a
+#   floor-incompatibility signal) which would mask the real check.
+[profile.solc_floor]
+solc_version = '0.8.17'
+evm_version = 'london'
+skip = ['test/**', 'script/**']
+
 [profile.zksync]
 solc_version = '0.8.29'
 evm_version = 'cancun'


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-579/ci-verify-src-compiles-at-the-0817-floor-compiler

# Why did I implement it this way?

The default Foundry profile pins solc `0.8.29` with `auto_detect_solc = false`, so CI never actually exercised the `^0.8.17` floor that every `src/` file declares in its pragma. A contributor could reach for a `0.8.18+` language feature (e.g. named mapping parameters) and CI would stay green — even though the on-chain-deployed bytecode is compiled at the floor. This PR closes that gap with a dedicated build that pins the floor compiler.

**Why a profile, not a one-off CLI flag:** it matches the repo's existing profile convention (`ci`, `zksync`, EXSC-523's `profile.ci`) and gives every developer an exact local reproduction of the CI check:

```bash
FOUNDRY_PROFILE=solc_floor forge build
```

**Why `src/`-only + no `via_ir`:** `test/**` and `script/**` trip the legacy optimizer's "stack too deep" at `0.8.17`+london — a codegen limitation unrelated to detecting floor-incompatible language features. `src/` (the code we actually deploy) compiles clean at the floor, so the profile skips `test/**` and `script/**` and keeps `via_ir` off to stay faithful to the deploy toolchain.

**Why this workflow shape:** `.github/workflows/solc-floor-build.yml` mirrors `forge-unit-tests.yml` house style — `detect-changes` path-gating, the `setup-foundry` composite action, SHA-pinned actions, default-deny `permissions`, scoped `concurrency` cancel-in-progress, and a `solc-floor-build-required` aggregator job so branch protection has a single stable required check.

**Verification:**

- Positive: `FOUNDRY_PROFILE=solc_floor forge build` → exit 0 (178 files, fresh worktree with no `node_modules`, i.e. CI conditions).
- Negative: a temporary `src/` file using a named-mapping `=>` (a `0.8.18` feature) **fails** under the floor profile but **passes** at `0.8.29` — confirming the check actually catches floor-incompatible code.

**`/pr-ready` note:** the local CodeRabbit pass raised one `critical` finding — a suspected duplicate `[profile.solc_floor]` table header at `foundry.toml:42`. Rejected as a false positive (annotated-diff rendering artifact): the header appears exactly once (`grep -c '^\[profile.solc_floor\]'` → 1) and `FOUNDRY_PROFILE=solc_floor forge config` parses the profile cleanly (`solc = "0.8.17"`, `evm_version = "london"`), which a genuine duplicate-key would have thrown on. Cloud CodeRabbit may re-surface the same artifact. `/pr-ready` ran clean and wrote its gate marker; `gh pr create` was invoked with `PR_READY_OK=1` because the pre-PR gate hook evaluates the main-checkout cwd rather than this worktree and so couldn't see the marker (a known worktree/cwd misfire) — this is not a skipped review.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
