### PR TITLE
fix(checkPauserFunds): flag free-gas chains as WARNING instead of ERROR (EXSC-583)

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -5763,6 +5763,8 @@ function removeNetworkFromTargetStateJSON() {
 # production LiFiDiamond on NETWORK. EVM only; optional PAUSER_ADDRESS overrides the --from
 # (defaults to config/global.json .pauserWallet).
 # Exit: 0 = cost on stdout · 2 = diamond already paused · 1 = any other failure (reason on stderr).
+# A cost of 0 with exit 0 unambiguously means the chain's gas PRICE is 0 (free gas, e.g. nibiru);
+# a zero gas ESTIMATE is rejected as an RPC anomaly (exit 1), never folded into a zero cost.
 function estimatePauseCost() {
   local NETWORK="${1:-}"
   local PAUSER_ADDRESS="${2:-}"
@@ -5837,6 +5839,13 @@ function estimatePauseCost() {
     sleep "$ESTIMATE_RETRY_SLEEP_SECONDS"
     ATTEMPT=$((ATTEMPT + 1))
   done
+
+  # Intrinsic tx gas alone is 21000, so a zero gas ESTIMATE can only be an RPC anomaly. Reject it
+  # here so a returned cost of 0 can only mean "gas price is 0" (free-gas chain) to callers.
+  if [[ "$GAS_ESTIMATE" -eq 0 ]]; then
+    error "estimatePauseCost: RPC returned a zero gas estimate for $NETWORK (implausible; treating as failure)" >&2
+    return 1
+  fi
 
   local GAS_PRICE
   ATTEMPT=1

--- a/script/utils/checkPauserFunds.sh
+++ b/script/utils/checkPauserFunds.sh
@@ -13,6 +13,8 @@
 # NUM OF PAUSES = balance ÷ cost of ONE pauseDiamond() — how many pauses the wallet can fund.
 # Status:  OK (>= 2.5 pauses)   WARNING (1 to 2.5)   CRITICAL (< 1 pause)
 #          PAUSED (already paused)   ERROR (estimate/RPC failed)   SKIP (filtered/no diamond)
+# Chains whose gas price is 0 (free gas, e.g. nibiru) report OK with NUM OF PAUSES "inf" —
+# a pause costs nothing there, so any balance affords unlimited pauses.
 # Exit code: 1 if any audited network is CRITICAL, else 0.
 #
 # Must be run from the repository root.
@@ -27,6 +29,7 @@ Usage: ./script/utils/checkPauserFunds.sh [NETWORK ...]
   NETWORK...  audit only the named networks
 NUM OF PAUSES = balance / cost of one pauseDiamond() (how many pauses the wallet can fund).
 Statuses: OK (>=2.5 pauses)  WARNING (1-2.5)  CRITICAL (<1)  PAUSED  ERROR  SKIP
+Free-gas chains (gas price 0) report OK with NUM OF PAUSES "inf".
 Exit code 1 if any network is CRITICAL.
 EOF
 }
@@ -46,6 +49,11 @@ source script/helperFunctions.sh
 # 2.5x expressed as 5/2 for integer bc math
 readonly WARN_MULT_NUM=5
 readonly WARN_MULT_DEN=2
+
+# Sort key for free-gas rows (gas price 0 → infinite pauses): 1e28, larger than any real ratio
+# (balance in wei tops out around 1e24 even against a 1-wei cost), so they land last among the
+# data rows. A plain digit string keeps `sort -g` portable (no reliance on "inf" parsing).
+readonly FREE_GAS_SORT_RATIO=9999999999999999999999999999
 
 # Retry transient RPC read failures (throttling/timeouts) a few times before marking a network
 # ERROR, so a brief blip on one chain doesn't show as a spurious ERROR row. (estimatePauseCost
@@ -166,7 +174,9 @@ function checkNetwork() {
     echo "$CAT_PAUSED|0|$(fmtRow "$NETWORK" "-" "-" "-" "-" "-" "PAUSED")"
     return
   fi
-  if [[ $RC -ne 0 || ! "$COST" =~ ^[0-9]+$ || "$COST" == "0" ]]; then
+  # COST 0 is NOT an error: estimatePauseCost rejects a zero gas ESTIMATE, so 0 can only mean
+  # the chain's gas PRICE is 0 (free gas) — handled after the balance read below.
+  if [[ $RC -ne 0 || ! "$COST" =~ ^[0-9]+$ ]]; then
     echo "$CAT_ERROR|0|$(fmtRow "$NETWORK" "-" "-" "-" "-" "-" "ERROR")"
     return
   fi
@@ -183,6 +193,14 @@ function checkNetwork() {
     sleep "$RPC_READ_RETRY_SLEEP_SECONDS"
     BAL_ATTEMPT=$((BAL_ATTEMPT + 1))
   done
+
+  # Free-gas chain: a pause costs nothing, so any balance affords unlimited pauses — report OK
+  # (a data row, so it counts as "evaluated" for the blind-sweep guard). Actual RPC/estimation
+  # failures still surface as ERROR above and via the balance-read retry loop.
+  if [[ "$COST" == "0" ]]; then
+    echo "$CAT_DATA|$FREE_GAS_SORT_RATIO|$(fmtRow "$NETWORK" "free gas" "-" "$(fmtAmount "$BALANCE") ${SYMBOL}" "inf" "-" "OK")"
+    return
+  fi
 
   local REQUIRED RATIO STATUS
   REQUIRED=$(echo "$COST * $WARN_MULT_NUM / $WARN_MULT_DEN" | bc)
@@ -261,7 +279,7 @@ if ! {
   exit 1
 fi
 
-echo "NUM OF PAUSES = balance ÷ cost of one pauseDiamond() · OK ≥2.5 · WARNING 1–2.5 · CRITICAL <1" >&2
+echo "NUM OF PAUSES = balance ÷ cost of one pauseDiamond() · OK ≥2.5 · WARNING 1–2.5 · CRITICAL <1 · free gas (price 0) = inf" >&2
 
 # Blind-sweep guard: if we audited in-scope networks but EVERY one returned ERROR — no
 # OK/WARNING/CRITICAL/PAUSED answer anywhere (e.g. a broad RPC outage, or a misconfigured pauser

--- a/script/utils/checkPauserFunds.sh
+++ b/script/utils/checkPauserFunds.sh
@@ -13,8 +13,9 @@
 # NUM OF PAUSES = balance ÷ cost of ONE pauseDiamond() — how many pauses the wallet can fund.
 # Status:  OK (>= 2.5 pauses)   WARNING (1 to 2.5)   CRITICAL (< 1 pause)
 #          PAUSED (already paused)   ERROR (estimate/RPC failed)   SKIP (filtered/no diamond)
-# Chains whose gas price is 0 (free gas, e.g. nibiru) report OK with NUM OF PAUSES "inf" —
-# a pause costs nothing there, so any balance affords unlimited pauses.
+# Chains whose RPC reports a gas price of 0 show COST "free gas" / NUM OF PAUSES "inf" with
+# status WARNING: a zero gas price is usually an RPC misreport rather than a real fee model,
+# so it needs investigating — but it is not the hard ERROR of a failed estimation/RPC read.
 # Exit code: 1 if any audited network is CRITICAL, else 0.
 #
 # Must be run from the repository root.
@@ -29,7 +30,7 @@ Usage: ./script/utils/checkPauserFunds.sh [NETWORK ...]
   NETWORK...  audit only the named networks
 NUM OF PAUSES = balance / cost of one pauseDiamond() (how many pauses the wallet can fund).
 Statuses: OK (>=2.5 pauses)  WARNING (1-2.5)  CRITICAL (<1)  PAUSED  ERROR  SKIP
-Free-gas chains (gas price 0) report OK with NUM OF PAUSES "inf".
+Chains whose RPC reports gas price 0 show "free gas" and WARNING (investigate the RPC).
 Exit code 1 if any network is CRITICAL.
 EOF
 }
@@ -49,11 +50,6 @@ source script/helperFunctions.sh
 # 2.5x expressed as 5/2 for integer bc math
 readonly WARN_MULT_NUM=5
 readonly WARN_MULT_DEN=2
-
-# Sort key for free-gas rows (gas price 0 → infinite pauses): 1e28, larger than any real ratio
-# (balance in wei tops out around 1e24 even against a 1-wei cost), so they land last among the
-# data rows. A plain digit string keeps `sort -g` portable (no reliance on "inf" parsing).
-readonly FREE_GAS_SORT_RATIO=9999999999999999999999999999
 
 # Retry transient RPC read failures (throttling/timeouts) a few times before marking a network
 # ERROR, so a brief blip on one chain doesn't show as a spurious ERROR row. (estimatePauseCost
@@ -194,11 +190,12 @@ function checkNetwork() {
     BAL_ATTEMPT=$((BAL_ATTEMPT + 1))
   done
 
-  # Free-gas chain: a pause costs nothing, so any balance affords unlimited pauses — report OK
-  # (a data row, so it counts as "evaluated" for the blind-sweep guard). Actual RPC/estimation
-  # failures still surface as ERROR above and via the balance-read retry loop.
+  # Gas price 0: the pauser could technically pause for free, but a zero gas price is usually
+  # an RPC misreport rather than a real fee model — surface it as WARNING (investigate), not a
+  # quiet OK and not the hard ERROR of a failed estimation. Still a data row, so it counts as
+  # "evaluated" for the blind-sweep guard; sort key 0 places it with the needs-attention rows.
   if [[ "$COST" == "0" ]]; then
-    echo "$CAT_DATA|$FREE_GAS_SORT_RATIO|$(fmtRow "$NETWORK" "free gas" "-" "$(fmtAmount "$BALANCE") ${SYMBOL}" "inf" "-" "OK")"
+    echo "$CAT_DATA|0|$(fmtRow "$NETWORK" "free gas" "-" "$(fmtAmount "$BALANCE") ${SYMBOL}" "inf" "-" "WARNING")"
     return
   fi
 
@@ -279,7 +276,16 @@ if ! {
   exit 1
 fi
 
-echo "NUM OF PAUSES = balance ÷ cost of one pauseDiamond() · OK ≥2.5 · WARNING 1–2.5 · CRITICAL <1 · free gas (price 0) = inf" >&2
+echo "NUM OF PAUSES = balance ÷ cost of one pauseDiamond() · OK ≥2.5 · WARNING 1–2.5 · CRITICAL <1 · gas price 0 = \"free gas\" + WARNING" >&2
+
+# A zero gas price deserves eyes: usually an RPC misreport, occasionally a genuine free-gas
+# chain — either way, verify before trusting the row. Kept out of the exit code (only CRITICAL
+# fails the run), but called out loudly on stderr.
+FREE_GAS_NETWORKS=$(printf '%s\n' "${ROWS[@]}" | grep -F $'\tfree gas\t' | cut -d'|' -f3 | cut -f1 | paste -sd',' -)
+if [[ -n "$FREE_GAS_NETWORKS" ]]; then
+  echo "" >&2
+  warning "gas price reported as 0 on: $FREE_GAS_NETWORKS — verify the RPC / chain fee model before trusting these rows" >&2
+fi
 
 # Blind-sweep guard: if we audited in-scope networks but EVERY one returned ERROR — no
 # OK/WARNING/CRITICAL/PAUSED answer anywhere (e.g. a broad RPC outage, or a misconfigured pauser


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-583](https://linear.app/lifi-linear/issue/EXSC-583/checkpauserfunds-spurious-error-for-free-gas-chains-nibiru)

# Why did I implement it this way?

Nibiru's RPC genuinely reports `eth_gasPrice = 0` (gas is free), so `estimatePauseCost` returns a cost of 0 and `checkPauserFunds.sh` marked the network ERROR in the weekly *Verify Emergency Pause Readiness* run — even though the pauser wallet holds ~289 NIBI and can pause at will.

The fix distinguishes "cost is genuinely zero" from real estimation/RPC failures at the source of truth:

- **`estimatePauseCost` (script/helperFunctions.sh)** now rejects a **zero gas estimate** as an RPC anomaly (intrinsic tx gas alone is 21000), so a returned cost of 0 can *only* mean the chain's gas **price** is 0. This keeps the ambiguity out of every caller instead of having each one guess why the product is zero. The only other caller (`deployAllContracts.sh`) is unaffected on free-gas chains and becomes strictly safer in the anomaly case (falls back to its flat funding default).
- **`checkPauserFunds.sh`** renders free-gas chains as a **WARNING data row** (`COST = "free gas"`, `NUM OF PAUSES = "inf"`, real balance shown) instead of ERROR — a zero gas price is usually an RPC misreport rather than a real fee model, so it must be investigated rather than blend into green (reviewer feedback), yet it's distinct from the hard ERROR of a failed estimation/RPC read. A stderr warning additionally names the affected networks. Because it's a data row, it counts as "evaluated" for the blind-sweep guard, whose semantics are unchanged: real RPC/estimation failures (including a failed balance read on a free-gas chain) still surface as ERROR, an all-ERROR sweep still fails the run, and only CRITICAL affects the exit code.
- Free-gas rows use sort key 0 so they land at the top of the data rows, with the needs-attention cluster.

The alternative — special-casing `COST == 0` only in `checkPauserFunds.sh` — would have conflated a bogus zero gas *estimate* with a zero gas *price*; rejecting the former in the helper makes the latter unambiguous.

Tested live: `bash script/utils/checkPauserFunds.sh nibiru bsc` →

```text
NETWORK  COST(1x)      REQUIRED(2.5x)  BALANCE      NUM OF PAUSES  TOP-UP TO OK  STATUS
nibiru   free gas      -               289 NIBI     inf            -             WARNING
bsc      0.000232 BNB  0.000581 BNB    0.00287 BNB  12.36          -             OK

[warning] gas price reported as 0 on: nibiru — verify the RPC / chain fee model before trusting these rows
```

exit 0. Also verified: unknown-network fail-fast still exits 1, and the blind-sweep guard still fails an all-ERROR sweep (observed live). The consuming workflow (`verifyEmergencyPauseReadiness.yml`) only reads the exit code, so the display change is safe.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
