### PR TITLE
fix(CalldataVerificationFacet): remove dead code, validate offset in extractNonEVMAddress (EXSC-592) [CalldataVerificationFacet v2.0.0]

### DIFF
--- a/src/Facets/CalldataVerificationFacet.sol
+++ b/src/Facets/CalldataVerificationFacet.sol
@@ -135,7 +135,10 @@ contract CalldataVerificationFacet {
         // `offset` is relative to the start of the parameters (i.e. right after
         // the 4-byte function selector); the non-EVM address occupies the 32
         // bytes at `offset + 0x24`, so the buffer must reach at least that far.
-        if (offset + 0x24 > callData.length) revert InvalidCallData();
+        // Subtraction-based guard so attacker-controlled offsets near 2^256
+        // hit InvalidCallData instead of an arithmetic overflow panic.
+        if (callData.length < 0x24 || offset > callData.length - 0x24)
+            revert InvalidCallData();
 
         assembly {
             nonEVMAddress := mload(add(callData, add(offset, 0x24))) // Get the non-EVM address

--- a/src/Facets/CalldataVerificationFacet.sol
+++ b/src/Facets/CalldataVerificationFacet.sol
@@ -101,6 +101,12 @@ contract CalldataVerificationFacet {
     }
 
     /// @notice Extracts the non-EVM address from the calldata
+    /// @dev Only supports facets whose bridge-specific data struct is
+    ///      dynamically encoded (contains at least one dynamic field) and has
+    ///      the bytes32 non-EVM receiver as its first field (e.g. Mayan,
+    ///      NEARIntents, AcrossV4). For facets that don't match this layout
+    ///      (e.g. Chainflip, Eco, DeBridgeDln, Garden, Glacis, AllBridge,
+    ///      PolymerCCTP) the returned value is undefined or the call reverts.
     /// @param data The calldata to extract the non-EVM address from
     /// @return nonEVMAddress The non-EVM address extracted from the calldata
     function extractNonEVMAddress(
@@ -109,7 +115,8 @@ contract CalldataVerificationFacet {
         bytes memory callData = data;
         bool hasSourceSwaps = _extractBridgeData(data).hasSourceSwaps;
 
-        // Non-EVM address is always the first parameter of bridge specific data.
+        // The bridge-specific data struct sits behind an ABI head-slot offset
+        // and starts with the bytes32 non-EVM receiver (see @dev above).
         // `offset` below is read directly out of calldata and is not validated by
         // the BridgeData decode above (which only covers its own struct region),
         // so a crafted/corrupted offset could otherwise point outside `callData`

--- a/src/Facets/CalldataVerificationFacet.sol
+++ b/src/Facets/CalldataVerificationFacet.sol
@@ -12,7 +12,7 @@ import { InvalidCallData } from "../Errors/GenericErrors.sol";
 /// @title CalldataVerificationFacet
 /// @author LI.FI (https://li.fi)
 /// @notice Provides functionality for verifying calldata
-/// @custom:version 1.3.1
+/// @custom:version 2.0.0
 contract CalldataVerificationFacet {
     using LibBytes for bytes;
 
@@ -107,18 +107,31 @@ contract CalldataVerificationFacet {
         bytes calldata data
     ) external pure returns (bytes32 nonEVMAddress) {
         bytes memory callData = data;
+        bool hasSourceSwaps = _extractBridgeData(data).hasSourceSwaps;
 
-        // Non-EVM address is always the first parameter of bridge specific data
-        if (_extractBridgeData(data).hasSourceSwaps) {
+        // Non-EVM address is always the first parameter of bridge specific data.
+        // `offset` below is read directly out of calldata and is not validated by
+        // the BridgeData decode above (which only covers its own struct region),
+        // so a crafted/corrupted offset could otherwise point outside `callData`
+        // and silently yield a garbage/zero address instead of reverting.
+        uint256 offset;
+        if (hasSourceSwaps) {
             assembly {
-                let offset := mload(add(callData, 0x64)) // Get the offset of the bridge specific data
-                nonEVMAddress := mload(add(callData, add(offset, 0x24))) // Get the non-EVM address
+                offset := mload(add(callData, 0x64)) // Get the offset of the bridge specific data
             }
         } else {
             assembly {
-                let offset := mload(add(callData, 0x44)) // Get the offset of the bridge specific data
-                nonEVMAddress := mload(add(callData, add(offset, 0x24))) // Get the non-EVM address
+                offset := mload(add(callData, 0x44)) // Get the offset of the bridge specific data
             }
+        }
+
+        // `offset` is relative to the start of the parameters (i.e. right after
+        // the 4-byte function selector); the non-EVM address occupies the 32
+        // bytes at `offset + 0x24`, so the buffer must reach at least that far.
+        if (offset + 0x24 > callData.length) revert InvalidCallData();
+
+        assembly {
+            nonEVMAddress := mload(add(callData, add(offset, 0x24))) // Get the non-EVM address
         }
     }
 
@@ -142,7 +155,7 @@ contract CalldataVerificationFacet {
             uint256 receivingAmount
         )
     {
-        // valid callData for a genericSwap call should have at least 484 bytes:
+        // valid callData for a genericSwap call should have more than 484 bytes:
         // Function selector: 4 bytes
         // _transactionId: 32 bytes
         // _integrator: 64 bytes
@@ -290,37 +303,6 @@ contract CalldataVerificationFacet {
                 );
         }
 
-        // Case: AcrossV3
-        if (selector == AcrossFacetV3.startBridgeTokensViaAcrossV3.selector) {
-            (, AcrossFacetV3.AcrossV3Data memory acrossV3Data) = abi.decode(
-                data[4:],
-                (ILiFi.BridgeData, AcrossFacetV3.AcrossV3Data)
-            );
-
-            return
-                keccak256(dstCalldata) == keccak256(acrossV3Data.message) &&
-                keccak256(callTo) ==
-                keccak256(abi.encode(acrossV3Data.receiverAddress));
-        }
-        if (
-            selector ==
-            AcrossFacetV3.swapAndStartBridgeTokensViaAcrossV3.selector
-        ) {
-            (, , AcrossFacetV3.AcrossV3Data memory acrossV3Data) = abi.decode(
-                data[4:],
-                (
-                    ILiFi.BridgeData,
-                    LibSwap.SwapData[],
-                    AcrossFacetV3.AcrossV3Data
-                )
-            );
-            return
-                keccak256(dstCalldata) == keccak256(acrossV3Data.message) &&
-                keccak256(callTo) ==
-                keccak256(abi.encode(acrossV3Data.receiverAddress));
-        }
-
-        // ---------------------------------------
         // Case: AcrossV3
         if (selector == AcrossFacetV3.startBridgeTokensViaAcrossV3.selector) {
             (, AcrossFacetV3.AcrossV3Data memory acrossV3Data) = abi.decode(

--- a/test/solidity/Facets/CalldataVerificationFacet.t.sol
+++ b/test/solidity/Facets/CalldataVerificationFacet.t.sol
@@ -174,6 +174,54 @@ contract CalldataVerificationFacetTest is TestBaseLocal {
         assertEq(returnedNonEVMAddress, bytes32("Just some address"));
     }
 
+    function testRevert_ExtractNonEVMAddressWithCorruptedOffset() public {
+        // produce valid MayanData
+        MayanFacet.MayanData memory mayanData = MayanFacet.MayanData(
+            bytes32("Just some address"),
+            0xF18f923480dC144326e6C65d4F3D47Aa459bb41C, // mayanProtocol address
+            hex"00"
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            MayanFacet.startBridgeTokensViaMayan.selector,
+            bridgeData,
+            mayanData
+        );
+
+        // BridgeData decodes fine on its own (it sits entirely within the first
+        // 548 bytes), but truncating away the tail means the bridge-specific
+        // data offset now points past the end of the buffer.
+        callData = _safeSlice(callData, 0, 547);
+
+        vm.expectRevert(InvalidCallData.selector);
+        calldataVerificationFacet.extractNonEVMAddress(callData);
+    }
+
+    function testRevert_ExtractNonEVMAddressWithSwapsAndCorruptedOffset()
+        public
+    {
+        bridgeData.hasSourceSwaps = true;
+
+        // produce valid MayanData
+        MayanFacet.MayanData memory mayanData = MayanFacet.MayanData(
+            bytes32("Just some address"),
+            0xF18f923480dC144326e6C65d4F3D47Aa459bb41C, // mayanProtocol address
+            hex"00"
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            MayanFacet.swapAndStartBridgeTokensViaMayan.selector,
+            bridgeData,
+            swapData,
+            mayanData
+        );
+
+        callData = _safeSlice(callData, 0, 931);
+
+        vm.expectRevert(InvalidCallData.selector);
+        calldataVerificationFacet.extractNonEVMAddress(callData);
+    }
+
     function test_CanExtractMainParameters() public {
         bytes memory callData = abi.encodeWithSelector(
             AcrossFacetV3.startBridgeTokensViaAcrossV3.selector,

--- a/test/solidity/Facets/CalldataVerificationFacet.t.sol
+++ b/test/solidity/Facets/CalldataVerificationFacet.t.sol
@@ -222,6 +222,31 @@ contract CalldataVerificationFacetTest is TestBaseLocal {
         calldataVerificationFacet.extractNonEVMAddress(callData);
     }
 
+    function testRevert_ExtractNonEVMAddressWithHugeOffset() public {
+        // produce valid MayanData
+        MayanFacet.MayanData memory mayanData = MayanFacet.MayanData(
+            bytes32("Just some address"),
+            0xF18f923480dC144326e6C65d4F3D47Aa459bb41C, // mayanProtocol address
+            hex"00"
+        );
+
+        bytes memory callData = abi.encodeWithSelector(
+            MayanFacet.startBridgeTokensViaMayan.selector,
+            bridgeData,
+            mayanData
+        );
+
+        // overwrite the bridge-specific data offset (second param head slot,
+        // bytes 36..68 of the buffer) with type(uint256).max so the bounds
+        // check must catch it via InvalidCallData, not an overflow panic
+        for (uint256 i = 36; i < 68; i++) {
+            callData[i] = 0xff;
+        }
+
+        vm.expectRevert(InvalidCallData.selector);
+        calldataVerificationFacet.extractNonEVMAddress(callData);
+    }
+
     function test_CanExtractMainParameters() public {
         bytes memory callData = abi.encodeWithSelector(
             AcrossFacetV3.startBridgeTokensViaAcrossV3.selector,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-592

# Why did I implement it this way?

Prompted by an external contribution from @2TheMoom (github.com/2TheMoom/contracts, branch `fix/calldata-verification-duplicate-across-branch`) — credit to olumi for the report. The fixes here diverge from the proposed diff after further investigation (see EXSC-592 for the per-finding rationale):

- Removes the duplicate/unreachable AcrossV3 branches in `validateDestinationCalldata` (dead code).
- Validates the offset in `extractNonEVMAddress` before use (new revert path).
- Adds regression tests covering both changes.
- Bumps `CalldataVerificationFacet` to 2.0.0 (new revert path).
- Corrects the inherited "always the first parameter" comment on `extractNonEVMAddress`: the layout assumption only holds for facets whose bridge-specific struct is dynamically encoded with a bytes32 non-EVM receiver as its first field (Mayan, NEARIntents, AcrossV4); Chainflip/Eco (`bytes` receiver), DeBridgeDln/PolymerCCTP (receiver not first) and fully static structs (Garden, Glacis, AllBridge) do not match and return undefined values or revert.
- Uses a subtraction-based bounds check (`callData.length < 0x24 || offset > callData.length - 0x24`) so attacker-controlled offsets near 2^256 revert with `InvalidCallData` instead of an arithmetic overflow panic (CodeRabbit finding, resolved).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


