### PR TITLE
fix(husky): allowlist public network/contract exclusion-list env keys

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -358,6 +358,15 @@ prepare_env_secrets() {
         ;;
     esac
 
+    # Comma-separated public name lists legitimately overlap with strings in
+    # foundry.toml/networks.json (e.g. DO_NOT_VERIFY_IN_THESE_NETWORKS contains
+    # network keys like "localanvil"); their values are not credentials.
+    case "$KEY_UPPER" in
+      DO_NOT_VERIFY_IN_THESE_NETWORKS|EXCLUDE_NETWORKS|EXCLUDE_PERIPHERY_CONTRACTS|EXCLUDE_FACET_CONTRACTS)
+        continue
+        ;;
+    esac
+
     # Skip short values only for clearly non-secret keys to avoid blind spots
     if [ ${#VALUE} -lt 8 ]; then
       case "$KEY_UPPER" in


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None provided — please link if one exists.

# Why did I implement it this way?

Split out of the `outlaw` → `robinhood` network-rename PR
([#2006](https://github.com/lifinance/contracts/pull/2006)) since it's an unrelated,
pre-existing infra bug — flagged during review that it shouldn't be bundled with the
rename.

`prepare_env_secrets` in `.husky/pre-commit` treats any `.env` value ≥ 8 chars as a
secret candidate and does a literal `grep -F` against every staged file. This currently
false-positives on **any** commit touching `foundry.toml`, because
`DO_NOT_VERIFY_IN_THESE_NETWORKS` (a public, comma-separated network-name list) contains
`localanvil`, which collides with the `localanvil = "${ETH_NODE_URI_LOCALANVIL}"` line
in `foundry.toml`:

```
[foundry.toml:149] Secret from .env file found (key: DO_NOT_VERIFY_IN_THESE_NETWORKS)
```

This blocks committing to `foundry.toml` (and would similarly affect `networks.json`,
though that file is already in the scanner's `EXCLUDED_PATHS`) regardless of what the
actual diff is — it's a false positive on file content that predates the change being
committed.

Fix: add an exact-key allowlist for the four known public list env vars
(`DO_NOT_VERIFY_IN_THESE_NETWORKS`, `EXCLUDE_NETWORKS`, `EXCLUDE_PERIPHERY_CONTRACTS`,
`EXCLUDE_FACET_CONTRACTS`), mirroring the existing `*_PATH`/`*_DIRECTORY`/`*_DIR` suffix
skip already in `prepare_env_secrets`. These four keys are consumed by
`script/helperFunctions.sh` / `script/playgroundHelpers.sh` as public config, never
credentials.

Verified by staging `foundry.toml` changes and running `.husky/pre-commit` directly —
exits 0, "All pre-commit checks passed!".

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or
      explicitly documented) all findings — see `.agents/commands/pr-ready.md`
      (clean run, no findings)
- [ ] I have added tests that cover the functionality / test the bug — bash hook logic,
      verified manually by running `.husky/pre-commit` against a staged `foundry.toml`
      change (no existing test harness for this hook)
- [ ] For new facets: not applicable
- [x] I have updated any required documentation — n/a, self-contained fix with rationale
      in this description

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
