### PR TITLE
feat(safe-decode): resolve role names for revokeRole/renounceRole

### DIFF
--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for role-name resolution and role-change display in safe-decode-utils.
+ * Covers getRoleName (hash -> OZ AccessControl role name) and formatRoleChange
+ * (the grantRole / revokeRole / renounceRole display path).
+ */
+import {
+  describe,
+  expect,
+  it,
+  afterEach,
+  spyOn,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import { consola } from 'consola'
+
+import { getRoleName, formatRoleChange } from './safe-decode-utils'
+
+const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
+const CANCELLER_ROLE =
+  '0xfd643c72710c63c0180259aba6b2d05451e3591a24e58b62239378085726f783'
+const PROPOSER_ROLE =
+  '0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1'
+const EXECUTOR_ROLE =
+  '0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63'
+const TIMELOCK_ADMIN_ROLE =
+  '0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5'
+
+describe('getRoleName', () => {
+  it('resolves known OpenZeppelin role hashes', () => {
+    expect(getRoleName(CANCELLER_ROLE)).toBe('CANCELLER_ROLE')
+    expect(getRoleName(PROPOSER_ROLE)).toBe('PROPOSER_ROLE')
+    expect(getRoleName(EXECUTOR_ROLE)).toBe('EXECUTOR_ROLE')
+    expect(getRoleName(TIMELOCK_ADMIN_ROLE)).toBe('TIMELOCK_ADMIN_ROLE')
+  })
+
+  it('resolves DEFAULT_ADMIN_ROLE (bytes32 zero, not a keccak hash)', () => {
+    expect(getRoleName(DEFAULT_ADMIN_ROLE)).toBe('DEFAULT_ADMIN_ROLE')
+  })
+
+  it('is case-insensitive on the hex digits', () => {
+    const upperHex = `0x${CANCELLER_ROLE.slice(2).toUpperCase()}`
+    expect(getRoleName(upperHex)).toBe('CANCELLER_ROLE')
+  })
+
+  it('accepts a hash without the 0x prefix', () => {
+    expect(getRoleName(CANCELLER_ROLE.slice(2))).toBe('CANCELLER_ROLE')
+  })
+
+  it('returns empty string for an unknown role hash', () => {
+    expect(getRoleName(`0x${'11'.repeat(32)}`)).toBe('')
+  })
+})
+
+describe('formatRoleChange', () => {
+  afterEach(() => {
+    spyOn(consola, 'info').mockRestore()
+  })
+
+  // Output is ANSI-colored, but the function name and the "(ROLE_NAME)" label
+  // are each emitted as contiguous substrings, so we assert on the raw joined
+  // output without stripping escape codes.
+  const capture = async (
+    functionName: string,
+    role: string,
+    account: string
+  ): Promise<string> => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatRoleChange(functionName, [role, account], 'mainnet')
+    return infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+  }
+
+  const account = '0xb05E63458A51731Aad26BdcD6E12246330E6095F'
+  const ROLE_LABEL = /\([A-Z_]+_ROLE\)/
+
+  it('labels the role on revokeRole (the previously unlabeled path)', async () => {
+    const output = await capture('revokeRole', CANCELLER_ROLE, account)
+    expect(output).toContain('Function:')
+    expect(output).toContain('revokeRole')
+    expect(output).toContain(CANCELLER_ROLE)
+    expect(output).toContain('(CANCELLER_ROLE)')
+  })
+
+  it('labels the role on renounceRole', async () => {
+    const output = await capture('renounceRole', PROPOSER_ROLE, account)
+    expect(output).toContain('renounceRole')
+    expect(output).toContain('(PROPOSER_ROLE)')
+  })
+
+  it('still labels the role on grantRole', async () => {
+    const output = await capture('grantRole', CANCELLER_ROLE, account)
+    expect(output).toContain('grantRole')
+    expect(output).toContain('(CANCELLER_ROLE)')
+  })
+
+  it('omits the role label for an unknown role hash', async () => {
+    const unknown = `0x${'11'.repeat(32)}`
+    const output = await capture('revokeRole', unknown, account)
+    expect(output).toContain('revokeRole')
+    expect(output).toContain(unknown)
+    expect(output).not.toMatch(ROLE_LABEL)
+  })
+
+  it('returns without logging when args are incomplete', async () => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatRoleChange('revokeRole', [CANCELLER_ROLE], 'mainnet')
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+})

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -542,10 +542,23 @@ const ABI_BATCH_SET_CONTRACT_SELECTOR_WHITELIST = parseAbi([
 const ABI_REGISTER_PERIPHERY_CONTRACT = parseAbi([
   'function registerPeripheryContract(string,address)',
 ])
-const ABI_GRANT_ROLE = parseAbi(['function grantRole(bytes32,address)'])
+// grantRole / revokeRole / renounceRole share the (bytes32,address) shape
+const ABI_ACCESS_CONTROL_ROLE = parseAbi([
+  'function grantRole(bytes32,address)',
+  'function revokeRole(bytes32,address)',
+  'function renounceRole(bytes32,address)',
+])
+const ACCESS_CONTROL_ROLE_FUNCTIONS = new Set([
+  'grantRole',
+  'revokeRole',
+  'renounceRole',
+])
 
 // OpenZeppelin TimelockController / AccessControl role names (keccak256 of role string)
-const KNOWN_ROLE_NAMES: Record<string, string> = {}
+const KNOWN_ROLE_NAMES: Record<string, string> = {
+  // DEFAULT_ADMIN_ROLE is bytes32(0), not a keccak256 hash of its name
+  [`0x${'00'.repeat(32)}`]: 'DEFAULT_ADMIN_ROLE',
+}
 for (const name of [
   'TIMELOCK_ADMIN_ROLE',
   'PROPOSER_ROLE',
@@ -556,7 +569,7 @@ for (const name of [
   KNOWN_ROLE_NAMES[hash.toLowerCase()] = name
 }
 
-function getRoleName(roleHash: string): string {
+export function getRoleName(roleHash: string): string {
   const normalized = roleHash.startsWith('0x')
     ? roleHash.toLowerCase()
     : `0x${roleHash}`.toLowerCase()
@@ -675,13 +688,16 @@ function getAbiForKnownFunction(functionName: string): Abi | null {
     case 'registerPeripheryContract':
       return ABI_REGISTER_PERIPHERY_CONTRACT
     case 'grantRole':
-      return ABI_GRANT_ROLE
+    case 'revokeRole':
+    case 'renounceRole':
+      return ABI_ACCESS_CONTROL_ROLE
     default:
       return null
   }
 }
 
-async function formatGrantRole(
+export async function formatRoleChange(
+  functionName: string,
   args: readonly unknown[],
   network: string,
   indent?: string
@@ -695,7 +711,7 @@ async function formatGrantRole(
     typeof account === 'string' ? account : String(account ?? '')
   const roleName = getRoleName(roleStr)
   const roleLabel = roleName ? ` \u001b[33m(${roleName})\u001b[0m` : ''
-  consola.info(`${pre}Function: \u001b[34mgrantRole\u001b[0m`)
+  consola.info(`${pre}Function: \u001b[34m${functionName}\u001b[0m`)
   consola.info(`${pre}  Role:   \u001b[32m${roleStr}\u001b[0m${roleLabel}`)
   const accountDisplay = formatAddressForNetworkCliDisplay(network, accountStr)
   const accountSuffix = await getTargetSuffix(network, accountStr)
@@ -824,11 +840,12 @@ export async function formatDecodedTxDataForDisplay(
     }
 
     if (
-      decoded?.functionName === 'grantRole' &&
+      decoded?.functionName &&
+      ACCESS_CONTROL_ROLE_FUNCTIONS.has(decoded.functionName) &&
       decoded.args &&
       decoded.args.length >= 2
     ) {
-      await formatGrantRole(decoded.args, network, pre)
+      await formatRoleChange(decoded.functionName, decoded.args, network, pre)
       return
     }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

No dedicated Linear ticket — small self-contained improvement to the Safe/timelock
proposal decoder surfaced while reviewing a live `revokeRole` proposal. Happy to
attach a ticket or apply the `trivial` label per the Ticket Linkage policy if
preferred.

# Why did I implement it this way?

When reviewing multisig/timelock proposals, `grantRole` already rendered the
human-readable OpenZeppelin role name next to the raw `bytes32` hash (e.g.
`(CANCELLER_ROLE)`), but `revokeRole` fell through to the generic argument
printer and showed only the raw hash — making revocations harder to verify at a
glance. `renounceRole` had the same gap.

`bytes32` roles are `keccak256("ROLE_NAME")` (a one-way hash), so there is no way
to reverse a hash back to its name — the resolver has to match against a known
set. The repo already precomputes that set (`KNOWN_ROLE_NAMES` + `getRoleName`);
it just wasn't wired into the revoke/renounce paths.

Changes:

- Generalized `formatGrantRole` → `formatRoleChange(functionName, …)` and route
  `grantRole` / `revokeRole` / `renounceRole` through it via a single shared ABI
  and a function-name set. All three now label the role.
- Added `DEFAULT_ADMIN_ROLE` (`bytes32(0)`) to the known-role map — it's the
  literal zero value, not a keccak hash of its name, so it needed an explicit
  entry. It's the role most likely to appear unlabeled in real proposals.
- Added a colocated `safe-decode-utils.test.ts` covering `getRoleName` (against
  the real keccak hashes, incl. the `CANCELLER_ROLE` hash from the proposal that
  prompted this) and `formatRoleChange` (grant/revoke/renounce all resolve the
  label; unknown roles stay unlabeled; incomplete args no-op).

Kept the change scoped to the display layer per `[CONV:SAFE-DECODE]` /
`[CONV:SAFE-DECODE-UTILS]`; no on-chain behavior, storage, or selector layout is
touched. A dynamic "read the contract's `*_ROLE()` getters over RPC" fallback for
project-specific roles was deliberately left out to avoid an RPC round-trip per
proposal — the static map covers every role currently defined in `src/`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
