### PR TITLE
docs(EcoFacet,NEARIntentsFacet): flag msg.sender refund target for next iteration

### DIFF
--- a/src/Facets/EcoFacet.sol
+++ b/src/Facets/EcoFacet.sol
@@ -120,6 +120,9 @@ contract EcoFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable, LiFiData {
     }
 
     /// @notice Swaps and bridges tokens via Eco Protocol
+    /// @dev TODO (next iteration): unused swap leftovers and excess native below are refunded
+    ///      to msg.sender (which may be a relayer), not _ecoData.refundRecipient, unlike the
+    ///      positive slippage refund further down. Align all three to refundRecipient.
     /// @param _bridgeData Bridge data containing core parameters
     /// @param _swapData Array of swap data for source swaps
     /// @param _ecoData Eco-specific parameters for the bridge

--- a/src/Facets/EcoFacet.sol
+++ b/src/Facets/EcoFacet.sol
@@ -122,7 +122,8 @@ contract EcoFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable, LiFiData {
     /// @notice Swaps and bridges tokens via Eco Protocol
     /// @dev TODO (next iteration): unused swap leftovers and excess native below are refunded
     ///      to msg.sender (which may be a relayer), not _ecoData.refundRecipient, unlike the
-    ///      positive slippage refund further down. Align all three to refundRecipient.
+    ///      positive slippage refund further down, which already uses refundRecipient. Align
+    ///      the two msg.sender-based refunds to refundRecipient as well.
     /// @param _bridgeData Bridge data containing core parameters
     /// @param _swapData Array of swap data for source swaps
     /// @param _ecoData Eco-specific parameters for the bridge

--- a/src/Facets/NEARIntentsFacet.sol
+++ b/src/Facets/NEARIntentsFacet.sol
@@ -144,6 +144,8 @@ contract NEARIntentsFacet is
     /// External Methods ///
 
     /// @notice Bridges tokens via NEAR Intents
+    /// @dev TODO (next iteration): excess native below is refunded to msg.sender (which may
+    ///      be a relayer), not _nearData.refundRecipient. Align to refundRecipient.
     /// @param _bridgeData The core information needed for bridging
     /// @param _nearData Data specific to NEAR Intents
     function startBridgeTokensViaNEARIntents(
@@ -168,6 +170,9 @@ contract NEARIntentsFacet is
     }
 
     /// @notice Performs a swap before bridging via NEAR Intents
+    /// @dev TODO (next iteration): unused swap leftovers and excess native below are refunded
+    ///      to msg.sender (which may be a relayer), not _nearData.refundRecipient, unlike the
+    ///      positive slippage refund further down. Align all three to refundRecipient.
     /// @param _bridgeData The core information needed for bridging
     /// @param _swapData An array of swap related data for performing swaps
     /// @param _nearData Data specific to NEAR Intents

--- a/src/Facets/NEARIntentsFacet.sol
+++ b/src/Facets/NEARIntentsFacet.sol
@@ -172,7 +172,8 @@ contract NEARIntentsFacet is
     /// @notice Performs a swap before bridging via NEAR Intents
     /// @dev TODO (next iteration): unused swap leftovers and excess native below are refunded
     ///      to msg.sender (which may be a relayer), not _nearData.refundRecipient, unlike the
-    ///      positive slippage refund further down. Align all three to refundRecipient.
+    ///      positive slippage refund further down, which already uses refundRecipient. Align
+    ///      the two msg.sender-based refunds to refundRecipient as well.
     /// @param _bridgeData The core information needed for bridging
     /// @param _swapData An array of swap related data for performing swaps
     /// @param _nearData Data specific to NEAR Intents


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None — comment-only doc fix, labelled `trivial` per the ticket-linkage carve-out.

# Why did I implement it this way?

Follow-up from a Slack design discussion with @gvladika: in `EcoFacet` and `NEARIntentsFacet`, unused swap leftovers (`_depositAndSwap(..., payable(msg.sender))`) and excess native (`refundExcessNative(payable(msg.sender))`) are currently refunded to `msg.sender` — which may be a relayer — instead of the caller-supplied `refundRecipient`, unlike the positive-slippage refund in the same functions, which already goes to `refundRecipient`. Max confirmed `refundRecipient` is the safer target and `msg.sender` is never safe to use for this.

This PR only adds `@dev TODO` NatSpec comments flagging the mismatch for the next iteration — no logic, storage, or interface change, so no audit is required and it's safe to merge as-is. Fixing the actual refund target is deferred to a follow-up PR since it changes bridging behavior and needs its own review/tests.

Per Daniel's explicit request, the local CodeRabbit `/pr-ready` gate was bypassed for this comment-only change (`PR_READY_OK=1`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md` — **skipped by explicit request; comment-only change**
- [ ] I have added tests that cover the functionality / test the bug — **N/A, comment-only**
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
