### PR TITLE
ci: guard upstream-only workflows against running in forks (EXSC-602)

### DIFF
--- a/.github/workflows/notifyDataTeamOnDeployment.yml
+++ b/.github/workflows/notifyDataTeamOnDeployment.yml
@@ -2,6 +2,8 @@
 # - posts a Slack message to the data team when a production deployment JSON file changes on main
 # - diffs the changed deployments/<network>.json files against the previous commit to extract contract names and addresses
 # - ignores diamond, staging, and the aggregated deployments log to avoid noise
+# - upstream-only: guarded to lifinance/contracts because forks that sync this file
+#   (contracts-tron) lack the Slack webhook secret and would fail on every push
 # - known limitations: requires fetch-depth: 2 to access the previous commit; does not validate deployment JSON schema
 
 name: Notify Data Team on Contract Deployments
@@ -21,6 +23,7 @@ permissions:
 
 jobs:
   notify-deployments:
+    if: github.repository == 'lifinance/contracts' # upstream-only, see header
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -4,6 +4,7 @@
 # - Key behaviors: clones our fork (`lifinance/clear-signing-erc7730-registry`, originally forked from LedgerHQ, now tracking the EF-hosted registry), regenerates the JSON with merged `display.formats`, pushes a branch to the fork, creates/updates a PR upstream, and posts the PR link to Slack.
 # - Trust model: this workflow assumes `config/clearSigningProposal.json` is current against the on-chain diamond, which is enforced at PR-merge time by `verifyClearSigning.yml`. If that gate is bypassed, the proposal may be stale.
 # - Note: The ERC-7730 registry moved from `LedgerHQ/clear-signing-erc7730-registry` to `ethereum/clear-signing-erc7730-registry` (Ethereum Foundation now hosts it). The fork retains its original name; only the upstream remote target changed.
+# - Upstream-only: guarded to lifinance/contracts because forks that sync this file (contracts-tron) lack `LEDGER_SYNC_TOKEN`/Slack secrets and must not push to the EF registry.
 
 name: Sync Clear Signing (ERC-7730) Registry
 
@@ -45,6 +46,7 @@ jobs:
       # never cross-cancel.
       group: sync-ledger-clear-signing-${{ github.event_name }}
       cancel-in-progress: true
+    if: github.repository == 'lifinance/contracts' # upstream-only, see header
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (with submodules)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-602](https://linear.app/lifi-linear/issue/EXSC-602/guard-upstream-only-workflows-so-they-dont-fail-in-the-contracts-tron)

# Why did I implement it this way?

`contracts-tron` syncs `.github/workflows/` verbatim from this repo (EXSC-587). Two workflows are upstream-only — `notifyDataTeamOnDeployment.yml` needs the data-team Slack webhook, `syncLedgerClearSigning.yml` needs `LEDGER_SYNC_TOKEN` and must not push to the EF clear-signing registry from a fork — so in `contracts-tron` they fail on every push to `main` (first observed on the initial automated sync push, [run history](https://github.com/lifinance/contracts-tron/actions)). That noise buries real post-merge CI failures in the fork.

A job-level `if: github.repository == 'lifinance/contracts'` guard placed **here** (rather than editing the fork's copies) keeps the fork byte-identical to upstream, so the fix syncs down conflict-free and future workflow changes keep merging cleanly. In the fork the jobs now skip instead of fail; upstream behavior is unchanged.

Deliberately not touched: `convertForkedPRsToInternal.yml` also shows push-event "workflow file issue" startup failures, but those occur identically in this repo (Dec 2025 runs) and happen before job-level `if` evaluation — a guard can't fix them.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
