### PR TITLE
feat(MayanFacet): signed arbitrary destination-call payloads (EXSC-604)

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -1572,7 +1572,7 @@
         }
       ]
     },
-    "startBridgeTokensViaMayan((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (bytes32 nonEVMReceiver, address mayanProtocol, bytes protocolData, address swapProtocol, bytes swapData, address middleToken, uint256 minMiddleAmount) _mayanData)": {
+    "startBridgeTokensViaMayan((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (bytes32 nonEVMReceiver, address mayanProtocol, bytes protocolData, address swapProtocol, bytes swapData, address middleToken, uint256 minMiddleAmount, bytes signature, uint256 deadline) _mayanData)": {
       "intent": "Bridge via Mayan",
       "interpolatedIntent": "Bridge {_bridgeData.minAmount} via Mayan to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
       "fields": [
@@ -4756,7 +4756,7 @@
         }
       ]
     },
-    "swapAndStartBridgeTokensViaMayan((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData, (bytes32 nonEVMReceiver, address mayanProtocol, bytes protocolData, address swapProtocol, bytes swapData, address middleToken, uint256 minMiddleAmount) _mayanData)": {
+    "swapAndStartBridgeTokensViaMayan((bytes32 transactionId, string bridge, string integrator, address referrer, address sendingAssetId, address receiver, uint256 minAmount, uint256 destinationChainId, bool hasSourceSwaps, bool hasDestinationCall) _bridgeData, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData, (bytes32 nonEVMReceiver, address mayanProtocol, bytes protocolData, address swapProtocol, bytes swapData, address middleToken, uint256 minMiddleAmount, bytes signature, uint256 deadline) _mayanData)": {
       "intent": "Swap & Bridge via Mayan",
       "interpolatedIntent": "Swap then bridge {_bridgeData.minAmount} via Mayan to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
       "fields": [

--- a/config/mayan.json
+++ b/config/mayan.json
@@ -1,4 +1,10 @@
 {
+  "staging": {
+    "backendSigner": "0x0000000000000000000000000000000000000000"
+  },
+  "production": {
+    "backendSigner": "0x0000000000000000000000000000000000000000"
+  },
   "bridges": {
     "mainnet": {
       "bridge": "0x337685fdaB40D39bd02028545a4FfA7D287cC3E2"

--- a/config/mayan.json
+++ b/config/mayan.json
@@ -1,9 +1,9 @@
 {
   "staging": {
-    "backendSigner": "0x0000000000000000000000000000000000000000"
+    "backendSigner": "0x981CCF8c09633F6F2AF3fe661C285ca1DB09caE1"
   },
   "production": {
-    "backendSigner": "0x0000000000000000000000000000000000000000"
+    "backendSigner": "0xAF4B7A83591a6c4c8B9d1341C3F08BBc3b800fc5"
   },
   "bridges": {
     "mainnet": {

--- a/docs/MayanFacet.md
+++ b/docs/MayanFacet.md
@@ -12,10 +12,38 @@ graph LR;
 
 ## Receiver validation
 
-Before forwarding to Mayan, the facet validates that the order's destination receiver matches `BridgeData.receiver`:
+The facet has two trust models, partitioned strictly by `BridgeData.hasDestinationCall`:
 
-- **EVM destinations:** the receiver parsed from the Mayan protocol data (`destAddr`) must equal `BridgeData.receiver`.
-- **Non-EVM destinations** (`BridgeData.receiver == NON_EVM_ADDRESS`): the receiver parsed from the protocol data must equal `MayanData.nonEVMReceiver` (full 32-byte comparison).
+- **Plain bridges (`hasDestinationCall == false`)** — permissionless, unchanged: before forwarding to Mayan, the facet validates that the order's destination receiver matches `BridgeData.receiver`:
+  - **EVM destinations:** the receiver parsed from the Mayan protocol data (`destAddr`) must equal `BridgeData.receiver`.
+  - **Non-EVM destinations** (`BridgeData.receiver == NON_EVM_ADDRESS`): the receiver parsed from the protocol data must equal `MayanData.nonEVMReceiver` (full 32-byte comparison).
+- **Destination calls (`hasDestinationCall == true`)** — signature-gated (see [Arbitrary destination calls](#arbitrary-destination-calls)): the on-chain `_parseReceiver` check is **skipped** and the receiver is instead attested by a backend EIP-712 signature.
+
+## Arbitrary destination calls
+
+A Mayan Swift v2 order can carry a `customPayload` that instructs Mayan's destination-side executor to perform an **arbitrary call** (target + calldata) after delivery. That target/calldata **cannot be validated on-chain** against `BridgeData.receiver` — the whole point of a destination call is that funds/control flow go somewhere other than a plain receiver.
+
+Following the repo's opaque-calldata convention, this capability is unlocked **only** behind a backend EIP-712 signature. When `BridgeData.hasDestinationCall == true`, both entrypoints verify — before any deposit or swap, over the **as-submitted** `protocolData` and **pre-swap** `minAmount` — a signature from the authorized backend signer over:
+
+```text
+MayanDestinationCallPayload(
+    bytes32 transactionId,
+    bytes32 receiver,            // NON_EVM-aware: nonEVMReceiver when receiver == NON_EVM_ADDRESS
+    uint256 minAmount,           // pre-swap minAmount, as submitted
+    address sendingAssetId,
+    uint256 destinationChainId,
+    bool    hasDestinationCall,
+    address mayanProtocol,
+    bytes32 protocolDataHash,    // keccak256(MayanData.protocolData), which contains the customPayload
+    uint256 deadline
+)
+```
+
+The domain separator binds `block.chainid` and `address(this)` (the diamond, under delegatecall), so a signature is valid on exactly one chain and one diamond. `deadline` time-boxes every signature, and `BridgeData.transactionId` is consumed in diamond storage (CEI, before the external Mayan call) to prevent same-chain replay.
+
+### Trust assumption (destination calls)
+
+On the destination-call path the receiver is **signer-attested, not on-chain-enforced**: the facet does not (and cannot) validate the opaque call target. The backend is trusted to only sign payloads it constructed for legitimate routes. A leaked signer key can authorize an arbitrary destination call, but the blast radius is bounded to the funds of the specific signed transaction — the facet custodies nothing persistently. The signer is **immutable**; rotation is a governance action (deploy a new facet with the new signer and run `diamondCut` through the Safe/timelock). There is deliberately **no owner setter** for it.
 
 ### HyperCore deposits
 
@@ -60,6 +88,8 @@ The methods listed above take a variable labeled `_mayanData`. This data is spec
 /// @param swapData The calldata forwarded to swapProtocol to perform the native swap
 /// @param middleToken The token the native input is swapped into before forwarding
 /// @param minMiddleAmount The minimum middleToken amount that must result from the swap
+/// @param signature The backend EIP-712 signature; consumed only when hasDestinationCall
+/// @param deadline The signature expiry; enforced only on the signed destination-call path
 struct MayanData {
   bytes32 nonEVMReceiver;
   address mayanProtocol;
@@ -68,6 +98,8 @@ struct MayanData {
   bytes swapData;
   address middleToken;
   uint256 minMiddleAmount;
+  bytes signature;
+  uint256 deadline;
 }
 ```
 

--- a/script/demoScripts/demoMayan.ts
+++ b/script/demoScripts/demoMayan.ts
@@ -84,6 +84,9 @@ const main = async () => {
     swapData: '0x',
     middleToken: '0x0000000000000000000000000000000000000000',
     minMiddleAmount: 0,
+    // Destination-call signature fields; unused on this plain (non-dest-call) path
+    signature: '0x',
+    deadline: 0,
   }
 
   console.info('Dev Wallet Address: ', address)

--- a/script/deploy/facets/DeployMayanFacet.s.sol
+++ b/script/deploy/facets/DeployMayanFacet.s.sol
@@ -27,6 +27,19 @@ contract DeployScript is DeployScriptBase {
             string.concat(".bridges.", network, ".bridge")
         );
 
-        return abi.encode(bridge);
+        string memory json = vm.readFile(path);
+
+        // check if production or staging
+        address backendSigner;
+        if (
+            keccak256(abi.encodePacked(fileSuffix)) ==
+            keccak256(abi.encodePacked("staging."))
+        ) {
+            backendSigner = json.readAddress(".staging.backendSigner");
+        } else {
+            backendSigner = json.readAddress(".production.backendSigner");
+        }
+
+        return abi.encode(bridge, backendSigner);
     }
 }

--- a/script/deploy/resources/deployRequirements.json
+++ b/script/deploy/resources/deployRequirements.json
@@ -797,6 +797,20 @@
       }
     }
   },
+  "MayanFacet": {
+    "configData": {
+      "_mayan": {
+        "configFileName": "mayan.json",
+        "keyInConfigFile": ".bridges.<NETWORK>.bridge",
+        "allowToDeployWithZeroAddress": "false"
+      },
+      "_backendSigner": {
+        "configFileName": "mayan.json",
+        "keyInConfigFile": ".<ENVIRONMENT>.backendSigner",
+        "allowToDeployWithZeroAddress": "false"
+      }
+    }
+  },
   "NEARIntentsFacet": {
     "configData": {
       "_backendSigner": {

--- a/src/Facets/MayanFacet.sol
+++ b/src/Facets/MayanFacet.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.17;
 
+import { ECDSA } from "solady/utils/ECDSA.sol";
 import { ILiFi } from "../Interfaces/ILiFi.sol";
 import { LibAsset, IERC20 } from "../Libraries/LibAsset.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -21,7 +22,17 @@ import { InvalidConfig, InvalidNonEVMReceiver } from "../Errors/GenericErrors.so
 ///      the customPayload receiver instead of destAddr, but only after verifying destAddr equals
 ///      MAYAN_HYPERCORE_DEPOSITOR, so the customPayload is trusted only for genuine HCDepositor
 ///      orders.
-/// @custom:version 2.0.0
+/// @dev Destination calls (BridgeData.hasDestinationCall == true) let a Mayan Swift v2 order carry
+///      a customPayload that instructs Mayan's destination executor to perform an arbitrary call.
+///      That target/calldata cannot be validated on-chain against BridgeData.receiver, so this path
+///      is gated by a backend EIP-712 signature that commits to the BridgeData fields and to
+///      keccak256(protocolData). On this path the destination receiver is SIGNER-ATTESTED, not
+///      parser-enforced: _parseReceiver is intentionally skipped and the backend is trusted to only
+///      sign legitimate payloads. Plain bridges (hasDestinationCall == false) stay permissionless
+///      and keep the existing on-chain _parseReceiver validation. The signer is rotated by
+///      redeploying the facet and running diamondCut through the Safe/timelock governance flow;
+///      there is deliberately no owner setter for it.
+/// @custom:version 3.0.0
 contract MayanFacet is
     ILiFi,
     ReentrancyGuard,
@@ -32,6 +43,10 @@ contract MayanFacet is
     /// Storage ///
 
     bytes32 internal constant NAMESPACE = keccak256("com.lifi.facets.mayan");
+
+    // EIP-712 typehash for MayanDestinationCallPayload: keccak256("MayanDestinationCallPayload(bytes32 transactionId,bytes32 receiver,uint256 minAmount,address sendingAssetId,uint256 destinationChainId,bool hasDestinationCall,address mayanProtocol,bytes32 protocolDataHash,uint256 deadline)");
+    bytes32 private constant MAYAN_DESTINATION_CALL_PAYLOAD_TYPEHASH =
+        0x041e97a5598cb2846a732dae40d31cf310e56e48655f817f07fb38dbe29e4535;
 
     /// @dev Mayan's sole HyperCore HCDepositor handler. HyperCore Swift v2 orders set this as
     ///      their destAddr while the real receiver lives in customPayload[0:20]. Mayan commits to
@@ -46,6 +61,16 @@ contract MayanFacet is
 
     IMayan public immutable MAYAN;
 
+    /// @notice The address of the backend signer authorized to sign destination-call payloads
+    address internal immutable BACKEND_SIGNER;
+
+    /// Types ///
+
+    struct Storage {
+        /// @notice Tracks used transaction IDs to prevent replay of signed destination calls
+        mapping(bytes32 => bool) usedTransactionIds;
+    }
+
     /// @dev Mayan specific bridge data
     /// @param nonEVMReceiver The address of the non-EVM receiver if applicable
     /// @param mayanProtocol The address of the Mayan protocol final contract
@@ -56,6 +81,8 @@ contract MayanFacet is
     /// @param swapData The calldata forwarded to swapProtocol to perform the native swap
     /// @param middleToken The token the native input is swapped into before forwarding
     /// @param minMiddleAmount The minimum middleToken amount that must result from the swap
+    /// @param signature The backend EIP-712 signature; consumed only when hasDestinationCall
+    /// @param deadline The signature expiry; enforced only on the signed destination-call path
     struct MayanData {
         bytes32 nonEVMReceiver;
         address mayanProtocol;
@@ -64,19 +91,32 @@ contract MayanFacet is
         bytes swapData;
         address middleToken;
         uint256 minMiddleAmount;
+        bytes signature;
+        uint256 deadline;
     }
 
     /// Errors ///
     error InvalidReceiver(address expected, address actual);
     error ProtocolDataTooShort();
+    /// @notice Thrown when the destination-call signature is invalid
+    error InvalidSignature();
+    /// @notice Thrown when the destination-call signature is expired
+    error SignatureExpired();
+    /// @notice Thrown when a transaction with the same ID has already been processed
+    error TransactionAlreadyProcessed();
 
     /// Constructor ///
 
     /// @notice Constructor for the contract.
-    constructor(IMayan _mayan) {
-        if (address(_mayan) == address(0)) revert InvalidConfig();
+    /// @param _mayan The Mayan forwarder contract
+    /// @param _backendSigner The address authorized to sign destination-call payloads
+    constructor(IMayan _mayan, address _backendSigner) {
+        if (address(_mayan) == address(0) || _backendSigner == address(0)) {
+            revert InvalidConfig();
+        }
 
         MAYAN = _mayan;
+        BACKEND_SIGNER = _backendSigner;
     }
 
     /// External Methods ///
@@ -94,8 +134,13 @@ contract MayanFacet is
         refundExcessNative(payable(msg.sender))
         validateBridgeData(_bridgeData)
         doesNotContainSourceSwaps(_bridgeData)
-        doesNotContainDestinationCalls(_bridgeData)
     {
+        // Arbitrary destination calls are only allowed when a backend signature attests to the
+        // opaque customPayload (verified over the as-submitted protocolData, before any deposit).
+        if (_bridgeData.hasDestinationCall) {
+            _verifyDestinationCallSignature(_bridgeData, _mayanData);
+        }
+
         LibAsset.depositAsset(
             _bridgeData.sendingAssetId,
             _bridgeData.minAmount
@@ -126,9 +171,14 @@ contract MayanFacet is
         nonReentrant
         refundExcessNative(payable(msg.sender))
         containsSourceSwaps(_bridgeData)
-        doesNotContainDestinationCalls(_bridgeData)
         validateBridgeData(_bridgeData)
     {
+        // The signature is intentionally verified with the pre-swap `minAmount` and over the
+        // as-submitted `protocolData`, before `_depositAndSwap`/`_replaceInputAmount` mutate them.
+        if (_bridgeData.hasDestinationCall) {
+            _verifyDestinationCallSignature(_bridgeData, _mayanData);
+        }
+
         _bridgeData.minAmount = _depositAndSwap(
             _bridgeData.transactionId,
             _bridgeData.minAmount,
@@ -169,31 +219,42 @@ contract MayanFacet is
         ILiFi.BridgeData memory _bridgeData,
         MayanData memory _mayanData
     ) internal {
-        // Validate receiver address
-        if (_bridgeData.receiver == NON_EVM_ADDRESS) {
-            if (_mayanData.nonEVMReceiver == bytes32(0)) {
-                revert InvalidNonEVMReceiver();
+        if (_bridgeData.hasDestinationCall) {
+            // Signed destination-call path: the receiver is signer-attested (verified at the
+            // entrypoint), so there is no on-chain receiver to compare against. Consume the
+            // transactionId before the external call (CEI) to prevent same-chain replay.
+            Storage storage s = getStorage();
+            if (s.usedTransactionIds[_bridgeData.transactionId]) {
+                revert TransactionAlreadyProcessed();
             }
-            bytes32 receiver = _parseReceiver(
-                _mayanData.protocolData,
-                _bridgeData.destinationChainId
-            );
-            if (_mayanData.nonEVMReceiver != receiver) {
-                revert InvalidNonEVMReceiver();
-            }
+            s.usedTransactionIds[_bridgeData.transactionId] = true;
         } else {
-            address receiver = address(
-                uint160(
-                    uint256(
-                        _parseReceiver(
-                            _mayanData.protocolData,
-                            _bridgeData.destinationChainId
+            // Plain-bridge path (unchanged): validate the receiver on-chain from protocolData.
+            if (_bridgeData.receiver == NON_EVM_ADDRESS) {
+                if (_mayanData.nonEVMReceiver == bytes32(0)) {
+                    revert InvalidNonEVMReceiver();
+                }
+                bytes32 receiver = _parseReceiver(
+                    _mayanData.protocolData,
+                    _bridgeData.destinationChainId
+                );
+                if (_mayanData.nonEVMReceiver != receiver) {
+                    revert InvalidNonEVMReceiver();
+                }
+            } else {
+                address receiver = address(
+                    uint160(
+                        uint256(
+                            _parseReceiver(
+                                _mayanData.protocolData,
+                                _bridgeData.destinationChainId
+                            )
                         )
                     )
-                )
-            );
-            if (_bridgeData.receiver != receiver) {
-                revert InvalidReceiver(_bridgeData.receiver, receiver);
+                );
+                if (_bridgeData.receiver != receiver) {
+                    revert InvalidReceiver(_bridgeData.receiver, receiver);
+                }
             }
         }
 
@@ -495,5 +556,75 @@ contract MayanFacet is
         }
 
         return modifiedData;
+    }
+
+    /// @dev Verifies the backend EIP-712 signature authorizing an arbitrary destination call.
+    ///      The struct commits to the BridgeData fields plus keccak256(protocolData) (which
+    ///      contains the opaque customPayload), so an attacker cannot repoint a signature at a
+    ///      different route, receiver, amount, Mayan target, or destination call.
+    /// @param _bridgeData The core information needed for bridging
+    /// @param _mayanData Data specific to Mayan (as submitted, before _replaceInputAmount)
+    function _verifyDestinationCallSignature(
+        ILiFi.BridgeData memory _bridgeData,
+        MayanData memory _mayanData
+    ) internal view {
+        if (block.timestamp > _mayanData.deadline) {
+            revert SignatureExpired();
+        }
+
+        bytes32 receiverBytes32 = _bridgeData.receiver == NON_EVM_ADDRESS
+            ? _mayanData.nonEVMReceiver
+            : bytes32(uint256(uint160(_bridgeData.receiver)));
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                MAYAN_DESTINATION_CALL_PAYLOAD_TYPEHASH,
+                _bridgeData.transactionId,
+                receiverBytes32,
+                _bridgeData.minAmount,
+                _bridgeData.sendingAssetId,
+                _bridgeData.destinationChainId,
+                _bridgeData.hasDestinationCall,
+                _mayanData.mayanProtocol,
+                keccak256(_mayanData.protocolData),
+                _mayanData.deadline
+            )
+        );
+
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", _domainSeparator(), structHash)
+        );
+
+        if (ECDSA.recover(digest, _mayanData.signature) != BACKEND_SIGNER) {
+            revert InvalidSignature();
+        }
+    }
+
+    /// @notice Returns the EIP-712 domain separator.
+    /// @dev The domain separator is calculated on the fly to ensure that `address(this)`
+    /// always refers to the diamond's address when called via delegatecall.
+    /// @return The EIP-712 domain separator.
+    function _domainSeparator() internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    ),
+                    keccak256(bytes("LI.FI Mayan Facet")),
+                    keccak256(bytes("1")),
+                    block.chainid,
+                    address(this) // This will be the diamond's address at runtime
+                )
+            );
+    }
+
+    /// @dev fetch local storage
+    function getStorage() private pure returns (Storage storage s) {
+        bytes32 namespace = NAMESPACE;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            s.slot := namespace
+        }
     }
 }

--- a/test/solidity/Facets/CalldataVerificationFacet.t.sol
+++ b/test/solidity/Facets/CalldataVerificationFacet.t.sol
@@ -140,6 +140,8 @@ contract CalldataVerificationFacetTest is TestBaseLocal {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -166,6 +168,8 @@ contract CalldataVerificationFacetTest is TestBaseLocal {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 

--- a/test/solidity/Facets/MayanFacet.t.sol
+++ b/test/solidity/Facets/MayanFacet.t.sol
@@ -12,7 +12,10 @@ import { TestWhitelistManagerBase } from "../utils/TestWhitelistManagerBase.sol"
 
 // Stub MayanFacet Contract
 contract TestMayanFacet is MayanFacet, TestWhitelistManagerBase {
-    constructor(IMayan _bridge) MayanFacet(_bridge) {}
+    constructor(
+        IMayan _bridge,
+        address _backendSigner
+    ) MayanFacet(_bridge, _backendSigner) {}
 }
 
 /// @notice Mirrors Mayan Swift v2 encoders for `abi.encodeCall` fixtures (no on-chain deployment).
@@ -63,7 +66,11 @@ interface ISwiftV2Encode {
 /// @notice This contract exposes _parseReceiver, _parseHypercoreReceiver and
 ///         _replaceInputAmount for testing purposes.
 contract TestMayanFacetExposed is MayanFacet {
-    constructor(IMayan _mayan) MayanFacet(_mayan) {}
+    /// @dev A fixed non-zero backend signer keeps the pure/view parser exposers' call sites
+    ///      one-arg; these helpers never verify a signature.
+    constructor(
+        IMayan _mayan
+    ) MayanFacet(_mayan, 0x000000000000000000000000000000000000dEaD) {}
 
     /// @dev Exposes the internal _parseReceiver function on the non-HyperCore (destAddr) path.
     function testParseReceiver(
@@ -153,8 +160,20 @@ contract MayanFacetTest is TestBaseFacet {
     address internal constant ARBITRUM_WETH =
         0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
 
+    /// @dev EIP-712 typehash mirrored from MayanFacet; keeping a local copy proves the on-chain
+    ///      constant matches the type string the backend signs.
+    bytes32 internal constant MAYAN_DESTINATION_CALL_PAYLOAD_TYPEHASH =
+        0x041e97a5598cb2846a732dae40d31cf310e56e48655f817f07fb38dbe29e4535;
+
+    uint256 internal backendSignerPrivateKey =
+        0x1234567890123456789012345678901234567890123456789012345678901234;
+    address internal backendSignerAddress = vm.addr(backendSignerPrivateKey);
+
     error InvalidReceiver(address expected, address actual);
     error ProtocolDataTooShort();
+    error InvalidSignature();
+    error SignatureExpired();
+    error TransactionAlreadyProcessed();
 
     function setUp() public {
         customBlockNumberForForking = 19968172;
@@ -175,6 +194,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -186,6 +207,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -197,12 +220,17 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
     }
 
     function setupMayan() internal {
-        mayanBridgeFacet = new TestMayanFacet(MAYAN_FORWARDER);
+        mayanBridgeFacet = new TestMayanFacet(
+            MAYAN_FORWARDER,
+            backendSignerAddress
+        );
         bytes4[] memory functionSelectors = new bytes4[](4);
         functionSelectors[0] = mayanBridgeFacet
             .startBridgeTokensViaMayan
@@ -271,7 +299,33 @@ contract MayanFacetTest is TestBaseFacet {
     function testRevert_WhenConstructedWithZeroAddress() public {
         vm.expectRevert(InvalidConfig.selector);
 
-        new TestMayanFacet(IMayan(address(0)));
+        new TestMayanFacet(IMayan(address(0)), backendSignerAddress);
+    }
+
+    function testRevert_WhenConstructedWithZeroBackendSigner() public {
+        vm.expectRevert(InvalidConfig.selector);
+
+        new TestMayanFacet(MAYAN_FORWARDER, address(0));
+    }
+
+    /// @dev EXSC-604 relaxes the unconditional doesNotContainDestinationCalls modifier: a
+    ///      destination call is now allowed but only with a valid backend signature. An unsigned
+    ///      dest-call (validMayanData carries no signature and deadline 0) therefore no longer
+    ///      reverts with InformationMismatch but with SignatureExpired (deadline checked first).
+    function testBase_Revert_BridgeWithInvalidDestinationCallFlag()
+        public
+        override
+    {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.hasDestinationCall = true;
+
+        vm.expectRevert(SignatureExpired.selector);
+
+        initiateBridgeTxWithFacet(false);
+        vm.stopPrank();
     }
 
     function testBase_CanSwapAndBridgeNativeTokens()
@@ -484,6 +538,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -551,6 +607,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -591,7 +649,9 @@ contract MayanFacetTest is TestBaseFacet {
             MAYAN_NATIVE_SWAP_PROTOCOL,
             swapCalldata,
             ARBITRUM_WETH,
-            0.99 ether
+            0.99 ether,
+            "",
+            0
         );
 
         vm.startPrank(USER_SENDER);
@@ -685,7 +745,9 @@ contract MayanFacetTest is TestBaseFacet {
             MAYAN_NATIVE_SWAP_PROTOCOL,
             swapCalldata,
             ARBITRUM_WETH,
-            0.5 ether
+            0.5 ether,
+            "",
+            0
         );
 
         vm.expectEmit(false, false, false, false, _facetTestContractAddress);
@@ -742,6 +804,8 @@ contract MayanFacetTest is TestBaseFacet {
             MAYAN_NATIVE_SWAP_PROTOCOL,
             "",
             ARBITRUM_WETH,
+            0,
+            "",
             0
         );
 
@@ -795,6 +859,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
         // invalid protocolData that produces wrong receiver for payload
@@ -1150,6 +1216,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -1188,6 +1256,8 @@ contract MayanFacetTest is TestBaseFacet {
             address(0),
             "",
             address(0),
+            0,
+            "",
             0
         );
 
@@ -1488,5 +1558,570 @@ contract MayanFacetTest is TestBaseFacet {
         protocolData = vm.parseBytes("0x99999999");
         receiver = testFacet.testParseReceiver(protocolData);
         assertEq(address(uint160(uint256(receiver))), address(0));
+    }
+
+    /// -----------------------------------------------------------------------
+    /// EXSC-604: signed arbitrary destination-call payloads
+    /// -----------------------------------------------------------------------
+
+    /// @dev EIP-712 domain separator mirrored from the facet; verifyingContract is the diamond.
+    function _mayanDomainSeparator() internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    ),
+                    keccak256(bytes("LI.FI Mayan Facet")),
+                    keccak256(bytes("1")),
+                    block.chainid,
+                    address(mayanBridgeFacet)
+                )
+            );
+    }
+
+    /// @dev Builds the EIP-712 digest the backend signs for a destination call.
+    function _destCallDigest(
+        ILiFi.BridgeData memory _bd,
+        MayanFacet.MayanData memory _md
+    ) internal view returns (bytes32) {
+        bytes32 receiverBytes32 = _bd.receiver == NON_EVM_ADDRESS
+            ? _md.nonEVMReceiver
+            : bytes32(uint256(uint160(_bd.receiver)));
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                MAYAN_DESTINATION_CALL_PAYLOAD_TYPEHASH,
+                _bd.transactionId,
+                receiverBytes32,
+                _bd.minAmount,
+                _bd.sendingAssetId,
+                _bd.destinationChainId,
+                _bd.hasDestinationCall,
+                _md.mayanProtocol,
+                keccak256(_md.protocolData),
+                _md.deadline
+            )
+        );
+
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19\x01",
+                    _mayanDomainSeparator(),
+                    structHash
+                )
+            );
+    }
+
+    /// @dev Returns `_md` with `signature` filled in for `_bd`, signed by `_privateKey`.
+    ///      `_md.deadline` must already be set (it is part of the signed struct).
+    function _signDestCall(
+        ILiFi.BridgeData memory _bd,
+        MayanFacet.MayanData memory _md,
+        uint256 _privateKey
+    ) internal view returns (MayanFacet.MayanData memory) {
+        bytes32 digest = _destCallDigest(_bd, _md);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_privateKey, digest);
+        _md.signature = abi.encodePacked(r, s, v);
+        return _md;
+    }
+
+    /// @dev Reads the facet's usedTransactionIds mapping straight from diamond storage.
+    function _isTxIdUsed(bytes32 _txId) internal view returns (bool) {
+        bytes32 slot = keccak256(
+            abi.encode(_txId, keccak256("com.lifi.facets.mayan"))
+        );
+        return vm.load(address(mayanBridgeFacet), slot) != bytes32(0);
+    }
+
+    /// @dev ERC20 destination-call template based on validMayanData; deadline in the future.
+    function _erc20DestCallData()
+        internal
+        view
+        returns (MayanFacet.MayanData memory md)
+    {
+        md = validMayanData;
+        md.deadline = block.timestamp + 1 hours;
+        md.signature = "";
+    }
+
+    // --- Happy paths ---
+
+    /// @dev H1: signed ERC20 destination call bridges and consumes the transactionId.
+    function test_DestCall_H1_ERC20SignedBridges() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("h1");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectEmit(false, false, false, false, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+
+        assertTrue(
+            _isTxIdUsed(bridgeData.transactionId),
+            "transactionId must be consumed"
+        );
+    }
+
+    /// @dev H2: signed native destination call routes through forwardEth (swapProtocol == 0).
+    function test_DestCall_H2_NativeSignedBridges() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("h2");
+        bridgeData.sendingAssetId = address(0);
+        bridgeData.minAmount = 1 ether;
+
+        MayanFacet.MayanData memory md = validMayanDataNative;
+        md.deadline = block.timestamp + 1 hours;
+        md = _signDestCall(bridgeData, md, backendSignerPrivateKey);
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardEth.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        vm.expectEmit(false, false, false, false, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        mayanBridgeFacet.startBridgeTokensViaMayan{ value: 1 ether }(
+            bridgeData,
+            md
+        );
+        vm.stopPrank();
+
+        assertTrue(_isTxIdUsed(bridgeData.transactionId));
+    }
+
+    /// @dev H3: on the swap path the signature (over pre-swap minAmount + as-submitted
+    ///      protocolData) still validates after _depositAndSwap/_replaceInputAmount mutate them.
+    function test_DestCall_H3_SwapPathSignedBridges() public {
+        bridgeData.hasSourceSwaps = true;
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("h3");
+
+        // sign over the pre-swap minAmount and the as-submitted protocolData
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        setDefaultSwapDataSingleDAItoUSDC();
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        dai.approve(_facetTestContractAddress, swapData[0].fromAmount);
+
+        vm.expectEmit(false, false, false, false, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        mayanBridgeFacet.swapAndStartBridgeTokensViaMayan(
+            bridgeData,
+            swapData,
+            md
+        );
+        vm.stopPrank();
+
+        assertTrue(_isTxIdUsed(bridgeData.transactionId));
+    }
+
+    /// @dev H4: NON_EVM receiver destination call; the signed receiver is nonEVMReceiver and
+    ///      BridgeToNonEVMChainBytes32 is emitted.
+    function test_DestCall_H4_NonEvmReceiverSignedBridges() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("h4");
+        bridgeData.receiver = NON_EVM_ADDRESS;
+
+        MayanFacet.MayanData memory md = _erc20DestCallData();
+        md.nonEVMReceiver = ACTUAL_SOL_ADDR;
+        md = _signDestCall(bridgeData, md, backendSignerPrivateKey);
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit BridgeToNonEVMChainBytes32(
+            bridgeData.transactionId,
+            bridgeData.destinationChainId,
+            ACTUAL_SOL_ADDR
+        );
+
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev H5: legacy path (hasDestinationCall == false) needs no signature and keeps the
+    ///      on-chain _parseReceiver validation. Proves 604 did not make the signer mandatory.
+    function test_DestCall_H5_LegacyPathNoSignature() public {
+        // validMayanData.protocolData parses to USER_RECEIVER; no signature is provided.
+        assertEq(bridgeData.hasDestinationCall, false);
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectEmit(false, false, false, false, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, validMayanData);
+        vm.stopPrank();
+
+        // legacy path must NOT touch the replay map
+        assertFalse(_isTxIdUsed(bridgeData.transactionId));
+    }
+
+    /// @dev H6: HyperCore deposit (hasDestinationCall == false) still validated via
+    ///      _parseHypercoreReceiver, no signature required.
+    function test_DestCall_H6_HyperCoreNoSignature() public {
+        bridgeData.receiver = HYPERCORE_RECEIVER;
+        bridgeData.destinationChainId = 1337;
+        bridgeData.sendingAssetId = ADDRESS_USDC;
+        bridgeData.minAmount = defaultUSDCAmount;
+        assertEq(bridgeData.hasDestinationCall, false);
+
+        MayanFacet.MayanData memory md = MayanFacet.MayanData(
+            "",
+            0xF18f923480dC144326e6C65d4F3D47Aa459bb41C,
+            _hyperCoreProtocolData(),
+            address(0),
+            "",
+            address(0),
+            0,
+            "",
+            0
+        );
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectEmit(false, false, false, false, _facetTestContractAddress);
+        emit LiFiTransferStarted(bridgeData);
+
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    // --- Negative guards ---
+
+    /// @dev N1: signature for protocolData A, submit protocolData B (customPayload altered).
+    function test_DestCall_N1_ForgedPayloadReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n1");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        // tamper only the protocolData tail (as a destination-call customPayload would live there)
+        bytes memory tampered = md.protocolData;
+        tampered[tampered.length - 1] = 0xff;
+        md.protocolData = tampered;
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N2: destination call with no signature (valid future deadline) reverts.
+    function test_DestCall_N2_AbsentSignatureReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n2");
+
+        MayanFacet.MayanData memory md = _erc20DestCallData(); // signature == ""
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N3: valid signature from a non-authorized key reverts.
+    function test_DestCall_N3_WrongSignerReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n3");
+
+        uint256 wrongKey = 0xB0B;
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            wrongKey
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N4: signing for receiver/mayanProtocol/destChainId/sendingAssetId R1 but submitting
+    ///      a mismatching BridgeData fails recovery.
+    function test_DestCall_N4_ReceiverMismatchReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n4");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        // receiver mismatch
+        ILiFi.BridgeData memory tampered = bridgeData;
+        tampered.receiver = address(0xBEEF);
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(tampered, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N4 variants: mayanProtocol / destinationChainId / sendingAssetId mismatch.
+    function test_DestCall_N4_RouteFieldMismatchReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n4b");
+
+        MayanFacet.MayanData memory signed = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        // mayanProtocol mismatch
+        MayanFacet.MayanData memory md1 = signed;
+        md1.mayanProtocol = address(0xDEAD);
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md1);
+
+        // destinationChainId mismatch
+        ILiFi.BridgeData memory bd2 = bridgeData;
+        bd2.destinationChainId = 42161;
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bd2, signed);
+
+        // sendingAssetId mismatch
+        ILiFi.BridgeData memory bd3 = bridgeData;
+        bd3.sendingAssetId = ADDRESS_DAI;
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bd3, signed);
+
+        vm.stopPrank();
+    }
+
+    /// @dev N5: expired deadline reverts SignatureExpired.
+    function test_DestCall_N5_ExpiredReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n5");
+
+        MayanFacet.MayanData memory md = _erc20DestCallData();
+        md.deadline = block.timestamp - 1;
+        md = _signDestCall(bridgeData, md, backendSignerPrivateKey);
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(SignatureExpired.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N6a: replaying a consumed transactionId reverts TransactionAlreadyProcessed.
+    function test_DestCall_N6_ReplayReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n6");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        vm.mockCall(
+            address(MAYAN_FORWARDER),
+            abi.encodeWithSelector(IMayan.forwardERC20.selector),
+            ""
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+
+        vm.expectRevert(TransactionAlreadyProcessed.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N6b: the same signature under a different chainid fails recovery (domain separator).
+    function test_DestCall_N6_CrossChainReplayReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n6b");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        // move to a different chain; the signature was bound to the original block.chainid
+        vm.chainId(999999);
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N7: HyperCore-shaped order flipped to hasDestinationCall == true with no signature
+    ///      cannot bypass into the trusted-customPayload code; it reverts.
+    function test_DestCall_N7_FlagFlipUpReverts() public {
+        bridgeData.receiver = HYPERCORE_RECEIVER;
+        bridgeData.destinationChainId = 1337;
+        bridgeData.sendingAssetId = ADDRESS_USDC;
+        bridgeData.minAmount = defaultUSDCAmount;
+        bridgeData.hasDestinationCall = true;
+
+        MayanFacet.MayanData memory md = MayanFacet.MayanData(
+            "",
+            0xF18f923480dC144326e6C65d4F3D47Aa459bb41C,
+            _hyperCoreProtocolData(),
+            address(0),
+            "",
+            address(0),
+            0,
+            "",
+            0 // no deadline / no signature
+        );
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(SignatureExpired.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
+    }
+
+    /// @dev N8: an arbitrary-call customPayload with hasDestinationCall == false takes the legacy
+    ///      branch, where _parseReceiver still enforces bridgeData.receiver (T7 boundary preserved).
+    function test_DestCall_N8_FlagFlipDownStillParserEnforced() public {
+        // validMayanData.protocolData parses to USER_RECEIVER; submit a mismatching receiver.
+        bridgeData.receiver = DEV_WALLET;
+        bridgeData.hasDestinationCall = false;
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidReceiver.selector,
+                DEV_WALLET,
+                USER_RECEIVER
+            )
+        );
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, validMayanData);
+        vm.stopPrank();
+    }
+
+    /// @dev N9: on the swap path, changing the signed minAmount desyncs the hash and reverts
+    ///      (the pre-swap minAmount is committed).
+    function test_DestCall_N9_SignedAmountDesyncReverts() public {
+        bridgeData.hasSourceSwaps = true;
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n9");
+
+        MayanFacet.MayanData memory md = _signDestCall(
+            bridgeData,
+            _erc20DestCallData(),
+            backendSignerPrivateKey
+        );
+
+        setDefaultSwapDataSingleDAItoUSDC();
+
+        // submit a different minAmount than what was signed
+        ILiFi.BridgeData memory tampered = bridgeData;
+        tampered.minAmount = bridgeData.minAmount + 1;
+
+        vm.startPrank(USER_SENDER);
+        dai.approve(_facetTestContractAddress, swapData[0].fromAmount);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.swapAndStartBridgeTokensViaMayan(
+            tampered,
+            swapData,
+            md
+        );
+        vm.stopPrank();
+    }
+
+    /// @dev N10: a malformed / wrong-length signature reverts via solady ECDSA (no silent
+    ///      address(0) acceptance). solady's InvalidSignature shares the facet's selector.
+    function test_DestCall_N10_MalformedSignatureReverts() public {
+        bridgeData.hasDestinationCall = true;
+        bridgeData.transactionId = keccak256("n10");
+
+        MayanFacet.MayanData memory md = _erc20DestCallData();
+        md.signature = hex"1234"; // wrong length
+
+        vm.startPrank(USER_SENDER);
+        usdc.approve(_facetTestContractAddress, type(uint256).max);
+
+        vm.expectRevert(InvalidSignature.selector);
+        mayanBridgeFacet.startBridgeTokensViaMayan(bridgeData, md);
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-604/sc-mayanfacet-support-arbitrary-destination-call-payloads-swift-v2

> **Stacked on #2042 (EXSC-364).** Base branch is the EXSC-364 branch, not `main`. Please review/audit the two together — the whole point of the stack is one audit over the combined change. Merge #2042 first; this retargets to `main` automatically.

# Why did I implement it this way?

MayanFacet forbade destination calls (`doesNotContainDestinationCalls` on both entrypoints). Mayan Swift v2 orders can carry a `customPayload` that makes the destination executor perform an **arbitrary call**, whose target/calldata cannot be validated on-chain against `bridgeData.receiver`. Per `.agents/rules/102-facets.md` (opaque calldata flows), the sanctioned mitigation is a **backend EIP-712 signature** committing to the `BridgeData` fields plus a hash of the opaque calldata — exactly the pattern already shipped in `UnitFacet`/`NEARIntentsFacet`, which this reuses verbatim.

**Design:**
- `hasDestinationCall == true` → verify a backend signature at the **top** of each entrypoint (before any deposit/swap), over `{transactionId, receiver (NON_EVM-aware), minAmount, sendingAssetId, destinationChainId, hasDestinationCall, mayanProtocol, keccak256(protocolData), deadline}`. On this path the receiver is **signer-attested**; `_parseReceiver` is skipped. `transactionId` is consumed CEI (marked used before the external Mayan call) for replay protection; the domain separator binds `block.chainid` + `address(this)` (diamond, under delegatecall).
- `hasDestinationCall == false` → **unchanged, permissionless** `_parseReceiver` path. No signature required; existing traffic is not gated.
- `MayanData` appends `bytes signature` + `uint256 deadline` (after 364's four fields; 364 order untouched). Immutable `BACKEND_SIGNER` set in the constructor; rotation is a governed facet-redeploy + `diamondCut` (no owner setter). `solady/utils/ECDSA` (reverts on malformed sig — no silent `address(0)`).
- `_parseReceiver`, `_parseHypercoreReceiver`, `_normalizeAmount`, `_replaceInputAmount`, and 364's native-swap branch are **untouched**.

**Version:** `2.0.0 → 3.0.0` (constructor-signature + ABI change — MAJOR).

**Security review:** an independent adversarial pass (forgery / replay / ECDSA / branch-integrity / coexistence / storage / test-quality lenses, cross-checked against the Unit/NEAR references) found **no critical or high-severity issue**. Two informational notes: (1) the native source-swap params (`swapProtocol`/`swapData`/`middleToken`/`minMiddleAmount`) are intentionally **not** in the signed struct — not theft-exploitable, since the destination call lives in the committed `protocolData` and only the submitter's own `msg.value` is at stake; (2) signature malleability is harmless because replay keys on `transactionId` (in the digest), not the signature bytes.

**Testing:** `forge test --match-contract MayanFacet` → 55 pass, incl. H1–H6 happy paths and N1–N10 negative guards (forged payload incl. customPayload-only tamper, absent/wrong signer, receiver/route mismatch, expired, same- and cross-chain replay, flag-flip both directions, malformed sig). Clean under the solc-0.8.17/london floor build (no stack-too-deep).

## Backend signer

`config/mayan.json.backendSigner` reuses the **shared** LI.FI backend signer — the same key Unit/NEAR use (`config/global.json`) — per an explicit decision to reuse the existing signer rather than provision a dedicated one. No separate key setup is required before deploy. (Tests use a stub signer and are independent of the config value.)

## Follow-ups (separate tickets, out of scope here)

- Unsigned-`customPayload` smuggling hardening (design OQ-3).
- `refundExcessNative(msg.sender)` → explicit `refundRecipient` (design OQ-4; pre-existing).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have run `/pr-ready` (local CodeRabbit) on this branch and resolved (or explicitly documented) all findings — **bypassed per the sanctioned interim (rate limits); independent adversarial security review done instead, documented above**
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list — **N/A (existing facet)**
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
