### PR TITLE
feat(PolymerCCTPFacet): pin HyperCore forwarder and validate hook receiver (EXSC-169) [PolymerCCTPFacet v3.0.0]

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -2108,7 +2108,7 @@
         }
       ]
     },
-    "startBridgeTokensViaPolymerCCTP((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (uint256 polymerTokenFee, uint256 maxCCTPFee, bytes32 nonEVMReceiver, bytes32 solanaReceiverATA, uint32 minFinalityThreshold, bytes32 destinationCaller, bytes hookData) _polymerData)": {
+    "startBridgeTokensViaPolymerCCTP((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (uint256 polymerTokenFee, uint256 maxCCTPFee, bytes32 nonEVMReceiver, bytes32 solanaReceiverATA, uint32 minFinalityThreshold, bytes hookData) _polymerData)": {
       "intent": "Bridge via PolymerCCTP",
       "interpolatedIntent": "Bridge {_bridgeData.minAmount} via PolymerCCTP to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
       "fields": [
@@ -5524,7 +5524,7 @@
         }
       ]
     },
-    "swapAndStartBridgeTokensViaPolymerCCTP((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData, (uint256 polymerTokenFee, uint256 maxCCTPFee, bytes32 nonEVMReceiver, bytes32 solanaReceiverATA, uint32 minFinalityThreshold, bytes32 destinationCaller, bytes hookData) _polymerData)": {
+    "swapAndStartBridgeTokensViaPolymerCCTP((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData, (uint256 polymerTokenFee, uint256 maxCCTPFee, bytes32 nonEVMReceiver, bytes32 solanaReceiverATA, uint32 minFinalityThreshold, bytes hookData) _polymerData)": {
       "intent": "Swap & Bridge via PolymerCCTP",
       "interpolatedIntent": "Swap then bridge {_bridgeData.minAmount} via PolymerCCTP to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
       "fields": [

--- a/docs/PolymerCCTPFacet.md
+++ b/docs/PolymerCCTPFacet.md
@@ -24,8 +24,12 @@ The facet enforces this flow on-chain via `depositForBurnWithHook`:
 
 ### Trust assumptions
 
-- The facet does not validate the remaining hook bytes (magic header, version, length, dex flag). A malformed hook cannot redirect funds (the recipient offset is validated), but it may fail on the forwarder; recovery in that case depends on Circle's forwarder implementation.
-- The forwarder is assumed to be single-purpose and stable: it always decodes `hookData[32:52]` as the deposit recipient. If Circle replaced or upgraded the forwarder's decoding under the same address, the on-chain receiver guarantee would no longer hold.
+Verified against the forwarder's published source ([`circlefin/hyperevm-circle-contracts`](https://github.com/circlefin/hyperevm-circle-contracts), `src/CctpForwarder.sol` + `src/messages/CctpForwarderHookData.sol`):
+
+- The forwarder requires `mintRecipient == address(this)` and decodes the deposit recipient from `hookData[32:52]` — exactly the field the facet validates against `BridgeData.receiver`, so the on-chain receiver guarantee binds to the bytes the forwarder actually uses. Its relay entrypoint (`mintAndForward`) is permissionless, but `destinationCaller` pinning means the mint can only ever happen through it, atomically with the forward.
+- The magic header (`hookData[0:24]`) and length field are ignored by the forwarder on-chain (they signal Circle's off-chain auto-relay service), which is why the facet does not validate them. The forwarder does require hook version `0` and length ≥ 52; a hook violating either makes `mintAndForward` revert, leaving the transfer burned-but-unmintable (hook bytes are part of the attested message and cannot be replayed with different content). The facet's length guard covers the ≥ 52 bound; version correctness is on the calldata source (LI.FI API).
+- `hookData[52:56]` (`destinationId`) selects the HyperCore balance: `0` = perp margin, `0xFFFFFFFF` = spot. It defaults to `0` (perp) if truncated. The facet intentionally does not validate it.
+- The forwarder at `0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757` **is** an EIP-1967 upgradeable proxy administered by Circle, and its owner can unset the per-token forwarding address (which would make relays revert until restored). The receiver guarantee therefore ultimately rests on Circle not changing the decode semantics under the same address.
 - `hasDestinationCall` remains `false` for HyperCore transfers: the hook is Circle/Polymer forwarding infrastructure with a validated recipient, not a user-defined destination call.
 
 ## Public Methods

--- a/docs/PolymerCCTPFacet.md
+++ b/docs/PolymerCCTPFacet.md
@@ -12,6 +12,22 @@ graph LR;
     PolymerCCTPFacet -- CALL --> TM(TokenMessenger)
 ```
 
+## HyperCore deposits
+
+HyperCore (Hyperliquid, LI.FI chain ID `1337`) has no CCTP domain of its own: the USDC burn targets HyperEVM's domain (`19`) and the deposit into HyperCore is performed by [Circle's `CctpForwarder` contract on HyperEVM](https://developers.circle.com/cctp/concepts/forwarding-service). Circle requires that both `mintRecipient` and `destinationCaller` are set to the forwarder; the actual HyperCore recipient is encoded in the `hookData` appended to the burn message (bytes `[32:52]`), together with a destination flag (`0` = perp margin balance, `0xFFFFFFFF` = spot balance).
+
+The facet enforces this flow on-chain via `depositForBurnWithHook`:
+
+- `hookData` is accepted **iff** `destinationChainId == 1337` (hooks toward any other destination revert with `InvalidCallData`, and a hookless transfer to `1337` reverts as well since the USDC would mint on HyperEVM and never reach HyperCore).
+- `mintRecipient` and `destinationCaller` are always set to the hardcoded `HYPERCORE_CCTP_FORWARDER` constant — never to caller-supplied values. Rotating the forwarder requires a facet upgrade.
+- The recipient encoded in `hookData[32:52]` must equal `BridgeData.receiver` (revert `InvalidReceiver` otherwise), so the emitted `LiFiTransferStarted.receiver` is always the real end user and calldata cannot redirect funds to a recipient other than the declared one.
+
+### Trust assumptions
+
+- The facet does not validate the remaining hook bytes (magic header, version, length, dex flag). A malformed hook cannot redirect funds (the recipient offset is validated), but it may fail on the forwarder; recovery in that case depends on Circle's forwarder implementation.
+- The forwarder is assumed to be single-purpose and stable: it always decodes `hookData[32:52]` as the deposit recipient. If Circle replaced or upgraded the forwarder's decoding under the same address, the on-chain receiver guarantee would no longer hold.
+- `hasDestinationCall` remains `false` for HyperCore transfers: the hook is Circle/Polymer forwarding infrastructure with a validated recipient, not a user-defined destination call.
+
 ## Public Methods
 
 - `function startBridgeTokensViaPolymerCCTP(BridgeData memory _bridgeData, PolymerCCTPData calldata _polymerData)`
@@ -48,9 +64,14 @@ struct PolymerCCTPData {
   uint256 maxCCTPFee;
   // Should only be nonzero if submitting to a nonEVM chain
   bytes32 nonEVMReceiver;
+  // For Solana: the receiver's Associated Token Account (ATA) for USDC
+  bytes32 solanaReceiverATA;
   // the minimum finality at which a burn message will be attested to, will be passed directly to tokenMessenger.depositForBurn method.
   // 1000 = fast path, 2000 = standard path
   uint32 minFinalityThreshold;
+  // CctpForwarder hook data for HyperCore deposits; must encode bridgeData.receiver at
+  // bytes [32:52]. Required iff destinationChainId == LIFI_CHAIN_ID_HYPERCORE.
+  bytes hookData;
 }
 ```
 

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -289,7 +289,8 @@ contract PolymerCCTPFacet is
             // pinned forwarder. Add new corridors (e.g. Stellar) as additional arms.
             if (
                 _bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE &&
-                _bridgeData.receiver != NON_EVM_ADDRESS
+                _bridgeData.receiver != NON_EVM_ADDRESS &&
+                _polymerData.hookData.length >= HOOK_RECIPIENT_OFFSET_END
             ) {
                 // The forwarder credits the account encoded in the hook data, so it
                 // must equal the declared receiver or events would misreport the

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -37,8 +37,9 @@ contract PolymerCCTPFacet is
     /// @notice Circle's CctpForwarder on HyperEVM. HyperCore hook flows mint to this contract,
     ///         which alone may execute the message and deposits the USDC into HyperCore for the
     ///         receiver encoded in the hook data (see _startBridge).
+    ///         https://developers.circle.com/cctp/references/hypercore-contract-addresses
     address internal constant HYPERCORE_CCTP_FORWARDER =
-        0x9765885053Da4835e98546139017EEee41712815;
+        0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757;
 
     /// @dev Byte offsets of the recipient address within CctpForwarder hook data
     ///      (24 bytes magic + 4 bytes version + 4 bytes payload length, then the recipient)

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -34,12 +34,13 @@ contract PolymerCCTPFacet is
     /// @notice bytes32(0) allows any address to complete the CCTP transfer on destination chain
     bytes32 private constant UNRESTRICTED_DESTINATION_CALLER = bytes32(0);
 
-    /// @notice Circle's CctpForwarder on HyperEVM. HyperCore hook flows mint to this contract,
-    ///         which alone may execute the message and deposits the USDC into HyperCore for the
-    ///         receiver encoded in the hook data (see _startBridge).
+    /// @notice Circle's CctpForwarder on HyperEVM (0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757),
+    ///         pre-encoded as the bytes32 mintRecipient/destinationCaller. HyperCore hook flows
+    ///         mint to this contract, which alone may execute the message and deposits the USDC
+    ///         into HyperCore for the receiver encoded in the hook data (see _startBridge).
     ///         https://developers.circle.com/cctp/references/hypercore-contract-addresses
-    address internal constant HYPERCORE_CCTP_FORWARDER =
-        0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757;
+    bytes32 internal constant HYPERCORE_CCTP_FORWARDER =
+        bytes32(uint256(uint160(0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757)));
 
     bytes32 internal constant NAMESPACE =
         keccak256("com.lifi.facets.polymercctp");
@@ -334,16 +335,12 @@ contract PolymerCCTPFacet is
                 // Mint to the pinned forwarder (never to the receiver directly) and
                 // restrict execution to it; the forwarder then deposits into
                 // HyperCore for the receiver validated above
-                bytes32 forwarder = bytes32(
-                    uint256(uint160(HYPERCORE_CCTP_FORWARDER))
-                );
-
                 TOKEN_MESSENGER.depositForBurnWithHook(
                     bridgeAmount,
                     domainId,
-                    forwarder,
+                    HYPERCORE_CCTP_FORWARDER,
                     USDC,
-                    forwarder,
+                    HYPERCORE_CCTP_FORWARDER,
                     _polymerData.maxCCTPFee,
                     _polymerData.minFinalityThreshold,
                     _polymerData.hookData

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -278,32 +278,31 @@ contract PolymerCCTPFacet is
         ILiFi.BridgeData memory _bridgeData,
         PolymerCCTPData calldata _polymerData
     ) internal {
-        bool isHookFlow = _polymerData.hookData.length > 0;
-
-        if (isHookFlow) {
-            // Corridor dispatch: hooks are only supported toward destinations with a
-            // pinned forwarder. Add new corridors (e.g. Stellar) as additional arms.
+        // Corridor dispatch: HyperCore requires a forwarder hook; hooks toward any
+        // other destination are unsupported. Add new corridors (e.g. Stellar) as
+        // additional arms.
+        if (_bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE) {
+            // Without a valid hook the USDC would mint on HyperEVM and never
+            // reach HyperCore
             if (
-                _bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE &&
-                _bridgeData.receiver != NON_EVM_ADDRESS &&
-                _polymerData.hookData.length >= 52
+                _bridgeData.receiver == NON_EVM_ADDRESS ||
+                _polymerData.hookData.length < 52
             ) {
-                // CctpForwarder hook layout: magic (24 bytes) + version (4) +
-                // payload length (4), then the recipient address at [32:52].
-                // The forwarder credits the account encoded there, so it must
-                // equal the declared receiver or events would misreport the
-                // beneficiary and calldata could redirect funds unnoticed.
-                if (
-                    address(bytes20(_polymerData.hookData[32:52])) !=
-                    _bridgeData.receiver
-                ) {
-                    revert InvalidReceiver();
-                }
-            } else {
                 revert InvalidCallData();
             }
-        } else if (_bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE) {
-            // Without a hook the USDC would mint on HyperEVM and never reach HyperCore
+
+            // CctpForwarder hook layout: magic (24 bytes) + version (4) +
+            // payload length (4), then the recipient address at [32:52].
+            // The forwarder credits the account encoded there, so it must
+            // equal the declared receiver or events would misreport the
+            // beneficiary and calldata could redirect funds unnoticed.
+            if (
+                address(bytes20(_polymerData.hookData[32:52])) !=
+                _bridgeData.receiver
+            ) {
+                revert InvalidReceiver();
+            }
+        } else if (_polymerData.hookData.length > 0) {
             revert InvalidCallData();
         }
 
@@ -331,7 +330,7 @@ contract PolymerCCTPFacet is
                 revert InvalidReceiver();
             }
 
-            if (isHookFlow) {
+            if (destinationChainId == LIFI_CHAIN_ID_HYPERCORE) {
                 // Mint to the pinned forwarder (never to the receiver directly) and
                 // restrict execution to it; the forwarder then deposits into
                 // HyperCore for the receiver validated above

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -11,11 +11,18 @@ import { LibSwap } from "../Libraries/LibSwap.sol";
 import { ReentrancyGuard } from "../Helpers/ReentrancyGuard.sol";
 import { SwapperV2 } from "../Helpers/SwapperV2.sol";
 import { Validatable } from "../Helpers/Validatable.sol";
-import { CannotBridgeToSameNetwork, InvalidAmount, InvalidConfig, InvalidReceiver, NotInitialized, UnsupportedChainId } from "../Errors/GenericErrors.sol";
+import { CannotBridgeToSameNetwork, InvalidAmount, InvalidCallData, InvalidConfig, InvalidReceiver, NotInitialized, UnsupportedChainId } from "../Errors/GenericErrors.sol";
 
 /// @title PolymerCCTPFacet
 /// @author LI.FI (https://li.fi)
 /// @notice Provides functionality for bridging USDC through Polymer CCTP
+/// @dev HyperCore deposits (BridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE) burn USDC
+///      toward the HyperEVM CCTP domain with hook data that Circle's CctpForwarder on HyperEVM
+///      uses to deposit into HyperCore. For these flows the facet mints to the pinned forwarder
+///      (mintRecipient == destinationCaller == HYPERCORE_CCTP_FORWARDER) and validates that the
+///      receiver encoded in hookData[32:52] equals BridgeData.receiver, so emitted events always
+///      carry the real end user. Hooks toward any other destination are rejected. Rotating the
+///      forwarder requires a facet upgrade.
 /// @custom:version 3.0.0
 contract PolymerCCTPFacet is
     ILiFi,
@@ -26,6 +33,17 @@ contract PolymerCCTPFacet is
 {
     /// @notice bytes32(0) allows any address to complete the CCTP transfer on destination chain
     bytes32 private constant UNRESTRICTED_DESTINATION_CALLER = bytes32(0);
+
+    /// @notice Circle's CctpForwarder on HyperEVM. HyperCore hook flows mint to this contract,
+    ///         which alone may execute the message and deposits the USDC into HyperCore for the
+    ///         receiver encoded in the hook data (see _startBridge).
+    address internal constant HYPERCORE_CCTP_FORWARDER =
+        0x9765885053Da4835e98546139017EEee41712815;
+
+    /// @dev Byte offsets of the recipient address within CctpForwarder hook data
+    ///      (24 bytes magic + 4 bytes version + 4 bytes payload length, then the recipient)
+    uint256 private constant HOOK_RECIPIENT_OFFSET_START = 32;
+    uint256 private constant HOOK_RECIPIENT_OFFSET_END = 52;
 
     bytes32 internal constant NAMESPACE =
         keccak256("com.lifi.facets.polymercctp");
@@ -49,9 +67,8 @@ contract PolymerCCTPFacet is
         // the minimum finality at which a burn message will be attested to, will be passed directly to tokenMessenger.depositForBurn method.
         // 1000 = fast path, 2000 = standard path
         uint32 minFinalityThreshold;
-        // Restricted caller on the destination domain for hook flows (e.g. HyperCore forwarding); only the forwarder contract may execute.
-        bytes32 destinationCaller;
-        // Hook data appended to the burn message for execution on the destination domain. When non-empty, depositForBurnWithHook is used instead of depositForBurn.
+        // CctpForwarder hook data for HyperCore deposits; must encode bridgeData.receiver at
+        // bytes [32:52]. Required iff destinationChainId == LIFI_CHAIN_ID_HYPERCORE.
         bytes hookData;
     }
 
@@ -265,14 +282,34 @@ contract PolymerCCTPFacet is
         ILiFi.BridgeData memory _bridgeData,
         PolymerCCTPData calldata _polymerData
     ) internal {
-        // When a hook is supplied, destinationCaller must restrict execution to a
-        // specific forwarder on the destination domain; otherwise anyone could
-        // execute the hook (see PolymerCCTPData.destinationCaller docs).
-        if (
-            _polymerData.hookData.length > 0 &&
-            _polymerData.destinationCaller == bytes32(0)
-        ) {
-            revert InvalidConfig();
+        bool isHookFlow = _polymerData.hookData.length > 0;
+
+        if (isHookFlow) {
+            // Corridor dispatch: hooks are only supported toward destinations with a
+            // pinned forwarder. Add new corridors (e.g. Stellar) as additional arms.
+            if (
+                _bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE &&
+                _bridgeData.receiver != NON_EVM_ADDRESS
+            ) {
+                // The forwarder credits the account encoded in the hook data, so it
+                // must equal the declared receiver or events would misreport the
+                // beneficiary and calldata could redirect funds unnoticed.
+                if (
+                    address(
+                        bytes20(
+                            _polymerData
+                                .hookData[HOOK_RECIPIENT_OFFSET_START:HOOK_RECIPIENT_OFFSET_END]
+                        )
+                    ) != _bridgeData.receiver
+                ) {
+                    revert InvalidReceiver();
+                }
+            } else {
+                revert InvalidCallData();
+            }
+        } else if (_bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE) {
+            // Without a hook the USDC would mint on HyperEVM and never reach HyperCore
+            revert InvalidCallData();
         }
 
         LibAsset.transferERC20(
@@ -299,17 +336,20 @@ contract PolymerCCTPFacet is
                 revert InvalidReceiver();
             }
 
-            bytes32 mintRecipient = bytes32(
-                uint256(uint160(_bridgeData.receiver))
-            );
+            if (isHookFlow) {
+                // Mint to the pinned forwarder (never to the receiver directly) and
+                // restrict execution to it; the forwarder then deposits into
+                // HyperCore for the receiver validated above
+                bytes32 forwarder = bytes32(
+                    uint256(uint160(HYPERCORE_CCTP_FORWARDER))
+                );
 
-            if (_polymerData.hookData.length > 0) {
                 TOKEN_MESSENGER.depositForBurnWithHook(
                     bridgeAmount,
                     domainId,
-                    mintRecipient,
+                    forwarder,
                     USDC,
-                    _polymerData.destinationCaller,
+                    forwarder,
                     _polymerData.maxCCTPFee,
                     _polymerData.minFinalityThreshold,
                     _polymerData.hookData
@@ -318,7 +358,7 @@ contract PolymerCCTPFacet is
                 TOKEN_MESSENGER.depositForBurn(
                     bridgeAmount,
                     domainId,
-                    mintRecipient,
+                    bytes32(uint256(uint160(_bridgeData.receiver))),
                     USDC,
                     UNRESTRICTED_DESTINATION_CALLER,
                     _polymerData.maxCCTPFee, // maxFee - 0 means no fee limit
@@ -339,28 +379,15 @@ contract PolymerCCTPFacet is
                 revert InvalidReceiver();
             }
 
-            if (_polymerData.hookData.length > 0) {
-                TOKEN_MESSENGER.depositForBurnWithHook(
-                    bridgeAmount,
-                    domainId,
-                    mintRecipient,
-                    USDC,
-                    _polymerData.destinationCaller,
-                    _polymerData.maxCCTPFee,
-                    _polymerData.minFinalityThreshold,
-                    _polymerData.hookData
-                );
-            } else {
-                TOKEN_MESSENGER.depositForBurn(
-                    bridgeAmount,
-                    domainId,
-                    mintRecipient,
-                    USDC,
-                    UNRESTRICTED_DESTINATION_CALLER,
-                    _polymerData.maxCCTPFee, // maxFee - 0 means no fee limit
-                    _polymerData.minFinalityThreshold
-                );
-            }
+            TOKEN_MESSENGER.depositForBurn(
+                bridgeAmount,
+                domainId,
+                mintRecipient,
+                USDC,
+                UNRESTRICTED_DESTINATION_CALLER,
+                _polymerData.maxCCTPFee, // maxFee - 0 means no fee limit
+                _polymerData.minFinalityThreshold
+            );
 
             emit BridgeToNonEVMChainBytes32(
                 _bridgeData.transactionId,

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -41,11 +41,6 @@ contract PolymerCCTPFacet is
     address internal constant HYPERCORE_CCTP_FORWARDER =
         0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757;
 
-    /// @dev Byte offsets of the recipient address within CctpForwarder hook data
-    ///      (24 bytes magic + 4 bytes version + 4 bytes payload length, then the recipient)
-    uint256 private constant HOOK_RECIPIENT_OFFSET_START = 32;
-    uint256 private constant HOOK_RECIPIENT_OFFSET_END = 52;
-
     bytes32 internal constant NAMESPACE =
         keccak256("com.lifi.facets.polymercctp");
 
@@ -291,18 +286,16 @@ contract PolymerCCTPFacet is
             if (
                 _bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE &&
                 _bridgeData.receiver != NON_EVM_ADDRESS &&
-                _polymerData.hookData.length >= HOOK_RECIPIENT_OFFSET_END
+                _polymerData.hookData.length >= 52
             ) {
-                // The forwarder credits the account encoded in the hook data, so it
-                // must equal the declared receiver or events would misreport the
+                // CctpForwarder hook layout: magic (24 bytes) + version (4) +
+                // payload length (4), then the recipient address at [32:52].
+                // The forwarder credits the account encoded there, so it must
+                // equal the declared receiver or events would misreport the
                 // beneficiary and calldata could redirect funds unnoticed.
                 if (
-                    address(
-                        bytes20(
-                            _polymerData
-                                .hookData[HOOK_RECIPIENT_OFFSET_START:HOOK_RECIPIENT_OFFSET_END]
-                        )
-                    ) != _bridgeData.receiver
+                    address(bytes20(_polymerData.hookData[32:52])) !=
+                    _bridgeData.receiver
                 ) {
                     revert InvalidReceiver();
                 }

--- a/src/Interfaces/ITokenMessenger.sol
+++ b/src/Interfaces/ITokenMessenger.sol
@@ -19,8 +19,8 @@ pragma solidity ^0.8.17;
  */
 
 /// @title ITokenMessenger
-/// @notice Interface for Circle's TokenMessenger contract (CCTP)
-/// https://github.com/circlefin/evm-cctp-contracts/blob/4061786a5726bc05f99fcdb53b0985599f0dbaf7/src/TokenMessenger.sol
+/// @notice Interface for Circle's TokenMessengerV2 contract (CCTP v2)
+/// https://github.com/circlefin/evm-cctp-contracts/blob/master/src/v2/TokenMessengerV2.sol
 /// @author LI.FI (https://li.fi)
 /// @custom:version 1.1.0
 interface ITokenMessenger {

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -601,6 +601,59 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         vm.stopPrank();
     }
 
+    function testRevert_HyperCoreHookDataBelowMinLength() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        // 51 bytes: one below the minimum that contains a full recipient
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(new bytes(51));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function test_CanBridgeToHyperCoreWithMinimalHookData() public {
+        vm.startPrank(USER_SENDER);
+
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        // Exactly 52 bytes: header + recipient, no destinationId
+        bytes memory hookData = abi.encodePacked(
+            bytes24("cctp-forward"),
+            uint32(0),
+            uint32(20),
+            bridgeData.receiver
+        );
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(hookData);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit PolymerCCTPFeeSent(
+            bridgeData.minAmount,
+            polymerDataWithHook.polymerTokenFee,
+            polymerDataWithHook.minFinalityThreshold
+        );
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
     /// @dev CctpForwarder hook data: magic (24) + version (4) + payload length (4)
     ///      + recipient (20) + destination dex (4, 0xFFFFFFFF = spot balance)
     function _buildHyperCoreHookData(

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -7,7 +7,8 @@ import { ILiFi } from "lifi/Interfaces/ILiFi.sol";
 import { TestWhitelistManagerBase } from "../utils/TestWhitelistManagerBase.sol";
 import { LibSwap } from "lifi/Libraries/LibSwap.sol";
 import { LiFiDiamond } from "../utils/DiamondTest.sol";
-import { InvalidConfig, InvalidReceiver, InvalidSendingToken, NotInitialized, OnlyContractOwner, UnsupportedChainId } from "lifi/Errors/GenericErrors.sol";
+import { InvalidCallData, InvalidConfig, InvalidReceiver, InvalidSendingToken, NotInitialized, OnlyContractOwner, UnsupportedChainId } from "lifi/Errors/GenericErrors.sol";
+import { ITokenMessenger } from "lifi/Interfaces/ITokenMessenger.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // Stub PolymerCCTPFacet Contract
@@ -37,6 +38,10 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
     TestPolymerCCTPFacet internal polymerCCTPFacet;
     address internal constant TOKEN_MESSENGER_V2_MAINNET =
         0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+    // Must match PolymerCCTPFacet.HYPERCORE_CCTP_FORWARDER
+    address internal constant HYPERCORE_CCTP_FORWARDER =
+        0x9765885053Da4835e98546139017EEee41712815;
+    uint32 internal constant HYPEREVM_CCTP_DOMAIN = 19;
     address internal polymerFeeReceiver = address(0x123);
 
     PolymerCCTPFacet.PolymerCCTPData internal validPolymerData;
@@ -156,7 +161,6 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
             nonEVMReceiver: bytes32(0),
             solanaReceiverATA: bytes32(0),
             minFinalityThreshold: 1000, // Fast route (1000)
-            destinationCaller: bytes32(0),
             hookData: ""
         });
 
@@ -237,7 +241,6 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
                 nonEVMReceiver: validPolymerData.nonEVMReceiver,
                 solanaReceiverATA: validPolymerData.solanaReceiverATA,
                 minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: validPolymerData.destinationCaller,
                 hookData: validPolymerData.hookData
             });
 
@@ -276,7 +279,6 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
                 nonEVMReceiver: validPolymerData.nonEVMReceiver,
                 solanaReceiverATA: validPolymerData.solanaReceiverATA,
                 minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: validPolymerData.destinationCaller,
                 hookData: validPolymerData.hookData
             });
 
@@ -419,23 +421,39 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         vm.stopPrank();
     }
 
-    function test_CanBridgeWithHookData_EVMReceiver() public {
+    function test_CanBridgeToHyperCoreWithHookData() public {
         vm.startPrank(USER_SENDER);
 
-        bytes memory hookData = hex"01";
-        bytes32 destinationCaller = bytes32(uint256(1));
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
         PolymerCCTPFacet.PolymerCCTPData
-            memory polymerDataWithHook = PolymerCCTPFacet.PolymerCCTPData({
-                polymerTokenFee: validPolymerData.polymerTokenFee,
-                maxCCTPFee: validPolymerData.maxCCTPFee,
-                nonEVMReceiver: validPolymerData.nonEVMReceiver,
-                solanaReceiverATA: validPolymerData.solanaReceiverATA,
-                minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: destinationCaller,
-                hookData: hookData
-            });
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildHyperCoreHookData(bridgeData.receiver)
+            );
 
         usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        uint256 bridgeAmount = bridgeData.minAmount -
+            polymerDataWithHook.polymerTokenFee;
+        bytes32 forwarder = bytes32(
+            uint256(uint160(HYPERCORE_CCTP_FORWARDER))
+        );
+        vm.expectCall(
+            TOKEN_MESSENGER_V2_MAINNET,
+            abi.encodeCall(
+                ITokenMessenger.depositForBurnWithHook,
+                (
+                    bridgeAmount,
+                    HYPEREVM_CCTP_DOMAIN,
+                    forwarder,
+                    ADDRESS_USDC,
+                    forwarder,
+                    polymerDataWithHook.maxCCTPFee,
+                    polymerDataWithHook.minFinalityThreshold,
+                    polymerDataWithHook.hookData
+                )
+            )
+        );
 
         vm.expectEmit(true, true, true, true, _facetTestContractAddress);
         emit PolymerCCTPFeeSent(
@@ -445,9 +463,7 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         );
 
         ILiFi.BridgeData memory adjustedBridgeData = bridgeData;
-        adjustedBridgeData.minAmount =
-            bridgeData.minAmount -
-            polymerDataWithHook.polymerTokenFee;
+        adjustedBridgeData.minAmount = bridgeAmount;
         vm.expectEmit(true, true, true, true, _facetTestContractAddress);
         emit LiFiTransferStarted(adjustedBridgeData);
 
@@ -459,49 +475,18 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         vm.stopPrank();
     }
 
-    function test_CanBridgeToNonEVMChainWithHookData() public {
+    function testRevert_HookDataToNonHyperCoreDestination() public {
         vm.startPrank(USER_SENDER);
-
-        bridgeData.receiver = NON_EVM_ADDRESS;
-        bridgeData.destinationChainId = LIFI_CHAIN_ID_SOLANA;
-        bytes memory hookData = hex"01";
-        bytes32 destinationCaller = bytes32(uint256(1));
-        bytes32 nonEVMReceiver = bytes32(uint256(0x1234));
-        bytes32 solanaReceiverATA = bytes32(uint256(0x5678));
-
-        PolymerCCTPFacet.PolymerCCTPData
-            memory polymerDataWithHook = PolymerCCTPFacet.PolymerCCTPData({
-                polymerTokenFee: validPolymerData.polymerTokenFee,
-                maxCCTPFee: validPolymerData.maxCCTPFee,
-                nonEVMReceiver: nonEVMReceiver,
-                solanaReceiverATA: solanaReceiverATA,
-                minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: destinationCaller,
-                hookData: hookData
-            });
 
         usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
 
-        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
-        emit ILiFi.BridgeToNonEVMChainBytes32(
-            bridgeData.transactionId,
-            bridgeData.destinationChainId,
-            polymerDataWithHook.nonEVMReceiver
-        );
+        // destinationChainId stays Base (8453) from setUp
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildHyperCoreHookData(bridgeData.receiver)
+            );
 
-        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
-        emit PolymerCCTPFeeSent(
-            bridgeData.minAmount,
-            polymerDataWithHook.polymerTokenFee,
-            polymerDataWithHook.minFinalityThreshold
-        );
-
-        ILiFi.BridgeData memory adjustedBridgeData = bridgeData;
-        adjustedBridgeData.minAmount =
-            bridgeData.minAmount -
-            polymerDataWithHook.polymerTokenFee;
-        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
-        emit LiFiTransferStarted(adjustedBridgeData);
+        vm.expectRevert(InvalidCallData.selector);
 
         polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
             bridgeData,
@@ -511,59 +496,142 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         vm.stopPrank();
     }
 
-    function testRevert_HookDataWithZeroDestinationCaller_EVM() public {
+    function testRevert_HookDataToNonEVMDestination() public {
         vm.startPrank(USER_SENDER);
 
         usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
 
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_SOLANA;
+
         PolymerCCTPFacet.PolymerCCTPData
-            memory polymerDataWithHook = PolymerCCTPFacet.PolymerCCTPData({
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildHyperCoreHookData(USER_RECEIVER)
+            );
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0x1234));
+        polymerDataWithHook.solanaReceiverATA = bytes32(uint256(0x5678));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_HyperCoreWithNonEVMReceiver() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildHyperCoreHookData(USER_RECEIVER)
+            );
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0x1234));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_HyperCoreWithoutHookData() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            validPolymerData
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_HyperCoreHookReceiverMismatch() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildHyperCoreHookData(address(0xDEADBEEF))
+            );
+
+        vm.expectRevert(InvalidReceiver.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_HyperCoreHookDataTooShort() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_HYPERCORE;
+
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(hex"01");
+
+        // calldata slice bounds check reverts without data
+        vm.expectRevert();
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    /// @dev CctpForwarder hook data: magic (24) + version (4) + payload length (4)
+    ///      + recipient (20) + destination dex (4, 0xFFFFFFFF = spot balance)
+    function _buildHyperCoreHookData(
+        address recipient
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                bytes24("cctp-forward"),
+                uint32(0),
+                uint32(24),
+                recipient,
+                uint32(0xFFFFFFFF)
+            );
+    }
+
+    function _polymerDataWithHook(
+        bytes memory hookData
+    ) internal view returns (PolymerCCTPFacet.PolymerCCTPData memory) {
+        return
+            PolymerCCTPFacet.PolymerCCTPData({
                 polymerTokenFee: validPolymerData.polymerTokenFee,
                 maxCCTPFee: validPolymerData.maxCCTPFee,
                 nonEVMReceiver: validPolymerData.nonEVMReceiver,
                 solanaReceiverATA: validPolymerData.solanaReceiverATA,
                 minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: bytes32(0),
-                hookData: hex"01"
+                hookData: hookData
             });
-
-        vm.expectRevert(InvalidConfig.selector);
-
-        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
-            bridgeData,
-            polymerDataWithHook
-        );
-
-        vm.stopPrank();
-    }
-
-    function testRevert_HookDataWithZeroDestinationCaller_NonEVM() public {
-        vm.startPrank(USER_SENDER);
-
-        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
-
-        bridgeData.receiver = NON_EVM_ADDRESS;
-        bridgeData.destinationChainId = LIFI_CHAIN_ID_SOLANA;
-
-        PolymerCCTPFacet.PolymerCCTPData
-            memory polymerDataWithHook = PolymerCCTPFacet.PolymerCCTPData({
-                polymerTokenFee: validPolymerData.polymerTokenFee,
-                maxCCTPFee: validPolymerData.maxCCTPFee,
-                nonEVMReceiver: bytes32(uint256(0x1234)),
-                solanaReceiverATA: bytes32(uint256(0x5678)),
-                minFinalityThreshold: validPolymerData.minFinalityThreshold,
-                destinationCaller: bytes32(0),
-                hookData: hex"01"
-            });
-
-        vm.expectRevert(InvalidConfig.selector);
-
-        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
-            bridgeData,
-            polymerDataWithHook
-        );
-
-        vm.stopPrank();
     }
 
     function testRevert_NonEVMReceiverWithZeroBytes32() public {

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -40,7 +40,7 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
     // Must match PolymerCCTPFacet.HYPERCORE_CCTP_FORWARDER
     address internal constant HYPERCORE_CCTP_FORWARDER =
-        0x9765885053Da4835e98546139017EEee41712815;
+        0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757;
     uint32 internal constant HYPEREVM_CCTP_DOMAIN = 19;
     address internal polymerFeeReceiver = address(0x123);
 

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -594,8 +594,7 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         PolymerCCTPFacet.PolymerCCTPData
             memory polymerDataWithHook = _polymerDataWithHook(hex"01");
 
-        // calldata slice bounds check reverts without data
-        vm.expectRevert();
+        vm.expectRevert(InvalidCallData.selector);
 
         polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
             bridgeData,

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -39,8 +39,8 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
     address internal constant TOKEN_MESSENGER_V2_MAINNET =
         0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
     // Must match PolymerCCTPFacet.HYPERCORE_CCTP_FORWARDER
-    address internal constant HYPERCORE_CCTP_FORWARDER =
-        0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757;
+    bytes32 internal constant HYPERCORE_CCTP_FORWARDER =
+        bytes32(uint256(uint160(0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757)));
     uint32 internal constant HYPEREVM_CCTP_DOMAIN = 19;
     address internal polymerFeeReceiver = address(0x123);
 
@@ -435,9 +435,6 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
 
         uint256 bridgeAmount = bridgeData.minAmount -
             polymerDataWithHook.polymerTokenFee;
-        bytes32 forwarder = bytes32(
-            uint256(uint160(HYPERCORE_CCTP_FORWARDER))
-        );
         vm.expectCall(
             TOKEN_MESSENGER_V2_MAINNET,
             abi.encodeCall(
@@ -445,9 +442,9 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
                 (
                     bridgeAmount,
                     HYPEREVM_CCTP_DOMAIN,
-                    forwarder,
+                    HYPERCORE_CCTP_FORWARDER,
                     ADDRESS_USDC,
-                    forwarder,
+                    HYPERCORE_CCTP_FORWARDER,
                     polymerDataWithHook.maxCCTPFee,
                     polymerDataWithHook.minFinalityThreshold,
                     polymerDataWithHook.hookData


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-169/polymer-hypercore-integration-as-destination-smart-contract

# Why did I implement it this way?

**Stacked on #1652** (base: `polymer-hypercore-ex-286`). Strengthens the HyperCore hook flow so its security properties are enforced on-chain instead of relying on API-generated calldata.

Per [Circle's HyperCore transfer docs](https://developers.circle.com/cctp/transfer-usdc-from-ethereum-to-hypercore), a HyperCore deposit must set **both** `mintRecipient` and `destinationCaller` to the `CctpForwarder` on HyperEVM, with the real recipient encoded in `hookData[32:52]`. In #1652 those values were caller-supplied and unvalidated, which meant: (a) `LiFiTransferStarted.receiver` would carry the forwarder, not the user, (b) compromised calldata could redirect funds via `hookData` with no on-chain check, and (c) a wrong `destinationCaller` would burn USDC unrecoverably.

This PR pins and validates the flow (same pattern as MayanFacet's `MAYAN_HYPERCORE_DEPOSITOR`, #1881):

- `mintRecipient == destinationCaller == HYPERCORE_CCTP_FORWARDER` (hardcoded constant; rotation requires a facet upgrade).
- `hookData[32:52]` must equal `BridgeData.receiver` (revert `InvalidReceiver`), so events always carry the real end user and calldata cannot silently redirect funds. No further hook-content validation (magic/version/dex flag) by design — the recipient offset is the security-critical field; a malformed tail cannot redirect funds.
- Hook ⇔ HyperCore: hooks toward any other destination revert `InvalidCallData` (fail closed — corridors without a pinned forwarder have no validated hook consumer), and hookless transfers to HyperCore revert as well (they would mint on HyperEVM and never reach HyperCore). The corridor dispatch is structured so future corridors (e.g. Stellar, CCTP domain 27, same CctpForwarder pattern) land as one additional arm plus constants.
- `destinationCaller` is removed from `PolymerCCTPData` — the facet supplies it from the pinned constant, so the field could only ever be redundant or wrong.

Version stays `3.0.0`: v3 was never production-deployed, so this folds into the existing major bump (struct/ABI change vs released v2.1.0).

**Open items before merge:**

- [ ] ~~Confirm the production `CctpForwarder` address~~ Resolved (`366a40496`): the pinned address is now Circle's published mainnet HyperEVM `CctpForwarder` `0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757` ([Circle reference](https://developers.circle.com/cctp/references/hypercore-contract-addresses)); the EXSC-169 address `0x9765...2815` turned out to be Polymer's test diamond (on-chain bytecode is a LibDiamond dispatch proxy), not a forwarder. Remaining ask to Polymer: confirm their relayer executes messages through Circle's forwarder.
- [ ] API must populate `BridgeData.receiver` with the end user (not the forwarder) for HyperCore quotes — the facet supplies the forwarder itself.
- [ ] Follow-up (not in this PR, per review agreement): `script/demoScripts/demoPolymerCCTP.ts` builds `PolymerCCTPData` without `hookData` and will need `hookData: '0x'` once `lifi-contract-types` regenerates.

Tests: `forge test --match-path test/solidity/Facets/PolymerCCTPFacet.t.sol` — 44/44 pass on a mainnet fork against the real TokenMessengerV2, including a HyperCore e2e with `vm.expectCall` asserting the forwarder as both `mintRecipient` and `destinationCaller`, and revert coverage for hook-to-wrong-destination, hookless HyperCore, receiver mismatch, non-EVM receiver, and truncated hook data.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md` — **partially**: first pass ran and its single finding was fixed (`747dcffe4`); the second pass reported 1 Major finding whose full text was lost to the CLI rate limit. Opening as draft with cloud CodeRabbit triggered instead; the cloud review must be clean/addressed before this leaves draft.
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
