### PR TITLE
feat(EXSC-556): S2b — performance fee (HWM dilution) + per-fee-type split at accrual

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -7,6 +7,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { MetadataReaderLib } from "solady/utils/MetadataReaderLib.sol";
 import { ILiFiVaultWrapper } from "./interfaces/ILiFiVaultWrapper.sol";
 import { ILiFiVaultWrapperFactory } from "./interfaces/ILiFiVaultWrapperFactory.sol";
@@ -28,10 +29,13 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      withdrawal. Identity (`underlying`/`adapter`/`owner`/`factory`) and the initial fee
 ///      configuration are set write-once in `initialize`. The per-vault admin role is OZ's
 ///      two-step `owner` (`transferOwnership`/`acceptOwnership`); renouncing it is disabled.
-///      Management (dilution), deposit, and withdrawal fees are charged: management fee-shares
-///      are minted to this contract via `_accrueFees`, and deposit/withdrawal asset fees are
-///      kept idle and tracked through `_routeFee`. This contract does not distribute the
-///      accrued fees. Pause is enforced on the deposit/mint path only (withdrawals stay open);
+///      All four fee types are charged: management (time-based dilution) and performance
+///      (high-water-mark dilution) fee-shares are minted to this contract via `_accrueFees`,
+///      and deposit/withdrawal asset fees are kept idle and tracked through `_routeFee`.
+///      Every fee is split between LI.FI and the integrator at accrual time using the
+///      fee type's own share, into per-recipient counters. This contract does not
+///      distribute the accrued fees. Pause is enforced on the deposit/mint path only
+///      (withdrawals stay open);
 ///      access logic remains a no-op seam (`_checkAccess`) with its body landing in a
 ///      follow-up ticket. Inflation-attack protection relies on the ERC-4626 virtual-share
 ///      offset.
@@ -63,13 +67,15 @@ contract LiFiVaultWrapper is
     /// @notice The factory that deployed this instance (the initializer); read by later
     ///         modules for the factory-level global circuit breaker.
     address public factory;
-    /// @notice The integrator's fee share (bps), snapshotted from the factory at deploy.
-    uint16 public integratorShareBps;
     /// @notice Whether this clone's deposits are paused by the integrator (the per-vault
     ///         `owner`), the only authority over this flag. LI.FI has no per-instance pause;
     ///         its lever is the factory-level global circuit breaker, a separate source read
     ///         live in `depositsPaused`. Both gate inflows, neither gates exits.
     bool public paused;
+    /// @notice The integrator's fee share (bps) per fee type (indexed by FeeType ordinal),
+    ///         snapshotted from the factory at deploy. LI.FI receives the remainder of
+    ///         each fee.
+    uint16[4] public integratorShareBps;
     /// @notice Opaque wrapper-side config (access mode, receivers, ToS hash, oracle),
     ///         stored verbatim for later modules to decode.
     bytes public initData;
@@ -77,14 +83,27 @@ contract LiFiVaultWrapper is
     /// @dev Per-fee-type rates and enabled flags, validated by the factory.
     FeeConfig internal _feeConfig;
 
-    /// @notice Total dilution fee-shares minted to this contract and not yet paid out.
-    ///         The LI.FI/integrator split is applied later at distribution, not here.
-    uint256 public accruedFeeShares;
-    /// @notice Total asset-side (deposit/withdrawal) fees held idle in this contract and
-    ///         not yet paid out. Kept out of the yield source so it does not move PPS.
-    uint256 public accruedFeeAssets;
+    /// @notice LI.FI's part of the dilution fee-shares minted to this contract and not
+    ///         yet paid out. Split at accrual; packed with the integrator counter so one
+    ///         accrual touches a single slot.
+    uint128 public lifiFeeShares;
+    /// @notice The integrator's part of the dilution fee-shares minted to this contract
+    ///         and not yet paid out.
+    uint128 public integratorFeeShares;
+    /// @notice LI.FI's part of the asset-side (deposit/withdrawal) fees held idle in this
+    ///         contract and not yet paid out. Kept out of the yield source so it does not
+    ///         move PPS.
+    uint128 public lifiFeeAssets;
+    /// @notice The integrator's part of the asset-side fees held idle in this contract
+    ///         and not yet paid out.
+    uint128 public integratorFeeAssets;
     /// @notice Timestamp of the last management-fee crystallization.
     uint64 public lastMgmtAccrual;
+    /// @notice Performance-fee high-water mark: the highest post-crystallization price
+    ///         per share (scaled by `LibVaultWrapperMath.PPS_SCALE`). Anchored at
+    ///         `initialize`, re-anchored when the performance fee is enabled from
+    ///         disabled, and ratcheted whenever a performance accrual mints shares.
+    uint192 public perfHighWaterMarkPps;
 
     /// @dev Reserved slots so future versions can append wrapper-level state without
     ///      shifting any storage that inheriting/derived modules occupy. This impl sits
@@ -110,7 +129,7 @@ contract LiFiVaultWrapper is
         address _underlying,
         address _adapter,
         address _vaultWrapperAdmin,
-        uint16 _integratorShareBps,
+        uint16[4] calldata _integratorShareBps,
         FeeConfig calldata _fees,
         bytes calldata _initData
     ) external initializer {
@@ -119,8 +138,10 @@ contract LiFiVaultWrapper is
             _adapter == address(0) ||
             _vaultWrapperAdmin == address(0)
         ) revert ZeroAddress();
-        if (_integratorShareBps >= 10_000)
-            revert InvalidIntegratorShareBps(_integratorShareBps);
+        for (uint256 i; i < 4; ++i) {
+            if (_integratorShareBps[i] >= 10_000)
+                revert InvalidIntegratorShareBps(_integratorShareBps[i]);
+        }
 
         address asset = IYieldAdapter(_adapter).resolveAsset(_underlying);
         if (asset == address(0)) revert ZeroAddress();
@@ -135,6 +156,15 @@ contract LiFiVaultWrapper is
         _feeConfig = _fees;
         initData = _initData;
         lastMgmtAccrual = uint64(block.timestamp);
+        // Anchor the performance watermark at the empty-vault share price, computed pure
+        // (supply and position are always 0 on a fresh single-shot-initialized proxy).
+        // Deliberately NOT read through the adapter: an underlying whose empty-position
+        // query reverts must not brick deployment. Assets donated to the predicted
+        // address before deployment therefore count as gain at the first accrual —
+        // charging a donation is harmless and disarms watermark-seeding games.
+        perfHighWaterMarkPps = SafeCast.toUint192(
+            LibVaultWrapperMath.pricePerShare(0, 0, _decimalsOffset())
+        );
 
         emit VaultWrapperConfigured(
             asset,
@@ -461,21 +491,20 @@ contract LiFiVaultWrapper is
 
     /// Fee config ///
 
-    /// @notice Sets the rate for a deposit, withdrawal, or management fee.
+    /// @notice Sets the rate for any fee type.
     /// @dev Only the owner may call. A zero rate disables the fee and skips
     ///      bounds validation (turning a fee off is always allowed); a non-zero rate must
     ///      sit within the factory's live bounds for the type. Accrues at the OLD rate
-    ///      first so elapsed time is priced before the change. The performance fee is not
-    ///      configurable here.
-    /// @param _feeType The fee type to update (Management, Deposit, or Withdrawal).
+    ///      first so elapsed time (management) and gains above the watermark
+    ///      (performance) are priced before the change. Enabling the performance fee
+    ///      from disabled re-anchors the watermark at the current share price, so gains
+    ///      made while it was disabled are never charged retroactively.
+    /// @param _feeType The fee type to update.
     /// @param _newRateBps The new rate in basis points (0 disables the fee).
     function setFeeRate(
         FeeType _feeType,
         uint16 _newRateBps
     ) external onlyOwner {
-        if (_feeType == FeeType.Performance)
-            revert FeeTypeNotConfigurable(_feeType);
-
         _accrueFees();
 
         uint8 idx = uint8(_feeType);
@@ -487,6 +516,15 @@ contract LiFiVaultWrapper is
                 .feeBounds(_feeType);
             if (_newRateBps < minBps || _newRateBps > maxBps)
                 revert FeeRateOutOfBounds(_newRateBps, minBps, maxBps);
+            if (_feeType == FeeType.Performance && !_feeConfig.enabled[idx]) {
+                perfHighWaterMarkPps = SafeCast.toUint192(
+                    LibVaultWrapperMath.pricePerShare(
+                        totalSupply(),
+                        totalAssets(),
+                        _decimalsOffset()
+                    )
+                );
+            }
             _feeConfig.enabled[idx] = true;
             _feeConfig.rateBps[idx] = _newRateBps;
         }
@@ -537,38 +575,51 @@ contract LiFiVaultWrapper is
         // TODO(access): decode the access mode from initData and authorize the caller.
     }
 
-    /// @dev Crystallizes the management fee by minting dilution shares to this contract.
-    ///      The baseline ALWAYS advances to now, whether or not anything was minted:
-    ///      elapsed time must never outlive the accrual that priced it, or it would be
-    ///      re-priced later against a larger AUM (charging depositors for time before they
-    ///      were invested — a dormant dust vault could confiscate most of a new deposit)
-    ///      or against a new rate (voiding `setFeeRate`'s accrue-at-old-rate-first
-    ///      guarantee). The cost is that elapsed time whose fee floors to zero shares is
-    ///      dropped — at most ~one share's worth of assets per accrual, favouring holders.
+    /// @dev Crystallizes the management and performance fees by minting dilution shares
+    ///      to this contract, splitting each between LI.FI and the integrator as it is
+    ///      booked. The management baseline ALWAYS advances to now, whether or not
+    ///      anything was minted: elapsed time must never outlive the accrual that priced
+    ///      it, or it would be re-priced later against a larger AUM (charging depositors
+    ///      for time before they were invested — a dormant dust vault could confiscate
+    ///      most of a new deposit) or against a new rate (voiding `setFeeRate`'s
+    ///      accrue-at-old-rate-first guarantee). The cost is that elapsed time whose fee
+    ///      floors to zero shares is dropped — at most ~one share's worth of assets per
+    ///      accrual, favouring holders. The performance fee is charged AFTER the
+    ///      management dilution (perf is net of management), and its watermark ratchets
+    ///      to the post-crystallization share price only when shares were actually
+    ///      minted — an uncharged gain stays chargeable, unlike elapsed time.
     function _accrueFees() private {
-        uint256 feeShares = _pendingManagementFee();
+        bool mgmtEnabled = _feeConfig.enabled[uint8(FeeType.Management)];
+        bool perfEnabled = _feeConfig.enabled[uint8(FeeType.Performance)];
+        if (!mgmtEnabled && !perfEnabled) {
+            lastMgmtAccrual = uint64(block.timestamp);
+            return;
+        }
+
+        uint256 supply = totalSupply();
+        uint256 assets = totalAssets();
+
+        uint256 mgmtShares = _pendingManagementFee(supply, assets);
         lastMgmtAccrual = uint64(block.timestamp);
-        if (feeShares == 0) return;
+        if (mgmtShares != 0) {
+            _mint(address(this), mgmtShares);
+            _bookDilution(FeeType.Management, mgmtShares);
+            supply += mgmtShares;
+        }
 
-        _mint(address(this), feeShares);
-        accruedFeeShares += feeShares;
-
-        emit DilutionFeeAccrued(FeeType.Management, feeShares);
-    }
-
-    /// @dev Entry for `_accrueFees`: performs the cheap storage guards (uninitialized
-    ///      baseline, disabled type, zero elapsed) BEFORE paying for the external
-    ///      `totalAssets()` adapter round-trip, then delegates to the parameterized
-    ///      computation.
-    /// @return Dilution shares the pending fee is worth.
-    function _pendingManagementFee() private view returns (uint256) {
-        if (
-            lastMgmtAccrual == 0 ||
-            !_feeConfig.enabled[uint8(FeeType.Management)] ||
-            block.timestamp == lastMgmtAccrual
-        ) return 0;
-
-        return _pendingManagementFee(totalSupply(), totalAssets());
+        uint256 perfShares = _pendingPerformanceFee(supply, assets);
+        if (perfShares != 0) {
+            _mint(address(this), perfShares);
+            _bookDilution(FeeType.Performance, perfShares);
+            supply += perfShares;
+            perfHighWaterMarkPps = SafeCast.toUint192(
+                LibVaultWrapperMath.pricePerShare(
+                    supply,
+                    assets,
+                    _decimalsOffset()
+                )
+            );
+        }
     }
 
     /// @dev Single source of the management-fee computation, shared by `_accrueFees` and the
