### PR TITLE
feat(safe): Ledger Flex signing filmstrip in confirm-safe-tx (EXSC-580)

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -22,6 +22,7 @@ import { createDefaultCache } from '../shared/deployment-cache'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import type { ILedgerAccountResult } from './ledger'
+import { renderLedgerFlexFlow } from './ledger-flex-preview'
 import {
   reconcileAllSubmittedSafeTxs,
   reconcileCoverageKey,
@@ -490,22 +491,50 @@ const processTxs = async (
         ? ` \u001b[33m⚠ on-chain nonce is ${expectedNonce} — cannot execute yet\u001b[0m`
         : ''
 
-    consola.info(`Safe Transaction Details:
-    Nonce:           \u001b[${nonceColor}m${
-      tx.safeTx.data.nonce
-    }\u001b[0m${nonceWarning}
-    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m
-    Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m
-    Operation:       \u001b[32m${
-      tx.safeTx.data.operation === 0 ? 'Call' : 'DelegateCall'
-    }\u001b[0m
-    Data:            \u001b[32m${tx.safeTx.data.data}\u001b[0m
-    Proposer:        \u001b[32m${proposerDisplay}\u001b[0m
-    Safe Tx Hash:    \u001b[36m${tx.safeTxHash}\u001b[0m
-    Signatures:      \u001b[32m${tx.safeTransaction.signatures.size}/${
-      tx.threshold
-    }\u001b[0m required
-    Execution Ready: \u001b[${tx.canExecute ? '32m✓' : '31m✗'}\u001b[0m`)
+    const detailLines = [
+      'Safe Transaction Details:',
+      `    Nonce:           \u001b[${nonceColor}m${tx.safeTx.data.nonce}\u001b[0m${nonceWarning}`,
+      `    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m`,
+      `    Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m`,
+      `    Operation:       \u001b[32m${
+        tx.safeTx.data.operation === 0 ? 'Call' : 'DelegateCall'
+      }\u001b[0m`,
+      `    Data:            \u001b[32m${tx.safeTx.data.data}\u001b[0m`,
+      `    Proposer:        \u001b[32m${proposerDisplay}\u001b[0m`,
+      `    Safe Tx Hash:    \u001b[36m${tx.safeTxHash}\u001b[0m`,
+      `    Signatures:      \u001b[32m${tx.safeTransaction.signatures.size}/${tx.threshold}\u001b[0m required`,
+      `    Execution Ready: \u001b[${tx.canExecute ? '32m✓' : '31m✗'}\u001b[0m`,
+    ]
+
+    consola.info(detailLines.join('\n'))
+
+    // Ledger Flex signing filmstrip: reproduce the on-device screens the
+    // signer steps through so values can be compared screen-by-screen. EVM
+    // only — the Flex EIP-712 blind-signing flow does not apply to Tron.
+    // A display error must never block signing.
+    if (
+      !isTronNetworkKey(network) &&
+      tx.safeTx.data.data &&
+      tx.safeTx.data.data !== '0x'
+    )
+      try {
+        const filmstrip = renderLedgerFlexFlow({
+          chainId: chain.id,
+          verifyingContract: safeAddress,
+          to: tx.safeTx.data.to,
+          value: String(tx.safeTx.data.value),
+          data: tx.safeTx.data.data as Hex,
+        })
+        consola.info(
+          [
+            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant).',
+            'Hex fields (addresses and data) wrap in a proportional font on the device, so line breaks may differ — compare the character sequence, not the layout.',
+            ...filmstrip,
+          ].join('\n')
+        )
+      } catch (error) {
+        consola.debug(`Ledger Flex filmstrip skipped: ${error}`)
+      }
 
     const storedResponse = tx.safeTx.data.data
       ? storedResponses[tx.safeTx.data.data]

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -22,7 +22,10 @@ import { createDefaultCache } from '../shared/deployment-cache'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import type { ILedgerAccountResult } from './ledger'
-import { renderLedgerFlexFlow } from './ledger-flex-preview'
+import {
+  LEDGER_FLEX_WRAP_NOTE,
+  renderLedgerFlexFlow,
+} from './ledger-flex-preview'
 import {
   reconcileAllSubmittedSafeTxs,
   reconcileCoverageKey,
@@ -527,9 +530,9 @@ const processTxs = async (
         })
         consola.info(
           [
-            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant).',
-            'Hex fields (addresses and data) wrap in a proportional font on the device, so line breaks may differ — compare the character sequence, not the layout.',
+            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant):',
             ...filmstrip,
+            LEDGER_FLEX_WRAP_NOTE,
           ].join('\n')
         )
       } catch (error) {

--- a/script/deploy/safe/ledger-flex-preview.test.ts
+++ b/script/deploy/safe/ledger-flex-preview.test.ts
@@ -1,0 +1,125 @@
+// eslint-disable-next-line import/no-unresolved
+import { describe, expect, it } from 'bun:test'
+import { type Hex } from 'viem'
+
+import {
+  joinPanelsHorizontally,
+  renderLedgerFlexFlow,
+  type ILedgerFlexFlowParams,
+} from './ledger-flex-preview'
+
+// swapOwner(address,address,address) calldata whose Ledger Flex `data` preview
+// was captured on-device; the first 104 chars drive the truncated preview.
+const SWAP_OWNER: Hex = ('0xe318b52b' +
+  '000000000000000000000000' +
+  '9740a8e0197689d144b19da4bdc9ef65fef11cda' +
+  '000000000000000000000000' +
+  'b137680000000000000000000000000000000000' +
+  '000000000000000000000000' +
+  '0000000000000000000000000000000000000001') as Hex
+
+const PARAMS: ILedgerFlexFlowParams = {
+  chainId: 34443,
+  // lowercase on purpose — must be rendered EIP-55 checksummed
+  verifyingContract: '0x031f25f640e0530a51f5617757b281a8df5614ee',
+  to: '0x57c676a0417233a0bd3cbbb705db158d4261074b',
+  value: '0',
+  data: SWAP_OWNER,
+}
+
+const ESC = String.fromCharCode(27)
+const stripAnsi = (s: string): string =>
+  s.replace(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '')
+
+describe('renderLedgerFlexFlow', () => {
+  const flow = renderLedgerFlexFlow(PARAMS)
+  const joined = flow.join('\n')
+
+  it('renders the five signing screens in order', () => {
+    expect(joined).toContain('Blind signing ahead') // warning
+    expect(joined).toContain('Review typed') // 1/8
+    expect(joined).toContain('EIP712Domain') // 2/8
+    expect(joined).toContain('SafeTx') // 3/8
+    expect(joined).toContain('data') // 4/8
+    expect(joined).toContain('1 of 8')
+    expect(joined).toContain('2 of 8')
+    expect(joined).toContain('3 of 8')
+    expect(joined).toContain('4 of 8')
+  })
+
+  it('omits the non-security-relevant screens 5–8', () => {
+    expect(joined).not.toContain('5 of 8')
+    expect(joined).not.toContain('nonce')
+  })
+
+  it('shows the domain values', () => {
+    expect(joined).toContain('34443')
+    // checksummed, wrapped at 18 chars (0x + 16)
+    expect(joined).toContain('0x031f25F640E0530a')
+    expect(joined).not.toContain('0x031f25f640e0530a') // not the lowercase form
+  })
+
+  it('shows the SafeTx to (checksummed) and value', () => {
+    expect(joined).toContain('0x57C676A0417233A0')
+    expect(joined).toContain('value')
+  })
+
+  it('reproduces the exact uppercased data rows with truncation', () => {
+    expect(joined).toContain('0xE318B52B00000000')
+    expect(joined).toContain('000000000000000097')
+    expect(joined).toContain('40A8E0197689D144B1')
+    expect(joined).toContain('DA0000000000000000')
+    expect(joined).toContain('00000000B13768…')
+    expect(joined).toContain('( More )')
+  })
+
+  it('highlights the "Accept risk and continue" action in bold green', () => {
+    expect(joined).toContain(`${ESC}[1;32mAccept risk and${ESC}[0m`)
+    expect(joined).toContain(`${ESC}[1;32mcontinue${ESC}[0m`)
+  })
+
+  it('renders the frame chrome (borders, Skip, Reject)', () => {
+    expect(flow[0]).toContain('╭')
+    expect(flow[flow.length - 1]).toContain('╰')
+    expect(joined).toContain('Skip')
+    expect(joined).toContain('Reject')
+  })
+
+  it('produces a rectangular block (all rows equal visible width)', () => {
+    const widths = new Set(flow.map((l) => [...stripAnsi(l)].length))
+    expect(widths.size).toBe(1)
+  })
+
+  it('stays rectangular when a value is at least the interior width', () => {
+    // a ≥20-char value must not overflow the box border by one column
+    const long = renderLedgerFlexFlow({ ...PARAMS, value: '1'.repeat(30) })
+    const widths = new Set(long.map((l) => [...stripAnsi(l)].length))
+    expect(widths.size).toBe(1)
+  })
+
+  it('does not show a "More" affordance when the data fits without truncation', () => {
+    const short = renderLedgerFlexFlow({ ...PARAMS, data: '0xa9059cbb' as Hex })
+    const j = short.join('\n')
+    expect(j).toContain('0xA9059CBB')
+    expect(j).not.toContain('( More )')
+    expect(j).not.toContain('…')
+  })
+})
+
+describe('joinPanelsHorizontally', () => {
+  it('concatenates equal-height panels with the given gap', () => {
+    const out = joinPanelsHorizontally(
+      [
+        ['AA', 'BB'],
+        ['CC', 'DD'],
+      ],
+      3
+    )
+    expect(out).toEqual(['AA   CC', 'BB   DD'])
+  })
+
+  it('pads missing lines of shorter panels with empty strings', () => {
+    const out = joinPanelsHorizontally([['A', 'B', 'C'], ['X']], 1)
+    expect(out).toEqual(['A X', 'B ', 'C '])
+  })
+})

--- a/script/deploy/safe/ledger-flex-preview.test.ts
+++ b/script/deploy/safe/ledger-flex-preview.test.ts
@@ -4,6 +4,7 @@ import { type Hex } from 'viem'
 
 import {
   joinPanelsHorizontally,
+  LEDGER_FLEX_WRAP_NOTE,
   renderLedgerFlexFlow,
   type ILedgerFlexFlowParams,
 } from './ledger-flex-preview'
@@ -103,6 +104,14 @@ describe('renderLedgerFlexFlow', () => {
     expect(j).toContain('0xA9059CBB')
     expect(j).not.toContain('( More )')
     expect(j).not.toContain('…')
+  })
+})
+
+describe('LEDGER_FLEX_WRAP_NOTE', () => {
+  it('is a red caveat about proportional-font line breaks', () => {
+    expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[31m`)
+    expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[0m`)
+    expect(stripAnsi(LEDGER_FLEX_WRAP_NOTE).toLowerCase()).toContain('wrap')
   })
 })
 

