### PR TITLE
feat(safe): Safe-signing review UX — role-name decode, Ledger Flex filmstrip, blind-signing pre-check (EXSC-580)

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -22,6 +22,7 @@ import { createDefaultCache } from '../shared/deployment-cache'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import type { ILedgerAccountResult } from './ledger'
+import { renderLedgerFlexFlow } from './ledger-flex-preview'
 import {
   reconcileAllSubmittedSafeTxs,
   reconcileCoverageKey,
@@ -490,22 +491,50 @@ const processTxs = async (
         ? ` \u001b[33m⚠ on-chain nonce is ${expectedNonce} — cannot execute yet\u001b[0m`
         : ''
 
-    consola.info(`Safe Transaction Details:
-    Nonce:           \u001b[${nonceColor}m${
-      tx.safeTx.data.nonce
-    }\u001b[0m${nonceWarning}
-    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m
-    Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m
-    Operation:       \u001b[32m${
-      tx.safeTx.data.operation === 0 ? 'Call' : 'DelegateCall'
-    }\u001b[0m
-    Data:            \u001b[32m${tx.safeTx.data.data}\u001b[0m
-    Proposer:        \u001b[32m${proposerDisplay}\u001b[0m
-    Safe Tx Hash:    \u001b[36m${tx.safeTxHash}\u001b[0m
-    Signatures:      \u001b[32m${tx.safeTransaction.signatures.size}/${
-      tx.threshold
-    }\u001b[0m required
-    Execution Ready: \u001b[${tx.canExecute ? '32m✓' : '31m✗'}\u001b[0m`)
+    const detailLines = [
+      'Safe Transaction Details:',
+      `    Nonce:           \u001b[${nonceColor}m${tx.safeTx.data.nonce}\u001b[0m${nonceWarning}`,
+      `    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m`,
+      `    Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m`,
+      `    Operation:       \u001b[32m${
+        tx.safeTx.data.operation === 0 ? 'Call' : 'DelegateCall'
+      }\u001b[0m`,
+      `    Data:            \u001b[32m${tx.safeTx.data.data}\u001b[0m`,
+      `    Proposer:        \u001b[32m${proposerDisplay}\u001b[0m`,
+      `    Safe Tx Hash:    \u001b[36m${tx.safeTxHash}\u001b[0m`,
+      `    Signatures:      \u001b[32m${tx.safeTransaction.signatures.size}/${tx.threshold}\u001b[0m required`,
+      `    Execution Ready: \u001b[${tx.canExecute ? '32m✓' : '31m✗'}\u001b[0m`,
+    ]
+
+    consola.info(detailLines.join('\n'))
+
+    // Ledger Flex signing filmstrip: reproduce the on-device screens the
+    // signer steps through so values can be compared screen-by-screen. EVM
+    // only — the Flex EIP-712 blind-signing flow does not apply to Tron.
+    // A display error must never block signing.
+    if (
+      !isTronNetworkKey(network) &&
+      tx.safeTx.data.data &&
+      tx.safeTx.data.data !== '0x'
+    )
+      try {
+        const filmstrip = renderLedgerFlexFlow({
+          chainId: chain.id,
+          verifyingContract: safeAddress,
+          to: tx.safeTx.data.to,
+          value: String(tx.safeTx.data.value),
+          data: tx.safeTx.data.data as Hex,
+        })
+        consola.info(
+          [
+            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant).',
+            'Hex fields (addresses and data) wrap in a proportional font on the device, so line breaks may differ — compare the character sequence, not the layout.',
+            ...filmstrip,
+          ].join('\n')
+        )
+      } catch (error) {
+        consola.debug(`Ledger Flex filmstrip skipped: ${error}`)
+      }
 
     const storedResponse = tx.safeTx.data.data
       ? storedResponses[tx.safeTx.data.data]

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -885,7 +885,7 @@ const main = defineCommand({
 
     // Create ledger connection once if using ledger
     let ledgerResult: ILedgerAccountResult | undefined
-    if (useLedger)
+    if (useLedger) {
       try {
         const { getLedgerAccount } = await import('./ledger')
         ledgerResult = await getLedgerAccount(ledgerOptions)
@@ -895,6 +895,20 @@ const main = defineCommand({
         consola.error(`Failed to connect to Ledger: ${errorMsg}`)
         throw error
       }
+
+      // Signing a Safe EIP-712 payload on a Ledger Flex needs blind signing on.
+      // Fail fast with enable instructions rather than dying mid-sign.
+      const { checkBlindSigningEnabled, closeLedgerConnection } = await import(
+        './ledger'
+      )
+      if (
+        ledgerResult &&
+        !(await checkBlindSigningEnabled(ledgerResult.transport))
+      ) {
+        await closeLedgerConnection(ledgerResult.transport)
+        process.exit(1)
+      }
+    }
 
     try {
       // Connect to MongoDB early to use it for network detection

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -22,7 +22,10 @@ import { createDefaultCache } from '../shared/deployment-cache'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import type { ILedgerAccountResult } from './ledger'
-import { renderLedgerFlexFlow } from './ledger-flex-preview'
+import {
+  LEDGER_FLEX_WRAP_NOTE,
+  renderLedgerFlexFlow,
+} from './ledger-flex-preview'
 import {
   reconcileAllSubmittedSafeTxs,
   reconcileCoverageKey,
@@ -527,9 +530,9 @@ const processTxs = async (
         })
         consola.info(
           [
-            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant).',
-            'Hex fields (addresses and data) wrap in a proportional font on the device, so line breaks may differ — compare the character sequence, not the layout.',
+            'Ledger Flex — verify these screens against your device (screens 5–8 are gas params / nonce, not security-relevant):',
             ...filmstrip,
+            LEDGER_FLEX_WRAP_NOTE,
           ].join('\n')
         )
       } catch (error) {

--- a/script/deploy/safe/ledger-flex-calibrate.ts
+++ b/script/deploy/safe/ledger-flex-calibrate.ts
@@ -1,0 +1,263 @@
+/**
+ * Ledger Flex wrap calibration harness (EXSC-580 spike).
+ *
+ * Displays crafted SafeTx EIP-712 payloads on a physical Ledger Flex so the
+ * device's native `data` review screen can be photographed and its exact line
+ * breaks recorded. The `data` field renders arbitrary UPPERCASE hex, so
+ * homogeneous strings (all `0`, all `A`, ...) isolate each glyph's width and
+ * reveal chars-per-line directly. The measured widths are baked into
+ * `ledger-flex-preview.ts` (GLYPH_WIDTH); rerun this to recalibrate, or to
+ * capture the still-unmeasured lowercase a-f from address fields.
+ *
+ * Run (device connected, unlocked, Ethereum app open):
+ *   bunx tsx script/deploy/safe/ledger-flex-calibrate.ts            # all targets
+ *   bunx tsx script/deploy/safe/ledger-flex-calibrate.ts --target T_A
+ *   bunx tsx script/deploy/safe/ledger-flex-calibrate.ts --list     # print only
+ *
+ * For each target you'll see the real "Review struct SafeTx" → `data` screens.
+ * Photograph the `data` field, record the chars on each line, then tap REJECT
+ * on the device. Nothing is broadcast — the verifyingContract/to are throwaway
+ * values and the payload never leaves your machine, so an accidental approval
+ * is harmless.
+ */
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import { getAddress, type Account, type Hex } from 'viem'
+
+import { closeLedgerConnection, getLedgerAccount } from './ledger'
+
+interface ICalibrationTarget {
+  name: string
+  /** Purpose / what this target isolates. */
+  note: string
+  /** 60 hex chars (no 0x); shown on-device as `0x` + this, uppercased. */
+  hex: string
+}
+
+// 30 bytes = 60 hex chars: several full on-device lines, and well under the
+// ~104-char `data` preview budget so every row is a real (untruncated) break.
+// One homogeneous target per uppercase glyph. The `data` field force-uppercases
+// hex, so lowercase a-f can't be measured here — fit those from address samples.
+const TARGETS: ICalibrationTarget[] = [
+  { name: 'T_ZERO', note: 'digit width baseline', hex: '0'.repeat(60) },
+  { name: 'T_A', note: 'uppercase A width', hex: 'A'.repeat(60) },
+  { name: 'T_B', note: 'uppercase B width', hex: 'B'.repeat(60) },
+  { name: 'T_C', note: 'uppercase C width', hex: 'C'.repeat(60) },
+  { name: 'T_D', note: 'uppercase D width', hex: 'D'.repeat(60) },
+  { name: 'T_E', note: 'uppercase E width', hex: 'E'.repeat(60) },
+  { name: 'T_F', note: 'uppercase F width', hex: 'F'.repeat(60) },
+  {
+    name: 'T_DIGITS',
+    note: 'confirms digits are equal-width (should match T_ZERO per line)',
+    hex: '0123456789'.repeat(6),
+  },
+  {
+    name: 'T_MIX',
+    note: 'alternating narrow/wide → cross-checks greedy fill',
+    hex: '0A'.repeat(30),
+  },
+  {
+    name: 'T_REAL',
+    note: 'realistic mixed sample (selector + address + padding) → validates cumulative-width drift; model predicts 18/17/18/9',
+    hex: 'E318B52B9740A8E0197689D144B19DA4BDC9EF65FEF11CDA000000000000',
+  },
+]
+
+// Throwaway values for the non-`data` fields. verifyingContract and `to` still
+// render as (proportional-wrapped) address screens — capturing those is a bonus
+// lowercase-glyph sample, but the `data` field is the primary instrument.
+const DUMMY_SAFE = getAddress('0x1111111111111111111111111111111111111111')
+const DUMMY_TO = getAddress('0x00000000000000000000000000000000000000ee')
+const ZERO_ADDR = getAddress('0x0000000000000000000000000000000000000000')
+const DISPLAY_CHAIN_ID = 1 // display-only; does not affect hex wrapping
+
+/**
+ * Build the Safe EIP-712 typed data with a crafted `data` field.
+ *
+ * The real Safe flow signs via viem's `walletClient.signTypedData`, which
+ * auto-injects the `EIP712Domain` type from `domain` before calling the
+ * account. We call the account's `signTypedData` directly (no walletClient),
+ * so we must spell out `EIP712Domain` ourselves — otherwise `hw-app-eth`
+ * rejects the payload with `0x6a80` (invalid data). The entries mirror the
+ * domain fields present (chainId, verifyingContract), in viem's field order.
+ */
+const buildSafeTypedData = (data: Hex) => ({
+  domain: {
+    chainId: DISPLAY_CHAIN_ID,
+    verifyingContract: DUMMY_SAFE,
+  },
+  types: {
+    EIP712Domain: [
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    SafeTx: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' },
+      { name: 'operation', type: 'uint8' },
+      { name: 'safeTxGas', type: 'uint256' },
+      { name: 'baseGas', type: 'uint256' },
+      { name: 'gasPrice', type: 'uint256' },
+      { name: 'gasToken', type: 'address' },
+      { name: 'refundReceiver', type: 'address' },
+      { name: 'nonce', type: 'uint256' },
+    ],
+  },
+  primaryType: 'SafeTx' as const,
+  message: {
+    to: DUMMY_TO,
+    value: 0n,
+    data,
+    operation: 0,
+    safeTxGas: 0n,
+    baseGas: 0n,
+    gasPrice: 0n,
+    gasToken: ZERO_ADDR,
+    refundReceiver: ZERO_ADDR,
+    nonce: 0n,
+  },
+})
+
+const displayString = (t: ICalibrationTarget): Hex =>
+  `0x${t.hex.toUpperCase()}` as Hex
+
+const printTargets = (): void => {
+  consola.info(
+    'Crafted calibration targets (shown on-device as the `data` field):'
+  )
+  for (const t of TARGETS)
+    consola.log(
+      `  ${t.name.padEnd(9)} ${displayString(t)}\n${' '.repeat(12)}${t.note}`
+    )
+}
+
+/** Display one target on the device and wait for the user to reject. */
+const runTarget = async (
+  account: Account,
+  t: ICalibrationTarget
+): Promise<void> => {
+  const display = displayString(t)
+  consola.box(
+    [
+      `Target: ${t.name}`,
+      t.note,
+      '',
+      `data = ${display}`,
+      '',
+      'On the device: step to "Review struct SafeTx" → the `data` screen.',
+      'Photograph it, note the chars on each line, then tap REJECT.',
+    ].join('\n')
+  )
+  await consola.prompt(`Press Enter to send ${t.name} to the device…`, {
+    type: 'confirm',
+    initial: true,
+  })
+
+  const sign = account.signTypedData
+  if (!sign) throw new Error('Ledger account does not support signTypedData')
+
+  try {
+    const typedData = buildSafeTypedData(display)
+    // Cast: the ledger signer forwards this straight to hw-app-eth's
+    // signEIP712Message; viem's TypedDataDefinition type is stricter than the
+    // runtime shape hw-app-eth accepts.
+    await sign(
+      typedData as Parameters<NonNullable<Account['signTypedData']>>[0]
+    )
+    consola.warn(
+      `${t.name}: device APPROVED (harmless — never broadcast). Recorded, moving on.`
+    )
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    // 0x6985 = "Condition of use not satisfied" — either a genuine user reject
+    // OR blind signing disabled (device auto-rejects). Surface everything so a
+    // fast flicker-then-error is distinguishable from a real on-screen reject.
+    const rejected = /0x6985|denied by the user|condition of use/i.test(msg)
+    if (rejected)
+      consola.info(
+        `${t.name}: device returned 0x6985 (reject OR blind-signing disabled). If the screen only flickered, enable Blind signing.`
+      )
+    else consola.error(`${t.name}: signing FAILED (not a reject): ${msg}`)
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'ledger-flex-calibrate',
+    description:
+      'Display crafted SafeTx data on a Ledger Flex to calibrate proportional-font hex wrapping (EXSC-580 spike).',
+  },
+  args: {
+    target: {
+      type: 'string',
+      description: `Single target to display (${TARGETS.map((t) => t.name).join(
+        ', '
+      )}); omit for all`,
+      required: false,
+    },
+    list: {
+      type: 'boolean',
+      description: 'Print the target strings and exit (no device interaction)',
+      required: false,
+    },
+    ledgerLive: {
+      type: 'boolean',
+      description: 'Use Ledger Live derivation path',
+      required: false,
+      default: true,
+    },
+    accountIndex: {
+      type: 'string',
+      description: 'Ledger account index (default: 0)',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    if (args.list) {
+      printTargets()
+      return
+    }
+
+    const selected = args.target
+      ? TARGETS.filter((t) => t.name === args.target)
+      : TARGETS
+    if (selected.length === 0) {
+      consola.error(
+        `Unknown target "${args.target}". Known: ${TARGETS.map(
+          (t) => t.name
+        ).join(', ')}`
+      )
+      process.exit(1)
+    }
+
+    consola.info('=== Ledger Flex wrap calibration ===')
+    consola.info('Connect + unlock your Ledger and open the Ethereum app.')
+    printTargets()
+
+    const { account, transport } = await getLedgerAccount({
+      ledgerLive: args.ledgerLive,
+      accountIndex: args.accountIndex ? Number(args.accountIndex) : 0,
+    })
+    consola.success(`Connected: ${account.address}`)
+
+    // The SafeTx struct is blind-signed; without this setting the device
+    // refuses and the `data` review screen never appears.
+    consola.warn(
+      'Ensure "Blind signing" is enabled in the Ethereum app settings, or the SafeTx `data` screen will not appear.'
+    )
+
+    try {
+      for (const t of selected) await runTarget(account, t)
+    } finally {
+      await closeLedgerConnection(transport)
+    }
+
+    consola.success(
+      'Done. Record the character count of each line per target; those counts calibrate GLYPH_WIDTH in ledger-flex-preview.ts.'
+    )
+  },
+})
+
+runMain(main)

--- a/script/deploy/safe/ledger-flex-preview.test.ts
+++ b/script/deploy/safe/ledger-flex-preview.test.ts
@@ -1,0 +1,125 @@
+// eslint-disable-next-line import/no-unresolved
+import { describe, expect, it } from 'bun:test'
+import { type Hex } from 'viem'
+
+import {
+  joinPanelsHorizontally,
+  renderLedgerFlexFlow,
+  type ILedgerFlexFlowParams,
+} from './ledger-flex-preview'
+
+// swapOwner(address,address,address) calldata whose Ledger Flex `data` preview
+// was captured on-device; the first 104 chars drive the truncated preview.
+const SWAP_OWNER: Hex = ('0xe318b52b' +
+  '000000000000000000000000' +
+  '9740a8e0197689d144b19da4bdc9ef65fef11cda' +
+  '000000000000000000000000' +
+  'b137680000000000000000000000000000000000' +
+  '000000000000000000000000' +
+  '0000000000000000000000000000000000000001') as Hex
+
+const PARAMS: ILedgerFlexFlowParams = {
+  chainId: 34443,
+  // lowercase on purpose — must be rendered EIP-55 checksummed
+  verifyingContract: '0x031f25f640e0530a51f5617757b281a8df5614ee',
+  to: '0x57c676a0417233a0bd3cbbb705db158d4261074b',
+  value: '0',
+  data: SWAP_OWNER,
+}
+
+const ESC = String.fromCharCode(27)
+const stripAnsi = (s: string): string =>
+  s.replace(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '')
+
+describe('renderLedgerFlexFlow', () => {
+  const flow = renderLedgerFlexFlow(PARAMS)
+  const joined = flow.join('\n')
+
+  it('renders the five signing screens in order', () => {
+    expect(joined).toContain('Blind signing ahead') // warning
+    expect(joined).toContain('Review typed') // 1/8
+    expect(joined).toContain('EIP712Domain') // 2/8
+    expect(joined).toContain('SafeTx') // 3/8
+    expect(joined).toContain('data') // 4/8
+    expect(joined).toContain('1 of 8')
+    expect(joined).toContain('2 of 8')
+    expect(joined).toContain('3 of 8')
+    expect(joined).toContain('4 of 8')
+  })
+
+  it('omits the non-security-relevant screens 5–8', () => {
+    expect(joined).not.toContain('5 of 8')
+    expect(joined).not.toContain('nonce')
+  })
+
+  it('shows the domain values', () => {
+    expect(joined).toContain('34443')
+    // checksummed, wrapped at 18 chars (0x + 16)
+    expect(joined).toContain('0x031f25F640E0530a')
+    expect(joined).not.toContain('0x031f25f640e0530a') // not the lowercase form
+  })
+
+  it('shows the SafeTx to (checksummed) and value', () => {
+    expect(joined).toContain('0x57C676A0417233A0')
+    expect(joined).toContain('value')
+  })
+
+  it('reproduces the exact uppercased data rows with truncation', () => {
+    expect(joined).toContain('0xE318B52B00000000')
+    expect(joined).toContain('000000000000000097')
+    expect(joined).toContain('40A8E0197689D144B1')
+    expect(joined).toContain('DA0000000000000000')
+    expect(joined).toContain('00000000B13768…')
+    expect(joined).toContain('( More )')
+  })
+
+  it('highlights the "Accept risk and continue" action in bold green', () => {
+    expect(joined).toContain(`${ESC}[1;32mAccept risk and${ESC}[0m`)
+    expect(joined).toContain(`${ESC}[1;32mcontinue${ESC}[0m`)
+  })
+
+  it('renders the frame chrome (borders, Skip, Reject)', () => {
+    expect(flow[0]).toContain('╭')
+    expect(flow[flow.length - 1]).toContain('╰')
+    expect(joined).toContain('Skip')
+    expect(joined).toContain('Reject')
+  })
+
+  it('produces a rectangular block (all rows equal visible width)', () => {
+    const widths = new Set(flow.map((l) => [...stripAnsi(l)].length))
+    expect(widths.size).toBe(1)
+  })
+
+  it('stays rectangular when a value is at least the interior width', () => {
+    // a ≥20-char value must not overflow the box border by one column
+    const long = renderLedgerFlexFlow({ ...PARAMS, value: '1'.repeat(30) })
+    const widths = new Set(long.map((l) => [...stripAnsi(l)].length))
+    expect(widths.size).toBe(1)
+  })
+
+  it('does not show a "More" affordance when the data fits without truncation', () => {
+    const short = renderLedgerFlexFlow({ ...PARAMS, data: '0xa9059cbb' as Hex })
+    const j = short.join('\n')
+    expect(j).toContain('0xA9059CBB')
+    expect(j).not.toContain('( More )')
+    expect(j).not.toContain('…')
+  })
+})
+
+describe('joinPanelsHorizontally', () => {
+  it('concatenates equal-height panels with the given gap', () => {
+    const out = joinPanelsHorizontally(
+      [
+        ['AA', 'BB'],
+        ['CC', 'DD'],
+      ],
+      3
+    )
+    expect(out).toEqual(['AA   CC', 'BB   DD'])
+  })
+
+  it('pads missing lines of shorter panels with empty strings', () => {
+    const out = joinPanelsHorizontally([['A', 'B', 'C'], ['X']], 1)
+    expect(out).toEqual(['A X', 'B ', 'C '])
+  })
+})

--- a/script/deploy/safe/ledger-flex-preview.test.ts
+++ b/script/deploy/safe/ledger-flex-preview.test.ts
@@ -5,12 +5,13 @@ import { type Hex } from 'viem'
 import {
   joinPanelsHorizontally,
   LEDGER_FLEX_WRAP_NOTE,
+  pixelWrap,
   renderLedgerFlexFlow,
   type ILedgerFlexFlowParams,
 } from './ledger-flex-preview'
 
-// swapOwner(address,address,address) calldata whose Ledger Flex `data` preview
-// was captured on-device; the first 104 chars drive the truncated preview.
+// swapOwner(address,address,address) calldata; its uppercased `data` wraps to
+// more than the 6-row preview budget, so the filmstrip truncates it with "…".
 const SWAP_OWNER: Hex = ('0xe318b52b' +
   '000000000000000000000000' +
   '9740a8e0197689d144b19da4bdc9ef65fef11cda' +
@@ -53,24 +54,25 @@ describe('renderLedgerFlexFlow', () => {
     expect(joined).not.toContain('nonce')
   })
 
-  it('shows the domain values', () => {
+  it('shows the domain values (checksummed, glyph-width wrapped)', () => {
     expect(joined).toContain('34443')
-    // checksummed, wrapped at 18 chars (0x + 16)
-    expect(joined).toContain('0x031f25F640E0530a')
+    // lowercase glyphs are narrower on-device, so 17 hex + 0x fit on row 1
+    expect(joined).toContain('0x031f25F640E0530a5')
     expect(joined).not.toContain('0x031f25f640e0530a') // not the lowercase form
   })
 
   it('shows the SafeTx to (checksummed) and value', () => {
     expect(joined).toContain('0x57C676A0417233A0')
+    expect(joined).toContain('Bd3Cbbb705Db158D42')
     expect(joined).toContain('value')
   })
 
-  it('reproduces the exact uppercased data rows with truncation', () => {
+  it('reproduces the glyph-width-wrapped data rows with truncation', () => {
     expect(joined).toContain('0xE318B52B00000000')
     expect(joined).toContain('000000000000000097')
     expect(joined).toContain('40A8E0197689D144B1')
     expect(joined).toContain('DA0000000000000000')
-    expect(joined).toContain('00000000B13768…')
+    expect(joined).toContain('00000000B137680000…')
     expect(joined).toContain('( More )')
   })
 
@@ -112,6 +114,41 @@ describe('LEDGER_FLEX_WRAP_NOTE', () => {
     expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[31m`)
     expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[0m`)
     expect(stripAnsi(LEDGER_FLEX_WRAP_NOTE).toLowerCase()).toContain('wrap')
+  })
+})
+
+describe('pixelWrap (on-device glyph-width wrapping)', () => {
+  // Per-line character counts captured on a physical Ledger Flex (EXSC-580):
+  // each target is `0x` + 60 hex; line 1 includes the `0x` prefix. The pixel
+  // model must reproduce these exactly for the uppercase `data` field.
+  const CALIBRATION: [string, string, number[]][] = [
+    ['digits', '0'.repeat(60), [18, 18, 18, 8]],
+    ['A', 'A'.repeat(60), [16, 16, 16, 14]],
+    ['B', 'B'.repeat(60), [17, 17, 17, 11]],
+    ['C', 'C'.repeat(60), [16, 16, 16, 14]],
+    ['D', 'D'.repeat(60), [16, 16, 16, 14]],
+    ['E', 'E'.repeat(60), [18, 18, 18, 8]],
+    ['F', 'F'.repeat(60), [19, 19, 19, 5]],
+    ['0-9 ruler', '0123456789'.repeat(6), [18, 18, 18, 8]],
+    ['0A alternating', '0A'.repeat(30), [17, 17, 17, 11]],
+    [
+      'realistic mixed',
+      'E318B52B9740A8E0197689D144B19DA4BDC9EF65FEF11CDA000000000000',
+      [18, 18, 18, 8],
+    ],
+  ]
+
+  for (const [name, hex, counts] of CALIBRATION)
+    it(`reproduces device line breaks: ${name}`, () => {
+      const rows = pixelWrap(`0x${hex.toUpperCase()}`)
+      expect(rows.map((r) => r.length)).toEqual(counts)
+      expect(rows.join('')).toBe(`0x${hex.toUpperCase()}`)
+    })
+
+  it('never emits a row wider than the panel interior', () => {
+    // an all-lowercase-f run is the narrowest glyph → most chars/line
+    const rows = pixelWrap(`0x${'f'.repeat(120)}`)
+    expect(Math.max(...rows.map((r) => r.length))).toBeLessThanOrEqual(19)
   })
 })
 

--- a/script/deploy/safe/ledger-flex-preview.test.ts
+++ b/script/deploy/safe/ledger-flex-preview.test.ts
@@ -4,6 +4,7 @@ import { type Hex } from 'viem'
 
 import {
   joinPanelsHorizontally,
+  LEDGER_FLEX_WRAP_NOTE,
   renderLedgerFlexFlow,
   type ILedgerFlexFlowParams,
 } from './ledger-flex-preview'
@@ -103,6 +104,14 @@ describe('renderLedgerFlexFlow', () => {
     expect(j).toContain('0xA9059CBB')
     expect(j).not.toContain('( More )')
     expect(j).not.toContain('…')
+  })
+})
+
+describe('LEDGER_FLEX_WRAP_NOTE', () => {
+  it('is a red caveat about proportional-font line breaks', () => {
+    expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[31m`)
+    expect(LEDGER_FLEX_WRAP_NOTE).toContain(`${ESC}[0m`)
+    expect(stripAnsi(LEDGER_FLEX_WRAP_NOTE).toLowerCase()).toContain('wrap')
   })
 })
 

--- a/script/deploy/safe/ledger-flex-preview.ts
+++ b/script/deploy/safe/ledger-flex-preview.ts
@@ -16,14 +16,45 @@
 
 import { getAddress, type Hex } from 'viem'
 
-// Layout constants derived from a Ledger Flex screenshot of the `data` field.
-// The Flex screen is identical across all company devices, so these are fixed.
-const ROW_WIDTH = 18 // hex chars per data row; the `0x` prefix counts inside row 1
-// Approximate chars shown before the "…" (~6 proportional-font rows). The exact
-// count varies with content; tune against a device if the cutoff looks off.
-const DATA_PREVIEW_CHARS = 104
 const INNER = 20 // interior width of each screen box (between the borders)
 const PANEL_GAP = 2 // spaces between panels in the row
+// On-device the `data` preview shows ~6 proportional-font rows before the "…".
+const DATA_PREVIEW_ROWS = 6
+// A row can never exceed the panel interior (1-space left margin + text).
+const MAX_ROW_CHARS = INNER - 1
+
+// The Flex wraps hex by PIXEL width, not character count. These are per-glyph
+// advance widths measured on-device (digit normalized to 1.0, EXSC-580 spike);
+// greedy-filling to LINE_BUDGET reproduces the device's `data` (uppercase) line
+// breaks exactly. Lowercase a-f are a best-guess — the device force-uppercases
+// the `data` field, so they can't be measured there, which makes ADDRESS-field
+// wrapping approximate (see LEDGER_FLEX_WRAP_NOTE). Unlisted glyphs fall back to 1.
+const LINE_BUDGET = 18.8 // digit-widths per line (measured range [18.60, 19.0))
+const GLYPH_WIDTH: Record<string, number> = {
+  '0': 1,
+  '1': 1,
+  '2': 1,
+  '3': 1,
+  '4': 1,
+  '5': 1,
+  '6': 1,
+  '7': 1,
+  '8': 1,
+  '9': 1,
+  x: 1,
+  A: 1.12,
+  B: 1.06,
+  C: 1.12,
+  D: 1.12,
+  E: 1.0,
+  F: 0.95,
+  a: 0.9,
+  b: 0.95,
+  c: 0.9,
+  d: 0.95,
+  e: 0.9,
+  f: 0.85,
+}
 
 // Bold green, to flag on the terminal side that "Accept risk and continue" is
 // the action the operator must tap to proceed (the device renders it plainly).
@@ -34,11 +65,12 @@ const RED = `${ESC}[31m`
 const RESET = `${ESC}[0m`
 
 /**
- * Red caveat to print BELOW the filmstrip: on-device the Flex wraps hex in a
- * proportional font, so line breaks won't match the fixed-width panel. The
- * character sequence still matches 1:1.
+ * Caveat to print BELOW the filmstrip. Rows are wrapped with measured on-device
+ * glyph widths, so the `data` field's breaks match the Ledger; address fields
+ * use best-guess lowercase widths and may wrap a character or two differently.
+ * Either way the character SEQUENCE matches 1:1 — the authoritative check.
  */
-export const LEDGER_FLEX_WRAP_NOTE = `${RED}⚠ Address and data lines may wrap at different points on your Ledger (proportional font) — compare the character sequence, not the line breaks.${RESET}`
+export const LEDGER_FLEX_WRAP_NOTE = `${RED}⚠ Address lines may wrap slightly differently on your Ledger — compare the character sequence, not the line breaks.${RESET}`
 
 interface IFlexLine {
   text: string
@@ -67,10 +99,30 @@ export interface ILedgerFlexFlowParams {
   data: Hex
 }
 
-/** Fixed-width chunk a string into rows of `width` characters. */
-const chunk = (s: string, width: number): string[] => {
+/**
+ * Greedy-fill a hex string into on-device rows by cumulative glyph width,
+ * mirroring how the Flex wraps proportional-font hex. Capped at MAX_ROW_CHARS
+ * so a row can never overflow the ASCII panel.
+ */
+export const pixelWrap = (display: string): string[] => {
   const rows: string[] = []
-  for (let i = 0; i < s.length; i += width) rows.push(s.slice(i, i + width))
+  let cur = ''
+  let width = 0
+  for (const ch of display) {
+    const w = GLYPH_WIDTH[ch] ?? 1
+    if (
+      cur !== '' &&
+      (width + w > LINE_BUDGET || cur.length >= MAX_ROW_CHARS)
+    ) {
+      rows.push(cur)
+      cur = ch
+      width = w
+    } else {
+      cur += ch
+      width += w
+    }
+  }
+  if (cur !== '') rows.push(cur)
   return rows.length ? rows : ['']
 }
 
@@ -101,25 +153,31 @@ const wrapWords = (text: string, width: number): string[] => {
 
 /**
  * Rows for the Ledger `data` field: uppercased hex with a lowercase `0x`
- * prefix, wrapped to `ROW_WIDTH`, truncated with a trailing "…" past the
- * device's preview budget.
+ * prefix, wrapped by on-device glyph width, truncated with a trailing "…" past
+ * the device's ~6-row preview budget.
  */
 const dataRows = (data: Hex): { rows: string[]; truncated: boolean } => {
   const display = `0x${data.replace(/^0x/i, '').toUpperCase()}`
-  const truncated = display.length > DATA_PREVIEW_CHARS
-  const shown = truncated ? display.slice(0, DATA_PREVIEW_CHARS) : display
-  const rows = chunk(shown, ROW_WIDTH)
-  if (truncated) rows[rows.length - 1] += '…'
+  const all = pixelWrap(display)
+  const truncated = all.length > DATA_PREVIEW_ROWS
+  const rows = truncated ? all.slice(0, DATA_PREVIEW_ROWS) : all
+  if (truncated) {
+    const last = rows.length - 1
+    // leave room for the ellipsis so it can't overflow the panel
+    const lastRow = rows[last] ?? ''
+    rows[last] =
+      (lastRow.length >= MAX_ROW_CHARS
+        ? lastRow.slice(0, MAX_ROW_CHARS - 1)
+        : lastRow) + '…'
+  }
   return { rows, truncated }
 }
 
 // Address fields render EIP-55 checksummed (mixed case), unlike the uppercased
-// `data` field. Wrapping is a fixed ROW_WIDTH approximation: the Flex renders
-// the hex in a PROPORTIONAL font (digits narrower than A–F), so a letter-dense
-// line wraps a character or two earlier on-device. The character sequence still
-// matches 1:1 — only the line breaks differ (compare the chars, not the layout).
+// `data` field. Wrapped by the same on-device glyph widths; lowercase a-f use
+// best-guess widths, so address breaks are approximate (LEDGER_FLEX_WRAP_NOTE).
 const addressRows = (addr: string): string[] =>
-  chunk(getAddress(addr as Hex), ROW_WIDTH)
+  pixelWrap(getAddress(addr as Hex))
 
 const navFooter = (page: number): string => {
   const left = 'Reject'

--- a/script/deploy/safe/ledger-flex-preview.ts
+++ b/script/deploy/safe/ledger-flex-preview.ts
@@ -1,0 +1,298 @@
+/**
+ * Ledger Flex signing filmstrip
+ *
+ * Renders an ASCII replica of the sequence of Ledger Flex screens a signer
+ * steps through when blind-signing a Safe transaction (EIP-712), populated with
+ * the actual to-be-signed values. Import from `confirm-safe-tx.ts` to print the
+ * filmstrip so the operator can compare each screen against the physical device
+ * instead of eyeballing a 200-character hex blob.
+ *
+ * Only the first five screens are reproduced (warning + screens 1–4 of 8): the
+ * security-relevant ones — domain chainId/verifyingContract, SafeTx to/value,
+ * and the calldata. Screens 5–8 (safeTxGas, baseGas, gasPrice, gasToken,
+ * refundReceiver, nonce) are boilerplate — typically zero and not worth
+ * comparing — so they are intentionally omitted.
+ */
+
+import { getAddress, type Hex } from 'viem'
+
+// Layout constants derived from a Ledger Flex screenshot of the `data` field.
+// The Flex screen is identical across all company devices, so these are fixed.
+const ROW_WIDTH = 18 // hex chars per data row; the `0x` prefix counts inside row 1
+// Approximate chars shown before the "…" (~6 proportional-font rows). The exact
+// count varies with content; tune against a device if the cutoff looks off.
+const DATA_PREVIEW_CHARS = 104
+const INNER = 20 // interior width of each screen box (between the borders)
+const PANEL_GAP = 2 // spaces between panels in the row
+
+// Bold green, to flag on the terminal side that "Accept risk and continue" is
+// the action the operator must tap to proceed (the device renders it plainly).
+const ESC = String.fromCharCode(27)
+const HIGHLIGHT = `${ESC}[1;32m`
+const BOLD = `${ESC}[1m`
+const RESET = `${ESC}[0m`
+
+interface IFlexLine {
+  text: string
+  align: 'left' | 'center'
+  /** Optional ANSI style applied to the text (not the padding). */
+  style?: string
+}
+
+interface IFlexScreen {
+  /** Right-aligned top affordance (e.g. "Skip"); empty for none. */
+  header: string
+  content: IFlexLine[]
+  /** Pre-formatted, exactly `INNER`-wide bottom line (nav / tap area). */
+  footer: string
+}
+
+export interface ILedgerFlexFlowParams {
+  chainId: number
+  /** EIP-712 domain verifyingContract — the Safe address. */
+  verifyingContract: string
+  /** SafeTx `to` target. */
+  to: string
+  /** SafeTx `value`, decimal string. */
+  value: string
+  /** SafeTx `data` calldata, `0x`-prefixed. */
+  data: Hex
+}
+
+/** Fixed-width chunk a string into rows of `width` characters. */
+const chunk = (s: string, width: number): string[] => {
+  const rows: string[] = []
+  for (let i = 0; i < s.length; i += width) rows.push(s.slice(i, i + width))
+  return rows.length ? rows : ['']
+}
+
+/** Word-wrap prose to `width`, hard-splitting any word longer than `width`. */
+const wrapWords = (text: string, width: number): string[] => {
+  const out: string[] = []
+  let line = ''
+  for (const word of text.split(' ')) {
+    let w = word
+    while (w.length > width) {
+      if (line) {
+        out.push(line)
+        line = ''
+      }
+      out.push(w.slice(0, width))
+      w = w.slice(width)
+    }
+    if (!line) line = w
+    else if (line.length + 1 + w.length <= width) line += ` ${w}`
+    else {
+      out.push(line)
+      line = w
+    }
+  }
+  if (line) out.push(line)
+  return out
+}
+
+/**
+ * Rows for the Ledger `data` field: uppercased hex with a lowercase `0x`
+ * prefix, wrapped to `ROW_WIDTH`, truncated with a trailing "…" past the
+ * device's preview budget.
+ */
+const dataRows = (data: Hex): { rows: string[]; truncated: boolean } => {
+  const display = `0x${data.replace(/^0x/i, '').toUpperCase()}`
+  const truncated = display.length > DATA_PREVIEW_CHARS
+  const shown = truncated ? display.slice(0, DATA_PREVIEW_CHARS) : display
+  const rows = chunk(shown, ROW_WIDTH)
+  if (truncated) rows[rows.length - 1] += '…'
+  return { rows, truncated }
+}
+
+// Address fields render EIP-55 checksummed (mixed case), unlike the uppercased
+// `data` field. Wrapping is a fixed ROW_WIDTH approximation: the Flex renders
+// the hex in a PROPORTIONAL font (digits narrower than A–F), so a letter-dense
+// line wraps a character or two earlier on-device. The character sequence still
+// matches 1:1 — only the line breaks differ (compare the chars, not the layout).
+const addressRows = (addr: string): string[] =>
+  chunk(getAddress(addr as Hex), ROW_WIDTH)
+
+const navFooter = (page: number): string => {
+  const left = 'Reject'
+  const right = `< ${page} of 8 >`
+  const gap = Math.max(1, INNER - left.length - right.length)
+  return `${left}${' '.repeat(gap)}${right}`
+}
+
+const buildScreens = (p: ILedgerFlexFlowParams): IFlexScreen[] => {
+  const { rows, truncated } = dataRows(p.data)
+
+  const warning: IFlexScreen = {
+    header: '',
+    content: [
+      { text: '/!\\', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Blind signing ahead', align: 'center', style: BOLD },
+      { text: '', align: 'center' },
+      ...wrapWords(
+        'If you sign this transaction, you could lose your assets.',
+        INNER - 2
+      ).map((text) => ({ text, align: 'left' as const })),
+      { text: '', align: 'center' },
+      { text: '[ Back to safety ]', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Accept risk and', align: 'center', style: HIGHLIGHT },
+      { text: 'continue', align: 'center', style: HIGHLIGHT },
+    ],
+    footer: '',
+  }
+
+  const typedMessage: IFlexScreen = {
+    header: '',
+    content: [
+      { text: '[=]', align: 'center' },
+      { text: '', align: 'center' },
+      { text: 'Review typed', align: 'center', style: BOLD },
+      { text: 'message', align: 'center', style: BOLD },
+      { text: '', align: 'center' },
+      { text: 'Blind signing', align: 'left' },
+      { text: 'required.', align: 'left' },
+    ],
+    footer: navFooter(1),
+  }
+
+  const domain: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'Review struct', align: 'left', style: BOLD },
+      { text: 'EIP712Domain', align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'chainId', align: 'left', style: BOLD },
+      { text: String(p.chainId), align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'verifyingContract', align: 'left', style: BOLD },
+      ...addressRows(p.verifyingContract).map((text) => ({
+        text,
+        align: 'left' as const,
+      })),
+    ],
+    footer: navFooter(2),
+  }
+
+  const safeTx: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'Review struct', align: 'left', style: BOLD },
+      { text: 'SafeTx', align: 'left' },
+      { text: '', align: 'left' },
+      { text: 'to', align: 'left', style: BOLD },
+      ...addressRows(p.to).map((text) => ({ text, align: 'left' as const })),
+      { text: '', align: 'left' },
+      { text: 'value', align: 'left', style: BOLD },
+      { text: p.value, align: 'left' },
+    ],
+    footer: navFooter(3),
+  }
+
+  const dataScreen: IFlexScreen = {
+    header: 'Skip',
+    content: [
+      { text: 'data', align: 'left', style: BOLD },
+      ...rows.map((text) => ({ text, align: 'left' as const })),
+      ...(truncated
+        ? [
+            { text: '', align: 'center' as const },
+            { text: '( More )', align: 'center' as const },
+          ]
+        : []),
+    ],
+    footer: navFooter(4),
+  }
+
+  return [warning, typedMessage, domain, safeTx, dataScreen]
+}
+
+/** One interior row, clipped/padded to `INNER` with a 1-space side margin. */
+const frameLine = ({ text, align, style }: IFlexLine): string => {
+  const t = text.length > INNER ? text.slice(0, INNER) : text
+  let body: string
+  if (align === 'center') {
+    const space = INNER - t.length
+    const left = Math.floor(space / 2)
+    body = ' '.repeat(left) + t + ' '.repeat(space - left)
+  } else {
+    // slice before padEnd: a 1-space margin + INNER-length text would be
+    // INNER+1 wide, and padEnd never truncates — breaking the row width.
+    body = ` ${t}`.slice(0, INNER).padEnd(INNER)
+  }
+  // Style only the text run so the padding (and thus the visible width) is
+  // untouched — keeps the box borders and neighbouring panels aligned.
+  if (style && t) body = body.replace(t, `${style}${t}${RESET}`)
+  return `│${body}│`
+}
+
+/** A row whose content is already exactly `INNER`-wide (footers, blanks). */
+const frameRaw = (raw: string): string =>
+  `│${raw.padEnd(INNER).slice(0, INNER)}│`
+
+const framePanel = (screen: IFlexScreen, contentHeight: number): string[] => {
+  const top = `╭${'─'.repeat(INNER)}╮`
+  const bottom = `╰${'─'.repeat(INNER)}╯`
+  const headerLine = screen.header
+    ? frameRaw(`${screen.header} `.padStart(INNER))
+    : frameRaw('')
+
+  // Centre the content vertically between the header and footer: split the
+  // slack evenly instead of dumping it all at the bottom (which made the
+  // shorter screens look top-heavy).
+  const slack = Math.max(0, contentHeight - screen.content.length)
+  const topPad = Math.floor(slack / 2)
+  const blank = () => frameRaw('')
+
+  return [
+    top,
+    headerLine,
+    ...Array.from({ length: topPad }, blank),
+    ...screen.content.map(frameLine),
+    ...Array.from({ length: slack - topPad }, blank),
+    frameRaw(screen.footer),
+    bottom,
+  ]
+}
+
+/** Concatenate equal-height panels left-to-right, separated by `gap` spaces. */
+export const joinPanelsHorizontally = (
+  panels: string[][],
+  gap: number = PANEL_GAP
+): string[] => {
+  const height = Math.max(...panels.map((p) => p.length))
+  const sep = ' '.repeat(gap)
+  const out: string[] = []
+  for (let i = 0; i < height; i++)
+    out.push(panels.map((p) => p[i] ?? '').join(sep))
+  return out
+}
+
+/**
+ * Render the Ledger Flex signing filmstrip for a Safe transaction.
+ *
+ * @param params - The to-be-signed domain and SafeTx values.
+ * @returns The filmstrip as an array of lines (a row of five framed screens).
+ * @throws If `verifyingContract` or `to` is not a valid EVM address — callers
+ *   must gate on EVM networks (the Flex EIP-712 flow does not apply to Tron).
+ */
+export const renderLedgerFlexFlow = (
+  params: ILedgerFlexFlowParams
+): string[] => {
+  const screens = buildScreens(params)
+  const contentHeight = Math.max(...screens.map((s) => s.content.length))
+  const panels = screens.map((s) => framePanel(s, contentHeight))
+
+  // A vertically-centred ">" between panels shows the left-to-right order the
+  // signer steps through the screens.
+  const height = panels[0]?.length ?? 0
+  const mid = Math.floor(height / 2)
+  const connector = Array.from({ length: height }, (_, i) =>
+    i === mid ? '>' : ' '
+  )
+  const withArrows = panels.flatMap((panel, i) =>
+    i === 0 ? [panel] : [connector, panel]
+  )
+  return joinPanelsHorizontally(withArrows, 1)
+}

--- a/script/deploy/safe/ledger-flex-preview.ts
+++ b/script/deploy/safe/ledger-flex-preview.ts
@@ -30,7 +30,15 @@ const PANEL_GAP = 2 // spaces between panels in the row
 const ESC = String.fromCharCode(27)
 const HIGHLIGHT = `${ESC}[1;32m`
 const BOLD = `${ESC}[1m`
+const RED = `${ESC}[31m`
 const RESET = `${ESC}[0m`
+
+/**
+ * Red caveat to print BELOW the filmstrip: on-device the Flex wraps hex in a
+ * proportional font, so line breaks won't match the fixed-width panel. The
+ * character sequence still matches 1:1.
+ */
+export const LEDGER_FLEX_WRAP_NOTE = `${RED}⚠ Address and data lines may wrap at different points on your Ledger (proportional font) — compare the character sequence, not the line breaks.${RESET}`
 
 interface IFlexLine {
   text: string

--- a/script/deploy/safe/ledger.ts
+++ b/script/deploy/safe/ledger.ts
@@ -256,6 +256,53 @@ async function createLedgerAccount({
 }
 
 /**
+ * Verifies that "Blind signing" (arbitrary contract data) is enabled in the
+ * Ledger Ethereum app. Signing a Safe EIP-712 payload on a Ledger Flex requires
+ * it; without it the device rejects the signature mid-flow. Call this on an
+ * already-open transport (the Ethereum app must be running) so the caller can
+ * fail fast with actionable guidance instead.
+ *
+ * @param transport An open Ledger transport with the Ethereum app running
+ * @returns `true` if blind signing is enabled (or the setting can't be read);
+ *   `false` if it is explicitly disabled, after printing enable instructions
+ */
+export async function checkBlindSigningEnabled(
+  transport: Transport
+): Promise<boolean> {
+  const { default: Eth } = await import('@ledgerhq/hw-app-eth')
+  const eth = new Eth(transport)
+
+  let arbitraryDataEnabled: number
+  try {
+    ;({ arbitraryDataEnabled } = await eth.getAppConfiguration())
+  } catch (error: unknown) {
+    // The app is already open (getAddress succeeded), so a read failure here is
+    // unexpected. Warn rather than block — the sign attempt will surface a hard
+    // error if blind signing is genuinely off.
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    consola.warn(`Could not read blind-signing setting: ${errorMsg}`)
+    return true
+  }
+
+  if (arbitraryDataEnabled === 1) {
+    consola.success('Checking blind signing: enabled')
+    return true
+  }
+
+  const YELLOW = `${String.fromCharCode(27)}[33m`
+  const RESET = `${String.fromCharCode(27)}[0m`
+  consola.error('Checking blind signing: DISABLED')
+  console.log(
+    `${YELLOW}Blind signing is turned off on this device. Enable it before signing:\n` +
+      '  1. Open the Ethereum app on the device.\n' +
+      '  2. Tap the settings (gear) icon, top-right.\n' +
+      '  3. Turn "Blind signing" ON ("Enable transaction blind signing").\n' +
+      `  4. Re-run this command.${RESET}`
+  )
+  return false
+}
+
+/**
  * Closes a Ledger transport connection
  *
  * @param transport The transport to close

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for role-name resolution and role-change display in safe-decode-utils.
+ * Covers getRoleName (hash -> OZ AccessControl role name) and formatRoleChange
+ * (the grantRole / revokeRole / renounceRole display path).
+ */
+import {
+  describe,
+  expect,
+  it,
+  afterEach,
+  spyOn,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import { consola } from 'consola'
+
+import { getRoleName, formatRoleChange } from './safe-decode-utils'
+
+const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
+const CANCELLER_ROLE =
+  '0xfd643c72710c63c0180259aba6b2d05451e3591a24e58b62239378085726f783'
+const PROPOSER_ROLE =
+  '0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1'
+const EXECUTOR_ROLE =
+  '0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63'
+const TIMELOCK_ADMIN_ROLE =
+  '0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5'
+
+describe('getRoleName', () => {
+  it('resolves known OpenZeppelin role hashes', () => {
+    expect(getRoleName(CANCELLER_ROLE)).toBe('CANCELLER_ROLE')
+    expect(getRoleName(PROPOSER_ROLE)).toBe('PROPOSER_ROLE')
+    expect(getRoleName(EXECUTOR_ROLE)).toBe('EXECUTOR_ROLE')
+    expect(getRoleName(TIMELOCK_ADMIN_ROLE)).toBe('TIMELOCK_ADMIN_ROLE')
+  })
+
+  it('resolves DEFAULT_ADMIN_ROLE (bytes32 zero, not a keccak hash)', () => {
+    expect(getRoleName(DEFAULT_ADMIN_ROLE)).toBe('DEFAULT_ADMIN_ROLE')
+  })
+
+  it('is case-insensitive on the hex digits', () => {
+    const upperHex = `0x${CANCELLER_ROLE.slice(2).toUpperCase()}`
+    expect(getRoleName(upperHex)).toBe('CANCELLER_ROLE')
+  })
+
+  it('accepts a hash without the 0x prefix', () => {
+    expect(getRoleName(CANCELLER_ROLE.slice(2))).toBe('CANCELLER_ROLE')
+  })
+
+  it('returns empty string for an unknown role hash', () => {
+    expect(getRoleName(`0x${'11'.repeat(32)}`)).toBe('')
+  })
+})
+
+describe('formatRoleChange', () => {
+  afterEach(() => {
+    spyOn(consola, 'info').mockRestore()
+  })
+
+  // Output is ANSI-colored, but the function name and the "(ROLE_NAME)" label
+  // are each emitted as contiguous substrings, so we assert on the raw joined
+  // output without stripping escape codes.
+  const capture = async (
+    functionName: string,
+    role: string,
+    account: string
+  ): Promise<string> => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatRoleChange(functionName, [role, account], 'mainnet')
+    return infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+  }
+
+  const account = '0xb05E63458A51731Aad26BdcD6E12246330E6095F'
+  const ROLE_LABEL = /\([A-Z_]+_ROLE\)/
+
+  it('labels the role on revokeRole (the previously unlabeled path)', async () => {
+    const output = await capture('revokeRole', CANCELLER_ROLE, account)
+    expect(output).toContain('Function:')
+    expect(output).toContain('revokeRole')
+    expect(output).toContain(CANCELLER_ROLE)
+    expect(output).toContain('(CANCELLER_ROLE)')
+  })
+
+  it('labels the role on renounceRole', async () => {
+    const output = await capture('renounceRole', PROPOSER_ROLE, account)
+    expect(output).toContain('renounceRole')
+    expect(output).toContain('(PROPOSER_ROLE)')
+  })
+
+  it('still labels the role on grantRole', async () => {
+    const output = await capture('grantRole', CANCELLER_ROLE, account)
+    expect(output).toContain('grantRole')
+    expect(output).toContain('(CANCELLER_ROLE)')
+  })
+
+  it('omits the role label for an unknown role hash', async () => {
+    const unknown = `0x${'11'.repeat(32)}`
+    const output = await capture('revokeRole', unknown, account)
+    expect(output).toContain('revokeRole')
+    expect(output).toContain(unknown)
+    expect(output).not.toMatch(ROLE_LABEL)
+  })
+
+  it('returns without logging when args are incomplete', async () => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatRoleChange('revokeRole', [CANCELLER_ROLE], 'mainnet')
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+})

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -542,10 +542,23 @@ const ABI_BATCH_SET_CONTRACT_SELECTOR_WHITELIST = parseAbi([
 const ABI_REGISTER_PERIPHERY_CONTRACT = parseAbi([
   'function registerPeripheryContract(string,address)',
 ])
-const ABI_GRANT_ROLE = parseAbi(['function grantRole(bytes32,address)'])
+// grantRole / revokeRole / renounceRole share the (bytes32,address) shape
+const ABI_ACCESS_CONTROL_ROLE = parseAbi([
+  'function grantRole(bytes32,address)',
+  'function revokeRole(bytes32,address)',
+  'function renounceRole(bytes32,address)',
+])
+const ACCESS_CONTROL_ROLE_FUNCTIONS = new Set([
+  'grantRole',
+  'revokeRole',
+  'renounceRole',
+])
 
 // OpenZeppelin TimelockController / AccessControl role names (keccak256 of role string)
-const KNOWN_ROLE_NAMES: Record<string, string> = {}
+const KNOWN_ROLE_NAMES: Record<string, string> = {
+  // DEFAULT_ADMIN_ROLE is bytes32(0), not a keccak256 hash of its name
+  [`0x${'00'.repeat(32)}`]: 'DEFAULT_ADMIN_ROLE',
+}
 for (const name of [
   'TIMELOCK_ADMIN_ROLE',
   'PROPOSER_ROLE',
@@ -556,7 +569,7 @@ for (const name of [
   KNOWN_ROLE_NAMES[hash.toLowerCase()] = name
 }
 
-function getRoleName(roleHash: string): string {
+export function getRoleName(roleHash: string): string {
   const normalized = roleHash.startsWith('0x')
     ? roleHash.toLowerCase()
     : `0x${roleHash}`.toLowerCase()
@@ -675,13 +688,16 @@ function getAbiForKnownFunction(functionName: string): Abi | null {
     case 'registerPeripheryContract':
       return ABI_REGISTER_PERIPHERY_CONTRACT
     case 'grantRole':
-      return ABI_GRANT_ROLE
+    case 'revokeRole':
+    case 'renounceRole':
+      return ABI_ACCESS_CONTROL_ROLE
     default:
       return null
   }
 }
 
-async function formatGrantRole(
+export async function formatRoleChange(
+  functionName: string,
   args: readonly unknown[],
   network: string,
   indent?: string
@@ -695,7 +711,7 @@ async function formatGrantRole(
     typeof account === 'string' ? account : String(account ?? '')
   const roleName = getRoleName(roleStr)
   const roleLabel = roleName ? ` \u001b[33m(${roleName})\u001b[0m` : ''
-  consola.info(`${pre}Function: \u001b[34mgrantRole\u001b[0m`)
+  consola.info(`${pre}Function: \u001b[34m${functionName}\u001b[0m`)
   consola.info(`${pre}  Role:   \u001b[32m${roleStr}\u001b[0m${roleLabel}`)
   const accountDisplay = formatAddressForNetworkCliDisplay(network, accountStr)
   const accountSuffix = await getTargetSuffix(network, accountStr)
@@ -824,11 +840,12 @@ export async function formatDecodedTxDataForDisplay(
     }
 
     if (
-      decoded?.functionName === 'grantRole' &&
+      decoded?.functionName &&
+      ACCESS_CONTROL_ROLE_FUNCTIONS.has(decoded.functionName) &&
       decoded.args &&
       decoded.args.length >= 2
     ) {
-      await formatGrantRole(decoded.args, network, pre)
+      await formatRoleChange(decoded.functionName, decoded.args, network, pre)
       return
     }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-580](https://linear.app/lifi-linear/issue/EXSC-580/confirm-safe-tx-show-ledger-flex-signing-filmstrip-for-calldata)
covers the Ledger Flex signing work. The Safe-decode role-name improvement has no
dedicated ticket — a small self-contained decoder fix surfaced while reviewing a
live `revokeRole` proposal (happy to attach a ticket or apply `trivial` if
preferred).

This PR combines two previously-separate PRs — #2001 and #2002 — into one review,
since both are display-layer improvements to the Safe-signing review flow under
`script/deploy/safe/`. The originals are closed in favour of this one.

> **CodeRabbit note:** the local `/pr-ready` pre-flight could not complete — the
> shared org CodeRabbit plan was rate-limited at creation time. #2001 and #2002
> were each CodeRabbit-reviewed in their own PRs; the only delta not yet seen by
> CodeRabbit is the blind-signing commit (section 3), which passed a manual
> self-review, `tsc`, `eslint`, and the test suite. Cloud CodeRabbit will still
> review this PR in CI as the safety net.

# Why did I implement it this way?

Three scoped, display-layer changes to make Safe/timelock proposal signing easier
to verify. No on-chain behavior, storage, or selector layout is touched.

## 1. Resolve role names for `revokeRole` / `renounceRole` (was #2001)

`grantRole` already rendered the human-readable OpenZeppelin role name next to the
raw `bytes32` hash (e.g. `(CANCELLER_ROLE)`), but `revokeRole` fell through to the
generic argument printer and showed only the raw hash — making revocations harder
to verify at a glance. `renounceRole` had the same gap.

- Generalized `formatGrantRole` → `formatRoleChange(functionName, …)` and route
  `grantRole` / `revokeRole` / `renounceRole` through it via a single shared ABI
  and a function-name set. All three now label the role.
- Added `DEFAULT_ADMIN_ROLE` (`bytes32(0)`) to the known-role map — it's the
  literal zero value, not a keccak hash of its name, so it needed an explicit
  entry.
- Colocated `safe-decode-utils.test.ts` covering `getRoleName` and
  `formatRoleChange` (grant/revoke/renounce resolve the label; unknown roles stay
  unlabeled; incomplete args no-op).

Kept scoped to the display layer per `[CONV:SAFE-DECODE]` /
`[CONV:SAFE-DECODE-UTILS]`.

## 2. Ledger Flex signing filmstrip (EXSC-580, was #2002)

When confirming a Safe transaction on a Ledger Flex, the signer must check that
the calldata on the device matches the proposal. Today the script prints the full
200+ char calldata blob, hard to eyeball against the small device screen.

Adds a **Ledger Flex signing filmstrip** below the Safe Transaction Details: an
ASCII replica of the on-device screens (⚠ warning → `1/8` typed message → `2/8`
EIP712Domain → `3/8` SafeTx → `4/8` data), populated with the actual to-be-signed
values.

- Pure, testable module (`ledger-flex-preview.ts`) kept out of
  `confirm-safe-tx.ts`, with a colocated test suite.
- Address fields render EIP-55 checksummed; `data` uppercased; labels bold; the
  `Accept risk and continue` tap bold-green.
- Proportional-font caveat: the Flex renders hex in a proportional font, so exact
  per-line wrapping isn't reproducible with a fixed width. The panel wraps at a
  fixed width and prints a note telling the operator to compare the character
  sequence, not the line layout (the sequence still matches 1:1).
- EVM-only (the Flex EIP-712 blind-signing flow doesn't apply to Tron); the render
  is wrapped in try/catch so a display error can never block signing; screens 5–8
  (gas params / nonce) are omitted as not security-relevant.

## 3. Ledger blind-signing pre-check (EXSC-580, new)

Signing a Safe EIP-712 payload on a Ledger Flex requires the Ethereum app's "Blind
signing" setting to be on; without it the device rejects the signature mid-flow
with a confusing, repeated error. This queries `getAppConfiguration()` right after
the Ledger connects and, if blind signing is off, prints a single red status line
plus **yellow enable instructions** and exits cleanly.

- New exported `checkBlindSigningEnabled(transport)` in `ledger.ts`, reusing the
  already-open transport (the Ethereum app is guaranteed running, since
  `getAddress` succeeded during connect).
- If the setting can't be read (unexpected, since the app is open) it warns and
  continues rather than blocking — the sign attempt would surface a hard error
  anyway.
- Called once after connect in `confirm-safe-tx.ts`; on disabled it closes the
  Ledger and `process.exit(1)` so there is no relabeled/duplicated error or stack
  trace.

> Note: the legacy `arbitraryDataEnabled` config bit can lag the actual toggle on
> Flex/Stax firmware; treat this as a best-effort fast-fail. The real enforcement
> remains the device's own rejection at sign time.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
