### PR TITLE
fix(husky): stop pre-commit secret scanner from flagging public env allowlists (EXSC-582)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -358,6 +358,15 @@ prepare_env_secrets() {
         ;;
     esac
 
+    # Comma-separated network/contract-name allowlists are public config, not
+    # credentials, and their values legitimately overlap with strings in
+    # foundry.toml/networks.json (e.g. DO_NOT_VERIFY_IN_THESE_NETWORKS=...,localanvil,...).
+    case "$KEY_UPPER" in
+      DO_NOT_VERIFY_IN_THESE_NETWORKS|EXCLUDE_NETWORKS|EXCLUDE_PERIPHERY_CONTRACTS|EXCLUDE_FACET_CONTRACTS)
+        continue
+        ;;
+    esac
+
     # Skip short values only for clearly non-secret keys to avoid blind spots
     if [ ${#VALUE} -lt 8 ]; then
       case "$KEY_UPPER" in

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -16,14 +16,16 @@ import { consola } from 'consola'
 import { getRoleName, formatRoleChange } from './safe-decode-utils'
 
 const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
+// OpenZeppelin AccessControl role hashes (public, keccak256 of role names) —
+// not private keys, despite matching the 64-hex-char shape.
 const CANCELLER_ROLE =
-  '0xfd643c72710c63c0180259aba6b2d05451e3591a24e58b62239378085726f783'
+  '0xfd643c72710c63c0180259aba6b2d05451e3591a24e58b62239378085726f783' // pre-commit-checker: not a secret
 const PROPOSER_ROLE =
-  '0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1'
+  '0xb09aa5aeb3702cfd50b6b62bc4532604938f21248a27a1d5ca736082b6819cc1' // pre-commit-checker: not a secret
 const EXECUTOR_ROLE =
-  '0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63'
+  '0xd8aa0f3194971a2a116679f7c2090f6939c8d4e01a2a8d7e41d55e5351469e63' // pre-commit-checker: not a secret
 const TIMELOCK_ADMIN_ROLE =
-  '0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5'
+  '0x5f58e3a2316349923ce3780f8d587db2d72378aed66a8261c916544fa6846ca5' // pre-commit-checker: not a secret
 
 describe('getRoleName', () => {
   it('resolves known OpenZeppelin role hashes', () => {

--- a/test/solidity/Facets/MayanFacet.t.sol
+++ b/test/solidity/Facets/MayanFacet.t.sol
@@ -1092,7 +1092,7 @@ contract MayanFacetTest is TestBaseFacet {
         receiver = testFacet.testParseReceiver(protocolData);
         assertEq(
             receiver,
-            hex"1ccbd4fdcd76cd2e3ba8d05205c012ecd28743f14359a7151b64da60a1679ece",
+            hex"1ccbd4fdcd76cd2e3ba8d05205c012ecd28743f14359a7151b64da60a1679ece", // [pre-commit-checker: not a secret]
             "parse receiver: Swift v2 backend sample destAddr (bytes32)"
         );
         bytes32 wordAt0xc4;


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-582](https://linear.app/lifi-linear/issue/EXSC-582/fix-husky-pre-commit-secret-scanner-false-positives-on-public-env)

# Why did I implement it this way?

`.husky/pre-commit`'s `prepare_env_secrets` treats any `.env` value ≥8 chars as a secret candidate and does a literal `grep -F` match against every staged file. Comma-separated public name lists — `DO_NOT_VERIFY_IN_THESE_NETWORKS` (e.g. containing `localanvil`), `EXCLUDE_NETWORKS`, `EXCLUDE_PERIPHERY_CONTRACTS`, `EXCLUDE_FACET_CONTRACTS` — are consumed by `script/helperFunctions.sh` / `script/playgroundHelpers.sh` as public config (network/contract names), never credentials, but their values legitimately overlap with strings in `foundry.toml`/config files, so the scanner has been repeatedly blocking unrelated commits with a false "Secret from .env file found" error.

Fix: added an exact-key allowlist for these 4 keys in `prepare_env_secrets`, mirroring the existing `*_PATH|*_DIRECTORY|*_DIR` suffix-skip already in the same function — same pattern, just an exact-match variant for keys whose entire value is public config rather than a path.

Also silenced two related, pre-existing, non-blocking "potential private key" warnings that are false positives (64-hex-char values that aren't private keys):
- `test/solidity/Facets/MayanFacet.t.sol:1095` — a `bytes32` destAddr pulled from a real backend/SDK calldata sample.
- `script/deploy/safe/safe-decode-utils.test.ts:20,22,24,26` — OpenZeppelin AccessControl role hashes (`keccak256` of role names).

Both use the repo's existing `pre-commit-checker: not a secret` marker convention (already established at `MayanFacet.t.sol:112`).

Verified by staging the changes and running `.husky/pre-commit` directly (not just `bash -n`): it now exits 0 with "All pre-commit checks passed!", the blocking `DO_NOT_VERIFY_IN_THESE_NETWORKS` match is gone, and the two targeted warnings are silenced. Unrelated pre-existing warn-only matches in `MayanFacet.t.sol` (tenderly tx-hash examples in comments, one unrelated `bytes32` constant) are out of scope and left untouched.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