@@ -606,9 +657,45 @@ contract LiFiVaultWrapper is
         });
     }
 
+    /// @dev Dilution shares the pending performance fee is worth: the fee on the share-
+    ///      price gain above the high-water mark. Called with the management fee-shares
+    ///      already included in `_supply` (whether minted or still pending), so the fee
+    ///      is charged on gains net of management dilution — the same sequence in
+    ///      accrual and previews.
+    /// @param _supply The total supply including any management fee-shares.
+    /// @param _assets The current total assets.
+    /// @return Dilution shares the pending fee is worth.
+    function _pendingPerformanceFee(
+        uint256 _supply,
+        uint256 _assets
+    ) private view returns (uint256) {
+        uint8 idx = uint8(FeeType.Performance);
+        if (!_feeConfig.enabled[idx]) return 0;
+
+        uint256 hwm = perfHighWaterMarkPps;
+        if (hwm == 0) return 0;
+
+        uint256 feeAssets = LibVaultWrapperMath.performanceFeeAssets({
+            _totalAssets: _assets,
+            _totalSupply: _supply,
+            _hwmPps: hwm,
+            _rateBps: _feeConfig.rateBps[idx],
+            _decimalsOffset: _decimalsOffset()
+        });
+
+        return
+            LibVaultWrapperMath.dilutionShares({
+                _feeAssets: feeAssets,
+                _totalSupply: _supply,
+                _totalAssets: _assets,
+                _decimalsOffset: _decimalsOffset()
+            });
+    }
+
     /// @dev Fee-shares pending since the last accrual, used by the effective-supply
-    ///      conversion overrides. Isolated as a seam so further dilution fees can extend it
-    ///      without changing the conversion math.
+    ///      conversion overrides. Management first, then performance on the post-
+    ///      management effective supply — the exact sequence `_accrueFees` crystallizes
+    ///      in, so previews match execution.
     /// @param _supply The current total supply (pre-accrual).
     /// @param _assets The current total assets.
     /// @return The dilution shares pending.
@@ -616,7 +703,10 @@ contract LiFiVaultWrapper is
         uint256 _supply,
         uint256 _assets
     ) private view returns (uint256) {
-        return _pendingManagementFee(_supply, _assets);
+        uint256 mgmtShares = _pendingManagementFee(_supply, _assets);
+
+        return
+            mgmtShares + _pendingPerformanceFee(_supply + mgmtShares, _assets);
     }
 
     /// @dev Reads the configured rate (bps) for a fee type; 0 when the type is disabled.
@@ -628,16 +718,46 @@ contract LiFiVaultWrapper is
         return _feeConfig.rateBps[idx];
     }
 
-    /// @dev Books an asset-side fee as idle and not-yet-distributed. The LI.FI/integrator
-    ///      split and payout happen elsewhere; here it only tracks the total. No-op on a
-    ///      zero fee.
+    /// @dev Books freshly minted dilution fee-shares, split between LI.FI and the
+    ///      integrator using the fee type's own share. The integrator's part rounds
+    ///      down, so split dust (at most 1 wei-share per accrual) goes to LI.FI.
+    ///      Payout happens elsewhere; here it only tracks the per-recipient totals.
+    /// @param _feeType The fee type that accrued (Management or Performance).
+    /// @param _feeShares The total shares minted to this contract for the fee.
+    function _bookDilution(FeeType _feeType, uint256 _feeShares) private {
+        uint256 integratorPart = (_feeShares *
+            integratorShareBps[uint8(_feeType)]) /
+            LibVaultWrapperMath.BASIS_POINT_SCALE;
+        integratorFeeShares = SafeCast.toUint128(
+            integratorFeeShares + integratorPart
+        );
+        lifiFeeShares = SafeCast.toUint128(
+            lifiFeeShares + (_feeShares - integratorPart)
+        );
+
+        emit DilutionFeeAccrued(_feeType, _feeShares, integratorPart);
+    }
+
+    /// @dev Books an asset-side fee as idle and not-yet-distributed, split between
+    ///      LI.FI and the integrator using the fee type's own share. The integrator's
+    ///      part rounds down, so split dust (at most 1 wei per charge) goes to LI.FI.
+    ///      Payout happens elsewhere; here it only tracks the per-recipient totals.
+    ///      No-op on a zero fee.
     /// @param _feeType The fee type charged (Deposit or Withdrawal).
     /// @param _feeAssets The fee amount, in assets, kept idle in this contract.
     function _routeFee(FeeType _feeType, uint256 _feeAssets) private {
         if (_feeAssets == 0) return;
 
-        accruedFeeAssets += _feeAssets;
+        uint256 integratorPart = (_feeAssets *
+            integratorShareBps[uint8(_feeType)]) /
+            LibVaultWrapperMath.BASIS_POINT_SCALE;
+        integratorFeeAssets = SafeCast.toUint128(
+            integratorFeeAssets + integratorPart
+        );
+        lifiFeeAssets = SafeCast.toUint128(
+            lifiFeeAssets + (_feeAssets - integratorPart)
+        );
 
-        emit AssetFeeCharged(_feeType, _feeAssets);
+        emit AssetFeeCharged(_feeType, _feeAssets, integratorPart);
     }
 }

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -241,8 +241,8 @@ contract LiFiVaultWrapperFactory is
     ///      `_params.namespace`. Each fee type carries its own integrator share; a
     ///      self-serve deployer (not the onboarding manager) may only set a share at
     ///      or below `defaultIntegratorShareBps`, so it can give LI.FI more than the
-    ///      default cut but never less; the onboarding manager may set any share up
-    ///      to 100%.
+    ///      default cut but never less; the onboarding manager may set any share below
+    ///      100%.
     ///      Deploys are intentionally allowed while `globalPaused` is set: a new
     ///      instance is a beacon proxy that reads the same live flag, so it is frozen
     ///      from birth and poses no deposit risk.

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -35,7 +35,7 @@ contract LiFiVaultWrapperFactory is
     uint16 internal constant CAP_WITHDRAWAL_BPS = 2000;
     /// @notice Integrator fee share (bps) applied when a deploy does not override it; 80% (LI.FI receives the remaining 20%).
     uint16 internal constant DEFAULT_INTEGRATOR_SHARE_BPS = 8000;
-    /// @notice Sentinel for DeployParams.integratorShareBps meaning "inherit the factory default".
+    /// @notice Sentinel for a DeployParams.integratorShareBps element meaning "inherit the factory default".
     uint16 internal constant USE_DEFAULT_SPLIT = type(uint16).max;
     /// @notice Basis-point denominator (100%).
     uint16 internal constant BPS_DENOMINATOR = 10000;
@@ -238,10 +238,11 @@ contract LiFiVaultWrapperFactory is
 
     /// @notice Deploy a new wrapper instance under an integrator namespace.
     /// @dev Caller must be the onboarding manager, or the deployer assigned to
-    ///      `_params.namespace`. A self-serve deployer (not the onboarding manager)
-    ///      may only set an integrator share at or below `defaultIntegratorShareBps`,
-    ///      so it can give LI.FI more than the default cut but never less; the
-    ///      onboarding manager may set any share up to 100%.
+    ///      `_params.namespace`. Each fee type carries its own integrator share; a
+    ///      self-serve deployer (not the onboarding manager) may only set a share at
+    ///      or below `defaultIntegratorShareBps`, so it can give LI.FI more than the
+    ///      default cut but never less; the onboarding manager may set any share up
+    ///      to 100%.
     ///      Deploys are intentionally allowed while `globalPaused` is set: a new
     ///      instance is a beacon proxy that reads the same live flag, so it is frozen
     ///      from birth and poses no deposit risk.
@@ -267,17 +268,9 @@ contract LiFiVaultWrapperFactory is
 
         _validateFees(_params.fees);
 
-        uint16 integratorShareBps = _params.integratorShareBps;
-        if (integratorShareBps == USE_DEFAULT_SPLIT) {
-            integratorShareBps = defaultIntegratorShareBps;
-        } else if (integratorShareBps >= BPS_DENOMINATOR) {
-            revert InvalidSplit();
-        } else if (
-            msg.sender != onboardingManager &&
-            integratorShareBps > defaultIntegratorShareBps
-        ) {
-            revert IntegratorShareAboveDefault();
-        }
+        uint16[4] memory integratorShareBps = _resolveSplits(
+            _params.integratorShareBps
+        );
 
         bytes32 salt = _salt(
             _params.namespace,
@@ -357,6 +350,32 @@ contract LiFiVaultWrapperFactory is
     ) internal pure returns (bytes32) {
         return
             keccak256(abi.encode(_namespace, _adapter, _underlying, _nonce));
+    }
+
+    /// @notice Resolves the requested per-fee-type integrator shares against the factory
+    ///         default and the caller's authority.
+    /// @dev Each element resolves independently: the `USE_DEFAULT_SPLIT` sentinel inherits
+    ///      the factory default; an explicit share must be < 100%, and a self-serve
+    ///      deployer may not set it above the default (which would cut LI.FI's share
+    ///      below its default cut).
+    /// @param _requested The per-fee-type shares from the deploy params.
+    /// @return resolved The validated per-fee-type shares snapshotted into the instance.
+    function _resolveSplits(
+        uint16[4] calldata _requested
+    ) internal view returns (uint16[4] memory resolved) {
+        uint16 defaultShare = defaultIntegratorShareBps;
+        bool selfServe = msg.sender != onboardingManager;
+        for (uint256 i; i < 4; ++i) {
+            uint16 share = _requested[i];
+            if (share == USE_DEFAULT_SPLIT) {
+                resolved[i] = defaultShare;
+                continue;
+            }
+            if (share >= BPS_DENOMINATOR) revert InvalidSplit();
+            if (selfServe && share > defaultShare)
+                revert IntegratorShareAboveDefault();
+            resolved[i] = share;
+        }
     }
 
     /// @notice CREATE2 init code for a wrapper instance: the OZ BeaconProxy