--- a/script/deploy/safe/ledger-flex-preview.ts
+++ b/script/deploy/safe/ledger-flex-preview.ts
@@ -1,0 +1,298 @@
+/**
+ * Ledger Flex signing filmstrip
+ *
+ * Renders an ASCII replica of the sequence of Ledger Flex screens a signer
+ * steps through when blind-signing a Safe transaction (EIP-712), populated with
+ * the actual to-be-signed values. Import from `confirm-safe-tx.ts` to print the
+ * filmstrip so the operator can compare each screen against the physical device
+ * instead of eyeballing a 200-character hex blob.
+ *
+ * Only the first five screens are reproduced (warning + screens 1–4 of 8): the
+ * security-relevant ones — domain chainId/verifyingContract, SafeTx to/value,
+ * and the calldata. Screens 5–8 (safeTxGas, baseGas, gasPrice, gasToken,
+ * refundReceiver, nonce) are boilerplate — typically zero and not worth
+ * comparing — so they are intentionally omitted.
+ */
+
+import { getAddress, type Hex } from 'viem'
+
+// Layout constants derived from a Ledger Flex screenshot of the `data` field.
+// The Flex screen is identical across all company devices, so these are fixed.
+const ROW_WIDTH = 18 // hex chars per data row; the `0x` prefix counts inside row 1
+// Approximate chars shown before the "…" (~6 proportional-font rows). The exact
+// count varies with content; tune against a device if the cutoff looks off.
+const DATA_PREVIEW_CHARS = 104
+const INNER = 20 // interior width of each screen box (between the borders)
+const PANEL_GAP = 2 // spaces between panels in the row
+
+// Bold green, to flag on the terminal side that "Accept risk and continue" is
+// the action the operator must tap to proceed (the device renders it plainly).
+const ESC = String.fromCharCode(27)
+const HIGHLIGHT = `${ESC}[1;32m`
+const BOLD = `${ESC}[1m`
+const RESET = `${ESC}[0m`
+
+interface IFlexLine {
+  text: string
+  align: 'left' | 'center'
+  /** Optional ANSI style applied to the text (not the padding). */
+  style?: string
+}
+
+interface IFlexScreen {
+  /** Right-aligned top affordance (e.g. "Skip"); empty for none. */
+  header: string
+  content: IFlexLine[]
+  /** Pre-formatted, exactly `INNER`-wide bottom line (nav / tap area). */
+  footer: string
+}
+
+export interface ILedgerFlexFlowParams {
+  chainId: number
+  /** EIP-712 domain verifyingContract — the Safe address. */
+  verifyingContract: string
+  /** SafeTx `to` target. */
+  to: string
+  /** SafeTx `value`, decimal string. */
+  value: string
+  /** SafeTx `data` calldata, `0x`-prefixed. */
+  data: Hex
+}
+
+/** Fixed-width chunk a string into rows of `width` characters. */
+const chunk = (s: string, width: number): string[] => {
+  const rows: string[] = []
+  for (let i = 0; i < s.length; i += width) rows.push(s.slice(i, i + width))
+  return rows.length ? rows : ['']
+}
+
+/** Word-wrap prose to `width`, hard-splitting any word longer than `width`. */
+const wrapWords = (text: string, width: number): string[] => {
+  const out: string[] = []
+  let line = ''
+  for (const word of text.split(' ')) {
+    let w = word
+    while (w.length > width) {
+      if (line) {
+        out.push(line)
+        line = ''
+      }
+      out.push(w.slice(0, width))
+      w = w.slice(width)
+    }
+    if (!line) line = w
+    else if (line.length + 1 + w.length <= width) line += ` ${w}`
+    else {
+      out.push(line)
+      line = w
+    }
+  }
+  if (line) out.push(line)
+  return out
+}
+
+/**
+ * Rows for the Ledger `data` field: uppercased hex with a lowercase `0x`
+ * prefix, wrapped to `ROW_WIDTH`, truncated with a trailing "…" past the
+ * device's preview budget.
+ */
+const dataRows = (data: Hex): { rows: string[]; truncated: boolean } => {
+  const display = `0x${data.replace(/^0x/i, '').toUpperCase()}`
+  const truncated = display.length > DATA_PREVIEW_CHARS
+  const shown = truncated ? display.slice(0, DATA_PREVIEW_CHARS) : display
+  const rows = chunk(shown, ROW_WIDTH)
+  if (truncated) rows[rows.length - 1] += '…'
+  return { rows, truncated }
+}
+
+// Address fields render EIP-55 checksummed (mixed case), unlike the uppercased
+// `data` field. Wrapping is a fixed ROW_WIDTH approximation: the Flex renders
+// the hex in a PROPORTIONAL font (digits narrower than A–F), so a letter-dense
+// line wraps a character or two earlier on-device. The character sequence still
+// matches 1:1 — only the line breaks differ (compare the chars, not the layout).
+const addressRows = (addr: string): string[] =>
+  chunk(getAddress(addr as Hex), ROW_WIDTH)
+
+const navFooter = (page: number): string => {
+  const left = 'Reject'
+  const right = `< ${page} of 8 >`
+  const gap = Math.max(1, INNER - left.length - right.length)
+  return `${left}${' '.repeat(gap)}${right}`
+}
+
+const buildScreens = (p: ILedgerFlexFlowParams): IFlexScreen[] => {
+  const { rows, truncated } = dataRows(p.data)
+
+  const warning: IFlexScreen = {
+    header: '',
+    content: [
+      { text: '/!\\', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Blind signing ahead', align: 'center', style: BOLD },
+      { text: '', align: 'center' },
+      ...wrapWords(
+        'If you sign this transaction, you could lose your assets.',
+        INNER - 2
+      ).map((text) => ({ text, align: 'left' as const })),
+      { text: '', align: 'center' },
+      { text: '[ Back to safety ]', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Accept risk and', align: 'center', style: HIGHLIGHT },
+      { text: 'continue', align: 'center', style: HIGHLIGHT },
+    ],
+    footer: '',
+  }
+
+  const typedMessage: IFlexScreen = {
+    header: '',
+    content: [
+      { text: '[=]', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Review typed', align: 'center', style: BOLD },
+      { text: 'message', align: 'center', style: BOLD },
+      { text: '', align: 'center' },
+      { text: 'Blind signing', align: 'left' },
+      { text: 'required.', align: 'left' },
+    ],
+    footer: navFooter(1),
+  }
+
+  const domain: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'Review struct', align: 'left', style: BOLD },
+      { text: 'EIP712Domain', align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'chainId', align: 'left', style: BOLD },
+      { text: String(p.chainId), align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'verifyingContract', align: 'left', style: BOLD },
+      ...addressRows(p.verifyingContract).map((text) => ({
+        text,
+        align: 'left' as const,
+      })),
+    ],
+    footer: navFooter(2),
+  }
+
+  const safeTx: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'Review struct', align: 'left', style: BOLD },
+      { text: 'SafeTx', align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'to', align: 'left', style: BOLD },
+      ...addressRows(p.to).map((text) => ({ text, align: 'left' as const })),
+      { text: '', align: 'left' },
+      { text: 'value', align: 'left', style: BOLD },
+      { text: p.value, align: 'left' },
+    ],
+    footer: navFooter(3),
+  }
+
+  const dataScreen: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'data', align: 'left', style: BOLD },
+      ...rows.map((text) => ({ text, align: 'left' as const })),
+      ...(truncated
+        ? [
+            { text: '', align: 'center' as const },
+            { text: '( More )', align: 'center' as const },
+          ]
+        : []),
+    ],
+    footer: navFooter(4),
+  }
+
+  return [warning, typedMessage, domain, safeTx, dataScreen]
+}
+
+/** One interior row, clipped/padded to `INNER` with a 1-space side margin. */
+const frameLine = ({ text, align, style }: IFlexLine): string => {
+  const t = text.length > INNER ? text.slice(0, INNER) : text
+  let body: string
+  if (align === 'center') {
+    const space = INNER - t.length
+    const left = Math.floor(space / 2)
+    body = ' '.repeat(left) + t + ' '.repeat(space - left)
+  } else {
+    // slice before padEnd: a 1-space margin + INNER-length text would be
+    // INNER+1 wide, and padEnd never truncates — breaking the row width.
+    body = ` ${t}`.slice(0, INNER).padEnd(INNER)
+  }
+  // Style only the text run so the padding (and thus the visible width) is
+  // untouched — keeps the box borders and neighbouring panels aligned.
+  if (style && t) body = body.replace(t, `${style}${t}${RESET}`)
+  return `│${body}│`
+}
+
+/** A row whose content is already exactly `INNER`-wide (footers, blanks). */
+const frameRaw = (raw: string): string =>
+  `│${raw.padEnd(INNER).slice(0, INNER)}│`
+
+const framePanel = (screen: IFlexScreen, contentHeight: number): string[] => {
+  const top = `╭${'─'.repeat(INNER)}╮`
+  const bottom = `╰${'─'.repeat(INNER)}╯`
+  const headerLine = screen.header
+    ? frameRaw(`${screen.header} `.padStart(INNER))
+    : frameRaw('')
+
+  // Centre the content vertically between the header and footer: split the
+  // slack evenly instead of dumping it all at the bottom (which made the
+  // shorter screens look top-heavy).
+  const slack = Math.max(0, contentHeight - screen.content.length)
+  const topPad = Math.floor(slack / 2)
+  const blank = () => frameRaw('')
+
+  return [
+    top,
+    headerLine,
+    ...Array.from({ length: topPad }, blank),
+    ...screen.content.map(frameLine),
+    ...Array.from({ length: slack - topPad }, blank),
+    frameRaw(screen.footer),
+    bottom,
+  ]
+}
+
+/** Concatenate equal-height panels left-to-right, separated by `gap` spaces. */
+export const joinPanelsHorizontally = (
+  panels: string[][],
+  gap: number = PANEL_GAP
+): string[] => {
+  const height = Math.max(...panels.map((p) => p.length))
+  const sep = ' '.repeat(gap)
+  const out: string[] = []
+  for (let i = 0; i < height; i++)
+    out.push(panels.map((p) => p[i] ?? '').join(sep))
+  return out
+}
+
+/**
+ * Render the Ledger Flex signing filmstrip for a Safe transaction.
+ *
+ * @param params - The to-be-signed domain and SafeTx values.
+ * @returns The filmstrip as an array of lines (a row of five framed screens).
+ * @throws If `verifyingContract` or `to` is not a valid EVM address — callers
+ *   must gate on EVM networks (the Flex EIP-712 flow does not apply to Tron).
+ */
+export const renderLedgerFlexFlow = (
+  params: ILedgerFlexFlowParams
+): string[] => {
+  const screens = buildScreens(params)
+  const contentHeight = Math.max(...screens.map((s) => s.content.length))
+  const panels = screens.map((s) => framePanel(s, contentHeight))
+
+  // A vertically-centred ">" between panels shows the left-to-right order the
+  // signer steps through the screens.
+  const height = panels[0]?.length ?? 0
+  const mid = Math.floor(height / 2)
+  const connector = Array.from({ length: height }, (_, i) =>
+    i === mid ? '>' : ' '
+  )
+  const withArrows = panels.flatMap((panel, i) =>
+    i === 0 ? [panel] : [connector, panel]
+  )
+  return joinPanelsHorizontally(withArrows, 1)
+}

