### PR TITLE
chore(whitelist): allow Nexroute post-hook wrapper on BSC (EXSC-495)

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4870,6 +4870,12 @@
               "0xafeb849c": "swapExactInput(address,address,uint256,uint256,uint256,bytes[])",
               "0x72d76b4b": "swapExactInputETH(address,uint256,uint256,bytes[])"
             }
+          },
+          {
+            "address": "0xdc7a4c55e9573eaa9399124b92019ff68874044c",
+            "functions": {
+              "0xf8989325": ""
+            }
           }
         ]
       }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-495

# Why did I implement it this way?

Whitelists Nexroute's post-hook wrapper contract (`0xdc7a4c55e9573eaa9399124b92019ff68874044c`) on BSC so it can be called as a post-hook step in `swapData`.

The address is added as a second contract under the existing `Nexroute` DEX entry's `bsc` block rather than creating a new DEX, since it belongs to the same integration that already has a BSC presence.

The selector `0xf8989325` is listed with an empty value. The sync script (`script/tasks/diamondSyncWhitelist.sh`) builds the on-chain `(address, selector)` allowlist pairs from the **keys** of the `functions` map, so an empty value is sufficient — matching the empty-value form already used by many entries in this file. Keeping the selector key (rather than an empty `functions: {}`) keeps the grant granular; an empty map would fall back to the `0xffffffff` approve-to-only selector, which whitelists the contract for any call.

Config-only change; no contract or script logic modified.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