--- a/src/VaultWrapper/LiFiVaultWrapperTypes.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperTypes.sol
@@ -40,6 +40,6 @@ struct DeployParams {
     address underlying; // Protocol-specific yield source (e.g. an ERC-4626 vault).
     uint256 nonce; // Disambiguates instances sharing the same (namespace, adapter, underlying).
     FeeConfig fees; // Per-fee-type rates and enabled flags; validated against bounds/caps.
-    uint16 integratorShareBps; // Integrator's fee share (bps); type(uint16).max = factory default, else must be <= 100%.
+    uint16[4] integratorShareBps; // Integrator's fee share (bps) per FeeType (index = ordinal); type(uint16).max = factory default, else must be < 100%.
     bytes initData; // Opaque wrapper-side config forwarded to the instance's initialize.
 }

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -17,14 +17,15 @@ interface ILiFiVaultWrapper {
     /// @param adapter The yield adapter the wrapper routes through.
     /// @param vaultWrapperAdmin The per-vault controller granted the instance admin role.
     /// @param factory The factory that deployed and initialized the instance.
-    /// @param integratorShareBps The integrator's fee share (bps) snapshotted at deploy.
+    /// @param integratorShareBps The integrator's per-fee-type shares (bps, indexed by
+    ///        FeeType ordinal) snapshotted at deploy.
     event VaultWrapperConfigured(
         address indexed asset,
         address indexed underlying,
         address indexed adapter,
         address vaultWrapperAdmin,
         address factory,
-        uint16 integratorShareBps
+        uint16[4] integratorShareBps
     );
 
     /// @notice Emitted when a fee type's rate (and enabled flag) is changed.
@@ -38,15 +39,28 @@ interface ILiFiVaultWrapper {
     );
 
     /// @notice Emitted when dilution fee-shares are minted to the wrapper.
-    /// @dev Reports the total before the LI.FI/integrator split.
-    /// @param feeType The fee type that accrued (Management today).
-    /// @param feeShares The shares minted to the wrapper.
-    event DilutionFeeAccrued(FeeType indexed feeType, uint256 feeShares);
+    /// @dev The LI.FI/integrator split is applied at accrual; LI.FI's part is
+    ///      `feeShares - integratorShares`.
+    /// @param feeType The fee type that accrued (Management or Performance).
+    /// @param feeShares The total shares minted to the wrapper.
+    /// @param integratorShares The integrator's part of the minted shares.
+    event DilutionFeeAccrued(
+        FeeType indexed feeType,
+        uint256 feeShares,
+        uint256 integratorShares
+    );
 
     /// @notice Emitted when an asset-side fee is charged and held idle.
+    /// @dev The LI.FI/integrator split is applied at charge; LI.FI's part is
+    ///      `feeAssets - integratorAssets`.
     /// @param feeType The fee type charged (Deposit or Withdrawal).
-    /// @param feeAssets The fee amount, in assets.
-    event AssetFeeCharged(FeeType indexed feeType, uint256 feeAssets);
+    /// @param feeAssets The total fee amount, in assets.
+    /// @param integratorAssets The integrator's part of the fee, in assets.
+    event AssetFeeCharged(
+        FeeType indexed feeType,
+        uint256 feeAssets,
+        uint256 integratorAssets
+    );
 
     /// @notice Emitted when the integrator toggles this clone's deposit pause.
     /// @param paused The new pause state.
@@ -61,7 +75,7 @@ interface ILiFiVaultWrapper {
     error InvalidFeeType(uint8 feeType);
     /// @notice Thrown when a required initialization address is the zero address.
     error ZeroAddress();
-    /// @notice Thrown when the integrator share exceeds 100% (10000 bps).
+    /// @notice Thrown when a fee type's integrator share is 100% (10000 bps) or more.
     error InvalidIntegratorShareBps(uint16 integratorShareBps);
     /// @notice Thrown when ownership renouncement is attempted; the admin role is non-renounceable.
     error RenounceDisabled();
@@ -69,9 +83,6 @@ interface ILiFiVaultWrapper {
     error AdapterDepositShortfall(uint256 expected, uint256 actual);
     /// @notice Thrown when the adapter returns less than the requested withdrawal amount.
     error AdapterWithdrawShortfall(uint256 expected, uint256 actual);
-    /// @notice Thrown when a rate change is attempted for the performance fee, which is
-    ///         not configurable through this setter.
-    error FeeTypeNotConfigurable(FeeType feeType);
     /// @notice Thrown when a requested rate is outside the factory's live bounds.
     error FeeRateOutOfBounds(uint16 rateBps, uint16 minBps, uint16 maxBps);
 
@@ -83,14 +94,15 @@ interface ILiFiVaultWrapper {
     /// @param _underlying The protocol-specific yield source (e.g. an ERC-4626 vault).
     /// @param _adapter The approved yield adapter the vault wrapper routes through at runtime.
     /// @param _vaultWrapperAdmin The per-vault controller granted the instance admin role.
-    /// @param _integratorShareBps The integrator's fee share (bps), resolved and bounded by the factory.
+    /// @param _integratorShareBps The integrator's fee share (bps) per fee type (indexed by
+    ///        FeeType ordinal), resolved and bounded by the factory.
     /// @param _fees The per-fee-type rates and enabled flags (already validated by the factory).
     /// @param _initData Opaque vault-wrapper-side config (access mode, receivers, ToS hash, oracle).
     function initialize(
         address _underlying,
         address _adapter,
         address _vaultWrapperAdmin,
-        uint16 _integratorShareBps,
+        uint16[4] calldata _integratorShareBps,
         FeeConfig calldata _fees,
         bytes calldata _initData
     ) external;

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
@@ -34,7 +34,8 @@ interface ILiFiVaultWrapperFactory {
     /// @param adapter The yield adapter the vault wrapper routes through.
     /// @param asset The ERC20 asset resolved from the underlying.
     /// @param vaultWrapperAdmin The per-vault controller granted the instance admin role.
-    /// @param integratorShareBps The integrator fee share (bps) snapshotted into the instance.
+    /// @param integratorShareBps The integrator's per-fee-type shares (bps, indexed by
+    ///        FeeType ordinal) snapshotted into the instance.
     /// @param nonce The caller-supplied nonce disambiguating instances.
     /// @param salt The CREATE2 salt used to deploy the vault wrapper.
     event WrapperDeployed(
@@ -44,7 +45,7 @@ interface ILiFiVaultWrapperFactory {
         address adapter,
         address asset,
         address vaultWrapperAdmin,
-        uint16 integratorShareBps,
+        uint16[4] integratorShareBps,
         uint256 nonce,
         bytes32 salt
     );

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -7,9 +7,10 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 /// @author LI.FI (https://li.fi)
 /// @notice Stateless arithmetic for the LI.FI vault wrapper fee engine: asset-side
 ///         deposit/withdrawal fees (the fee is a percentage of the net amount, so gross =
-///         net + fee), time-based management-fee dilution, and the fee-inclusive share/asset
-///         conversions. Centralizing the math here gives auditing and fuzzing a single,
-///         side-effect-free surface; all state, minting, and routing stay in the wrapper.
+///         net + fee), time-based management-fee dilution, high-water-mark performance-fee
+///         dilution, and the fee-inclusive share/asset conversions. Centralizing the math
+///         here gives auditing and fuzzing a single, side-effect-free surface; all state,
+///         minting, and routing stay in the wrapper.
 /// @custom:version 1.0.0
 library LibVaultWrapperMath {
     using Math for uint256;
@@ -19,6 +20,10 @@ library LibVaultWrapperMath {
 
     /// @notice Seconds in a fee year, fixed at 365 days for management accrual.
     uint256 internal constant SECONDS_PER_YEAR = 365 days;
+
+    /// @notice Fixed-point scale of the price-per-share values (`pricePerShare` results
+    ///         and the performance-fee high-water mark).
+    uint256 internal constant PPS_SCALE = 1e18;
 
     /// @notice Fee taken on top of a net amount (gross = net + fee).
     /// @dev Used where `_assets` is the net amount the user wants moved (previewMint,
@@ -73,6 +78,66 @@ library LibVaultWrapperMath {
             BASIS_POINT_SCALE * SECONDS_PER_YEAR,
             Math.Rounding.Floor
         );
+        if (feeAssets >= _totalAssets) feeAssets = _totalAssets - 1;
+    }
+
+    /// @notice Price per share as a `PPS_SCALE`-scaled fixed-point value.
+    /// @dev `convertToAssets(PPS_SCALE)` under OZ's virtual-offset convention:
+    ///      `pps = (totalAssets + 1) * PPS_SCALE / (totalSupply + 10**offset)`, rounded
+    ///      down. The same convention as the share/asset conversions so the performance
+    ///      watermark is measured on exactly the price depositors transact at.
+    /// @param _totalSupply Current share supply.
+    /// @param _totalAssets Gross assets under management.
+    /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
+    /// @return The current price per share, scaled by `PPS_SCALE`.
+    function pricePerShare(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint8 _decimalsOffset
+    ) internal pure returns (uint256) {
+        return
+            (_totalAssets + 1).mulDiv(
+                PPS_SCALE,
+                _totalSupply + 10 ** _decimalsOffset,
+                Math.Rounding.Floor
+            );
+    }
+
+    /// @notice Performance fee in assets on the share-price gain above a high-water mark.
+    /// @dev `gainAssets = totalSupply * (pps - hwm) / PPS_SCALE` (only real holder shares
+    ///      participate; the virtual offset shares are excluded), then
+    ///      `feeAssets = feeOnRaw(gainAssets, rateBps)`. Returns 0 when the current price
+    ///      per share is at or below the watermark, so a net loss is never charged.
+    ///      Clamped strictly below `_totalAssets` so the dilution-share denominator stays
+    ///      positive even at extreme watermark/rate inputs.
+    /// @param _totalAssets Gross assets under management at accrual time.
+    /// @param _totalSupply Current share supply.
+    /// @param _hwmPps The high-water mark, a `PPS_SCALE`-scaled price per share.
+    /// @param _rateBps Performance fee rate in basis points.
+    /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
+    /// @return feeAssets The performance fee owed, in assets.
+    function performanceFeeAssets(
+        uint256 _totalAssets,
+        uint256 _totalSupply,
+        uint256 _hwmPps,
+        uint16 _rateBps,
+        uint8 _decimalsOffset
+    ) internal pure returns (uint256 feeAssets) {
+        if (_totalAssets == 0 || _totalSupply == 0 || _rateBps == 0) return 0;
+
+        uint256 pps = pricePerShare(
+            _totalSupply,
+            _totalAssets,
+            _decimalsOffset
+        );
+        if (pps <= _hwmPps) return 0;
+
+        uint256 gainAssets = _totalSupply.mulDiv(
+            pps - _hwmPps,
+            PPS_SCALE,
+            Math.Rounding.Floor
+        );
+        feeAssets = feeOnRaw(gainAssets, _rateBps);
         if (feeAssets >= _totalAssets) feeAssets = _totalAssets - 1;
     }
 

--- a/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
+++ b/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
@@ -64,7 +64,12 @@ contract BeaconUpgradeTest is Test {
             underlying: address(underlying),
             nonce: nonce_,
             fees: fees,
-            integratorShareBps: type(uint16).max,
+            integratorShareBps: [
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max
+            ],
             initData: ""
         });
         vm.prank(onboarder);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -121,7 +121,7 @@ contract LiFiVaultWrapperTest is Test {
         address indexed adapter,
         address vaultWrapperAdmin,
         address factory,
-        uint16 integratorShareBps
+        uint16[4] integratorShareBps
     );
 
     /// @dev This test contract is the `factory` (it deploys the beacon proxies), so the
@@ -150,7 +150,9 @@ contract LiFiVaultWrapperTest is Test {
         assertEq(wrapper.adapter(), address(adapter));
         assertEq(wrapper.owner(), vaultAdmin);
         assertEq(wrapper.factory(), address(this));
-        assertEq(wrapper.integratorShareBps(), 8000);
+        for (uint256 i; i < 4; ++i) {
+            assertEq(wrapper.integratorShareBps(i), 8000);
+        }
         assertEq(wrapper.decimals(), 18);
         assertEq(wrapper.name(), "LI.FI Earn TKN");
         assertEq(wrapper.symbol(), "lfTKN");
@@ -160,7 +162,14 @@ contract LiFiVaultWrapperTest is Test {
         FeeConfig memory fees;
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
-            (address(underlying), address(adapter), vaultAdmin, 8000, fees, "")
+            (
+                address(underlying),
+                address(adapter),
+                vaultAdmin,
+                _splits8000(),
+                fees,
+                ""
+            )
         );
 
         vm.expectEmit(true, true, true, true);
@@ -170,7 +179,7 @@ contract LiFiVaultWrapperTest is Test {
             address(adapter),
             vaultAdmin,
             address(this),
-            8000
+            _splits8000()
         );
 
         new BeaconProxy(address(beacon), initCall);
@@ -185,7 +194,7 @@ contract LiFiVaultWrapperTest is Test {
             address(underlying),
             address(adapter),
             vaultAdmin,
-            8000,
+            _splits8000(),
             fees,
             ""
         );
@@ -195,7 +204,14 @@ contract LiFiVaultWrapperTest is Test {
         FeeConfig memory fees;
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
-            (address(underlying), address(adapter), address(0), 8000, fees, "")
+            (
+                address(underlying),
+                address(adapter),
+                address(0),
+                _splits8000(),
+                fees,
+                ""
+            )
         );
 
         vm.expectRevert(ILiFiVaultWrapper.ZeroAddress.selector);
@@ -212,7 +228,7 @@ contract LiFiVaultWrapperTest is Test {
                 address(underlying),
                 address(zeroAdapter),
                 vaultAdmin,
-                8000,
+                _splits8000(),
                 fees,
                 ""
             )
@@ -225,13 +241,14 @@ contract LiFiVaultWrapperTest is Test {
 
     function testRevert_InitializeRejectsFullIntegratorShare() public {
         FeeConfig memory fees;
+        // Only one element is invalid, proving each fee type's share is validated.
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
             (
                 address(underlying),
                 address(adapter),
                 vaultAdmin,
-                10_000,
+                [uint16(8000), 10_000, 8000, 8000],
                 fees,
                 ""
             )
@@ -284,7 +301,7 @@ contract LiFiVaultWrapperTest is Test {
                 address(noSymbolUnderlying),
                 address(adapter),
                 vaultAdmin,
-                8000,
+                _splits8000(),
                 fees,
                 ""
             )
@@ -558,13 +575,24 @@ contract LiFiVaultWrapperTest is Test {
 
     /// Helpers ///
 
+    function _splits8000() internal pure returns (uint16[4] memory) {
+        return [uint16(8000), 8000, 8000, 8000];
+    }
+
     function _newWrapper(
         address _underlying
     ) internal returns (LiFiVaultWrapper w) {
         FeeConfig memory fees;
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
-            (_underlying, address(adapter), vaultAdmin, 8000, fees, "")
+            (
+                _underlying,
+                address(adapter),
+                vaultAdmin,
+                _splits8000(),
+                fees,
+                ""
+            )
         );
 
         w = LiFiVaultWrapper(

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -326,9 +326,13 @@ contract LiFiVaultWrapperFactoryTest is Test {
             underlying: address(underlying),
             nonce: nonce_,
             fees: FeeConfig({ rateBps: rates, enabled: enabled }),
-            integratorShareBps: type(uint16).max, // inherit factory default
+            integratorShareBps: _splitsAll(type(uint16).max), // inherit factory default
             initData: hex"1234"
         });
+    }
+
+    function _splitsAll(uint16 _v) internal pure returns (uint16[4] memory) {
+        return [_v, _v, _v, _v];
     }
 
     function test_OnboardingManagerDeploysAndWiresClone() public {
@@ -355,7 +359,9 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(w.adapter(), address(adapter));
         assertEq(w.owner(), vaultAdmin);
         assertEq(w.factory(), address(factory));
-        assertEq(w.integratorShareBps(), 8000); // factory default
+        for (uint256 i; i < 4; ++i) {
+            assertEq(w.integratorShareBps(i), 8000); // factory default
+        }
         assertEq(w.feeRate(uint8(FeeType.Performance)), 1000);
         assertTrue(w.feeEnabled(uint8(FeeType.Performance)));
         assertEq(w.initData(), hex"1234");
@@ -382,7 +388,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
             address(adapter),
             assetToken,
             vaultAdmin,
-            8000, // factory default
+            _splitsAll(8000), // factory default
             0,
             expectedSalt
         );
@@ -404,10 +410,17 @@ contract LiFiVaultWrapperFactoryTest is Test {
     function test_DeployWithSplitOverride() public {
         _enableUnderlyingAndBounds();
         DeployParams memory p = _params(0);
-        p.integratorShareBps = 5000;
+        // Distinct per-fee-type shares, with one element left on the sentinel to prove
+        // each element resolves independently against the factory default.
+        p.integratorShareBps = [uint16(5000), 6000, type(uint16).max, 0];
         vm.prank(onboarder);
         address instance = factory.deploy(p);
-        assertEq(LiFiVaultWrapper(instance).integratorShareBps(), 5000);
+
+        LiFiVaultWrapper w = LiFiVaultWrapper(instance);
+        assertEq(w.integratorShareBps(0), 5000);
+        assertEq(w.integratorShareBps(1), 6000);
+        assertEq(w.integratorShareBps(2), 8000); // sentinel -> factory default
+        assertEq(w.integratorShareBps(3), 0);
     }
 
     function test_SelfDeployerSetsSplit() public {
@@ -415,10 +428,13 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.prank(onboarder);
         factory.setApprovedIntegratorDeployer(NS, deployer);
         DeployParams memory p = _params(0);
-        p.integratorShareBps = 7000;
+        p.integratorShareBps = _splitsAll(7000);
         vm.prank(deployer);
         address instance = factory.deploy(p);
-        assertEq(LiFiVaultWrapper(instance).integratorShareBps(), 7000);
+
+        for (uint256 i; i < 4; ++i) {
+            assertEq(LiFiVaultWrapper(instance).integratorShareBps(i), 7000);
+        }
     }
 
     function test_SelfDeployerCannotSetSplitAboveDefault() public {
@@ -426,7 +442,8 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.prank(onboarder);
         factory.setApprovedIntegratorDeployer(NS, deployer);
         DeployParams memory p = _params(0);
-        p.integratorShareBps = factory.defaultIntegratorShareBps() + 1;
+        // A single above-default element must trip the check, sentinels elsewhere.
+        p.integratorShareBps[2] = factory.defaultIntegratorShareBps() + 1;
         vm.prank(deployer);
         vm.expectRevert(
             ILiFiVaultWrapperFactory.IntegratorShareAboveDefault.selector
@@ -437,16 +454,18 @@ contract LiFiVaultWrapperFactoryTest is Test {
     function test_OnboardingManagerCanSetSplitAboveDefault() public {
         _enableUnderlyingAndBounds();
         DeployParams memory p = _params(0);
-        p.integratorShareBps = 9000; // above the 8000 default; LI.FI's call to make
+        // above the 8000 default; LI.FI's call to make
+        p.integratorShareBps[1] = 9000;
         vm.prank(onboarder);
         address instance = factory.deploy(p);
-        assertEq(LiFiVaultWrapper(instance).integratorShareBps(), 9000);
+
+        assertEq(LiFiVaultWrapper(instance).integratorShareBps(1), 9000);
     }
 
     function test_DeployRevertsAtFullIntegratorShare() public {
         _enableUnderlyingAndBounds();
         DeployParams memory p = _params(0);
-        p.integratorShareBps = 10000;
+        p.integratorShareBps[3] = 10000;
         vm.prank(onboarder);
         vm.expectRevert(ILiFiVaultWrapperFactory.InvalidSplit.selector);
         factory.deploy(p);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -37,6 +37,7 @@ contract LiFiVaultWrapperFeesTest is Test {
     uint16 internal constant MGMT_RATE = 200; // 2% / year
     uint16 internal constant DEP_RATE = 100; // 1%
     uint16 internal constant WD_RATE = 100; // 1%
+    uint16 internal constant SPLIT = 8000; // integrator share used for every fee type here
     uint256 internal constant YEAR = 365 days;
 
     event FeeConfigUpdated(
@@ -45,9 +46,17 @@ contract LiFiVaultWrapperFeesTest is Test {
         bool enabled
     );
 
-    event DilutionFeeAccrued(FeeType indexed feeType, uint256 feeShares);
+    event DilutionFeeAccrued(
+        FeeType indexed feeType,
+        uint256 feeShares,
+        uint256 integratorShares
+    );
 
-    event AssetFeeCharged(FeeType indexed feeType, uint256 feeAssets);
+    event AssetFeeCharged(
+        FeeType indexed feeType,
+        uint256 feeAssets,
+        uint256 integratorAssets
+    );
 
     /// @dev This test contract is the `factory` for the direct beacon-proxy wrappers (it
     ///      deploys and initializes them), so the wrapper reads the global circuit breaker
@@ -72,7 +81,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         wrapper = _newWrapperMgmtOnly(MGMT_RATE);
         _deposit(alice, DEPOSIT);
 
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
 
         vm.warp(block.timestamp + YEAR);
 
@@ -86,7 +95,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         // the triggering deposit's size.
         _crystallize();
 
-        assertEq(wrapper.accruedFeeShares(), expectedShares);
+        assertEq(_accruedFeeShares(), expectedShares);
         assertEq(wrapper.balanceOf(address(wrapper)), expectedShares);
         assertEq(wrapper.lastMgmtAccrual(), block.timestamp);
 
@@ -125,7 +134,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         _crystallize();
 
         assertEq(wrapper.balanceOf(address(wrapper)), wrapperSharesBefore);
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
     }
 
     function test_DisabledManagementFeeDoesNotAccrue() public {
@@ -138,7 +147,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         _crystallize();
 
         assertEq(wrapper.balanceOf(address(wrapper)), wrapperSharesBefore);
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
     }
 
     function test_ManagementFeeNoAccrualOnEmptyVault() public {
@@ -149,7 +158,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         vm.warp(block.timestamp + YEAR);
         _crystallize();
 
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
     }
 
     function test_ZeroShareAccrualStillAdvancesBaseline() public {
@@ -161,7 +170,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         vm.warp(block.timestamp + 1);
         _crystallize();
 
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
         // The baseline still advances: sub-threshold elapsed time is dropped (favouring
         // holders), never carried forward to be re-priced against a larger future AUM.
         assertEq(wrapper.lastMgmtAccrual(), block.timestamp);
@@ -189,8 +198,8 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         // One second at 10%/yr on ~1e24 assets is ~3e15 fee-shares; carrying the dormant
         // year would have charged ~1e23 (10% of bob's deposit). Assert second-scale.
-        assertGt(wrapper.accruedFeeShares(), 0);
-        assertLt(wrapper.accruedFeeShares(), 1e18);
+        assertGt(_accruedFeeShares(), 0);
+        assertLt(_accruedFeeShares(), 1e18);
     }
 
     function test_DilutionFeeAccruedEventEmitted() public {
@@ -206,7 +215,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         vm.recordLogs();
         _crystallize();
 
-        bytes32 sig = keccak256("DilutionFeeAccrued(uint8,uint256)");
+        bytes32 sig = keccak256("DilutionFeeAccrued(uint8,uint256,uint256)");
         Vm.Log[] memory logs = vm.getRecordedLogs();
         uint256 matches;
         for (uint256 i; i < logs.length; ++i) {
@@ -216,8 +225,12 @@ contract LiFiVaultWrapperFeesTest is Test {
                 uint256(logs[i].topics[1]),
                 uint256(uint8(FeeType.Management))
             );
-            uint256 shares = abi.decode(logs[i].data, (uint256));
+            (uint256 shares, uint256 integratorShares) = abi.decode(
+                logs[i].data,
+                (uint256, uint256)
+            );
             assertEq(shares, expectedShares);
+            assertEq(integratorShares, (expectedShares * SPLIT) / 10_000);
             ++matches;
         }
         assertEq(matches, 1);
@@ -318,7 +331,7 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         uint256 ppsBefore = wrapper.convertToAssets(1e18);
         uint256 totalAssetsBefore = wrapper.totalAssets();
-        uint256 feeAssetsBefore = wrapper.accruedFeeAssets();
+        uint256 feeAssetsBefore = _accruedFeeAssets();
         uint256 idleBefore = asset.balanceOf(address(wrapper));
 
         uint256 amount = 100e18;
@@ -334,7 +347,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         // bob's shares reflect only the NET (post-fee) amount.
         assertEq(minted, wrapper.previewDeposit(amount));
         // fee assets are tracked and stay idle in the wrapper (not invested).
-        assertEq(wrapper.accruedFeeAssets(), feeAssetsBefore + expectedFee);
+        assertEq(_accruedFeeAssets(), feeAssetsBefore + expectedFee);
         assertEq(asset.balanceOf(address(wrapper)), idleBefore + expectedFee);
         // only the net amount reached the yield source...
         assertEq(wrapper.totalAssets(), totalAssetsBefore + netInvested);
@@ -356,7 +369,7 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         // alice receives exactly the requested amount; the fee is redeemed on top.
         assertEq(asset.balanceOf(alice), amount);
-        assertEq(wrapper.accruedFeeAssets(), expectedFee);
+        assertEq(_accruedFeeAssets(), expectedFee);
         assertEq(asset.balanceOf(address(wrapper)), expectedFee);
         // PPS for the remaining holders is unaffected by the fee event.
         assertEq(wrapper.convertToAssets(1e18), ppsBefore);
@@ -398,7 +411,11 @@ contract LiFiVaultWrapperFeesTest is Test {
         asset.approve(address(wrapper), amount);
 
         vm.expectEmit(true, false, false, true, address(wrapper));
-        emit AssetFeeCharged(FeeType.Deposit, expectedFee);
+        emit AssetFeeCharged(
+            FeeType.Deposit,
+            expectedFee,
+            (expectedFee * SPLIT) / 10_000
+        );
 
         wrapper.deposit(amount, bob);
         vm.stopPrank();
@@ -413,7 +430,11 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, false, false, true, address(wrapper));
-        emit AssetFeeCharged(FeeType.Withdrawal, expectedFee);
+        emit AssetFeeCharged(
+            FeeType.Withdrawal,
+            expectedFee,
+            (expectedFee * SPLIT) / 10_000
+        );
 
         wrapper.withdraw(amount, alice, alice);
     }
@@ -425,7 +446,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         wrapper = _newWrapperAssetFees(DEP_RATE, 0);
         _deposit(alice, DEPOSIT);
 
-        uint256 feeBefore = wrapper.accruedFeeAssets();
+        uint256 feeBefore = _accruedFeeAssets();
         uint256 idleBefore = asset.balanceOf(address(wrapper));
 
         uint256 dust = 1;
@@ -440,7 +461,7 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         assertEq(minted, previewed);
         // The whole dust input was carved as fee and held idle; nothing reached the source.
-        assertEq(wrapper.accruedFeeAssets(), feeBefore + dust);
+        assertEq(_accruedFeeAssets(), feeBefore + dust);
         assertEq(asset.balanceOf(address(wrapper)), idleBefore + dust);
     }
 
@@ -485,8 +506,79 @@ contract LiFiVaultWrapperFeesTest is Test {
 
         assertEq(out, previewed);
         assertApproxEqAbs(out, DEPOSIT + 50e18, 1);
-        assertEq(wrapper.accruedFeeShares(), 0);
-        assertEq(wrapper.accruedFeeAssets(), 0);
+        assertEq(_accruedFeeShares(), 0);
+        assertEq(_accruedFeeAssets(), 0);
+    }
+
+    /// Per-fee-type LI.FI/integrator split (applied at accrual) ///
+
+    function test_AssetFeeSplitUsesEachFeeTypesOwnShare() public {
+        uint16[4] memory rates = [uint16(0), 0, DEP_RATE, WD_RATE];
+        bool[4] memory enabled = [false, false, true, true];
+        // Distinct shares per fee type: deposit 30% / withdrawal 40% to the integrator.
+        wrapper = _newWrapperWithSplits(
+            FeeConfig({ rateBps: rates, enabled: enabled }),
+            [uint16(0), 0, 3000, 4000]
+        );
+        _deposit(alice, DEPOSIT);
+
+        uint256 depFee = LibVaultWrapperMath.feeOnTotal(DEPOSIT, DEP_RATE);
+        uint256 depIntegrator = (depFee * 3000) / 10_000;
+        assertEq(wrapper.integratorFeeAssets(), depIntegrator);
+        assertEq(wrapper.lifiFeeAssets(), depFee - depIntegrator);
+
+        uint256 amount = 100e18;
+        uint256 wdFee = LibVaultWrapperMath.feeOnRaw(amount, WD_RATE);
+        uint256 wdIntegrator = (wdFee * 4000) / 10_000;
+
+        vm.prank(alice);
+        wrapper.withdraw(amount, alice, alice);
+
+        assertEq(wrapper.integratorFeeAssets(), depIntegrator + wdIntegrator);
+        assertEq(
+            wrapper.lifiFeeAssets(),
+            (depFee - depIntegrator) + (wdFee - wdIntegrator)
+        );
+    }
+
+    function test_DilutionFeeSplitUsesManagementShare() public {
+        uint16[4] memory rates = [uint16(0), MGMT_RATE, 0, 0];
+        bool[4] memory enabled = [false, true, false, false];
+        wrapper = _newWrapperWithSplits(
+            FeeConfig({ rateBps: rates, enabled: enabled }),
+            [uint16(0), 2500, 0, 0]
+        );
+        _deposit(alice, DEPOSIT);
+
+        vm.warp(block.timestamp + YEAR);
+        (uint256 expectedShares, ) = _expectedMgmt(wrapper);
+        assertGt(expectedShares, 0);
+
+        _crystallize();
+
+        uint256 integratorPart = (expectedShares * 2500) / 10_000;
+        assertEq(wrapper.integratorFeeShares(), integratorPart);
+        assertEq(wrapper.lifiFeeShares(), expectedShares - integratorPart);
+        // The wrapper custodies the total; the split is bookkeeping only.
+        assertEq(wrapper.balanceOf(address(wrapper)), expectedShares);
+    }
+
+    function test_SplitRoundingRemainderGoesToLifi() public {
+        uint16[4] memory rates = [uint16(0), 0, DEP_RATE, 0];
+        bool[4] memory enabled = [false, false, true, false];
+        wrapper = _newWrapperWithSplits(
+            FeeConfig({ rateBps: rates, enabled: enabled }),
+            [uint16(0), 0, 3333, 0]
+        );
+        _deposit(alice, DEPOSIT);
+
+        uint256 fee = LibVaultWrapperMath.feeOnTotal(DEPOSIT, DEP_RATE);
+        uint256 integratorPart = (fee * 3333) / 10_000;
+        // The integrator's part rounds down and the split dust goes to LI.FI, so the
+        // two counters always sum to the full fee.
+        assertEq(wrapper.integratorFeeAssets(), integratorPart);
+        assertEq(wrapper.lifiFeeAssets(), fee - integratorPart);
+        assertEq(_accruedFeeAssets(), fee);
     }
 
     /// setFeeRate ///
@@ -534,19 +626,6 @@ contract LiFiVaultWrapperFeesTest is Test {
         wrapper.setFeeRate(FeeType.Management, 500);
     }
 
-    function testRevert_SetFeeRatePerformanceRejected() public {
-        _stackWithFactory(MGMT_RATE);
-
-        vm.prank(vaultAdmin);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILiFiVaultWrapper.FeeTypeNotConfigurable.selector,
-                FeeType.Performance
-            )
-        );
-        wrapper.setFeeRate(FeeType.Performance, 100);
-    }
-
     function testRevert_SetFeeRateAboveBound() public {
         _stackWithFactory(MGMT_RATE); // mgmt bounds set to 0..1000
 
@@ -592,7 +671,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         vm.prank(vaultAdmin);
         wrapper.setFeeRate(FeeType.Management, 1000);
 
-        assertEq(wrapper.accruedFeeShares(), expectedShares);
+        assertEq(_accruedFeeShares(), expectedShares);
         assertEq(wrapper.lastMgmtAccrual(), block.timestamp);
     }
 
@@ -610,7 +689,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         // The elapsed month was priced (to zero) at the old rate and dropped; it must
         // not be re-priced at the new 10% rate by the next accrual.
         assertEq(wrapper.lastMgmtAccrual(), block.timestamp);
-        assertEq(wrapper.accruedFeeShares(), 0);
+        assertEq(_accruedFeeShares(), 0);
     }
 
     function test_SetFeeRateDepositChargesNewRateOnNextDeposit() public {
@@ -637,7 +716,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         wrapper.deposit(amount, bob);
         vm.stopPrank();
 
-        assertEq(wrapper.accruedFeeAssets(), expectedFee);
+        assertEq(_accruedFeeAssets(), expectedFee);
     }
 
     function test_SetFeeRateWithdrawalChargesNewRateOnNextWithdraw() public {
@@ -659,7 +738,7 @@ contract LiFiVaultWrapperFeesTest is Test {
         wrapper.withdraw(amount, alice, alice);
 
         assertEq(asset.balanceOf(alice), amount);
-        assertEq(wrapper.accruedFeeAssets(), expectedFee);
+        assertEq(_accruedFeeAssets(), expectedFee);
     }
 
     function testRevert_SetFeeRateDepositValidatedAgainstDepositBounds()
@@ -691,6 +770,13 @@ contract LiFiVaultWrapperFeesTest is Test {
 
     function _newWrapper(
         FeeConfig memory _fees
+    ) internal returns (LiFiVaultWrapper) {
+        return _newWrapperWithSplits(_fees, [SPLIT, SPLIT, SPLIT, SPLIT]);
+    }
+
+    function _newWrapperWithSplits(
+        FeeConfig memory _fees,
+        uint16[4] memory _splits
     ) internal returns (LiFiVaultWrapper w) {
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
@@ -698,7 +784,7 @@ contract LiFiVaultWrapperFeesTest is Test {
                 address(underlying),
                 address(adapter),
                 vaultAdmin,
-                8000,
+                _splits,
                 _fees,
                 ""
             )
@@ -765,7 +851,12 @@ contract LiFiVaultWrapperFeesTest is Test {
             underlying: address(underlying),
             nonce: 0,
             fees: FeeConfig({ rateBps: rates, enabled: enabled }),
-            integratorShareBps: type(uint16).max,
+            integratorShareBps: [
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max
+            ],
             initData: ""
         });
 
@@ -791,6 +882,18 @@ contract LiFiVaultWrapperFeesTest is Test {
             _totalAssets: assets,
             _decimalsOffset: 0
         });
+    }
+
+    /// @dev Total dilution fee-shares accrued, both sides of the at-accrual split.
+    function _accruedFeeShares() internal view returns (uint256) {
+        return
+            uint256(wrapper.lifiFeeShares()) + wrapper.integratorFeeShares();
+    }
+
+    /// @dev Total asset-side fees accrued, both sides of the at-accrual split.
+    function _accruedFeeAssets() internal view returns (uint256) {
+        return
+            uint256(wrapper.lifiFeeAssets()) + wrapper.integratorFeeAssets();
     }
 
     function _deposit(address _from, uint256 _amount) internal {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
+import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";
+import { FeeType, FeeConfig, DeployParams } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+
+/// @notice Tests for the performance fee (EXSC-556): high-water-mark dilution charged on
+///         share-price gains only, watermark ratcheting after crystallization, preview
+///         consistency with pending performance fees, interaction with the management fee,
+///         and the `setFeeRate` enable/disable/bounds paths. Mirrors the direct
+///         beacon-proxy setup of `LiFiVaultWrapperFees.t.sol`.
+contract LiFiVaultWrapperPerformanceFeeTest is Test {
+    MockERC20 internal asset;
+    MockERC4626 internal underlying;
+    ERC4626Adapter internal adapter;
+    UpgradeableBeacon internal beacon;
+    LiFiVaultWrapper internal wrapper;
+    LiFiVaultWrapperFactory internal factory;
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal owner = makeAddr("owner");
+
+    uint256 internal constant DEPOSIT = 1_000e18;
+    uint16 internal constant PERF_RATE = 2000; // 20% of gains
+    uint16 internal constant MGMT_RATE = 200; // 2% / year
+    uint16 internal constant SPLIT = 8000; // integrator share used for every fee type here
+    uint256 internal constant YEAR = 365 days;
+
+    /// @dev This test contract is the `factory` for the direct beacon-proxy wrappers (it
+    ///      deploys and initializes them), so the wrapper reads the global circuit breaker
+    ///      back from here.
+    function globalPaused() external pure returns (bool) {
+        return false;
+    }
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        underlying = new MockERC4626(asset, "Yield Token", "yTKN");
+        adapter = new ERC4626Adapter();
+        beacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper()),
+            address(this)
+        );
+    }
+
+    /// Charging on gains above the watermark ///
+
+    function test_PerformanceFeeChargedOnGainAboveHwm() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+
+        // At 1:1 the current PPS equals the initialize-anchored watermark: no charge.
+        assertEq(_pps(), wrapper.perfHighWaterMarkPps());
+
+        _simulateYield(200e18); // PPS ~1.2
+
+        uint256 expectedShares = _expectedPerf(
+            wrapper.totalSupply(),
+            wrapper.totalAssets()
+        );
+        assertGt(expectedShares, 0);
+
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), expectedShares);
+        assertEq(wrapper.balanceOf(address(wrapper)), expectedShares);
+        uint256 integratorPart = (expectedShares * SPLIT) / 10_000;
+        assertEq(wrapper.integratorFeeShares(), integratorPart);
+        assertEq(wrapper.lifiFeeShares(), expectedShares - integratorPart);
+
+        // The minted fee-shares are worth ~20% of the 200e18 gain at the new PPS.
+        assertApproxEqRel(
+            wrapper.convertToAssets(expectedShares),
+            (200e18 * uint256(PERF_RATE)) / 10_000,
+            1e15
+        );
+    }
+
+    function test_NoChargeOnNetLoss() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+
+        _simulateLoss(100e18); // PPS ~0.9, below the 1.0 watermark
+
+        uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), 0);
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
+    }
+
+    function test_PerfOnYieldOnlyDepositsAloneNeverCharge() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+        _deposit(bob, 3 * DEPOSIT);
+        _deposit(alice, DEPOSIT / 2);
+
+        // Deposits mint shares at the current PPS, so the price never moves above the
+        // watermark without actual yield: nothing accrues.
+        assertEq(_accruedFeeShares(), 0);
+        assertEq(wrapper.balanceOf(address(wrapper)), 0);
+    }
+
+    function test_NoDoubleChargeAcrossDrawdownAndRecovery() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+
+        _simulateYield(200e18);
+        _crystallize(); // charged; watermark ratchets to the post-fee PPS
+
+        uint256 hwmAfterCharge = wrapper.perfHighWaterMarkPps();
+        uint256 sharesAfterCharge = _accruedFeeShares();
+        assertGt(hwmAfterCharge, 1e18);
+
+        _simulateLoss(300e18); // drawdown well below the watermark
+        _crystallize();
+        _simulateYield(300e18); // recover to just about the pre-drawdown level
+        _crystallize();
+
+        // The recovery back up to the watermark is NOT new performance: no extra
+        // fee-shares were minted and the watermark did not move.
+        assertLe(_pps(), hwmAfterCharge);
+        assertEq(_accruedFeeShares(), sharesAfterCharge);
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmAfterCharge);
+
+        // Only yield beyond the watermark is charged again.
+        _simulateYield(100e18);
+        _crystallize();
+
+        assertGt(_accruedFeeShares(), sharesAfterCharge);
+    }
+
+    function test_HwmRatchetsToPostCrystallizationPps() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+
+        _simulateYield(200e18);
+        uint256 ppsBeforeCharge = _pps();
+        uint256 supply = wrapper.totalSupply();
+        uint256 assets = wrapper.totalAssets();
+        uint256 expectedShares = _expectedPerf(supply, assets);
+        uint256 expectedHwm = LibVaultWrapperMath.pricePerShare(
+            supply + expectedShares,
+            assets,
+            0
+        );
+
+        _crystallize();
+
+        // The watermark equals the diluted (post-fee-mint) PPS, sitting below the
+        // pre-charge peak: holders' realized value is the new baseline.
+        uint256 hwm = wrapper.perfHighWaterMarkPps();
+        assertEq(hwm, expectedHwm);
+        assertLt(hwm, ppsBeforeCharge);
+
+        // Idempotence: crystallizing again at the same level mints nothing more.
+        uint256 sharesAfterCharge = _accruedFeeShares();
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), sharesAfterCharge);
+    }
+
+    function test_SubThresholdGainMintsNothingAndStaysChargeable() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+
+        // A gain below one PPS unit (supply / PPS_SCALE = 1000 wei here) floors to a
+        // zero-share fee: nothing is minted and, unlike the management baseline, the
+        // watermark does NOT advance — the gain stays chargeable.
+        _simulateYield(500);
+        uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), 0);
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
+
+        // Once the cumulative gain is material it is charged in full from the original
+        // watermark, not from the sub-threshold peak.
+        _simulateYield(200e18);
+        _crystallize();
+
+        assertGt(_accruedFeeShares(), 0);
+    }
+
+    /// Preview == execution with pending performance fees ///
+
+    function test_PreviewRedeemMatchesExecutionWithPendingPerf() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+        _simulateYield(200e18); // pending, not yet crystallized
+
+        uint256 sharesToRedeem = wrapper.balanceOf(alice) / 2;
+        uint256 previewed = wrapper.previewRedeem(sharesToRedeem);
+
+        vm.prank(alice);
+        uint256 assetsOut = wrapper.redeem(sharesToRedeem, alice, alice);
+
+        assertEq(assetsOut, previewed);
+    }
+
+    function test_PreviewDepositMatchesExecutionWithPendingPerf() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+        _simulateYield(200e18);
+
+        asset.mint(bob, DEPOSIT);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), DEPOSIT);
+        uint256 previewed = wrapper.previewDeposit(DEPOSIT);
+        uint256 minted = wrapper.deposit(DEPOSIT, bob);
+        vm.stopPrank();
+
+        assertEq(minted, previewed);
+    }
+
+    /// Interaction with the management fee ///
+
+    function test_CombinedManagementAndPerformanceAccrueSequentially() public {
+        wrapper = _newWrapperPerfAndMgmt(PERF_RATE, MGMT_RATE);
+        _deposit(alice, DEPOSIT);
+
+        _simulateYield(200e18);
+        vm.warp(block.timestamp + YEAR);
+
+        // Replicate the accrual sequence: management on elapsed time first, then
+        // performance on the post-management share price.
+        uint256 supply = wrapper.totalSupply();
+        uint256 assets = wrapper.totalAssets();
+        uint256 mgmtFeeAssets = LibVaultWrapperMath.managementFeeAssets({
+            _totalAssets: assets,
+            _rateBps: MGMT_RATE,
+            _elapsed: YEAR
+        });
+        uint256 mgmtShares = LibVaultWrapperMath.dilutionShares({
+            _feeAssets: mgmtFeeAssets,
+            _totalSupply: supply,
+            _totalAssets: assets,
+            _decimalsOffset: 0
+        });
+        uint256 perfShares = _expectedPerf(supply + mgmtShares, assets);
+        assertGt(mgmtShares, 0);
+        assertGt(perfShares, 0);
+
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), mgmtShares + perfShares);
+        assertEq(wrapper.balanceOf(address(wrapper)), mgmtShares + perfShares);
+    }
+
+    function test_ManagementDilutionAloneNeverTriggersPerformanceFee() public {
+        wrapper = _newWrapperPerfAndMgmt(PERF_RATE, MGMT_RATE);
+        _deposit(alice, DEPOSIT);
+
+        // No yield: management dilution only ever LOWERS the PPS, which can never
+        // exceed the watermark.
+        vm.warp(block.timestamp + YEAR);
+        _crystallize();
+
+        uint256 supply = wrapper.totalSupply();
+        uint256 assets = wrapper.totalAssets();
+        assertGt(_accruedFeeShares(), 0); // management accrued...
+        assertEq(_expectedPerf(supply, assets), 0); // ...but no perf is pending
+        assertLt(_pps(), wrapper.perfHighWaterMarkPps());
+    }
+
+    /// setFeeRate: enable / disable / bounds ///
+
+    function test_SetFeeRateEnablePerformanceReanchorsHwm() public {
+        _stackWithFactory(0); // performance disabled at deploy
+        _deposit(alice, DEPOSIT);
+
+        // Yield earned while the fee is disabled must never be charged retroactively.
+        _simulateYield(200e18);
+
+        vm.prank(vaultAdmin);
+        wrapper.setFeeRate(FeeType.Performance, PERF_RATE);
+
+        // The watermark re-anchored at the current (post-yield) PPS...
+        assertEq(wrapper.perfHighWaterMarkPps(), _pps());
+        assertEq(_accruedFeeShares(), 0);
+
+        // ...so crystallizing right away charges nothing...
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), 0);
+
+        // ...and only NEW yield is charged.
+        _simulateYield(100e18);
+        _crystallize();
+
+        assertGt(_accruedFeeShares(), 0);
+    }
+
+    function test_SetFeeRateDisablePerformanceCrystallizesFirst() public {
+        _stackWithFactory(PERF_RATE);
+        _deposit(alice, DEPOSIT);
+        _simulateYield(200e18);
+
+        uint256 expectedShares = _expectedPerf(
+            wrapper.totalSupply(),
+            wrapper.totalAssets()
+        );
+        assertGt(expectedShares, 0);
+
+        // Turning the fee off prices the pending gain at the OLD rate first.
+        vm.prank(vaultAdmin);
+        wrapper.setFeeRate(FeeType.Performance, 0);
+
+        assertEq(_accruedFeeShares(), expectedShares);
+        assertFalse(wrapper.feeEnabled(uint8(FeeType.Performance)));
+
+        // Further yield accrues nothing while disabled.
+        _simulateYield(100e18);
+        _crystallize();
+
+        assertEq(_accruedFeeShares(), expectedShares);
+    }
+
+    function testRevert_SetFeeRatePerformanceOutOfBounds() public {
+        _stackWithFactory(PERF_RATE);
+        vm.prank(owner);
+        factory.setFeeBounds(FeeType.Performance, 100, 5000);
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILiFiVaultWrapper.FeeRateOutOfBounds.selector,
+                uint16(50),
+                uint16(100),
+                uint16(5000)
+            )
+        );
+        wrapper.setFeeRate(FeeType.Performance, 50);
+    }
+
+    /// Split ///
+
+    function test_PerformanceFeeSplitUsesPerformanceShare() public {
+        uint16[4] memory rates = [PERF_RATE, 0, 0, 0];
+        bool[4] memory enabled = [true, false, false, false];
+        // Performance split differs from every other type's share (all zero here).
+        wrapper = _newWrapperWithSplits(
+            FeeConfig({ rateBps: rates, enabled: enabled }),
+            [uint16(4500), 0, 0, 0]
+        );
+        _deposit(alice, DEPOSIT);
+        _simulateYield(200e18);
+
+        uint256 expectedShares = _expectedPerf(
+            wrapper.totalSupply(),
+            wrapper.totalAssets()
+        );
+
+        _crystallize();
+
+        uint256 integratorPart = (expectedShares * 4500) / 10_000;
+        assertEq(wrapper.integratorFeeShares(), integratorPart);
+        assertEq(wrapper.lifiFeeShares(), expectedShares - integratorPart);
+    }
+
+    /// Helpers ///
+
+    function _newWrapperWithSplits(
+        FeeConfig memory _fees,
+        uint16[4] memory _splits
+    ) internal returns (LiFiVaultWrapper w) {
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(underlying),
+                address(adapter),
+                vaultAdmin,
+                _splits,
+                _fees,
+                ""
+            )
+        );
+
+        w = LiFiVaultWrapper(
+            address(new BeaconProxy(address(beacon), initCall))
+        );
+    }
+
+    function _newWrapperPerfOnly(
+        uint16 _rate
+    ) internal returns (LiFiVaultWrapper) {
+        uint16[4] memory rates = [_rate, 0, 0, 0];
+        bool[4] memory enabled = [_rate != 0, false, false, false];
+
+        return
+            _newWrapperWithSplits(
+                FeeConfig({ rateBps: rates, enabled: enabled }),
+                [SPLIT, SPLIT, SPLIT, SPLIT]
+            );
+    }
+
+    function _newWrapperPerfAndMgmt(
+        uint16 _perf,
+        uint16 _mgmt
+    ) internal returns (LiFiVaultWrapper) {
+        uint16[4] memory rates = [_perf, _mgmt, 0, 0];
+        bool[4] memory enabled = [true, true, false, false];
+
+        return
+            _newWrapperWithSplits(
+                FeeConfig({ rateBps: rates, enabled: enabled }),
+                [SPLIT, SPLIT, SPLIT, SPLIT]
+            );
+    }
+
+    /// @dev Stands up the full factory stack and deploys an instance so `setFeeRate`
+    ///      reads live `feeBounds` (performance bounds 0..5000).
+    function _stackWithFactory(uint16 _perfRate) internal {
+        factory = new LiFiVaultWrapperFactory(
+            address(beacon),
+            owner,
+            makeAddr("pauser"),
+            makeAddr("onboarder"),
+            makeAddr("lifiRecipient")
+        );
+
+        vm.startPrank(owner);
+        factory.setAdapterApproved(address(adapter), true);
+        factory.setUnderlyingAllowed(address(underlying), true);
+        factory.setFeeBounds(FeeType.Performance, 0, 5000);
+        vm.stopPrank();
+
+        uint16[4] memory rates = [_perfRate, 0, 0, 0];
+        bool[4] memory enabled = [_perfRate != 0, false, false, false];
+        DeployParams memory p = DeployParams({
+            namespace: bytes32("Coinbase"),
+            vaultWrapperAdmin: vaultAdmin,
+            adapter: address(adapter),
+            underlying: address(underlying),
+            nonce: 0,
+            fees: FeeConfig({ rateBps: rates, enabled: enabled }),
+            integratorShareBps: [
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max
+            ],
+            initData: ""
+        });
+
+        vm.prank(makeAddr("onboarder"));
+        wrapper = LiFiVaultWrapper(factory.deploy(p));
+    }
+
+    /// @dev Replicates the pending performance fee for a given state against the
+    ///      wrapper's stored watermark, mirroring `_pendingPerformanceFee`.
+    function _expectedPerf(
+        uint256 _supply,
+        uint256 _assets
+    ) internal view returns (uint256) {
+        uint256 feeAssets = LibVaultWrapperMath.performanceFeeAssets({
+            _totalAssets: _assets,
+            _totalSupply: _supply,
+            _hwmPps: wrapper.perfHighWaterMarkPps(),
+            _rateBps: wrapper.feeRate(uint8(FeeType.Performance)),
+            _decimalsOffset: 0
+        });
+
+        return
+            LibVaultWrapperMath.dilutionShares({
+                _feeAssets: feeAssets,
+                _totalSupply: _supply,
+                _totalAssets: _assets,
+                _decimalsOffset: 0
+            });
+    }
+
+    function _pps() internal view returns (uint256) {
+        return
+            LibVaultWrapperMath.pricePerShare(
+                wrapper.totalSupply(),
+                wrapper.totalAssets(),
+                0
+            );
+    }
+
+    function _accruedFeeShares() internal view returns (uint256) {
+        return
+            uint256(wrapper.lifiFeeShares()) + wrapper.integratorFeeShares();
+    }
+
+    function _deposit(address _from, uint256 _amount) internal {
+        asset.mint(_from, _amount);
+        vm.startPrank(_from);
+        asset.approve(address(wrapper), _amount);
+        wrapper.deposit(_amount, _from);
+        vm.stopPrank();
+    }
+
+    function _simulateYield(uint256 _amount) internal {
+        asset.mint(address(underlying), _amount);
+    }
+
+    function _simulateLoss(uint256 _amount) internal {
+        deal(
+            address(asset),
+            address(underlying),
+            asset.balanceOf(address(underlying)) - _amount
+        );
+    }
+
+    /// @dev Triggers `_beforeOperation -> _accrueFees` via a dust deposit. 1 gwei (vs a
+    ///      1000e18 base) so solmate's MockERC4626 does not revert ZERO_SHARES once its
+    ///      own PPS exceeds 1 after simulated yield; the accrual runs before the
+    ///      deposit's own mint, so fee bookkeeping is exact regardless of this dust.
+    function _crystallize() internal {
+        asset.mint(address(this), 1e9);
+        asset.approve(address(wrapper), 1e9);
+        wrapper.deposit(1e9, address(this));
+    }
+}

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -60,7 +60,14 @@ contract VaultWrapperPauseTest is Test {
         FeeConfig memory fees;
         bytes memory initCall = abi.encodeCall(
             LiFiVaultWrapper.initialize,
-            (address(underlying), address(adapter), vaultAdmin, 8000, fees, "")
+            (
+                address(underlying),
+                address(adapter),
+                vaultAdmin,
+                [uint16(8000), 8000, 8000, 8000],
+                fees,
+                ""
+            )
         );
         wrapper = LiFiVaultWrapper(
             factory.deployWrapper(address(beacon), initCall)
@@ -401,7 +408,12 @@ contract VaultWrapperGlobalPauseE2ETest is Test {
             underlying: address(underlying),
             nonce: _nonce,
             fees: fees,
-            integratorShareBps: type(uint16).max,
+            integratorShareBps: [
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max,
+                type(uint16).max
+            ],
             initData: ""
         });
 

--- a/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
+++ b/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
@@ -50,6 +50,36 @@ contract LibMathHarness {
             });
     }
 
