### PR TITLE
feat(EXSC-412): vault wrapper access control — whitelist/blacklist/both, sanctions oracle (S4)

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -14,6 +14,7 @@ import { ILiFiVaultWrapperFactory } from "./interfaces/ILiFiVaultWrapperFactory.
 import { IYieldAdapter } from "./interfaces/IYieldAdapter.sol";
 import { FeeConfig, FeeType } from "./LiFiVaultWrapperTypes.sol";
 import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
+import { VaultWrapperAccessControl } from "./VaultWrapperAccessControl.sol";
 
 /// @title LiFiVaultWrapper
 /// @author LI.FI (https://li.fi)
@@ -35,13 +36,17 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      Every fee is split between LI.FI and the integrator at accrual time using the
 ///      fee type's own share, into per-recipient counters. This contract does not
 ///      distribute the accrued fees. Pause is enforced on the deposit/mint path only
-///      (withdrawals stay open);
-///      access logic remains a no-op seam (`_checkAccess`) with its body landing in a
-///      follow-up ticket. Inflation-attack protection relies on the ERC-4626 virtual-share
-///      offset.
+///      (withdrawals stay open). Access control (VaultWrapperAccessControl) gates the
+///      deposit path on the share receiver and freezes transfers while a gate is
+///      active; withdrawals are never gated. Inflation-attack protection relies on the
+///      ERC-4626 virtual-share offset.
 /// @custom:version 1.0.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
+    // Access control keeps its state in an ERC-7201 namespaced slot (see the module),
+    // so inheriting it adds no slot to this layout and is collision-free behind a
+    // beacon proxy.
+    VaultWrapperAccessControl,
     // OZ v5's Ownable/Ownable2Step keep `_owner`/`_pendingOwner` in fixed ERC-7201
     // namespaced slots, not sequential ones, so they add no slot to this layout and are
     // collision-free behind a beacon proxy. They provide the per-vault admin role: `owner()`
@@ -76,10 +81,6 @@ contract LiFiVaultWrapper is
     ///         snapshotted from the factory at deploy. LI.FI receives the remainder of
     ///         each fee.
     uint16[4] public integratorShareBps;
-    /// @notice Opaque wrapper-side config (access mode, receivers, ToS hash, oracle),
-    ///         stored verbatim for later modules to decode.
-    bytes public initData;
-
     /// @dev Per-fee-type rates and enabled flags, validated by the factory.
     FeeConfig internal _feeConfig;
 
@@ -156,7 +157,7 @@ contract LiFiVaultWrapper is
         adapter = _adapter;
         integratorShareBps = _integratorShareBps;
         _feeConfig = _fees;
-        initData = _initData;
+        _initializeAccessControl(_initData);
         lastMgmtAccrual = uint64(block.timestamp);
         // Anchor the performance watermark at the empty-vault share price, computed pure
         // (supply and position are always 0 on a fresh single-shot-initialized proxy).
@@ -198,6 +199,14 @@ contract LiFiVaultWrapper is
     }
 
     /// Admin role ///
+
+    /// @dev Supplies the access-control module's admin gate: the module's mutators are
+    ///      owner-only, expressed through OZ's `_checkOwner` (reverts
+    ///      `OwnableUnauthorizedAccount`). Kept as a seam because the module cannot
+    ///      inherit OwnableUpgradeable itself (diamond clash with Ownable2Step).
+    function _requireAccessAdmin() internal view override {
+        _checkOwner();
+    }
 
     /// @notice Disabled: the per-vault admin role cannot be renounced.
     /// @dev A custody contract must never be left ownerless. The admin is rotated via OZ's
@@ -284,7 +293,8 @@ contract LiFiVaultWrapper is
         address receiver
     ) public override nonReentrant returns (uint256) {
         if (depositsPaused()) revert DepositsPaused();
-        _beforeOperation();
+        _checkDepositAccess(receiver);
+        _accrueFees();
 
         return super.deposit(assets, receiver);
     }
