### PR TITLE
feat(EXSC-411): retain failed integrator fee payouts in wrapper instead of redirecting to LI.FI

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -623,9 +623,11 @@ contract LiFiVaultWrapper is
     ///      LI.FI's parts go to the factory's live `lifiFeeRecipient`; the integrator's
     ///      parts are fanned across its wallets by bps (last absorbs the rounding
     ///      remainder). CEI: all four counters are zeroed before any transfer, and the call
-    ///      is `nonReentrant`. A failing integrator transfer (e.g. a blacklisted wallet) is
-    ///      redirected to LI.FI rather than reverting the distribution, so the integrator can
-    ///      never block it. No-op when every counter is empty.
+    ///      is `nonReentrant`. A failing integrator transfer (e.g. a blacklisted wallet) does
+    ///      not revert the distribution — its share is left in the wrapper and re-booked as
+    ///      still-owed integrator fees, so the integrator can rotate to a working wallet via
+    ///      `setIntegratorFeeReceivers` and call this again to claim it. No-op when every
+    ///      counter is empty.
     function distributeFees() external nonReentrant {
         _accrueFees();
 
@@ -648,18 +650,24 @@ contract LiFiVaultWrapper is
         address lifiRecipient = ILiFiVaultWrapperFactory(factory)
             .lifiFeeRecipient();
 
-        _distributeFeePool(
+        uint256 assetsRetained = _distributeFeePool(
             asset(),
             lifiAssets,
             integratorAssets,
             lifiRecipient
         );
-        _distributeFeePool(
+        uint256 sharesRetained = _distributeFeePool(
             address(this),
             lifiShares,
             integratorShares,
             lifiRecipient
         );
+
+        // Fees whose integrator transfer failed stay in the wrapper as still-owed
+        // integrator fees, claimable on a later distribution (nonReentrant guards this
+        // post-transfer write).
+        integratorFeeAssets = uint128(assetsRetained);
+        integratorFeeShares = uint128(sharesRetained);
     }
 
     /// Pause controls ///
@@ -1053,49 +1061,44 @@ contract LiFiVaultWrapper is
 
     /// @dev Pays out one fee pool of `_token` from the per-recipient parts booked at
     ///      accrual — no split happens here (see `_splitFee`). The integrator's part is
-    ///      fanned across the receiver wallets; LI.FI is paid last — its booked part plus
-    ///      any integrator amount redirected by `_payIntegrators` — and is NOT caught, so
-    ///      a reverting LI.FI recipient (factory-governed) is its own concern. Caller must
-    ///      zero the counters first (CEI). No-op on an empty fee pool.
+    ///      fanned across the receiver wallets; LI.FI is paid its booked part and is NOT
+    ///      caught, so a reverting LI.FI recipient (factory-governed) is its own concern.
+    ///      Caller must zero the counters first (CEI). No-op on an empty fee pool.
     /// @param _token The fee-pool token (the vault asset, or this wrapper's shares).
     /// @param _lifiPart LI.FI's booked part of the fee pool.
     /// @param _integratorPart The integrator's booked part of the fee pool.
     /// @param _lifiRecipient The live LI.FI fee recipient.
+    /// @return retained The integrator amount whose transfer failed, left in the wrapper.
     function _distributeFeePool(
         address _token,
         uint256 _lifiPart,
         uint256 _integratorPart,
         address _lifiRecipient
-    ) private {
-        if (_lifiPart == 0 && _integratorPart == 0) return;
+    ) private returns (uint256 retained) {
+        if (_lifiPart == 0 && _integratorPart == 0) return 0;
 
-        // pay integrators and note how many fees failed to transfer, those are redirected to lifi
-        uint256 redirected = _payIntegrators(_token, _integratorPart);
-        uint256 lifiPaid = _lifiPart + redirected;
+        // pay integrators; any wallet whose transfer fails leaves its share in the wrapper
+        retained = _payIntegrators(_token, _integratorPart);
 
-        if (lifiPaid > 0) {
-            SafeERC20.safeTransfer(IERC20(_token), _lifiRecipient, lifiPaid);
+        if (_lifiPart > 0) {
+            SafeERC20.safeTransfer(IERC20(_token), _lifiRecipient, _lifiPart);
         }
 
-        emit FeePoolDistributed(
-            _token,
-            lifiPaid,
-            _integratorPart - redirected
-        );
+        emit FeePoolDistributed(_token, _lifiPart, _integratorPart - retained);
     }
 
     /// @dev Fans `_integratorTotal` of `_token` across the integrator wallets by their bps, the
     ///      last wallet absorbing the integer-division remainder so the portion zeroes exactly.
     ///      Each payout uses OZ's non-reverting `trySafeTransfer`; a failed transfer (e.g. a
-    ///      blacklisted wallet) has its share returned as `redirected` for the caller to route
-    ///      to LI.FI, so one hostile wallet can never block the distribution.
+    ///      blacklisted wallet) has its share returned as `retained` and left in the wrapper,
+    ///      so one hostile wallet can never block the distribution.
     /// @param _token The fee-pool token to distribute.
     /// @param _integratorTotal The integrator's portion of the fee pool.
-    /// @return redirected The sum of shares whose transfer failed (to be paid to LI.FI).
+    /// @return retained The sum of shares whose transfer failed (left in the wrapper).
     function _payIntegrators(
         address _token,
         uint256 _integratorTotal
-    ) private returns (uint256 redirected) {
+    ) private returns (uint256 retained) {
         FeeReceiver[] memory receivers = integratorFeeReceivers;
         uint256 count = receivers.length;
         uint256 distributed;
@@ -1121,9 +1124,9 @@ contract LiFiVaultWrapper is
                 continue;
             }
 
-            // instead we redirect the failed transfer amount to lifi
-            redirected += share;
-            emit IntegratorPayoutRedirected(wallet, _token, share);
+            // the failed transfer amount stays in the wrapper as still-owed integrator fees
+            retained += share;
+            emit IntegratorPayoutRetained(wallet, _token, share);
         }
     }
 }

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -68,20 +68,24 @@ interface ILiFiVaultWrapper {
 
     /// @notice Emitted once per non-empty fee pool distributed by `distributeFees`.
     /// @param token The fee-pool token (the vault asset, or this wrapper's shares).
-    /// @param lifiAmount Amount delivered to the LI.FI recipient (LI.FI's split + any redirected).
-    /// @param integratorAmount Amount delivered across the integrator wallets.
+    /// @param lifiAmount Amount delivered to the LI.FI recipient (LI.FI's split only).
+    /// @param integratorAmount Amount delivered across the integrator wallets (excludes any
+    ///        retained after a failed transfer).
     event FeePoolDistributed(
         address indexed token,
         uint256 lifiAmount,
         uint256 integratorAmount
     );
 
-    /// @notice Emitted when an integrator payout fails (e.g. a blacklisted wallet) and the
-    ///         amount is redirected to the LI.FI recipient instead of reverting the distribution.
+    /// @notice Emitted when an integrator payout fails (e.g. a blacklisted wallet). The amount
+    ///         is left in the wrapper — still tracked as owed integrator fees — instead of
+    ///         reverting the distribution or being redirected to LI.FI. The integrator can
+    ///         rotate to a working wallet via `setIntegratorFeeReceivers` and call
+    ///         `distributeFees` again to claim it.
     /// @param receiver The integrator wallet whose transfer reverted.
-    /// @param token The fee-pool token redirected (the asset, or this wrapper's shares).
-    /// @param amount The amount redirected to LI.FI.
-    event IntegratorPayoutRedirected(
+    /// @param token The fee-pool token retained (the asset, or this wrapper's shares).
+    /// @param amount The amount retained in the wrapper.
+    event IntegratorPayoutRetained(
         address indexed receiver,
         address indexed token,
         uint256 amount

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -14,7 +14,7 @@ import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapper
 import { FeeType, FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 
 /// @notice A blacklisting ERC20: `transfer` reverts to any blocked address (mirrors USDC).
-///         Used to exercise the distributeFees redirect-failed-integrator-payout-to-LI.FI path.
+///         Used to exercise the distributeFees retain-failed-integrator-payout-in-wrapper path.
 contract BlacklistERC20 is MockERC20 {
     mapping(address => bool) public blocked;
 
@@ -39,7 +39,7 @@ contract BlacklistERC20 is MockERC20 {
 ///         receiver config, the permissionless `distributeFees` paying out the per-recipient
 ///         counters booked at accrual (no re-split at distribution) over both fee pools (idle
 ///         asset + dilution shares), the 1..50 wallet fan-out with last-receiver remainder, and the
-///         redirect-failed-integrator-payout-to-LI.FI behaviour. Fees are driven through real
+///         retain-failed-integrator-payout-in-wrapper behaviour. Fees are driven through real
 ///         deposit/withdraw/time accrual (the S2 engine), not seeded directly. Pause-bypass
 ///         coverage is deferred to S5 integration.
 contract VaultWrapperDistributionTest is Test {
@@ -69,7 +69,7 @@ contract VaultWrapperDistributionTest is Test {
         uint256 lifiAmount,
         uint256 integratorAmount
     );
-    event IntegratorPayoutRedirected(
+    event IntegratorPayoutRetained(
         address indexed receiver,
         address indexed token,
         uint256 amount
@@ -337,7 +337,7 @@ contract VaultWrapperDistributionTest is Test {
 
     /// Fee distribution — robustness ///
 
-    function test_DistributeFeesRedirectsFailedIntegratorTransferToLifi()
+    function test_DistributeFeesRetainsFailedIntegratorTransferInWrapper()
         public
     {
         // Rebuild the stack on a blacklisting asset so a blocked integrator wallet reverts.
@@ -346,29 +346,36 @@ contract VaultWrapperDistributionTest is Test {
         wrapper = _deploy(_assetFees(), SPLIT, _single(blocked), _full());
         _deposit(alice, DEPOSIT);
 
-        uint256 fee = _accruedFeeAssets();
+        uint256 lifiPart = wrapper.lifiFeeAssets();
         uint256 integratorPart = wrapper.integratorFeeAssets();
         BlacklistERC20(address(asset)).setBlocked(blocked, true);
 
         vm.expectEmit(true, true, false, true, address(wrapper));
-        emit IntegratorPayoutRedirected(
-            blocked,
-            address(asset),
-            integratorPart
-        );
+        emit IntegratorPayoutRetained(blocked, address(asset), integratorPart);
+
         wrapper.distributeFees(); // must not revert
 
-        // Blocked wallet got nothing; its share was redirected to LI.FI on top of LI.FI's part.
+        // Blocked wallet got nothing; LI.FI got only its own part; the integrator's share is
+        // left in the wrapper, re-booked as still-owed integrator fees (not redirected to LI.FI).
         assertEq(asset.balanceOf(blocked), 0);
-        assertEq(asset.balanceOf(lifiRecipient), fee);
+        assertEq(asset.balanceOf(lifiRecipient), lifiPart);
+        assertEq(wrapper.integratorFeeAssets(), integratorPart);
+        assertEq(wrapper.lifiFeeAssets(), 0);
+
+        // Integrator rotates to a working wallet and re-sweeps — the retained fees are claimed.
+        address fresh = makeAddr("fresh");
+        vm.prank(vaultAdmin);
+        wrapper.setIntegratorFeeReceivers(_receivers(_single(fresh), _full()));
+
+        wrapper.distributeFees();
+
+        assertEq(asset.balanceOf(fresh), integratorPart);
         assertEq(_accruedFeeAssets(), 0);
     }
 
-    function test_DistributeFeesRedirectsOnlyFailedWalletWithinFanOut()
-        public
-    {
-        // A single blocked wallet inside a multi-wallet fan-out redirects only its own share
-        // to LI.FI; the other wallets are still paid in full and distributeFees does not revert.
+    function test_DistributeFeesRetainsOnlyFailedWalletWithinFanOut() public {
+        // A single blocked wallet inside a multi-wallet fan-out leaves only its own share in
+        // the wrapper; the other wallets are still paid in full and distributeFees does not revert.
         _useBlacklistAsset();
         address[] memory wallets = _wallets3();
         wrapper = _deploy(_assetFees(), SPLIT, wallets, _bps3()); // 50% / 30% / 20%
@@ -384,14 +391,32 @@ contract VaultWrapperDistributionTest is Test {
         BlacklistERC20(address(asset)).setBlocked(wallets[1], true);
 
         vm.expectEmit(true, true, false, true, address(wrapper));
-        emit IntegratorPayoutRedirected(wallets[1], address(asset), share1);
+        emit IntegratorPayoutRetained(wallets[1], address(asset), share1);
+
         wrapper.distributeFees(); // must not revert
 
         assertEq(asset.balanceOf(wallets[0]), share0);
         assertEq(asset.balanceOf(wallets[1]), 0); // blocked: got nothing
         assertEq(asset.balanceOf(wallets[2]), share2);
-        // LI.FI receives its booked part plus only the blocked wallet's redirected share.
-        assertEq(asset.balanceOf(lifiRecipient), lifiPart + share1);
+        // LI.FI receives only its booked part; the blocked wallet's share stays in the wrapper.
+        assertEq(asset.balanceOf(lifiRecipient), lifiPart);
+        assertEq(wrapper.integratorFeeAssets(), share1);
+        assertEq(wrapper.lifiFeeAssets(), 0);
+
+        // Once the wallet is un-blacklisted, a re-sweep drains the retained pool. Retained fees
+        // carry no per-wallet memory, so the pool is re-fanned across the current receiver set
+        // (not handed back to the originally-failed wallet); the integrator's total is paid out.
+        BlacklistERC20(address(asset)).setBlocked(wallets[1], false);
+
+        wrapper.distributeFees();
+
+        assertEq(
+            asset.balanceOf(wallets[0]) +
+                asset.balanceOf(wallets[1]) +
+                asset.balanceOf(wallets[2]),
+            integratorPart
+        );
+        assertGt(asset.balanceOf(wallets[1]), 0);
         assertEq(_accruedFeeAssets(), 0);
     }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref EXSC-411

# Why did I implement it this way?

Follow-up on EXSC-411 (S3 — fee receivers & sweep distribution) implementing the conclusion reached with Alessandro in the [fee-distribution Slack thread](https://lifi-protocol.slack.com/archives/C0B9Q24JQM9/p1783421350972529): a failed integrator payout must **not** be auto-redirected to the LI.FI treasury (the legal implications of LI.FI claiming integrator funds are unresolved). Instead the funds stay in the wrapper, and the integrator recovers them by rotating to a working wallet via `setIntegratorFeeReceivers` and re-sweeping — so nothing gets stuck without LI.FI ever taking custody of integrator fees.

In `distributeFees`, the four counters are still zeroed up front (CEI); each `_distributeFeePool` now returns the integrator amount whose `trySafeTransfer` failed, and those totals are re-booked into `integratorFeeAssets` / `integratorFeeShares` after the transfers. The post-transfer write is safe under the existing `nonReentrant` guard. LI.FI is paid only its own booked part — no redirected top-up. The retained pool carries no per-wallet memory, so on the next sweep it is re-fanned across the current receiver set (consistent with `setIntegratorFeeReceivers`' existing semantics). Retained asset fees remain idle-and-tracked, so they stay excluded from `totalAssets()` and are never claimable by depositors.

The now-misnamed `IntegratorPayoutRedirected` event is renamed to `IntegratorPayoutRetained`. `@custom:version` stays at 1.0.0 — the subsystem is not deployed anywhere yet. Merges into `dev-vault-wrapper`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>