+    function pricePerShare(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint8 _decimalsOffset
+    ) external pure returns (uint256) {
+        return
+            LibVaultWrapperMath.pricePerShare({
+                _totalSupply: _totalSupply,
+                _totalAssets: _totalAssets,
+                _decimalsOffset: _decimalsOffset
+            });
+    }
+
+    function performanceFeeAssets(
+        uint256 _totalAssets,
+        uint256 _totalSupply,
+        uint256 _hwmPps,
+        uint16 _rateBps,
+        uint8 _decimalsOffset
+    ) external pure returns (uint256) {
+        return
+            LibVaultWrapperMath.performanceFeeAssets({
+                _totalAssets: _totalAssets,
+                _totalSupply: _totalSupply,
+                _hwmPps: _hwmPps,
+                _rateBps: _rateBps,
+                _decimalsOffset: _decimalsOffset
+            });
+    }
+
     function convertToShares(
         uint256 _assets,
         uint256 _totalSupply,
@@ -510,5 +540,128 @@ contract LibVaultWrapperMathTest is Test {
 
         assertGe(sharesWithFee, sharesNoFee);
         assertLe(assetsWithFee, assetsNoFee);
+    }
+
+    /* ---------------------- pricePerShare / performanceFeeAssets ------------- */
+
+    function test_PricePerShare_EmptyVaultIsOneToOne() public view {
+        // (0 + 1) * 1e18 / (0 + 10**offset)
+        assertEq(lib.pricePerShare(0, 0, 0), 1e18);
+        assertEq(lib.pricePerShare(0, 0, 3), 1e15);
+    }
+
+    function testFuzz_PricePerShare_MatchesConvertToAssets(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint8 _decimalsOffset
+    ) public view {
+        _totalSupply = bound(_totalSupply, 0, type(uint128).max);
+        _totalAssets = bound(_totalAssets, 0, type(uint128).max);
+        _decimalsOffset = uint8(bound(_decimalsOffset, 0, 12));
+
+        // The watermark unit is exactly the price a holder converts at: PPS equals
+        // convertToAssets(PPS_SCALE) under the same virtual-offset convention.
+        assertEq(
+            lib.pricePerShare(_totalSupply, _totalAssets, _decimalsOffset),
+            lib.convertToAssets({
+                _shares: 1e18,
+                _totalSupply: _totalSupply,
+                _pendingFeeShares: 0,
+                _totalAssets: _totalAssets,
+                _decimalsOffset: _decimalsOffset,
+                _rounding: Math.Rounding.Floor
+            })
+        );
+    }
+
+    function test_PerformanceFee_ZeroInputs() public view {
+        assertEq(lib.performanceFeeAssets(0, 1e18, 1e18, 2000, 0), 0);
+        assertEq(lib.performanceFeeAssets(1e18, 0, 1e18, 2000, 0), 0);
+        assertEq(lib.performanceFeeAssets(1e18, 1e18, 1e18, 0, 0), 0);
+    }
+
+    function test_PerformanceFee_NeverChargesAtOrBelowWatermark() public view {
+        // PPS exactly at the watermark: no gain.
+        uint256 pps = lib.pricePerShare(1e21, 1e21, 0);
+
+        assertEq(lib.performanceFeeAssets(1e21, 1e21, pps, 2000, 0), 0);
+        // PPS below the watermark (net loss): no charge.
+        assertEq(lib.performanceFeeAssets(9e20, 1e21, pps, 2000, 0), 0);
+    }
+
+    function test_PerformanceFee_KnownValue() public view {
+        // supply 1000e18, assets 1200e18, hwm 1e18 => gain ~200e18; 20% => ~40e18.
+        // The flooring of the PPS quantizes the gain to steps of supply/PPS_SCALE
+        // (1000 wei here), always in the holders' favour.
+        uint256 fee = lib.performanceFeeAssets(
+            1200e18,
+            1000e18,
+            1e18,
+            2000,
+            0
+        );
+
+        assertLe(fee, 40e18);
+        assertApproxEqAbs(fee, 40e18, 1000);
+    }
+
+    function testFuzz_PerformanceFee_BoundedByRateTimesGain(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint256 _hwmPps,
+        uint16 _rateBps
+    ) public view {
+        _totalSupply = bound(_totalSupply, 1, type(uint96).max);
+        _totalAssets = bound(_totalAssets, 1, type(uint96).max);
+        _hwmPps = bound(_hwmPps, 0, type(uint96).max);
+        _rateBps = uint16(bound(_rateBps, 1, 5000));
+
+        uint256 fee = lib.performanceFeeAssets(
+            _totalAssets,
+            _totalSupply,
+            _hwmPps,
+            _rateBps,
+            0
+        );
+
+        uint256 pps = lib.pricePerShare(_totalSupply, _totalAssets, 0);
+        if (pps <= _hwmPps) {
+            assertEq(fee, 0);
+        } else {
+            uint256 gain = Math.mulDiv(_totalSupply, pps - _hwmPps, 1e18);
+            // feeOnRaw ceil, then clamped strictly below totalAssets.
+            assertLe(fee, Math.mulDiv(gain, _rateBps, BPS) + 1);
+            assertLt(fee, _totalAssets);
+        }
+    }
+
+    function testFuzz_PerformanceFee_MonotonicInAssets(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint256 _extraYield
+    ) public view {
+        _totalSupply = bound(_totalSupply, 1e6, type(uint96).max);
+        _totalAssets = bound(_totalAssets, 1e6, type(uint96).max);
+        _extraYield = bound(_extraYield, 1, type(uint96).max);
+
+        uint256 hwm = lib.pricePerShare(_totalSupply, _totalAssets, 0);
+        uint256 feeBefore = lib.performanceFeeAssets(
+            _totalAssets,
+            _totalSupply,
+            hwm,
+            2000,
+            0
+        );
+        uint256 feeAfter = lib.performanceFeeAssets(
+            _totalAssets + _extraYield,
+            _totalSupply,
+            hwm,
+            2000,
+            0
+        );
+
+        // More yield on the same supply/watermark never charges less.
+        assertEq(feeBefore, 0);
+        assertGe(feeAfter, feeBefore);
     }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-556 — S2b: Performance fee (HWM dilution, holding-period accrual)](https://linear.app/lifi-linear/issue/EXSC-556/s2b-performance-fee-hwm-dilution-holding-period-accrual)

Also completes the per-fee-type LI.FI/integrator split scoped into [EXSC-410](https://linear.app/lifi-linear/issue/EXSC-410/s2-fee-engine-4-types-accrual-caps-per-fee-split) ("per-fee split"), which EXSC-556 builds on.

Stacked on S2 (#1993, `feature/exsc-410-s2-fee-engine-4-types-accrual-caps-per-fee-split`).

# Why did I implement it this way?

## Per-fee-type split, applied at accrual

- `DeployParams.integratorShareBps` and `initialize` now take `uint16[4]` (indexed by `FeeType` ordinal). Each element resolves independently in the factory: `type(uint16).max` inherits the single factory default, an explicit value must be `< 100%`, and a self-serve deployer cannot set any element above the default (LI.FI's cut per fee type can only grow).
- The split is applied **the moment a fee accrues**, into per-recipient counters: `lifiFeeShares`/`integratorFeeShares` (dilution fees) and `lifiFeeAssets`/`integratorFeeAssets` (deposit/withdrawal fees). Each pair is two packed `uint128`s so one accrual updates a single storage slot; sums are `SafeCast`-checked. This removes any later split-at-distribution step — S3's sweep only pays out the tracked entitlements, and a future `setDefaultSplit`/re-onboarding change can never retroactively re-split already-earned fees.
- `DilutionFeeAccrued`/`AssetFeeCharged` now carry the integrator's part next to the total (LI.FI's part is the difference).

## Performance fee (EXSC-556)

Charged as virtual-shares dilution gated by a global price-per-share high-water mark, per the ticket's carried design decisions:

- **Watermark unit**: PPS scaled by 1e18, defined as `convertToAssets(1e18)` under the same OZ virtual-offset convention as all share pricing (`LibVaultWrapperMath.pricePerShare`). Stored as `uint192 perfHighWaterMarkPps`, packed into one slot with `lastMgmtAccrual` (append-only, beacon-safe; consumes the same accrual-metadata slot).
- **Accrual**: in `_accrueFees`, management (time-based) crystallizes first, then performance is charged on the **post-management** share price — performance is net of management. Gain = `supply * (pps - hwm) / 1e18` on real holder shares (virtual-offset shares excluded), fee = `feeOnRaw(gain, rateBps)` (ceil), converted through the same `dilutionShares` floor as the management fee.
- **Ratchet**: the watermark moves to the post-crystallization PPS **only when fee-shares were actually minted**. A gain whose fee floors to zero shares stays chargeable — unlike management's elapsed time (which must always be dropped so it cannot be re-priced), a price level can be re-measured later without overcharging anyone.
- **Previews**: `_pendingFeeShares` now returns management pending + performance pending computed in the same sequence the accrual crystallizes in, so `preview* == execution` holds with pending performance fees (tested).
- **`setFeeRate` accepts Performance** now that a code path reads the rate: accrues at the old rate first (disabling crystallizes pending gains), and enabling from disabled **re-anchors the watermark at the current PPS** so gains made while disabled are never charged retroactively. `FeeTypeNotConfigurable` is removed (nothing throws it anymore). Bounds come live from the factory (`feeBounds(Performance)` within the immutable 50% cap, unchanged from S1/S2).

## Default decisions taken (documented for review)

1. **Split rounding**: the integrator's part rounds down; the ≤1 wei remainder per accrual goes to LI.FI.
2. **Factory default split stays a single value** applied to any sentinel element. Per-fee-type *defaults* were not added — no requirement for them yet; explicit per-type values cover the need at deploy time.
3. **Watermark anchor at `initialize` is computed pure** at the empty-vault price (supply and position are provably 0 on a fresh single-shot proxy) instead of reading `totalAssets()` through the adapter — an underlying whose empty-position query reverts must not brick deployment. Consequence: assets donated to the predicted address pre-deployment count as gain at the first accrual; charging a donation is harmless and disarms watermark-seeding.
4. **Management fee-shares participate in the performance gain measurement** (they exist at crystallization time). The effect is fee-on-fee dust that only shifts value between the two fee recipients, never from depositors.
5. **Global HWM as holding-period approximation** is carried from the ticket unchanged (a post-drawdown entrant rides free until the prior peak is reclaimed; product sign-off on the U15 rewording is tracked in the ticket, not here).
6. **Counters are `uint128`**: a fee balance ≥ 2^128 of any real asset is unreachable; `SafeCast` still reverts rather than truncates if an adversarial mock manufactures one.

## Tests

- New `LiFiVaultWrapperPerformanceFee.t.sol` (14 tests): charge on gain above HWM with exact dilution math and split, never on net loss, deposits alone never charge, no double-charge across drawdown→recovery, HWM ratchet to post-crystallization PPS + idempotence, sub-threshold gain stays chargeable, preview==execution with pending perf, combined management+performance sequence (exact), management dilution alone never triggers perf, setFeeRate enable re-anchor / disable crystallize-first / bounds.
- Split tests in `LiFiVaultWrapperFees.t.sol`: distinct shares per fee type applied at accrual, rounding remainder to LI.FI, events carry the integrator part.
- Factory tests: per-element sentinel resolution, per-element `InvalidSplit` and above-default rejection.
- `LibVaultWrapperMath.t.sol`: `pricePerShare` == `convertToAssets(1e18)` (fuzz), performance fee zero-inputs / at-or-below-watermark / known value / bounded-by-rate×gain (fuzz) / monotonic in yield (fuzz).
- Key behaviors mutation-verified (split indexing, HWM ratchet, mgmt→perf ordering, enable re-anchor: each mutation breaks the matching tests; code restored).
- Full VaultWrapper suite: **209 tests, 0 failures**.

## /pr-ready (local CodeRabbit) findings

- Applied: deploy NatSpec wording ("below 100%", `LiFiVaultWrapperFactory.sol`) — own `pr-ready:` commit.
- Rejected (documented): "Preserve the existing beacon-proxy storage layout" — the flagged reordering (replacing `accruedFee*` slots, moving `integratorShareBps`) would matter only for already-initialized proxies. **No wrapper instance or beacon is deployed anywhere**; the subsystem is pre-release and the storage layout is finalized before first deployment (same rationale as the S1/S2 reviews; `replace, don't deprecate`). The `__gap` stays `[50]` until the pre-deployment layout freeze.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
