### PR TITLE
feat(whitelist): allowlist Symbiosis OnchainSwapV3 router on ETH/BSC/RSK/ERA (EXSC-267)

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4905,6 +4905,60 @@
           }
         ]
       }
+    },
+    {
+      "name": "Symbiosis OnchainSwapV3",
+      "key": "symbiosisOnchainSwapV3",
+      "contracts": {
+        "mainnet": [
+          {
+            "address": "0x92114294e42a96c9ef3163da18ee7efdba6cc661",
+            "functions": {
+              "0x21c69a19": "onswap(address,uint256,address,address,bytes)"
+            }
+          },
+          {
+            "address": "0xdacb78cb349bad001117c90861b32d40972a30a6",
+            "functions": {}
+          }
+        ],
+        "bsc": [
+          {
+            "address": "0x628613064b1902a1a422825cf11b687c6f17961e",
+            "functions": {
+              "0x21c69a19": "onswap(address,uint256,address,address,bytes)"
+            }
+          },
+          {
+            "address": "0x5c5e6cceb3435f49473c5fef0b9506070c5880f1",
+            "functions": {}
+          }
+        ],
+        "rootstock": [
+          {
+            "address": "0xa257f3fe4e4032291516dc355edf90664e9eb932",
+            "functions": {
+              "0x21c69a19": "onswap(address,uint256,address,address,bytes)"
+            }
+          },
+          {
+            "address": "0xa2e7705bbec9acf477115fa12b9fde4b2cb17c36",
+            "functions": {}
+          }
+        ],
+        "zksync": [
+          {
+            "address": "0x35e3dc1f3383bd348ec651edd73fe1d7a7da5aaa",
+            "functions": {
+              "0x21c69a19": "onswap(address,uint256,address,address,bytes)"
+            }
+          },
+          {
+            "address": "0x344ce0b8836a868f3c3418dd4d9059a4bc727ba1",
+            "functions": {}
+          }
+        ]
+      }
     }
   ],
   "PERIPHERY": {

--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4909,6 +4909,8 @@
     {
       "name": "Symbiosis OnchainSwapV3",
       "key": "symbiosisOnchainSwapV3",
+      "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/bridges/symbiosis.svg",
+      "webUrl": "https://app.symbiosis.finance/swap",
       "contracts": {
         "mainnet": [
           {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-267](https://linear.app/lifi-linear/issue/EXSC-267/sc-symbiosis-add-support-for-onchainswapv3-routes) — unblocks [EXBE-291](https://linear.app/lifi-linear/issue/EXBE-291/be-symbiosis-add-support-for-onchainswapv3-routes).

# Why did I implement it this way?

Symbiosis introduced a new **zero-fee `OnchainSwapV3`** fee-collector router, used only for **ETH / BSC / Rootstock / zkSync-Era → Bitcoin** routes. For these directions the diamond invokes `OnchainSwapV3.onswap(...)` as an allowlist-checked **swap step** (`SwapData.callTo`), so `SwapperV2._executeSwaps` reverts `ContractCallNotAllowed()` because the router was never allowlisted — the "tx fails on chain" the BE ticket describes.

> Note: normal Symbiosis routes go through the facet's **immutable** `metaRouter` (`SymbiosisFacet._startBridge`), which bypasses the diamond allowlist — which is exactly why there was no prior Symbiosis entry in `whitelist.json`. Only this new `onswap`-based flow hits the allowlist.

This adds one `DEXS` entry (`symbiosisOnchainSwapV3`) to `config/whitelist.json` for the four origin chains, each with two contracts:

- **router** (`callTo`) → `onswap(address,uint256,address,address,bytes)` = `0x21c69a19`
- **onchainGateway** (`approveTo`) → approveTo-only (`functions: {}` → `0xffffffff`), because `onswap` pulls ERC-20s via `onchainGateway.claimTokens(token, msg.sender, amount)`, so `approveTo != callTo` and `SwapperV2._executeSwaps` additionally requires the gateway to be allowlisted.

| chain | `OnchainSwapV3` router | `onchainGateway` |
|---|---|---|
| mainnet | `0x92114294e42a96c9ef3163da18ee7efdba6cc661` | `0xdacb78cb349bad001117c90861b32d40972a30a6` |
| bsc | `0x628613064b1902a1a422825cf11b687c6f17961e` | `0x5c5e6cceb3435f49473c5fef0b9506070c5880f1` |
| rootstock | `0xa257f3fe4e4032291516dc355edf90664e9eb932` | `0xa2e7705bbec9acf477115fa12b9fde4b2cb17c36` |
| zksync | `0x35e3dc1f3383bd348ec651edd73fe1d7a7da5aaa` | `0x344ce0b8836a868f3c3418dd4d9059a4bc727ba1` |

Addresses are the zero-fee variants from the Symbiosis js-sdk `ZERO_FEE_COLLECTOR_ADDRESSES` map, **verified on-chain**: contract name `OnchainSwapV3`, `fee() == 0` on all four (the contract default is `0.05 ether`), and each `onchainGateway()` returns the paired gateway address. Selector re-derived with `cast sig`. Lowercase addresses per the file's dominant convention; keys `mainnet/bsc/rootstock/zksync` match sibling entries.

Whitelist-only change per rule `502-whitelist-branching` (targets `main`, standalone). No contract/facet changes — `SymbiosisFacet` is untouched. Config-only, so no unit test and no docs page apply.

**Out of scope (not in this PR):** the on-chain whitelist **sync** to each diamond (production is human-gated multisig; merging this PR does not itself change on-chain state) and the BE guard removal + end-to-end quote→bridge→`DONE` per direction ([EXBE-291](https://linear.app/lifi-linear/issue/EXBE-291/be-symbiosis-add-support-for-onchainswapv3-routes)).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — see `.agents/commands/pr-ready.md`
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

> Checklist notes: local `/pr-ready` intentionally not run — the local CodeRabbit gate is being retired repo-wide (#2020); `self-review-pass` was run instead. No tests / no new facet / no docs: this is a config-only whitelist entry (no Solidity or script changes).

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