@@ -298,49 +308,56 @@ contract LiFiVaultWrapper is
         address receiver
     ) public override nonReentrant returns (uint256) {
         if (depositsPaused()) revert DepositsPaused();
-        _beforeOperation();
+        _checkDepositAccess(receiver);
+        _accrueFees();
 
         return super.mint(shares, receiver);
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Reports 0 while any pause source is engaged so EIP-4626 consumers see the vault
-    ///      as closed to deposits and do not build deposits that would revert.
+    /// @dev Reports 0 while any pause source is engaged or while the receiver fails the
+    ///      access check, so EIP-4626 consumers see the vault as closed to deposits and
+    ///      do not build deposits that would revert.
     function maxDeposit(
         address receiver
     ) public view override returns (uint256) {
-        if (depositsPaused()) return 0;
+        if (depositsPaused() || !isDepositAllowed(receiver)) return 0;
 
         return super.maxDeposit(receiver);
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Reports 0 while any pause source is engaged so EIP-4626 consumers see the vault
-    ///      as closed to mints and do not build mints that would revert.
+    /// @dev Reports 0 while any pause source is engaged or while the receiver fails the
+    ///      access check, so EIP-4626 consumers see the vault as closed to mints and do
+    ///      not build mints that would revert.
     function maxMint(address receiver) public view override returns (uint256) {
-        if (depositsPaused()) return 0;
+        if (depositsPaused() || !isDepositAllowed(receiver)) return 0;
 
         return super.maxMint(receiver);
     }
 
     /// @inheritdoc ERC4626Upgradeable
+    /// @dev No access check: withdrawals are never gated (the structural
+    ///      withdrawals-always-open guarantee), only fee accrual runs up front.
     function withdraw(
         uint256 assets,
         address receiver,
         address owner
     ) public override nonReentrant returns (uint256) {
-        _beforeOperation();
+        _accrueFees();
 
         return super.withdraw(assets, receiver, owner);
     }
 
     /// @inheritdoc ERC4626Upgradeable
+    /// @dev No access check: withdrawals are never gated (the structural
+    ///      withdrawals-always-open guarantee), only fee accrual runs up front.
     function redeem(
         uint256 shares,
         address receiver,
         address owner
     ) public override nonReentrant returns (uint256) {
-        _beforeOperation();
+        _accrueFees();
 
         return super.redeem(shares, receiver, owner);
     }
@@ -570,23 +587,24 @@ contract LiFiVaultWrapper is
     }
 
     /// Fees and access ///
-    /// @dev `_checkAccess` below is a no-op seam; its body lands with access control.
-    ///      TODO(pause): any future inflow entrypoint (e.g. the V2 reward-injection path) must
+    /// @dev TODO(pause): any future inflow entrypoint (e.g. the V2 reward-injection path) must
     ///      gate on `if (depositsPaused()) revert DepositsPaused();` like `deposit`/`mint`.
 
-    /// @dev Runs on every state-changing entrypoint (deposit/mint/withdraw/redeem): enforces
-    ///      the vault's access mode on the caller and accrues time/yield-based fees so the
-    ///      operation transacts at the post-accrual share price. Deposit-pause is enforced
-    ///      separately and only on inflows, so this is shared by exits too.
-    function _beforeOperation() private {
-        _checkAccess(msg.sender);
-        _accrueFees();
-    }
+    /// @dev ERC-20 transfer hook, extended with the access perimeter: mints (deposits,
+    ///      fee-share accrual), burns (withdrawals — never gated), and payouts from the
+    ///      wrapper's own fee-share balance are exempt; every other share movement runs
+    ///      the transfer-path access check (frozen while any gate is active, recipient
+    ///      screened by the sanctions oracle otherwise).
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    ) internal override {
+        if (from != address(0) && to != address(0) && from != address(this)) {
+            _checkTransferAccess(to);
+        }
 
-    /// @dev Enforces the vault's access mode (open / allowlist / permissioned) on the caller.
-    ///      Widens to `view` once it reads the access mode from initData.
-    function _checkAccess(address /* caller */) private pure {
-        // TODO(access): decode the access mode from initData and authorize the caller.
+        super._update(from, to, value);
     }
 
     /// @dev Crystallizes the management and performance fees by minting dilution shares

--- a/src/VaultWrapper/LiFiVaultWrapperTypes.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperTypes.sol
@@ -32,6 +32,32 @@ struct FeeBounds {
     uint16 maxBps; // Highest rate an instance may set; must not exceed the fee type's cap.
 }
 
+/// @notice The two access gates a wrapper instance can enforce on the deposit path.
+enum ListGate {
+    Allow,
+    Deny
+}
+
+/// @notice Storage backend for one access gate. `Merkle` is valid for the allow gate
+///         only: a Merkle deny gate would require non-inclusion proofs, which plain
+///         Merkle trees cannot provide.
+enum ListBackend {
+    Disabled,
+    Mapping,
+    Merkle,
+    External
+}
+
+/// @notice Deploy-time access-control configuration, ABI-encoded as `initialize`'s
+///         `_initData`. Empty bytes configure a fully open instance.
+struct AccessConfig {
+    ListBackend allowBackend; // Deposits require receiver membership when not Disabled.
+    ListBackend denyBackend; // Deposits require receiver absence when not Disabled; never Merkle.
+    address externalAdapter; // IVaultAccessControl serving both gates; required by an External gate.
+    address sanctionsOracle; // ISanctionsOracle screening receivers; address(0) disables the hook.
+    bytes32 allowMerkleRoot; // Membership root; required when allowBackend is Merkle.
+}
+
 /// @notice Inputs for a single `deploy` call.
 struct DeployParams {
     bytes32 namespace; // Integrator identity seeding the salt (e.g. "Coinbase"); must be assigned to the caller.

--- a/src/VaultWrapper/VaultWrapperAccessControl.sol
+++ b/src/VaultWrapper/VaultWrapperAccessControl.sol
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { IVaultAccessControl } from "./interfaces/IVaultAccessControl.sol";
+import { ISanctionsOracle } from "./interfaces/ISanctionsOracle.sol";
+import { AccessConfig, ListBackend, ListGate } from "./LiFiVaultWrapperTypes.sol";
+
+/// @title VaultWrapperAccessControl
+/// @author LI.FI (https://li.fi)
+/// @notice Deposit-path access control for a vault wrapper instance: an allow gate and a
+///         deny gate (each independently backed by an on-chain mapping, a Merkle root —
+///         allow gate only — or an external IVaultAccessControl adapter) plus an optional
+///         sanctions-oracle hook. Checks validate the share receiver, never `msg.sender`,
+///         so direct ERC-4626 calls and proxied (Composer) deposits are gated identically.
+///         While any gate is active, shares are non-transferable; withdrawals are never
+///         gated. All checks fail closed: a reverting or misconfigured backend blocks
+///         deposits, not exits. This module holds no funds.
+/// @dev Abstract module inherited by LiFiVaultWrapper; state lives in an ERC-7201
+///      namespaced slot so inheriting it does not shift the wrapper's sequential storage
+///      layout (the same convention OZ v5 upgradeable modules use). All mutators are
+///      gated on the instance's `owner` — the integrator brings their own authority
+///      model (EOA / multisig / timelock) by holding that role. The module deliberately
+///      does not inherit OwnableUpgradeable (the wrapper's Ownable2Step branch would
+///      diamond-clash on `transferOwnership`); the inheriting contract supplies the
+///      owner check through the abstract `_requireAccessAdmin` seam instead.
+/// @custom:version 1.0.0
+abstract contract VaultWrapperAccessControl {
+    /// Events ///
+
+    /// @notice Emitted when a gate's storage backend is set (Disabled = gate off).
+    /// @param gate The gate updated.
+    /// @param backend The backend now serving the gate.
+    event ListBackendSet(ListGate indexed gate, ListBackend backend);
+
+    /// @notice Emitted per account added to or removed from a gate's on-chain mapping.
+    /// @param gate The gate whose mapping changed.
+    /// @param account The account added or removed.
+    /// @param listed True if the account is now on the list.
+    event ListUpdated(
+        ListGate indexed gate,
+        address indexed account,
+        bool listed
+    );
+
+    /// @notice Emitted when the allow gate's Merkle root is set or rotated.
+    /// @param root The new membership root.
+    event AllowMerkleRootSet(bytes32 indexed root);
+
+    /// @notice Emitted when the external access-control adapter is set.
+    /// @param adapter The adapter serving External gates.
+    event ExternalAdapterSet(address indexed adapter);
+
+    /// @notice Emitted when the sanctions oracle is set (address(0) disables the hook).
+    /// @param oracle The oracle screening receivers and transfer recipients.
+    event SanctionsOracleSet(address indexed oracle);
+
+    /// @notice Emitted when an account proves allow-gate membership under a root.
+    /// @param root The Merkle root the proof verified against.
+    /// @param account The account now cached as proven under that root.
+    event AllowProven(bytes32 indexed root, address indexed account);
+
+    /// Errors ///
+
+    /// @notice Thrown when the share receiver fails the active allow gate.
+    error ReceiverNotAllowed(address account);
+    /// @notice Thrown when the share receiver is on the active deny gate's list.
+    error ReceiverDenied(address account);
+    /// @notice Thrown when the sanctions oracle reports an account as sanctioned.
+    error AccountSanctioned(address account);
+    /// @notice Thrown on share transfers while any access gate is active.
+    error SharesNotTransferable();
+    /// @notice Thrown when an access configuration is internally inconsistent (Merkle
+    ///         deny gate, External gate without an adapter, Merkle gate without a root).
+    error InvalidAccessConfig();
+    /// @notice Thrown when a Merkle proof does not verify against the current root.
+    error InvalidMerkleProof(address account);
+
+    /// Storage ///
+
+    /// @custom:storage-location erc7201:lifi.storage.VaultWrapperAccessControl
+    struct AccessControlStorage {
+        ListBackend allowBackend;
+        ListBackend denyBackend;
+        address externalAdapter;
+        address sanctionsOracle;
+        bytes32 allowMerkleRoot;
+        mapping(address => bool) allowlisted;
+        mapping(address => bool) denylisted;
+        // Proven allow-gate membership, keyed by the root the proof verified against so
+        // a root rotation invalidates every cached entry without iteration.
+        mapping(bytes32 => mapping(address => bool)) provenAllowed;
+    }
+
+    /// @dev Gates a mutator on the instance's admin; the inheriting contract implements
+    ///      `_requireAccessAdmin` (the wrapper forwards to OZ's `_checkOwner`).
+    modifier onlyAccessAdmin() {
+        _requireAccessAdmin();
+        _;
+    }
+
+    /// @dev Reverts unless the caller is the instance's admin. Implemented by the
+    ///      inheriting contract so this module stays decoupled from the ownership model.
+    function _requireAccessAdmin() internal view virtual;
+
+    /// @dev keccak256(abi.encode(uint256(keccak256("lifi.storage.VaultWrapperAccessControl")) - 1))
+    ///      & ~bytes32(uint256(0xff)) per ERC-7201.
+    bytes32 private constant ACCESS_CONTROL_STORAGE_LOCATION =
+        0x3618cf1862ee8d06fdabca72ccfb8c798e32678dc37729ae2fad3a1c3da3b800;
+
+    /// @dev Returns the module's namespaced storage struct. Assembly is the only way to
+    ///      point a storage pointer at a fixed slot (the ERC-7201 accessor idiom OZ v5
+    ///      modules use).
+    function _getAccessControlStorage()
+        private
+        pure
+        returns (AccessControlStorage storage $)
+    {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            $.slot := ACCESS_CONTROL_STORAGE_LOCATION
+        }
+    }
+
+    /// Views ///
+
+    /// @notice The instance's current access configuration (gates, adapter, oracle, root).
+    /// @return config The configuration; all-defaults for a fully open instance.
+    function accessConfig() public view returns (AccessConfig memory config) {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        config = AccessConfig({
+            allowBackend: $.allowBackend,
+            denyBackend: $.denyBackend,
+            externalAdapter: $.externalAdapter,
+            sanctionsOracle: $.sanctionsOracle,
+            allowMerkleRoot: $.allowMerkleRoot
+        });
+    }
+
+    /// @notice Whether an account is on a gate's on-chain mapping list.
+    /// @param _gate The gate to query.
+    /// @param _account The account to query.
+    /// @return True if the account is on the gate's mapping list.
+    function isListed(
+        ListGate _gate,
+        address _account
+    ) public view returns (bool) {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+
+        return
+            _gate == ListGate.Allow
+                ? $.allowlisted[_account]
+                : $.denylisted[_account];
+    }
+
+    /// @notice Whether an account has proven allow-gate membership under the current root.
+    /// @param _account The account to query.
+    /// @return True if a valid proof was cached for the account under the current root.
+    function isProvenAllowed(address _account) public view returns (bool) {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+
+        return $.provenAllowed[$.allowMerkleRoot][_account];
+    }
+
+    /// @notice Whether wrapper shares are currently transferable. Any active gate makes
+    ///         shares non-transferable so the deposit-path perimeter cannot be bypassed
+    ///         by secondary transfer; the sanctions oracle alone does not freeze
+    ///         transfers (recipients are screened instead).
+    /// @return True if no access gate is active.
+    function sharesTransferable() public view returns (bool) {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+
+        return
+            $.allowBackend == ListBackend.Disabled &&
+            $.denyBackend == ListBackend.Disabled;
+    }
+
+    /// @notice Reverts with the specific denial reason if `_receiver` may not receive
+    ///         freshly minted shares; returns silently otherwise. View mirror of the
+    ///         deposit-path check for frontends and integrators (eth_call it).
+    /// @param _receiver The prospective share receiver to validate.
+    function checkDepositAccess(address _receiver) external view {
+        _checkDepositAccess(_receiver);
+    }
+
+    /// @notice Whether `_receiver` currently passes the full deposit-path access check,
+    ///         reported without reverting: a reverting backend reads as blocked, the
+    ///         same fail-closed outcome the execution path enforces by reverting.
+    /// @dev Feeds the EIP-4626 limit views (`maxDeposit`/`maxMint`), which MUST NOT
+    ///      revert. The self-staticcall is the only way to catch the reverting check.
+    /// @param _receiver The prospective share receiver to validate.
+    /// @return True if a deposit minting to `_receiver` would pass the access check.
+    function isDepositAllowed(address _receiver) public view returns (bool) {
+        try this.checkDepositAccess(_receiver) {
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /// Mutators ///
+
+    /// @notice Sets a gate's storage backend; `Disabled` switches the gate off. Enabling
+    ///         any gate mechanically freezes share transfers (and disabling the last
+    ///         active gate re-enables them) — transferability is coupled to access-mode
+    ///         state, never a separate dial.
+    /// @dev Only the owner may call. The gate's data source must already be consistent:
+    ///      External requires a configured adapter, Merkle a non-zero root, and the deny
+    ///      gate can never be Merkle (no non-inclusion proofs).
+    /// @param _gate The gate to update.
+    /// @param _backend The backend to serve the gate with.
+    function setListBackend(
+        ListGate _gate,
+        ListBackend _backend
+    ) external onlyAccessAdmin {
+        _setListBackend(_gate, _backend);
+    }
+
+    /// @notice Adds or removes accounts on a gate's on-chain mapping list.
+    /// @dev Only the owner may call. Entries are independent of the gate's active
+    ///      backend, so a list can be seeded before the Mapping backend is enabled.
+    /// @param _gate The gate whose mapping list to update.
+    /// @param _accounts The accounts to add or remove.
+    /// @param _listed True to add every account, false to remove.
+    function updateList(
+        ListGate _gate,
+        address[] calldata _accounts,
+        bool _listed
+    ) external onlyAccessAdmin {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        mapping(address => bool) storage list = _gate == ListGate.Allow
+            ? $.allowlisted
+            : $.denylisted;
+        for (uint256 i; i < _accounts.length; ++i) {
+            list[_accounts[i]] = _listed;
+            emit ListUpdated(_gate, _accounts[i], _listed);
+        }
+    }
+
+    /// @notice Sets or rotates the allow gate's Merkle root. Rotation invalidates every
+    ///         cached `proveAllowed` entry (the cache is keyed by root).
+    /// @dev Only the owner may call. The root cannot be zeroed while the Merkle backend
+    ///      is active — disable the gate first.
+    /// @param _root The new membership root.
+    function setAllowMerkleRoot(bytes32 _root) external onlyAccessAdmin {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        if (_root == bytes32(0) && $.allowBackend == ListBackend.Merkle)
+            revert InvalidAccessConfig();
+        $.allowMerkleRoot = _root;
+
+        emit AllowMerkleRootSet(_root);
+    }
+
+    /// @notice Sets the external access-control adapter serving External gates.
+    /// @dev Only the owner may call. The adapter cannot be zeroed while either gate is
+    ///      on the External backend — switch the gates first.
+    /// @param _adapter The IVaultAccessControl adapter.
+    function setExternalAdapter(address _adapter) external onlyAccessAdmin {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        if (
+            _adapter == address(0) &&
+            ($.allowBackend == ListBackend.External ||
+                $.denyBackend == ListBackend.External)
+        ) revert InvalidAccessConfig();
+        $.externalAdapter = _adapter;
+
+        emit ExternalAdapterSet(_adapter);
+    }
+
+    /// @notice Sets the sanctions oracle; address(0) disables the hook.
+    /// @dev Only the owner may call.
+    /// @param _oracle The ISanctionsOracle to screen receivers and transfer recipients.
+    function setSanctionsOracle(address _oracle) external onlyAccessAdmin {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        $.sanctionsOracle = _oracle;
+
+        emit SanctionsOracleSet(_oracle);
+    }
+
+    /// @notice Permissionlessly proves an account's allow-gate membership under the
+    ///         current Merkle root and caches the result, so anyone (the account, an
+    ///         integrator backend, a Composer pre-step) can unlock deposits for a
+    ///         receiver without touching the ERC-4626 call surface.
+    /// @param _account The account whose membership the proof attests.
+    /// @param _proof The Merkle proof for the account's double-hashed leaf.
+    function proveAllowed(
+        address _account,
+        bytes32[] calldata _proof
+    ) external {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        bytes32 root = $.allowMerkleRoot;
+        bytes32 leaf = keccak256(
+            bytes.concat(keccak256(abi.encode(_account)))
+        );
+        if (!MerkleProof.verifyCalldata(_proof, root, leaf))
+            revert InvalidMerkleProof(_account);
+        $.provenAllowed[root][_account] = true;
+
+        emit AllowProven(root, _account);
+    }
+
+    /// Internal hooks ///
+
+    /// @dev Decodes, validates, and stores the deploy-time AccessConfig. Empty bytes
+    ///      configure a fully open instance. Emits the same events the setters would,
+    ///      so indexers see the initial configuration without decoding calldata.
+    function _initializeAccessControl(bytes memory _initData) internal {
+        if (_initData.length == 0) return;
+
+        AccessConfig memory config = abi.decode(_initData, (AccessConfig));
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        $.externalAdapter = config.externalAdapter;
+        $.sanctionsOracle = config.sanctionsOracle;
+        $.allowMerkleRoot = config.allowMerkleRoot;
+
+        if (config.allowBackend != ListBackend.Disabled)
+            _setListBackend(ListGate.Allow, config.allowBackend);
+        if (config.denyBackend != ListBackend.Disabled)
+            _setListBackend(ListGate.Deny, config.denyBackend);
+
+        if (config.externalAdapter != address(0))
+            emit ExternalAdapterSet(config.externalAdapter);
+        if (config.sanctionsOracle != address(0))
+            emit SanctionsOracleSet(config.sanctionsOracle);
+        if (config.allowMerkleRoot != bytes32(0))
+            emit AllowMerkleRootSet(config.allowMerkleRoot);
+    }
+
+    /// @dev Deposit-path gate: validates the share receiver against the allow gate, the
+    ///      deny gate, and the sanctions oracle, in that order. Fail-closed: a reverting
+    ///      backend blocks the deposit (withdrawals never run this check).
+    function _checkDepositAccess(address _receiver) internal view {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+
+        ListBackend allowBackend = $.allowBackend;
+        if (allowBackend != ListBackend.Disabled) {
+            bool allowed;
+            if (allowBackend == ListBackend.Mapping) {
+                allowed = $.allowlisted[_receiver];
+            } else if (allowBackend == ListBackend.Merkle) {
+                allowed = $.provenAllowed[$.allowMerkleRoot][_receiver];
+            } else {
+                allowed = IVaultAccessControl($.externalAdapter).isAllowed(
+                    _receiver
+                );
+            }
+            if (!allowed) revert ReceiverNotAllowed(_receiver);
+        }
+
+        ListBackend denyBackend = $.denyBackend;
+        if (denyBackend != ListBackend.Disabled) {
+            bool denied = denyBackend == ListBackend.Mapping
+                ? $.denylisted[_receiver]
+                : IVaultAccessControl($.externalAdapter).isDenied(_receiver);
+            if (denied) revert ReceiverDenied(_receiver);
+        }
+
+        _checkSanctions($, _receiver);
+    }
+
+    /// @dev Transfer-path gate: reverts while any gate is active (the perimeter must not
+    ///      be bypassable by secondary transfer); otherwise screens the recipient through
+    ///      the sanctions oracle when one is set. The sender is deliberately not
+    ///      screened — blocking a holder's outbound movement is a custodial posture the
+    ///      wrapper avoids, and exits are structurally open anyway.
+    function _checkTransferAccess(address _to) internal view {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        if (
+            $.allowBackend != ListBackend.Disabled ||
+            $.denyBackend != ListBackend.Disabled
+        ) revert SharesNotTransferable();
+
+        _checkSanctions($, _to);
+    }
+
+    /// @dev Sets a gate's backend after validating it against the currently stored data
+    ///      sources; shared by the owner setter and `_initializeAccessControl`.
+    function _setListBackend(ListGate _gate, ListBackend _backend) private {
+        AccessControlStorage storage $ = _getAccessControlStorage();
+        if (
+            _backend == ListBackend.External && $.externalAdapter == address(0)
+        ) revert InvalidAccessConfig();
+        if (_backend == ListBackend.Merkle) {
+            if (_gate == ListGate.Deny || $.allowMerkleRoot == bytes32(0))
+                revert InvalidAccessConfig();
+        }
+
+        if (_gate == ListGate.Allow) {
+            $.allowBackend = _backend;
+        } else {
+            $.denyBackend = _backend;
+        }
+
+        emit ListBackendSet(_gate, _backend);
+    }
+
+    /// @dev Reverts if the sanctions oracle is set and reports the account as
+    ///      sanctioned. Fail-closed: an oracle revert bubbles up.
+    function _checkSanctions(
+        AccessControlStorage storage $,
+        address _account
+    ) private view {
+        address oracle = $.sanctionsOracle;
+        if (
+            oracle != address(0) &&
+            ISanctionsOracle(oracle).isSanctioned(_account)
+        ) revert AccountSanctioned(_account);
+    }
+}

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -97,7 +97,8 @@ interface ILiFiVaultWrapper {
     /// @param _integratorShareBps The integrator's fee share (bps) per fee type (indexed by
     ///        FeeType ordinal), resolved and bounded by the factory.
     /// @param _fees The per-fee-type rates and enabled flags (already validated by the factory).
-    /// @param _initData Opaque vault-wrapper-side config (access mode, receivers, ToS hash, oracle).
+    /// @param _initData ABI-encoded AccessConfig (gates, adapter, oracle, Merkle root);
+    ///        empty bytes configure a fully open instance.
     function initialize(
         address _underlying,
         address _adapter,

--- a/src/VaultWrapper/interfaces/ISanctionsOracle.sol
+++ b/src/VaultWrapper/interfaces/ISanctionsOracle.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+/// @title ISanctionsOracle
+/// @author LI.FI (https://li.fi)
+/// @notice Sanctions-screening oracle hook, signature-compatible with Chainalysis'
+///         on-chain `SanctionsList` so a live oracle drops in without a shim. An
+///         instance disables the hook by setting the oracle to `address(0)`.
+/// @custom:version 1.0.0
+interface ISanctionsOracle {
+    /// @notice Whether an account appears on the sanctions list.
+    /// @param _account The account to screen (the share receiver or transfer recipient).
+    /// @return True if the account is sanctioned.
+    function isSanctioned(address _account) external view returns (bool);
+}

--- a/src/VaultWrapper/interfaces/IVaultAccessControl.sol
+++ b/src/VaultWrapper/interfaces/IVaultAccessControl.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+/// @title IVaultAccessControl
+/// @author LI.FI (https://li.fi)
+/// @notice External access-control adapter a vault wrapper instance can gate deposits
+///         through. The two predicates are independent so one adapter can serve an
+///         allowlist gate, a denylist gate, or both at once; the wrapper queries the
+///         share receiver (the end user), never `msg.sender`. Named to avoid clashing
+///         with OpenZeppelin's role-based `IAccessControl`.
+/// @custom:version 1.0.0
+interface IVaultAccessControl {
+    /// @notice Whether an account is a member of the adapter's allowlist.
+    /// @param _account The account to check (the share receiver).
+    /// @return True if the account may receive shares under an allow gate.
+    function isAllowed(address _account) external view returns (bool);
+
+    /// @notice Whether an account is a member of the adapter's denylist.
+    /// @param _account The account to check (the share receiver).
+    /// @return True if the account must be rejected under a deny gate.
+    function isDenied(address _account) external view returns (bool);
+}

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
@@ -1,0 +1,1152 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { VaultWrapperAccessControl } from "lifi/VaultWrapper/VaultWrapperAccessControl.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { FeeConfig, FeeType, AccessConfig, ListBackend, ListGate } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { MockVaultAccessControl, RevertingVaultAccessControl } from "./mocks/MockVaultAccessControl.sol";
+import { MockSanctionsOracle, RevertingSanctionsOracle } from "./mocks/MockSanctionsOracle.sol";
+import { MockGatedERC4626 } from "./mocks/MockGatedERC4626.sol";
+
+contract LiFiVaultWrapperAccessTest is Test {
+    MockERC20 internal asset;
+    MockERC4626 internal underlying;
+    ERC4626Adapter internal yieldAdapter;
+    UpgradeableBeacon internal beacon;
+    LiFiVaultWrapper internal wrapper;
+
+    MockVaultAccessControl internal accessAdapter;
+    MockSanctionsOracle internal oracle;
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal carol = makeAddr("carol");
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal stranger = makeAddr("stranger");
+
+    uint256 internal constant DEPOSIT = 1_000e18;
+
+    event ListBackendSet(ListGate indexed gate, ListBackend backend);
+    event ListUpdated(
+        ListGate indexed gate,
+        address indexed account,
+        bool listed
+    );
+    event AllowMerkleRootSet(bytes32 indexed root);
+    event ExternalAdapterSet(address indexed adapter);
+    event SanctionsOracleSet(address indexed oracle);
+    event AllowProven(bytes32 indexed root, address indexed account);
+
+    /// @dev This test contract acts as the deploying factory, so the wrapper reads the
+    ///      global circuit breaker back from here.
+    function globalPaused() external pure returns (bool) {
+        return false;
+    }
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        underlying = new MockERC4626(asset, "Yield Token", "yTKN");
+        yieldAdapter = new ERC4626Adapter();
+        beacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper()),
+            address(this)
+        );
+        accessAdapter = new MockVaultAccessControl();
+        oracle = new MockSanctionsOracle();
+    }
+
+    /// Helpers ///
+
+    function _cfg() internal pure returns (AccessConfig memory config) {
+        config = AccessConfig({
+            allowBackend: ListBackend.Disabled,
+            denyBackend: ListBackend.Disabled,
+            externalAdapter: address(0),
+            sanctionsOracle: address(0),
+            allowMerkleRoot: bytes32(0)
+        });
+    }
+
+    function _noFees() internal pure returns (FeeConfig memory fees) {
+        fees = FeeConfig({
+            rateBps: [uint16(0), 0, 0, 0],
+            enabled: [false, false, false, false]
+        });
+    }
+
+    function _newWrapper(
+        AccessConfig memory _config
+    ) internal returns (LiFiVaultWrapper) {
+        return _newWrapperWithFees(_config, _noFees());
+    }
+
+    function _newWrapperWithFees(
+        AccessConfig memory _config,
+        FeeConfig memory _fees
+    ) internal returns (LiFiVaultWrapper w) {
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(underlying),
+                address(yieldAdapter),
+                vaultAdmin,
+                [uint16(8000), 8000, 8000, 8000],
+                _fees,
+                abi.encode(_config)
+            )
+        );
+
+        w = LiFiVaultWrapper(
+            address(new BeaconProxy(address(beacon), initCall))
+        );
+    }
+
+    function _deposit(
+        LiFiVaultWrapper _w,
+        address _from,
+        uint256 _amount,
+        address _receiver
+    ) internal returns (uint256 shares) {
+        asset.mint(_from, _amount);
+        vm.startPrank(_from);
+        asset.approve(address(_w), _amount);
+        shares = _w.deposit(_amount, _receiver);
+        vm.stopPrank();
+    }
+
+    function _expectDepositRevert(
+        LiFiVaultWrapper _w,
+        address _from,
+        address _receiver,
+        bytes memory _revertData
+    ) internal {
+        asset.mint(_from, DEPOSIT);
+        vm.startPrank(_from);
+        asset.approve(address(_w), DEPOSIT);
+        vm.expectRevert(_revertData);
+
+        _w.deposit(DEPOSIT, _receiver);
+        vm.stopPrank();
+    }
+
+    /// @dev OZ standard-tree leaf: double-hashed so a leaf can never collide with an
+    ///      internal node.
+    function _leaf(address _account) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(_account))));
+    }
+
+    /// @dev OZ MerkleProof sorted-pair (commutative) node hash.
+    function _hashPair(
+        bytes32 _a,
+        bytes32 _b
+    ) internal pure returns (bytes32) {
+        return
+            _a < _b
+                ? keccak256(bytes.concat(_a, _b))
+                : keccak256(bytes.concat(_b, _a));
+    }
+
+    /// @dev Two-leaf tree over (alice, bob): each account's proof is the other's leaf.
+    function _aliceBobRoot() internal view returns (bytes32) {
+        return _hashPair(_leaf(alice), _leaf(bob));
+    }
+
+    function _proofFor(
+        address _other
+    ) internal pure returns (bytes32[] memory proof) {
+        proof = new bytes32[](1);
+        proof[0] = _leaf(_other);
+    }
+
+    /// Initialization ///
+
+    function test_EmptyInitDataConfiguresOpenInstance() public {
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(underlying),
+                address(yieldAdapter),
+                vaultAdmin,
+                [uint16(8000), 8000, 8000, 8000],
+                _noFees(),
+                ""
+            )
+        );
+        wrapper = LiFiVaultWrapper(
+            address(new BeaconProxy(address(beacon), initCall))
+        );
+
+        AccessConfig memory config = wrapper.accessConfig();
+        assertEq(uint8(config.allowBackend), uint8(ListBackend.Disabled));
+        assertEq(uint8(config.denyBackend), uint8(ListBackend.Disabled));
+        assertEq(config.externalAdapter, address(0));
+        assertEq(config.sanctionsOracle, address(0));
+        assertEq(config.allowMerkleRoot, bytes32(0));
+        assertTrue(wrapper.sharesTransferable());
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    function test_InitializeDecodesAndStoresAccessConfig() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Merkle;
+        config.allowMerkleRoot = _aliceBobRoot();
+        config.denyBackend = ListBackend.Mapping;
+        config.sanctionsOracle = address(oracle);
+        wrapper = _newWrapper(config);
+
+        AccessConfig memory stored = wrapper.accessConfig();
+        assertEq(uint8(stored.allowBackend), uint8(ListBackend.Merkle));
+        assertEq(uint8(stored.denyBackend), uint8(ListBackend.Mapping));
+        assertEq(stored.externalAdapter, address(0));
+        assertEq(stored.sanctionsOracle, address(oracle));
+        assertEq(stored.allowMerkleRoot, _aliceBobRoot());
+    }
+
+    function test_InitializeEmitsConfigEvents() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.External;
+        config.denyBackend = ListBackend.External;
+        config.externalAdapter = address(accessAdapter);
+        config.sanctionsOracle = address(oracle);
+
+        vm.expectEmit(true, false, false, true);
+        emit ListBackendSet(ListGate.Allow, ListBackend.External);
+        vm.expectEmit(true, false, false, true);
+        emit ListBackendSet(ListGate.Deny, ListBackend.External);
+        vm.expectEmit(true, false, false, false);
+        emit ExternalAdapterSet(address(accessAdapter));
+        vm.expectEmit(true, false, false, false);
+        emit SanctionsOracleSet(address(oracle));
+
+        _newWrapper(config);
+    }
+
+    function testRevert_InitializeRejectsMerkleDenyGate() public {
+        AccessConfig memory config = _cfg();
+        config.denyBackend = ListBackend.Merkle;
+
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        _newWrapper(config);
+    }
+
+    function testRevert_InitializeRejectsExternalGateWithoutAdapter() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.External;
+
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        _newWrapper(config);
+    }
+
+    function testRevert_InitializeRejectsMerkleAllowWithoutRoot() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Merkle;
+
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        _newWrapper(config);
+    }
+
+    function testRevert_InitializeRejectsMalformedInitData() public {
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(underlying),
+                address(yieldAdapter),
+                vaultAdmin,
+                [uint16(8000), 8000, 8000, 8000],
+                _noFees(),
+                hex"1234"
+            )
+        );
+
+        vm.expectRevert();
+
+        new BeaconProxy(address(beacon), initCall);
+    }
+
+    /// Mapping allowlist ///
+
+    function _mappingAllowWrapper() internal returns (LiFiVaultWrapper w) {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Mapping;
+        w = _newWrapper(config);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = alice;
+        vm.prank(vaultAdmin);
+        w.updateList(ListGate.Allow, accounts, true);
+    }
+
+    function test_MappingAllowlist_AllowsListedReceiver() public {
+        wrapper = _mappingAllowWrapper();
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertGt(wrapper.balanceOf(alice), 0);
+        assertTrue(wrapper.isListed(ListGate.Allow, alice));
+    }
+
+    function testRevert_MappingAllowlist_BlocksUnlistedReceiver() public {
+        wrapper = _mappingAllowWrapper();
+
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+    }
+
+    function test_MappingAllowlist_ValidatesReceiverNotSender() public {
+        wrapper = _mappingAllowWrapper();
+
+        // Unlisted sender depositing for a listed receiver passes: the perimeter is on
+        // who may hold shares, not on who routes the deposit (Composer dual-path).
+        _deposit(wrapper, bob, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+
+        // Listed sender depositing for an unlisted receiver is blocked.
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            carol,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                carol
+            )
+        );
+    }
+
+    function testRevert_MappingAllowlist_GatesMintPath() public {
+        wrapper = _mappingAllowWrapper();
+        asset.mint(bob, DEPOSIT);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), DEPOSIT);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+
+        wrapper.mint(DEPOSIT, bob);
+        vm.stopPrank();
+    }
+
+    function test_UpdateList_AddAndRemove() public {
+        wrapper = _mappingAllowWrapper();
+        address[] memory accounts = new address[](1);
+        accounts[0] = bob;
+
+        vm.expectEmit(true, true, false, true, address(wrapper));
+        emit ListUpdated(ListGate.Allow, bob, true);
+
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, accounts, true);
+
+        _deposit(wrapper, bob, DEPOSIT, bob);
+        assertGt(wrapper.balanceOf(bob), 0);
+
+        vm.expectEmit(true, true, false, true, address(wrapper));
+        emit ListUpdated(ListGate.Allow, bob, false);
+
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, accounts, false);
+
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+    }
+
+    function testRevert_UpdateList_OnlyOwner() public {
+        wrapper = _mappingAllowWrapper();
+        address[] memory accounts = new address[](1);
+        accounts[0] = stranger;
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+
+        wrapper.updateList(ListGate.Allow, accounts, true);
+    }
+
+    /// Mapping denylist ///
+
+    function _mappingDenyWrapper() internal returns (LiFiVaultWrapper w) {
+        AccessConfig memory config = _cfg();
+        config.denyBackend = ListBackend.Mapping;
+        w = _newWrapper(config);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = bob;
+        vm.prank(vaultAdmin);
+        w.updateList(ListGate.Deny, accounts, true);
+    }
+
+    function test_MappingDenylist_OpenForCleanReceivers() public {
+        wrapper = _mappingDenyWrapper();
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    function testRevert_MappingDenylist_BlocksDeniedReceiver() public {
+        wrapper = _mappingDenyWrapper();
+
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverDenied.selector,
+                bob
+            )
+        );
+    }
+
+    function test_MappingDenylist_ValidatesReceiverNotSender() public {
+        wrapper = _mappingDenyWrapper();
+
+        // A denied sender routing a deposit to a clean receiver passes: the denylist
+        // gates who may hold shares, not who pays.
+        _deposit(wrapper, bob, DEPOSIT, alice);
+
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    /// Both gates at once ///
+
+    function test_BothGates_RequireAllowedAndNotDenied() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Mapping;
+        config.denyBackend = ListBackend.Mapping;
+        wrapper = _newWrapper(config);
+
+        address[] memory listed = new address[](2);
+        listed[0] = alice;
+        listed[1] = bob;
+        vm.startPrank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, listed, true);
+        address[] memory denied = new address[](1);
+        denied[0] = bob;
+        wrapper.updateList(ListGate.Deny, denied, true);
+        vm.stopPrank();
+
+        // Allowed and clean: passes.
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+
+        // Allowed but denied: the deny gate still blocks.
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverDenied.selector,
+                bob
+            )
+        );
+
+        // Clean but not allowed: the allow gate blocks first.
+        _expectDepositRevert(
+            wrapper,
+            carol,
+            carol,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                carol
+            )
+        );
+    }
+
+    /// Merkle allowlist ///
+
+    function _merkleAllowWrapper() internal returns (LiFiVaultWrapper w) {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Merkle;
+        config.allowMerkleRoot = _aliceBobRoot();
+        w = _newWrapper(config);
+    }
+
+    function test_MerkleAllowlist_ProveThenDeposit() public {
+        wrapper = _merkleAllowWrapper();
+
+        // Membership alone is not enough: the proof must be submitted first.
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                alice
+            )
+        );
+
+        vm.expectEmit(true, true, false, false, address(wrapper));
+        emit AllowProven(_aliceBobRoot(), alice);
+
+        wrapper.proveAllowed(alice, _proofFor(bob));
+
+        assertTrue(wrapper.isProvenAllowed(alice));
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    function test_ProveAllowed_IsPermissionless() public {
+        wrapper = _merkleAllowWrapper();
+
+        vm.prank(stranger);
+        wrapper.proveAllowed(bob, _proofFor(alice));
+
+        assertTrue(wrapper.isProvenAllowed(bob));
+    }
+
+    function testRevert_ProveAllowed_RejectsInvalidProof() public {
+        wrapper = _merkleAllowWrapper();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.InvalidMerkleProof.selector,
+                carol
+            )
+        );
+
+        wrapper.proveAllowed(carol, _proofFor(alice));
+    }
+
+    function test_SetAllowMerkleRoot_RotationInvalidatesCache() public {
+        wrapper = _merkleAllowWrapper();
+        wrapper.proveAllowed(alice, _proofFor(bob));
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        // Rotate to a single-leaf tree over carol (root == leaf, empty proof).
+        bytes32 newRoot = _leaf(carol);
+
+        vm.expectEmit(true, false, false, false, address(wrapper));
+        emit AllowMerkleRootSet(newRoot);
+
+        vm.prank(vaultAdmin);
+        wrapper.setAllowMerkleRoot(newRoot);
+
+        // Alice's cached membership died with the old root.
+        assertFalse(wrapper.isProvenAllowed(alice));
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                alice
+            )
+        );
+
+        wrapper.proveAllowed(carol, new bytes32[](0));
+        _deposit(wrapper, carol, DEPOSIT, carol);
+        assertGt(wrapper.balanceOf(carol), 0);
+    }
+
+    function testRevert_SetAllowMerkleRoot_OnlyOwner() public {
+        wrapper = _merkleAllowWrapper();
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+
+        wrapper.setAllowMerkleRoot(bytes32(uint256(1)));
+    }
+
+    function testRevert_SetAllowMerkleRoot_RejectsZeroRootWhileMerkleActive()
+        public
+    {
+        wrapper = _merkleAllowWrapper();
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        wrapper.setAllowMerkleRoot(bytes32(0));
+    }
+
+    /// External adapter ///
+
+    function _externalAllowWrapper() internal returns (LiFiVaultWrapper w) {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.External;
+        config.externalAdapter = address(accessAdapter);
+        w = _newWrapper(config);
+    }
+
+    function test_ExternalAllowGate_FollowsAdapterPredicate() public {
+        wrapper = _externalAllowWrapper();
+        accessAdapter.setAllowed(alice, true);
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+    }
+
+    function test_ExternalDenyGate_FollowsAdapterPredicate() public {
+        AccessConfig memory config = _cfg();
+        config.denyBackend = ListBackend.External;
+        config.externalAdapter = address(accessAdapter);
+        wrapper = _newWrapper(config);
+        accessAdapter.setDenied(bob, true);
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverDenied.selector,
+                bob
+            )
+        );
+    }
+
+    function testRevert_ExternalGate_FailsClosedOnBrokenAdapter() public {
+        RevertingVaultAccessControl broken = new RevertingVaultAccessControl();
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.External;
+        config.externalAdapter = address(broken);
+        wrapper = _newWrapper(config);
+
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                RevertingVaultAccessControl.AdapterBroken.selector
+            )
+        );
+    }
+
+    function testRevert_SetExternalAdapter_OnlyOwner() public {
+        wrapper = _externalAllowWrapper();
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+
+        wrapper.setExternalAdapter(address(0));
+    }
+
+    function testRevert_SetExternalAdapter_RejectsZeroWhileExternalActive()
+        public
+    {
+        wrapper = _externalAllowWrapper();
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        wrapper.setExternalAdapter(address(0));
+    }
+
+    /// Sanctions oracle ///
+
+    function _oracleWrapper() internal returns (LiFiVaultWrapper w) {
+        AccessConfig memory config = _cfg();
+        config.sanctionsOracle = address(oracle);
+        w = _newWrapper(config);
+    }
+
+    function test_Oracle_ScreensReceiverNotSender() public {
+        wrapper = _oracleWrapper();
+        oracle.setSanctioned(bob, true);
+
+        // Clean receiver passes even when the sender is sanctioned.
+        _deposit(wrapper, bob, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.AccountSanctioned.selector,
+                bob
+            )
+        );
+    }
+
+    function test_Oracle_AppliesOnTopOfAllowlist() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Mapping;
+        config.sanctionsOracle = address(oracle);
+        wrapper = _newWrapper(config);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = alice;
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, accounts, true);
+        oracle.setSanctioned(alice, true);
+
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.AccountSanctioned.selector,
+                alice
+            )
+        );
+    }
+
+    function test_Oracle_DisabledViaZeroAddress() public {
+        wrapper = _oracleWrapper();
+        oracle.setSanctioned(alice, true);
+
+        vm.expectEmit(true, false, false, false, address(wrapper));
+        emit SanctionsOracleSet(address(0));
+
+        vm.prank(vaultAdmin);
+        wrapper.setSanctionsOracle(address(0));
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    function testRevert_Oracle_FailsClosedOnBrokenOracle() public {
+        RevertingSanctionsOracle broken = new RevertingSanctionsOracle();
+        AccessConfig memory config = _cfg();
+        config.sanctionsOracle = address(broken);
+        wrapper = _newWrapper(config);
+
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                RevertingSanctionsOracle.OracleBroken.selector
+            )
+        );
+    }
+
+    function testRevert_SetSanctionsOracle_OnlyOwner() public {
+        wrapper = _oracleWrapper();
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+
+        wrapper.setSanctionsOracle(address(0));
+    }
+
+    /// Transfer coupling ///
+
+    function test_Transfer_OpenWhenNoGateActive() public {
+        wrapper = _newWrapper(_cfg());
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertTrue(wrapper.sharesTransferable());
+
+        vm.prank(alice);
+        wrapper.transfer(bob, shares);
+
+        assertEq(wrapper.balanceOf(bob), shares);
+    }
+
+    function testRevert_Transfer_FrozenWhileAllowGateActive() public {
+        wrapper = _mappingAllowWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertFalse(wrapper.sharesTransferable());
+
+        vm.prank(alice);
+        vm.expectRevert(
+            VaultWrapperAccessControl.SharesNotTransferable.selector
+        );
+
+        wrapper.transfer(bob, shares);
+    }
+
+    function testRevert_Transfer_FrozenWhileDenyGateActive() public {
+        wrapper = _mappingDenyWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertFalse(wrapper.sharesTransferable());
+
+        vm.prank(alice);
+        vm.expectRevert(
+            VaultWrapperAccessControl.SharesNotTransferable.selector
+        );
+
+        wrapper.transfer(carol, shares);
+    }
+
+    function testRevert_TransferFrom_FrozenWhileGateActive() public {
+        wrapper = _mappingAllowWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+
+        vm.prank(alice);
+        wrapper.approve(bob, shares);
+
+        vm.prank(bob);
+        vm.expectRevert(
+            VaultWrapperAccessControl.SharesNotTransferable.selector
+        );
+
+        wrapper.transferFrom(alice, bob, shares);
+    }
+
+    function test_Transfer_ReEnabledWhenGatesDisabled() public {
+        wrapper = _mappingAllowWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+
+        vm.prank(vaultAdmin);
+        wrapper.setListBackend(ListGate.Allow, ListBackend.Disabled);
+
+        assertTrue(wrapper.sharesTransferable());
+
+        vm.prank(alice);
+        wrapper.transfer(bob, shares);
+
+        assertEq(wrapper.balanceOf(bob), shares);
+    }
+
+    function test_Transfer_OracleOnlyScreensRecipient() public {
+        wrapper = _oracleWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+        oracle.setSanctioned(bob, true);
+
+        // Oracle alone does not freeze transfers...
+        assertTrue(wrapper.sharesTransferable());
+
+        vm.prank(alice);
+        wrapper.transfer(carol, shares / 2);
+
+        assertEq(wrapper.balanceOf(carol), shares / 2);
+
+        // ...but a sanctioned recipient cannot acquire shares.
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.AccountSanctioned.selector,
+                bob
+            )
+        );
+
+        wrapper.transfer(bob, shares / 2);
+    }
+
+    function test_Transfer_SanctionedSenderMayStillTransferOut() public {
+        wrapper = _oracleWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+        oracle.setSanctioned(alice, true);
+
+        // The oracle screens recipients, not senders: freezing a holder's assets is a
+        // custodial posture the wrapper deliberately avoids.
+        vm.prank(alice);
+        wrapper.transfer(carol, shares);
+
+        assertEq(wrapper.balanceOf(carol), shares);
+    }
+
+    function test_Transfer_FeeSweepFromWrapperExemptWhileGateActive() public {
+        AccessConfig memory config = _cfg();
+        config.allowBackend = ListBackend.Mapping;
+        FeeConfig memory fees = _noFees();
+        fees.rateBps[uint8(FeeType.Management)] = 200;
+        fees.enabled[uint8(FeeType.Management)] = true;
+        wrapper = _newWrapperWithFees(config, fees);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = alice;
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, accounts, true);
+
+        _deposit(wrapper, alice, DEPOSIT, alice);
+        vm.warp(block.timestamp + 30 days);
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        uint256 feeShares = wrapper.balanceOf(address(wrapper));
+        assertGt(feeShares, 0);
+
+        // Payouts from the wrapper's own fee-share balance stay possible while the
+        // perimeter is active (S3's sweep path), even to a receiver off the list.
+        vm.prank(address(wrapper));
+        wrapper.transfer(carol, feeShares);
+
+        assertEq(wrapper.balanceOf(carol), feeShares);
+    }
+
+    /// Withdrawals are never gated ///
+
+    function test_Withdraw_OpenAfterRemovalFromAllowlist() public {
+        wrapper = _mappingAllowWrapper();
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = alice;
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Allow, accounts, false);
+
+        uint256 maxAssets = wrapper.maxWithdraw(alice);
+        vm.prank(alice);
+        wrapper.withdraw(maxAssets, alice, alice);
+
+        assertEq(wrapper.balanceOf(alice), 0);
+        assertEq(asset.balanceOf(alice), maxAssets);
+    }
+
+    function test_Redeem_OpenForSanctionedHolderAndForeignReceiver() public {
+        wrapper = _oracleWrapper();
+        uint256 shares = _deposit(wrapper, alice, DEPOSIT, alice);
+        oracle.setSanctioned(alice, true);
+
+        // Exit stays structurally open for a holder sanctioned after entry, and the
+        // asset receiver is not access-checked either (assets, not shares, leave).
+        vm.prank(alice);
+        wrapper.redeem(shares, bob, alice);
+
+        assertEq(wrapper.balanceOf(alice), 0);
+        assertGt(asset.balanceOf(bob), 0);
+    }
+
+    function test_Withdraw_OpenWhileDenyGateListsHolder() public {
+        wrapper = _mappingDenyWrapper();
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        address[] memory accounts = new address[](1);
+        accounts[0] = alice;
+        vm.prank(vaultAdmin);
+        wrapper.updateList(ListGate.Deny, accounts, true);
+
+        uint256 maxAssets = wrapper.maxWithdraw(alice);
+        vm.prank(alice);
+        wrapper.withdraw(maxAssets, alice, alice);
+
+        assertEq(wrapper.balanceOf(alice), 0);
+    }
+
+    /// Backend toggles ///
+
+    function test_SetListBackend_TogglesGateOnAndOff() public {
+        wrapper = _newWrapper(_cfg());
+
+        // Open instance: anyone deposits.
+        _deposit(wrapper, bob, DEPOSIT, bob);
+
+        vm.expectEmit(true, false, false, true, address(wrapper));
+        emit ListBackendSet(ListGate.Allow, ListBackend.Mapping);
+
+        vm.prank(vaultAdmin);
+        wrapper.setListBackend(ListGate.Allow, ListBackend.Mapping);
+
+        // Gate on (empty list): closed until seeded.
+        _expectDepositRevert(
+            wrapper,
+            bob,
+            bob,
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+
+        vm.prank(vaultAdmin);
+        wrapper.setListBackend(ListGate.Allow, ListBackend.Disabled);
+
+        _deposit(wrapper, bob, DEPOSIT, bob);
+        assertGt(wrapper.balanceOf(bob), 0);
+    }
+
+    function testRevert_SetListBackend_RejectsMerkleDenyGate() public {
+        wrapper = _newWrapper(_cfg());
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        wrapper.setListBackend(ListGate.Deny, ListBackend.Merkle);
+    }
+
+    function testRevert_SetListBackend_RejectsExternalWithoutAdapter() public {
+        wrapper = _newWrapper(_cfg());
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        wrapper.setListBackend(ListGate.Allow, ListBackend.External);
+    }
+
+    function test_SetListBackend_ExternalAfterAdapterConfigured() public {
+        wrapper = _newWrapper(_cfg());
+
+        vm.startPrank(vaultAdmin);
+        wrapper.setExternalAdapter(address(accessAdapter));
+        wrapper.setListBackend(ListGate.Allow, ListBackend.External);
+        vm.stopPrank();
+
+        accessAdapter.setAllowed(alice, true);
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+
+    function testRevert_SetListBackend_RejectsMerkleWithoutRoot() public {
+        wrapper = _newWrapper(_cfg());
+
+        vm.prank(vaultAdmin);
+        vm.expectRevert(
+            VaultWrapperAccessControl.InvalidAccessConfig.selector
+        );
+
+        wrapper.setListBackend(ListGate.Allow, ListBackend.Merkle);
+    }
+
+    function testRevert_SetListBackend_OnlyOwner() public {
+        wrapper = _newWrapper(_cfg());
+
+        vm.prank(stranger);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
+                stranger
+            )
+        );
+
+        wrapper.setListBackend(ListGate.Allow, ListBackend.Mapping);
+    }
+
+    /// View mirror ///
+
+    function test_CheckDepositAccess_MirrorsExecution() public {
+        wrapper = _mappingAllowWrapper();
+
+        // Passes silently for a listed receiver.
+        wrapper.checkDepositAccess(alice);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                VaultWrapperAccessControl.ReceiverNotAllowed.selector,
+                bob
+            )
+        );
+
+        wrapper.checkDepositAccess(bob);
+    }
+
+    /// EIP-4626 limit views ///
+
+    function test_MaxDepositAndMint_ZeroForGatedReceiver() public {
+        wrapper = _mappingAllowWrapper();
+
+        // Listed receiver sees the open limit, gated receiver sees 0 (EIP-4626: limits
+        // MUST factor in user-specific restrictions), and the view does not revert.
+        assertGt(wrapper.maxDeposit(alice), 0);
+        assertGt(wrapper.maxMint(alice), 0);
+        assertEq(wrapper.maxDeposit(bob), 0);
+        assertEq(wrapper.maxMint(bob), 0);
+    }
+
+    function test_MaxDeposit_ZeroOnBrokenOracleWithoutReverting() public {
+        RevertingSanctionsOracle broken = new RevertingSanctionsOracle();
+        AccessConfig memory config = _cfg();
+        config.sanctionsOracle = address(broken);
+        wrapper = _newWrapper(config);
+
+        // The execution path fails closed by reverting; the limit view fails closed
+        // by reporting 0 — EIP-4626 forbids maxDeposit/maxMint from reverting.
+        assertEq(wrapper.maxDeposit(alice), 0);
+        assertEq(wrapper.maxMint(alice), 0);
+    }
+
+    /// Gated underlying (perimeter of the wrapped vault) ///
+
+    function test_GatedUnderlying_RevertsBubbleUpVerbatim() public {
+        MockGatedERC4626 gated = new MockGatedERC4626(asset);
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(gated),
+                address(yieldAdapter),
+                vaultAdmin,
+                [uint16(8000), 8000, 8000, 8000],
+                _noFees(),
+                ""
+            )
+        );
+        wrapper = LiFiVaultWrapper(
+            address(new BeaconProxy(address(beacon), initCall))
+        );
+
+        // The underlying's own access control rejects the non-onboarded wrapper loudly
+        // (no silent bypass of the wrapped vault's perimeter)...
+        _expectDepositRevert(
+            wrapper,
+            alice,
+            alice,
+            abi.encodeWithSelector(
+                MockGatedERC4626.DepositorNotWhitelisted.selector,
+                address(wrapper)
+            )
+        );
+
+        // ...and deposits work once the underlying's operator onboards the wrapper.
+        gated.setWhitelisted(address(wrapper), true);
+        _deposit(wrapper, alice, DEPOSIT, alice);
+
+        assertGt(wrapper.balanceOf(alice), 0);
+    }
+}

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -9,7 +9,7 @@ import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { Errors } from "@openzeppelin/contracts/utils/Errors.sol";
-import { FeeType, DeployParams, FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { FeeType, DeployParams, FeeConfig, AccessConfig, ListBackend } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { UnAuthorized, InvalidContract } from "lifi/Errors/GenericErrors.sol";
 import { MockERC4626Underlying } from "./mocks/MockERC4626Underlying.sol";
 import { MockZeroAdapter } from "./mocks/MockZeroAdapter.sol";
@@ -27,6 +27,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     address internal deployer = makeAddr("deployer");
     address internal vaultAdmin = makeAddr("vaultAdmin");
     bytes32 internal constant NS = bytes32("Coinbase");
+    address internal constant SANCTIONS_ORACLE = address(0x5AFE);
     MockERC4626Underlying internal underlying;
     address internal assetToken = makeAddr("asset");
 
@@ -327,7 +328,17 @@ contract LiFiVaultWrapperFactoryTest is Test {
             nonce: nonce_,
             fees: FeeConfig({ rateBps: rates, enabled: enabled }),
             integratorShareBps: _splitsAll(type(uint16).max), // inherit factory default
-            initData: hex"1234"
+            // A non-default access config so the deploy→initialize forwarding is
+            // observable through the typed getter.
+            initData: abi.encode(
+                AccessConfig({
+                    allowBackend: ListBackend.Disabled,
+                    denyBackend: ListBackend.Disabled,
+                    externalAdapter: address(0),
+                    sanctionsOracle: SANCTIONS_ORACLE,
+                    allowMerkleRoot: bytes32(0)
+                })
+            )
         });
     }
 