--- a/script/deploy/safe/ledger-flex-preview.ts
+++ b/script/deploy/safe/ledger-flex-preview.ts
@@ -30,7 +30,15 @@ const PANEL_GAP = 2 // spaces between panels in the row
 const ESC = String.fromCharCode(27)
 const HIGHLIGHT = `${ESC}[1;32m`
 const BOLD = `${ESC}[1m`
+const RED = `${ESC}[31m`
 const RESET = `${ESC}[0m`
+
+/**
+ * Red caveat to print BELOW the filmstrip: on-device the Flex wraps hex in a
+ * proportional font, so line breaks won't match the fixed-width panel. The
+ * character sequence still matches 1:1.
+ */
+export const LEDGER_FLEX_WRAP_NOTE = `${RED}⚠ Address and data lines may wrap at different points on your Ledger (proportional font) — compare the character sequence, not the line breaks.${RESET}`
 
 interface IFlexLine {
   text: string


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-580](https://linear.app/lifi-linear/issue/EXSC-580/confirm-safe-tx-show-ledger-flex-signing-filmstrip-for-calldata)

# Why did I implement it this way?

When confirming a Safe transaction on a Ledger Flex, the signer must check that the calldata on the device matches the proposal. Today the script prints the full 200+ char calldata blob, which is hard to eyeball against the small device screen.

This adds a **Ledger Flex signing filmstrip** printed below the Safe Transaction Details: an ASCII replica of the on-device screens the signer steps through (⚠ warning → `1/8` typed message → `2/8` EIP712Domain → `3/8` SafeTx → `4/8` data), populated with the **actual to-be-signed values** (`chainId`, `verifyingContract` = Safe address, `to`, `value`, calldata), joined left-to-right with `>` connectors.

Design decisions:

- **Pure, testable module** (`ledger-flex-preview.ts`) kept out of `confirm-safe-tx.ts`, with a colocated test suite (100% of the rendering logic).
- **Fidelity to the device:** address fields render EIP-55 checksummed; the `data` field is uppercased; labels are bold; the `Accept risk and continue` tap is bold-green so the operator knows the required action.
- **Proportional-font caveat:** the Flex renders hex (addresses *and* data) in a proportional font, so exact per-line wrapping is not reproducible with a fixed width (verified against device screenshots — a digit/letter width model is inconsistent). Rather than fake precision, the panel wraps at a fixed width as an approximation and prints a note telling the operator to **compare the character sequence, not the line layout**. The character sequence still matches 1:1.
- **Safety:** EVM-only (the Flex EIP-712 blind-signing flow doesn't apply to Tron); the render is wrapped in try/catch so a display error can never block signing; screens 5–8 (gas params / nonce) are intentionally omitted as not security-relevant.
- Styling is applied only to the text run (never the padding), so ANSI codes never affect box-border alignment — asserted by an "all rows equal visible width" test.

Only screens the signer actually verifies are shown; no protocol/contract behavior is touched.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
