### PR TITLE
fix(diamondSyncWhitelist): treat decimals()==0 as non-token (EXSC-365)

### DIFF
--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -91,16 +91,17 @@ function diamondSyncWhitelist {
   fi
 
   # Function to check if an address is a token contract
-  # tries to call decimals() function and returns true if a number value is returned
+  # tries to call decimals() and returns true only if a non-zero uint8 is returned
   function isTokenContract {
     local ADDRESS=$1
     local RPC_URL=$2
     local NETWORK=$3  # Add network parameter
     local RESULT
-    
+
     if RESULT=$(universalCast "call" "$NETWORK" "$ADDRESS" "decimals() returns (uint8)" 2>/dev/null); then
-      # Validate 0-255 strictly
-      if [[ "$RESULT" =~ ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ ]]; then
+      # Accept 1-255 only. A returned 0 means the address has no real decimals()
+      # and is answering via a catch-all fallback that returns zeros, not a token.
+      if [[ "$RESULT" =~ ^([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ ]]; then
         return 0
       fi
     fi

--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -91,18 +91,33 @@ function diamondSyncWhitelist {
   fi
 
   # Function to check if an address is a token contract
-  # tries to call decimals() and returns true only if a non-zero uint8 is returned
+  # tries to call decimals() and returns true if a uint8 value is returned.
+  # A returned 0 is ambiguous: genuine 0-decimal tokens return it, but so do
+  # contracts whose catch-all fallback answers every selector with 32 zero bytes.
+  # Disambiguate via symbol(): a real token returns a non-empty string, while a
+  # zero-returning fallback decodes to an empty one.
   function isTokenContract {
     local ADDRESS=$1
     local RPC_URL=$2
     local NETWORK=$3  # Add network parameter
     local RESULT
+    local SYMBOL
 
     if RESULT=$(universalCast "call" "$NETWORK" "$ADDRESS" "decimals() returns (uint8)" 2>/dev/null); then
-      # Accept 1-255 only. A returned 0 means the address has no real decimals()
-      # and is answering via a catch-all fallback that returns zeros, not a token.
+      # Validate 1-255 strictly
       if [[ "$RESULT" =~ ^([1-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$ ]]; then
         return 0
+      fi
+      if [[ "$RESULT" == "0" ]]; then
+        if SYMBOL=$(universalCast "call" "$NETWORK" "$ADDRESS" "symbol() returns (string)" 2>/dev/null); then
+          # cast wraps decoded strings in literal quotes ("USDT"; "" when empty),
+          # troncast strips them entirely - remove surrounding quotes before testing
+          SYMBOL="${SYMBOL%\"}"
+          SYMBOL="${SYMBOL#\"}"
+          if [[ -n "${SYMBOL// /}" ]]; then
+            return 0
+          fi
+        fi
       fi
     fi
     return 1


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-365](https://linear.app/lifi-linear/issue/EXSC-365/improve-istokencontract-detection-for-fallback-contracts)

# Why did I implement it this way?

`isTokenContract` in `diamondSyncWhitelist.sh` classified any address as a token when `decimals()` did **not** revert. Contracts with a catch-all fallback that returns 32 zero bytes for unknown selectors decode `decimals()` as `0`, so they were misclassified as tokens and the whitelist sync aborted.

This surfaced while rolling out the Nexroute post-hook wrapper on BSC (`0xdc7A4C55E9573eAA9399124b92019fF68874044C`, whitelisting selector `0xf8989325` = `backrun(bytes)`). The address has no real `decimals()` — its fallback answers every selector (`0xdeadbeef`, `0x12345678`, …) with `0` — and `name()`/`symbol()`/`totalSupply()` are all empty/zero, so it is not a token.

The fix keeps the `decimals()` heuristic for 1–255 (normal tokens classified exactly as before) and treats a returned `0` as ambiguous: it then probes `symbol() returns (string)`. A genuine 0-decimal token returns a non-empty symbol and is still classified as a token; a catch-all fallback decodes `symbol()` to an empty string and is rejected. This addresses the review feedback that the initial reject-all-zeros version introduced a false negative for genuine 0-decimal tokens.

Implementation notes:

- The `symbol()` probe runs **only** when `decimals() == 0`, not for every address — requiring a `string`-decodable `symbol()` unconditionally would misclassify tokens whose `symbol()` returns `bytes32` (MKR-style) even though their `decimals()` is normal.
- `cast` prints decoded strings wrapped in literal quotes (`"USDT"`, and `""` when empty) while `troncast` strips quotes entirely, so surrounding quotes are removed before the emptiness check.
- Verified with a 10-case mocked matrix (cast/troncast formats, reverts, whitespace-only symbols, out-of-range decimals) and live on BSC: USDT → token, the Nexroute wrapper → not a token, PancakeRouter → not a token.

Note: `/pr-ready` (local CodeRabbit CLI) was **not** run to completion. The first attempt wedged on "Preparing review" for 30+ minutes (service-side issue); the re-run after the symbol() probe commit hit the plan's review rate limit and the local gate was then skipped on explicit dev instruction. Cloud CodeRabbit runs on this PR as the safety net.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