@@ -364,7 +375,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         }
         assertEq(w.feeRate(uint8(FeeType.Performance)), 1000);
         assertTrue(w.feeEnabled(uint8(FeeType.Performance)));
-        assertEq(w.initData(), hex"1234");
+        assertEq(w.accessConfig().sanctionsOracle, SANCTIONS_ORACLE);
     }
 
     function test_WrapperDeployedEmitsAssetAndSplit() public {

--- a/test/solidity/VaultWrapper/mocks/MockGatedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockGatedERC4626.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+
+/// @notice ERC-4626 vault with its own depositor whitelist, standing in for an
+///         access-gated underlying: deposits from a non-whitelisted caller (e.g. a
+///         wrapper the vault's operator has not onboarded) revert with a vault-specific
+///         error the wrapper must bubble up verbatim.
+contract MockGatedERC4626 is MockERC4626 {
+    error DepositorNotWhitelisted(address depositor);
+
+    mapping(address => bool) public whitelisted;
+
+    constructor(ERC20 _asset) MockERC4626(_asset, "Gated Yield", "gyTKN") {}
+
+    function setWhitelisted(address _account, bool _whitelisted) external {
+        whitelisted[_account] = _whitelisted;
+    }
+
+    function deposit(
+        uint256 assets,
+        address receiver
+    ) public override returns (uint256) {
+        if (!whitelisted[msg.sender])
+            revert DepositorNotWhitelisted(msg.sender);
+
+        return super.deposit(assets, receiver);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockSanctionsOracle.sol
+++ b/test/solidity/VaultWrapper/mocks/MockSanctionsOracle.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { ISanctionsOracle } from "lifi/VaultWrapper/interfaces/ISanctionsOracle.sol";
+
+/// @notice Configurable Chainalysis-shaped sanctions oracle for the access-control suite.
+contract MockSanctionsOracle is ISanctionsOracle {
+    mapping(address => bool) public sanctioned;
+
+    function setSanctioned(address _account, bool _sanctioned) external {
+        sanctioned[_account] = _sanctioned;
+    }
+
+    function isSanctioned(address _account) external view returns (bool) {
+        return sanctioned[_account];
+    }
+}
+
+/// @notice Oracle that always reverts, used to assert the wrapper's fail-closed
+///         behavior on a broken sanctions source.
+contract RevertingSanctionsOracle is ISanctionsOracle {
+    error OracleBroken();
+
+    function isSanctioned(address) external pure returns (bool) {
+        revert OracleBroken();
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockVaultAccessControl.sol
+++ b/test/solidity/VaultWrapper/mocks/MockVaultAccessControl.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { IVaultAccessControl } from "lifi/VaultWrapper/interfaces/IVaultAccessControl.sol";
+
+/// @notice Configurable IVaultAccessControl adapter: both predicates are independent
+///         settable sets, so one instance can serve an allow gate, a deny gate, or both.
+contract MockVaultAccessControl is IVaultAccessControl {
+    mapping(address => bool) public allowed;
+    mapping(address => bool) public denied;
+
+    function setAllowed(address _account, bool _allowed) external {
+        allowed[_account] = _allowed;
+    }
+
+    function setDenied(address _account, bool _denied) external {
+        denied[_account] = _denied;
+    }
+
+    function isAllowed(address _account) external view returns (bool) {
+        return allowed[_account];
+    }
+
+    function isDenied(address _account) external view returns (bool) {
+        return denied[_account];
+    }
+}
+
+/// @notice Adapter whose predicates always revert, used to assert the wrapper's
+///         fail-closed behavior on a broken external backend.
+contract RevertingVaultAccessControl is IVaultAccessControl {
+    error AdapterBroken();
+
+    function isAllowed(address) external pure returns (bool) {
+        revert AdapterBroken();
+    }
+
+    function isDenied(address) external pure returns (bool) {
+        revert AdapterBroken();
+    }
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-412](https://linear.app/lifi-linear/issue/EXSC-412/s4-access-control-whitelistblacklistboth-oracle-hook) — S4, vault-wrapper access control (whitelist/blacklist/both, sanctions-oracle hook).

**Stacked PR.** Base is `feature/exsc-410-s2-fee-engine-4-types-accrual-caps-per-fee-split` (#1993, S2) — review the incremental diff; do not merge before S2 lands.

Note: the ticket lists S11 (EXSC-408 / #1981) as a dependency; per agreement the interfaces are defined here from scratch instead, and #1981 is superseded for the interface part (EXSC-408 remains for the integrator-facing reference adapter).

# Why did I implement it this way?

Fills the `_checkAccess` no-op seam S1 left behind, as an abstract module (`VaultWrapperAccessControl`) the wrapper inherits.

- **Two independent gates, per-gate backend.** Allow gate and deny gate each select `{Disabled, Mapping, Merkle, External}` — "whitelist", "blacklist", and "both" fall out of the combination, including mixed backends (e.g. Merkle allowlist + mapping denylist). One `IVaultAccessControl` adapter serves both External gates (`isAllowed`/`isDenied` are independent predicates). The deny gate can never be Merkle: that would require non-inclusion proofs, which plain Merkle trees cannot provide — the natural blacklist shapes are the mapping (ops adds addresses as discovered) or an external adapter.
- **Interface names.** The ticket says `IAccessControl`, but OZ v5 (which this subsystem vendors) exports a role-based `IAccessControl` that would clash on import — hence `IVaultAccessControl`. `ISanctionsOracle.isSanctioned(address)` matches Chainalysis' `SanctionsList` verbatim so a live oracle drops in without a shim; `address(0)` disables the hook.
- **Receiver-validated, dual-path safe.** All deposit-path checks validate the **share receiver**, never `msg.sender`, so direct ERC-4626 calls and Composer-proxied deposits are gated identically (I29/U5). Withdraw/redeem run no access check at all — withdrawals-always-open is structural (U20), including for holders who fall off the list or get sanctioned after entry.
- **Merkle via permissionless prove-and-cache.** `deposit(assets, receiver)` has no proof slot and U25 locks the standard ERC-4626 surface, so proofs are delivered out-of-band: `proveAllowed(account, proof)` verifies against the current root and caches `provenAllowed[root][account]`. Anyone can prove for any account (an integrator backend can pre-prove a Composer receiver). The cache is keyed by root, so a rotation (I7) invalidates every cached entry with zero iteration. OZ standard-tree double-hashed leaves, compatible with `@openzeppelin/merkle-tree` tooling.
- **Transfer ↔ access-mode coupling.** Any active gate makes shares non-transferable (`_update` hook, I9/U10); mints, burns, and transfers **from the wrapper itself** are exempt (fee-share accrual and S3's sweep keep working). With only the oracle active, shares stay transferable but the **recipient** is screened — otherwise a sanctioned address could acquire shares by secondary transfer and exit via the ungated withdrawal path. The sender is deliberately not screened (freezing a holder's outbound movement is a custodial posture the wrapper avoids, A24). This is a small extension over the story wording; stories are being updated.
- **Fail-closed, loudly.** Adapter/oracle calls have no try/catch on the execution path: a reverting backend blocks deposits (never exits) and surfaces its own error verbatim. The EIP-4626 limit views (`maxDeposit`/`maxMint`) must not revert, so they report 0 for a gated receiver via a non-reverting mirror (`isDepositAllowed`), consistent with how pause already reports 0.
- **Typed init config.** `initialize`'s `_initData` is now a decoded-once `AccessConfig` (empty bytes = fully open instance); the raw `bytes initData` storage var is deleted — persisting an already-decoded blob was pure waste, and the subsystem is pre-deployment so the layout change is free. Config invariants (External ⇒ adapter set, Merkle ⇒ root set, deny ≠ Merkle) are enforced at `initialize` and on every setter, and the initial config emits the same events the setters would (A20 indexers need no calldata decoding). No seed arrays in init — a mapping-backed instance is closed until the owner seeds it post-deploy.
- **Module storage & admin gating.** State lives in an ERC-7201 namespaced slot (same idiom as the OZ v5 modules already in the inheritance list), so the module adds no sequential slot. It deliberately does not inherit `OwnableUpgradeable` — the wrapper's `Ownable2Step` branch would diamond-clash on `transferOwnership` — so the wrapper supplies the owner check through the abstract `_requireAccessAdmin` seam (mutators revert `OwnableUnauthorizedAccount` as usual). Mutation authority is the per-vault `owner` only: the integrator brings their own authority model (EOA/multisig/timelock, I7) by holding that role.
- **Underlying-vault perimeter (ticket note).** There is no standard interface to enforce a third-party vault's own access list from our side. What this PR guarantees: if the underlying blocks the wrapper, the revert bubbles verbatim (test with a gated-4626 mock). The per-user question (wrapper aggregates users the underlying's KYB never sees) is an onboarding criterion for the factory's underlying allowlist (A5/A6, Q6.6 → S8 docs), with the External backend as the mitigation — an integrator wrapping a gated vault points their allow gate at the underlying's own list.

Tests: 54 new cases in `LiFiVaultWrapperAccess.t.sol` (mode matrix incl. none, receiver-vs-sender validation, transfer coupling incl. sweep exemption, oracle enable/disable, fail-closed backends, Merkle prove/rotate/invalidate, EIP-4626 limit views, gated-underlying bubbling) + factory forwarding test reworked to the typed config. Full suite: 1944 passed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
