### PR TITLE
feat(safe): parked-tasks store layer for deferred diamond-cleanup queue

### DIFF
--- a/script/deploy/safe/enqueue-parked-task.ts
+++ b/script/deploy/safe/enqueue-parked-task.ts
@@ -2,14 +2,14 @@
  * Enqueue a Parked Diamond-Cleanup Task (write)
  *
  * Parks a single facet-removal task in the deferred diamond-cleanup queue
- * (`sc_private.parkedTasks`, design: PR #2049) instead of proposing the removal
+ * (`deferred-cleanup.parkedTasks`, design: PR #2049) instead of proposing the removal
  * eagerly. Called by `/deprecate-contract` (once the deprecation PR URL is known)
  * per (facet, network); the removal rides along the next time the network is
  * touched. Refuses to enqueue without the originating PR URL — the reviewer must
  * be able to see which PR a deferred removal belongs to at signing time (spec §6).
  *
  * Exit codes: 0 enqueued (or a harmless duplicate no-op), 1 invalid input / real
- * error, 2 recoverable misconfig (missing SC_MONGODB_URI / VPN not connected).
+ * error, 2 recoverable misconfig (missing MONGODB_URI).
  */
 
 import { execSync } from 'node:child_process'
@@ -137,12 +137,11 @@ const main = defineCommand({
       ;({ client: mongoClient, parkedTasks } = await getParkedTasksCollection())
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
-      consola.error(`Could not connect to Safe MongoDB: ${errorMsg}`)
-      if (
-        errorMsg.includes('SC_MONGODB_URI') ||
-        errorMsg.includes('VPN connection required')
+      consola.error(
+        `Could not connect to the parked-tasks MongoDB: ${errorMsg}`
       )
-        process.exit(2)
+      // missing env var is a recoverable misconfig, not a hard error
+      if (errorMsg.includes('MONGODB_URI')) process.exit(2)
       process.exit(1)
     }
 

--- a/script/deploy/safe/enqueue-parked-task.ts
+++ b/script/deploy/safe/enqueue-parked-task.ts
@@ -114,6 +114,11 @@ const main = defineCommand({
       process.exit(1)
     }
 
+    if (!args.facetName || args.facetName.trim() === '') {
+      consola.error('facetName is required and cannot be blank')
+      process.exit(1)
+    }
+
     const input: IParkedTaskInput = {
       kind: 'facet-removal',
       network: args.network.toLowerCase(),
@@ -155,7 +160,8 @@ const main = defineCommand({
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       consola.error(`Failed to enqueue parked task: ${errorMsg}`)
-      process.exit(1)
+      // Set exitCode (not process.exit) so the finally below still closes Mongo.
+      process.exitCode = 1
     } finally {
       try {
         await mongoClient.close(true)

--- a/script/deploy/safe/enqueue-parked-task.ts
+++ b/script/deploy/safe/enqueue-parked-task.ts
@@ -1,0 +1,171 @@
+/**
+ * Enqueue a Parked Diamond-Cleanup Task (write)
+ *
+ * Parks a single facet-removal task in the deferred diamond-cleanup queue
+ * (`sc_private.parkedTasks`, design: PR #2049) instead of proposing the removal
+ * eagerly. Called by `/deprecate-contract` (once the deprecation PR URL is known)
+ * per (facet, network); the removal rides along the next time the network is
+ * touched. Refuses to enqueue without the originating PR URL — the reviewer must
+ * be able to see which PR a deferred removal belongs to at signing time (spec §6).
+ *
+ * Exit codes: 0 enqueued (or a harmless duplicate no-op), 1 invalid input / real
+ * error, 2 recoverable misconfig (missing SC_MONGODB_URI / VPN not connected).
+ */
+
+import { execSync } from 'node:child_process'
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import * as dotenv from 'dotenv'
+import { getAddress, type Address } from 'viem'
+
+import { EnvironmentEnum } from '../../common/types'
+
+import {
+  enqueueParkedTask,
+  getParkedTasksCollection,
+  type IParkedTaskInput,
+} from './parked-tasks'
+
+dotenv.config()
+
+/** Resolves the enqueuer identity from git; falls back to `unknown` off a checkout. */
+function resolveEnqueuer(): string {
+  try {
+    return (
+      execSync('git config user.email', { encoding: 'utf8' }).trim() ||
+      'unknown'
+    )
+  } catch {
+    return 'unknown'
+  }
+}
+
+/** Parses+checksums an address arg, exiting 1 on an invalid value. */
+function requireAddress(label: string, value: string): Address {
+  try {
+    return getAddress(value)
+  } catch {
+    consola.error(`Invalid ${label}: "${value}" is not a valid address`)
+    process.exit(1)
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'enqueue-parked-task',
+    description:
+      'Park a facet-removal task in the deferred diamond-cleanup queue (requires the originating PR URL)',
+  },
+  args: {
+    network: {
+      type: 'string',
+      description: 'Network slug (matches networks.json keys)',
+      required: true,
+    },
+    environment: {
+      type: 'string',
+      description: 'Deployment environment (production only in v1)',
+      default: EnvironmentEnum.production,
+      required: false,
+    },
+    facetName: {
+      type: 'string',
+      description:
+        'Facet to park for removal (identity; selectors resolved at drain)',
+      required: true,
+    },
+    diamondAddress: {
+      type: 'string',
+      description: 'Diamond address snapshot from the deploy log',
+      required: true,
+    },
+    facetAddress: {
+      type: 'string',
+      description: 'Facet address snapshot from the deploy log',
+      required: true,
+    },
+    prUrl: {
+      type: 'string',
+      description:
+        'Originating deprecation PR URL (REQUIRED — shown to the signer)',
+      required: true,
+    },
+    notes: {
+      type: 'string',
+      description: 'Optional free-text note stored on the task',
+      required: false,
+    },
+  },
+  async run({ args }) {
+    // v1 parks production removals only — the fatigue problem it solves is prod
+    // Safe signing; staging/testnet broadcast directly and need no deferral.
+    if (args.environment !== EnvironmentEnum.production) {
+      consola.error(
+        `Only '${EnvironmentEnum.production}' tasks can be parked in v1 (got "${args.environment}")`
+      )
+      process.exit(1)
+    }
+
+    if (!args.prUrl || args.prUrl.trim() === '') {
+      consola.error(
+        'prUrl is required — a parked removal must carry its originating PR so the signer can see it'
+      )
+      process.exit(1)
+    }
+
+    const input: IParkedTaskInput = {
+      kind: 'facet-removal',
+      network: args.network.toLowerCase(),
+      environment: EnvironmentEnum.production,
+      facetName: args.facetName,
+      diamondAddress: requireAddress('diamondAddress', args.diamondAddress),
+      facetAddress: requireAddress('facetAddress', args.facetAddress),
+      prUrl: args.prUrl.trim(),
+      enqueuer: resolveEnqueuer(),
+      ...(args.notes ? { notes: args.notes } : {}),
+    }
+
+    let mongoClient
+    let parkedTasks
+    try {
+      ;({ client: mongoClient, parkedTasks } = await getParkedTasksCollection())
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      consola.error(`Could not connect to Safe MongoDB: ${errorMsg}`)
+      if (
+        errorMsg.includes('SC_MONGODB_URI') ||
+        errorMsg.includes('VPN connection required')
+      )
+        process.exit(2)
+      process.exit(1)
+    }
+
+    try {
+      const result = await enqueueParkedTask(parkedTasks, input)
+      if (result === null) {
+        consola.info(
+          `${input.facetName} on ${input.network} is already parked (queued/proposed) — no-op`
+        )
+        return
+      }
+      consola.success(
+        `Parked ${input.facetName} removal on ${input.network} (origin PR ${input.prUrl})`
+      )
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      consola.error(`Failed to enqueue parked task: ${errorMsg}`)
+      process.exit(1)
+    } finally {
+      try {
+        await mongoClient.close(true)
+      } catch (closeError: unknown) {
+        const closeMsg =
+          closeError instanceof Error ? closeError.message : String(closeError)
+        consola.warn(`Failed to close MongoDB connection: ${closeMsg}`)
+      }
+    }
+  },
+})
+
+runMain(main)

--- a/script/deploy/safe/list-parked-tasks.ts
+++ b/script/deploy/safe/list-parked-tasks.ts
@@ -2,13 +2,13 @@
  * List Parked Diamond-Cleanup Tasks (read-only)
  *
  * Non-interactive view of the deferred diamond-cleanup queue
- * (`sc_private.parkedTasks`, design: PR #2049). Shows which facet removals are
+ * (`deferred-cleanup.parkedTasks`, design: PR #2049). Shows which facet removals are
  * parked per network, their status, age, and originating deprecation PR — so an
  * operator can see the backlog and audit the parked set without a live drain.
- * Mirrors list-pending-proposals.ts (citty/consola, `--json`, VPN-gated).
+ * Mirrors list-pending-proposals.ts (citty/consola, `--json`).
  *
  * Exit codes: 0 success (even with zero matches), 1 real error,
- * 2 recoverable misconfig (missing SC_MONGODB_URI / VPN not connected).
+ * 2 recoverable misconfig (missing MONGODB_URI).
  */
 
 import { defineCommand, runMain } from 'citty'
@@ -108,13 +108,11 @@ const main = defineCommand({
       ;({ client: mongoClient, parkedTasks } = await getParkedTasksCollection())
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
-      consola.error(`Could not connect to Safe MongoDB: ${errorMsg}`)
-      // missing env var or VPN are recoverable misconfigs, not hard errors
-      if (
-        errorMsg.includes('SC_MONGODB_URI') ||
-        errorMsg.includes('VPN connection required')
+      consola.error(
+        `Could not connect to the parked-tasks MongoDB: ${errorMsg}`
       )
-        process.exit(2)
+      // missing env var is a recoverable misconfig, not a hard error
+      if (errorMsg.includes('MONGODB_URI')) process.exit(2)
       process.exit(1)
     }
 

--- a/script/deploy/safe/list-parked-tasks.ts
+++ b/script/deploy/safe/list-parked-tasks.ts
@@ -89,10 +89,14 @@ const main = defineCommand({
     }
 
     const networks = args.network
-      ? args.network
-          .split(',')
-          .map((n: string) => n.trim().toLowerCase())
-          .filter(Boolean)
+      ? [
+          ...new Set(
+            args.network
+              .split(',')
+              .map((n: string) => n.trim().toLowerCase())
+              .filter(Boolean)
+          ),
+        ]
       : undefined
 
     // JSON consumers parse stdout; suppress info/success but keep errors visible

--- a/script/deploy/safe/list-parked-tasks.ts
+++ b/script/deploy/safe/list-parked-tasks.ts
@@ -186,7 +186,8 @@ const main = defineCommand({
     } catch (error: unknown) {
       const errorMsg = error instanceof Error ? error.message : String(error)
       consola.error(`Failed to query parked tasks: ${errorMsg}`)
-      process.exit(1)
+      // Set exitCode (not process.exit) so the finally below still closes Mongo.
+      process.exitCode = 1
     } finally {
       // A cleanup-only failure must not flip an otherwise-successful run
       try {

--- a/script/deploy/safe/list-parked-tasks.ts
+++ b/script/deploy/safe/list-parked-tasks.ts
@@ -1,0 +1,199 @@
+/**
+ * List Parked Diamond-Cleanup Tasks (read-only)
+ *
+ * Non-interactive view of the deferred diamond-cleanup queue
+ * (`sc_private.parkedTasks`, design: PR #2049). Shows which facet removals are
+ * parked per network, their status, age, and originating deprecation PR — so an
+ * operator can see the backlog and audit the parked set without a live drain.
+ * Mirrors list-pending-proposals.ts (citty/consola, `--json`, VPN-gated).
+ *
+ * Exit codes: 0 success (even with zero matches), 1 real error,
+ * 2 recoverable misconfig (missing SC_MONGODB_URI / VPN not connected).
+ */
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import * as dotenv from 'dotenv'
+
+import {
+  getParkedTasksCollection,
+  listParkedTasks,
+  type IListParkedTasksFilter,
+  type IParkedTask,
+  type ParkedTaskStatus,
+} from './parked-tasks'
+
+dotenv.config()
+
+const VALID_STATUSES = [
+  'queued',
+  'proposed',
+  'executed',
+  'cancelled',
+  'superseded',
+  'all',
+] as const
+
+/** Human-readable age (e.g. "3d 4h", "5h", "12m") from `createdAt` to now. */
+function formatAge(createdAt: Date): string {
+  const ms = Date.now() - new Date(createdAt).getTime()
+  const minutes = Math.floor(ms / 60_000)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  return `${days}d ${hours % 24}h`
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'list-parked-tasks',
+    description:
+      'List parked diamond-cleanup tasks from MongoDB grouped by network (read-only)',
+  },
+  args: {
+    network: {
+      type: 'string',
+      description:
+        'Only show tasks for these networks (comma-separated, e.g. "arbitrum,base,mainnet")',
+      required: false,
+    },
+    pr: {
+      type: 'string',
+      description: 'Only show tasks whose originating PR URL matches exactly',
+      required: false,
+    },
+    status: {
+      type: 'string',
+      description: `Task status to list (${VALID_STATUSES.join(
+        '|'
+      )}), default: all`,
+      required: false,
+    },
+    json: {
+      type: 'boolean',
+      description: 'Print machine-readable JSON to stdout instead of a table',
+      default: false,
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const status = (args.status || 'all').toLowerCase()
+    if (!VALID_STATUSES.includes(status as (typeof VALID_STATUSES)[number])) {
+      consola.error(
+        `Invalid status "${
+          args.status
+        }" - must be one of: ${VALID_STATUSES.join(', ')}`
+      )
+      process.exit(1)
+    }
+
+    const networks = args.network
+      ? args.network
+          .split(',')
+          .map((n: string) => n.trim().toLowerCase())
+          .filter(Boolean)
+      : undefined
+
+    // JSON consumers parse stdout; suppress info/success but keep errors visible
+    if (args.json) consola.level = 0
+
+    let mongoClient
+    let parkedTasks
+    try {
+      ;({ client: mongoClient, parkedTasks } = await getParkedTasksCollection())
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      consola.error(`Could not connect to Safe MongoDB: ${errorMsg}`)
+      // missing env var or VPN are recoverable misconfigs, not hard errors
+      if (
+        errorMsg.includes('SC_MONGODB_URI') ||
+        errorMsg.includes('VPN connection required')
+      )
+        process.exit(2)
+      process.exit(1)
+    }
+
+    try {
+      const base: IListParkedTasksFilter = {}
+      if (args.pr) base.prUrl = args.pr
+      if (status !== 'all') base.status = status as ParkedTaskStatus
+
+      // One filtered read per requested network (reuses the store helper); a
+      // single unfiltered read when no --network is given.
+      const filters: IListParkedTasksFilter[] = networks?.length
+        ? networks.map((network) => ({ ...base, network }))
+        : [base]
+      const tasks = (
+        await Promise.all(filters.map((f) => listParkedTasks(parkedTasks, f)))
+      )
+        .flat()
+        .sort(
+          (a, b) =>
+            a.network.localeCompare(b.network) ||
+            a.facetName.localeCompare(b.facetName)
+        )
+
+      if (args.json) {
+        process.stdout.write(
+          `${JSON.stringify({ count: tasks.length, tasks }, null, 2)}\n`
+        )
+        return
+      }
+
+      if (!tasks.length) {
+        consola.info(
+          `No ${status === 'all' ? '' : `'${status}' `}parked tasks found${
+            networks ? ` for: ${networks.join(', ')}` : ''
+          }`
+        )
+        return
+      }
+
+      let currentNetwork = ''
+      const perNetwork: Record<string, { queued: number; proposed: number }> =
+        {}
+      tasks.forEach((t: IParkedTask) => {
+        if (t.network !== currentNetwork) {
+          currentNetwork = t.network
+          consola.info('')
+          consola.info(`=== ${t.network} ===`)
+        }
+        const counts = (perNetwork[t.network] ??= { queued: 0, proposed: 0 })
+        if (t.status === 'queued') counts.queued++
+        if (t.status === 'proposed') counts.proposed++
+        consola.info(
+          [
+            `${t.facetName}`,
+            `status ${t.status}`,
+            `age ${formatAge(t.createdAt)}`,
+            `PR ${t.prUrl}`,
+            `safeTxHash ${t.safeTxHash ?? '-'}`,
+          ].join(' | ')
+        )
+      })
+
+      consola.info('')
+      for (const [network, counts] of Object.entries(perNetwork))
+        consola.info(
+          `${network}: ${counts.queued} queued, ${counts.proposed} proposed`
+        )
+      consola.success(`${tasks.length} parked task(s) listed`)
+    } catch (error: unknown) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      consola.error(`Failed to query parked tasks: ${errorMsg}`)
+      process.exit(1)
+    } finally {
+      // A cleanup-only failure must not flip an otherwise-successful run
+      try {
+        await mongoClient.close(true)
+      } catch (closeError: unknown) {
+        const closeMsg =
+          closeError instanceof Error ? closeError.message : String(closeError)
+        consola.warn(`Failed to close MongoDB connection: ${closeMsg}`)
+      }
+    }
+  },
+})
+
+runMain(main)

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -271,6 +271,34 @@ describe('enqueueParkedTask', () => {
     )
     expect(coll.rows).toHaveLength(0)
   })
+
+  it('throws when facetName is blank', async () => {
+    const coll = createFakeCollection()
+    await expectRejects(
+      enqueueParkedTask(coll, buildInput({ facetName: '  ' })),
+      /facetName is required/
+    )
+    expect(coll.rows).toHaveLength(0)
+  })
+
+  it('trims network, facetName and prUrl before storing/keying', async () => {
+    const coll = createFakeCollection()
+    await enqueueParkedTask(
+      coll,
+      buildInput({
+        network: '  Arbitrum ',
+        facetName: '  GenericSwapFacet  ',
+        prUrl: `  ${PR_URL}  `,
+      })
+    )
+    const row = coll.rows[0]
+    expect(row?.network).toBe('arbitrum')
+    expect(row?.facetName).toBe('GenericSwapFacet')
+    expect(row?.prUrl).toBe(PR_URL)
+    expect(row?.taskKey).toBe(
+      'facet-removal|arbitrum|production|GenericSwapFacet'
+    )
+  })
 })
 
 describe('listParkedTasks', () => {

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Tests for the deferred diamond-cleanup queue store layer (parked-tasks.ts).
+ *
+ * The store persists `IParkedTask` rows in `sc_private.parkedTasks` and enforces
+ * a partial unique index on `taskKey` (status ∈ {queued, proposed}) so a facet
+ * can only be parked once per network while still open. Every pure helper takes
+ * an injected `Collection<IParkedTask>` so the logic is exercised against an
+ * in-memory fake that mirrors the partial-unique-index and atomic-flip semantics
+ * MongoDB provides — no live cluster / VPN required. Only the thin live adapter
+ * `getParkedTasksCollection()` (a `MongoClient` connect + VPN gate) is unit-test
+ * exempt, exactly as its sibling `getSafeMongoCollection()` is.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import {
+  type Collection,
+  type Filter,
+  type InsertOneResult,
+  type UpdateFilter,
+  type WithId,
+} from 'mongodb'
+import { type Address } from 'viem'
+
+import { EnvironmentEnum } from '../../common/types'
+
+import {
+  claimForProposal,
+  computeTaskKey,
+  enqueueParkedTask,
+  ensureParkedTasksIndexes,
+  listParkedTasks,
+  markCancelled,
+  markExecuted,
+  markSuperseded,
+  revertToQueued,
+  type IParkedTask,
+  type IParkedTaskInput,
+} from './parked-tasks'
+
+const DIAMOND = '0x1111111111111111111111111111111111111111' as Address
+const FACET = '0x2222222222222222222222222222222222222222' as Address
+const PR_URL = 'https://github.com/lifinance/contracts/pull/2046'
+
+function buildInput(
+  overrides: Partial<IParkedTaskInput> = {}
+): IParkedTaskInput {
+  return {
+    kind: 'facet-removal',
+    network: 'arbitrum',
+    environment: EnvironmentEnum.production,
+    facetName: 'GenericSwapFacet',
+    diamondAddress: DIAMOND,
+    facetAddress: FACET,
+    prUrl: PR_URL,
+    enqueuer: 'dev@li.finance',
+    ...overrides,
+  }
+}
+
+/**
+ * Asserts `promise` rejects with an error whose message matches `match`. Kept as
+ * a helper (rather than `expect().rejects`) so the awaited value is a real
+ * Promise — `@typescript-eslint/await-thenable` rejects awaiting bun's matcher.
+ */
+async function expectRejects(
+  promise: Promise<unknown>,
+  match: RegExp | string
+): Promise<void> {
+  let error: Error | undefined
+  try {
+    await promise
+  } catch (caught) {
+    error = caught as Error
+  }
+  expect(error).toBeInstanceOf(Error)
+  if (match instanceof RegExp) expect(error?.message).toMatch(match)
+  else expect(error?.message).toContain(match)
+}
+
+class FakeDuplicateKeyError extends Error {
+  public code = 11000
+  public constructor() {
+    super(
+      'E11000 duplicate key error collection: sc_private.parkedTasks index: unique_open_task_key'
+    )
+  }
+}
+
+/** True when `value` matches a Mongo leaf filter (`$eq` / `$in` / literal). */
+function matchesLeaf(value: unknown, cond: unknown): boolean {
+  if (cond !== null && typeof cond === 'object') {
+    const c = cond as { $eq?: unknown; $in?: unknown[] }
+    if ('$eq' in c) return value === c.$eq
+    if ('$in' in c) return (c.$in ?? []).includes(value)
+  }
+  return value === cond
+}
+
+function matchesFilter(row: IParkedTask, filter: Filter<IParkedTask>): boolean {
+  const record = row as unknown as Record<string, unknown>
+  return Object.entries(filter).every(([key, cond]) =>
+    matchesLeaf(record[key], cond)
+  )
+}
+
+interface IFakeOptions {
+  createIndexError?: Error
+}
+
+type IFakeCollection = Collection<IParkedTask> & {
+  rows: IParkedTask[]
+  createIndexCalls: { spec: unknown; options: unknown }[]
+}
+
+/**
+ * In-memory stand-in for the `parkedTasks` collection. Replicates the partial
+ * unique index (an insert whose `taskKey` collides with an existing
+ * queued/proposed row throws code 11000), `find().toArray()`, the atomic
+ * `findOneAndUpdate` used by the status transitions, and `createIndex`.
+ */
+function createFakeCollection(
+  initial: IParkedTask[] = [],
+  options: IFakeOptions = {}
+): IFakeCollection {
+  const rows: IParkedTask[] = initial.map((r) => ({ ...r }))
+  const createIndexCalls: { spec: unknown; options: unknown }[] = []
+  const OPEN = ['queued', 'proposed']
+  const api = {
+    rows,
+    createIndexCalls,
+    async insertOne(doc: IParkedTask): Promise<InsertOneResult> {
+      const duplicate = rows.some(
+        (r) =>
+          r.taskKey === doc.taskKey &&
+          OPEN.includes(r.status) &&
+          OPEN.includes(doc.status)
+      )
+      if (duplicate) throw new FakeDuplicateKeyError()
+      rows.push({ ...doc })
+      return {
+        acknowledged: true,
+        insertedId: rows.length,
+      } as unknown as InsertOneResult
+    },
+    find(filter: Filter<IParkedTask>) {
+      return {
+        async toArray(): Promise<WithId<IParkedTask>[]> {
+          return rows.filter((r) =>
+            matchesFilter(r, filter)
+          ) as WithId<IParkedTask>[]
+        },
+      }
+    },
+    async findOneAndUpdate(
+      filter: Filter<IParkedTask>,
+      update: UpdateFilter<IParkedTask>
+    ): Promise<WithId<IParkedTask> | null> {
+      const row = rows.find((r) => matchesFilter(r, filter))
+      if (!row) return null
+      Object.assign(row, update.$set ?? {})
+      const record = row as unknown as Record<string, unknown>
+      for (const field of Object.keys(update.$unset ?? {})) delete record[field]
+      return row as WithId<IParkedTask>
+    },
+    async createIndex(spec: unknown, opts: unknown): Promise<string> {
+      createIndexCalls.push({ spec, options: opts })
+      if (options.createIndexError) throw options.createIndexError
+      return (opts as { name: string }).name
+    },
+  }
+  return api as unknown as IFakeCollection
+}
+
+describe('computeTaskKey', () => {
+  it('joins kind|network|environment|facetName', () => {
+    expect(
+      computeTaskKey(
+        'facet-removal',
+        'arbitrum',
+        EnvironmentEnum.production,
+        'GenericSwapFacet'
+      )
+    ).toBe('facet-removal|arbitrum|production|GenericSwapFacet')
+  })
+
+  it('lowercases only the network segment', () => {
+    expect(
+      computeTaskKey(
+        'facet-removal',
+        'Arbitrum',
+        EnvironmentEnum.production,
+        'GenericSwapFacet'
+      )
+    ).toBe('facet-removal|arbitrum|production|GenericSwapFacet')
+  })
+})
+
+describe('enqueueParkedTask', () => {
+  it('inserts a queued task and stamps taskKey/status/createdAt', async () => {
+    const coll = createFakeCollection()
+    const result = await enqueueParkedTask(coll, buildInput())
+    expect(result).not.toBeNull()
+    expect(coll.rows).toHaveLength(1)
+    const row = coll.rows[0]
+    expect(row?.taskKey).toBe(
+      'facet-removal|arbitrum|production|GenericSwapFacet'
+    )
+    expect(row?.status).toBe('queued')
+    expect(row?.createdAt).toBeInstanceOf(Date)
+    expect(row?.prUrl).toBe(PR_URL)
+    expect(row?.network).toBe('arbitrum')
+  })
+
+  it('lowercases the network before storing', async () => {
+    const coll = createFakeCollection()
+    await enqueueParkedTask(coll, buildInput({ network: 'Arbitrum' }))
+    expect(coll.rows[0]?.network).toBe('arbitrum')
+    expect(coll.rows[0]?.taskKey).toBe(
+      'facet-removal|arbitrum|production|GenericSwapFacet'
+    )
+  })
+
+  it('returns null on a duplicate open task (E11000), without throwing', async () => {
+    const coll = createFakeCollection()
+    await enqueueParkedTask(coll, buildInput())
+    const second = await enqueueParkedTask(coll, buildInput())
+    expect(second).toBeNull()
+    expect(coll.rows).toHaveLength(1)
+  })
+
+  it('rethrows a non-duplicate insert error', async () => {
+    const coll = createFakeCollection()
+    coll.insertOne = async () => {
+      throw new Error('connection reset')
+    }
+    await expectRejects(
+      enqueueParkedTask(coll, buildInput()),
+      'connection reset'
+    )
+  })
+
+  it('throws when prUrl is missing', async () => {
+    const coll = createFakeCollection()
+    await expectRejects(
+      enqueueParkedTask(
+        coll,
+        buildInput({ prUrl: undefined as unknown as string })
+      ),
+      /prUrl is required/
+    )
+    expect(coll.rows).toHaveLength(0)
+  })
+
+  it('throws when prUrl is blank', async () => {
+    const coll = createFakeCollection()
+    await expectRejects(
+      enqueueParkedTask(coll, buildInput({ prUrl: '   ' })),
+      /prUrl is required/
+    )
+    expect(coll.rows).toHaveLength(0)
+  })
+})
+
+describe('listParkedTasks', () => {
+  function seed(): IFakeCollection {
+    return createFakeCollection([
+      {
+        taskKey: 'facet-removal|arbitrum|production|A',
+        kind: 'facet-removal',
+        network: 'arbitrum',
+        environment: EnvironmentEnum.production,
+        facetName: 'A',
+        diamondAddress: DIAMOND,
+        facetAddress: FACET,
+        prUrl: 'https://github.com/lifinance/contracts/pull/1',
+        status: 'queued',
+        enqueuer: 'dev@li.finance',
+        createdAt: new Date(),
+      },
+      {
+        taskKey: 'facet-removal|base|production|B',
+        kind: 'facet-removal',
+        network: 'base',
+        environment: EnvironmentEnum.production,
+        facetName: 'B',
+        diamondAddress: DIAMOND,
+        facetAddress: FACET,
+        prUrl: 'https://github.com/lifinance/contracts/pull/2',
+        status: 'proposed',
+        enqueuer: 'dev@li.finance',
+        createdAt: new Date(),
+      },
+      {
+        taskKey: 'facet-removal|base|production|C',
+        kind: 'facet-removal',
+        network: 'base',
+        environment: EnvironmentEnum.production,
+        facetName: 'C',
+        diamondAddress: DIAMOND,
+        facetAddress: FACET,
+        prUrl: 'https://github.com/lifinance/contracts/pull/1',
+        status: 'executed',
+        enqueuer: 'dev@li.finance',
+        createdAt: new Date(),
+      },
+    ])
+  }
+
+  it('returns all tasks with no filter', async () => {
+    const tasks = await listParkedTasks(seed(), {})
+    expect(tasks).toHaveLength(3)
+  })
+
+  it('filters by network (lowercased)', async () => {
+    const tasks = await listParkedTasks(seed(), { network: 'Base' })
+    expect(tasks.map((t) => t.facetName).sort()).toEqual(['B', 'C'])
+  })
+
+  it('filters by status', async () => {
+    const tasks = await listParkedTasks(seed(), { status: 'queued' })
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]?.facetName).toBe('A')
+  })
+
+  it('filters by prUrl', async () => {
+    const tasks = await listParkedTasks(seed(), {
+      prUrl: 'https://github.com/lifinance/contracts/pull/1',
+    })
+    expect(tasks.map((t) => t.facetName).sort()).toEqual(['A', 'C'])
+  })
+
+  it('combines network + status filters', async () => {
+    const tasks = await listParkedTasks(seed(), {
+      network: 'base',
+      status: 'proposed',
+    })
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]?.facetName).toBe('B')
+  })
+})
+
+describe('claimForProposal', () => {
+  function seedOne(status: IParkedTask['status']): IFakeCollection {
+    return createFakeCollection([
+      {
+        taskKey: 'facet-removal|arbitrum|production|A',
+        kind: 'facet-removal',
+        network: 'arbitrum',
+        environment: EnvironmentEnum.production,
+        facetName: 'A',
+        diamondAddress: DIAMOND,
+        facetAddress: FACET,
+        prUrl: PR_URL,
+        status,
+        enqueuer: 'dev@li.finance',
+        createdAt: new Date(),
+      },
+    ])
+  }
+
+  it('atomically flips a queued task to proposed and stamps proposedAt', async () => {
+    const coll = seedOne('queued')
+    const claimed = await claimForProposal(
+      coll,
+      'facet-removal|arbitrum|production|A'
+    )
+    expect(claimed).not.toBeNull()
+    expect(claimed?.status).toBe('proposed')
+    expect(claimed?.proposedAt).toBeInstanceOf(Date)
+    expect(coll.rows[0]?.status).toBe('proposed')
+  })
+
+  it('returns null when the task is already claimed (not queued)', async () => {
+    const coll = seedOne('proposed')
+    const claimed = await claimForProposal(
+      coll,
+      'facet-removal|arbitrum|production|A'
+    )
+    expect(claimed).toBeNull()
+    expect(coll.rows[0]?.status).toBe('proposed')
+  })
+
+  it('returns null for an unknown taskKey', async () => {
+    const coll = seedOne('queued')
+    expect(await claimForProposal(coll, 'nope')).toBeNull()
+  })
+})
+
+describe('status transitions', () => {
+  const KEY = 'facet-removal|arbitrum|production|A'
+  function seedOne(status: IParkedTask['status']): IFakeCollection {
+    return createFakeCollection([
+      {
+        taskKey: KEY,
+        kind: 'facet-removal',
+        network: 'arbitrum',
+        environment: EnvironmentEnum.production,
+        facetName: 'A',
+        diamondAddress: DIAMOND,
+        facetAddress: FACET,
+        prUrl: PR_URL,
+        status,
+        enqueuer: 'dev@li.finance',
+        createdAt: new Date(),
+        proposedAt: new Date(),
+        safeTxHash: '0xabc',
+      },
+    ])
+  }
+
+  it('markExecuted flips proposed→executed and sets resolvedAt', async () => {
+    const coll = seedOne('proposed')
+    const doc = await markExecuted(coll, KEY)
+    expect(doc?.status).toBe('executed')
+    expect(doc?.resolvedAt).toBeInstanceOf(Date)
+  })
+
+  it('markExecuted is a no-op (null) on a queued task', async () => {
+    const coll = seedOne('queued')
+    expect(await markExecuted(coll, KEY)).toBeNull()
+    expect(coll.rows[0]?.status).toBe('queued')
+  })
+
+  it('markSuperseded flips a queued task to superseded', async () => {
+    const coll = seedOne('queued')
+    const doc = await markSuperseded(coll, KEY)
+    expect(doc?.status).toBe('superseded')
+    expect(doc?.resolvedAt).toBeInstanceOf(Date)
+  })
+
+  it('markSuperseded flips a proposed task to superseded', async () => {
+    const coll = seedOne('proposed')
+    expect((await markSuperseded(coll, KEY))?.status).toBe('superseded')
+  })
+
+  it('markSuperseded is a no-op (null) on an executed task', async () => {
+    const coll = seedOne('executed')
+    expect(await markSuperseded(coll, KEY)).toBeNull()
+  })
+
+  it('markCancelled flips a queued task to cancelled', async () => {
+    const coll = seedOne('queued')
+    const doc = await markCancelled(coll, KEY)
+    expect(doc?.status).toBe('cancelled')
+    expect(doc?.resolvedAt).toBeInstanceOf(Date)
+  })
+
+  it('markCancelled is a no-op (null) on a cancelled task', async () => {
+    const coll = seedOne('cancelled')
+    expect(await markCancelled(coll, KEY)).toBeNull()
+  })
+
+  it('revertToQueued flips proposed→queued and clears proposedAt+safeTxHash', async () => {
+    const coll = seedOne('proposed')
+    const doc = await revertToQueued(coll, KEY)
+    expect(doc?.status).toBe('queued')
+    expect(doc?.proposedAt).toBeUndefined()
+    expect(doc?.safeTxHash).toBeUndefined()
+  })
+
+  it('revertToQueued is a no-op (null) on a queued task', async () => {
+    const coll = seedOne('queued')
+    expect(await revertToQueued(coll, KEY)).toBeNull()
+  })
+})
+
+describe('ensureParkedTasksIndexes', () => {
+  it('creates the partial unique index on taskKey for open statuses', async () => {
+    const coll = createFakeCollection()
+    await ensureParkedTasksIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(1)
+    const call = coll.createIndexCalls[0]
+    expect(call?.spec).toEqual({ taskKey: 1 })
+    expect(call?.options).toEqual({
+      unique: true,
+      partialFilterExpression: { status: { $in: ['queued', 'proposed'] } },
+      name: 'unique_open_task_key',
+    })
+  })
+
+  it('surfaces an index-options conflict (code 85) as a clear error', async () => {
+    const err = Object.assign(new Error('conflict'), { code: 85 })
+    const coll = createFakeCollection([], { createIndexError: err })
+    await expectRejects(ensureParkedTasksIndexes(coll), /Index conflict/)
+  })
+
+  it('surfaces an index-keyspec conflict (code 86) as a clear error', async () => {
+    const err = Object.assign(new Error('conflict'), { code: 86 })
+    const coll = createFakeCollection([], { createIndexError: err })
+    await expectRejects(ensureParkedTasksIndexes(coll), /Index conflict/)
+  })
+
+  it('rethrows any other createIndex error unchanged', async () => {
+    const err = Object.assign(new Error('network down'), { code: 6 })
+    const coll = createFakeCollection([], { createIndexError: err })
+    await expectRejects(ensureParkedTasksIndexes(coll), 'network down')
+  })
+})

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -1,14 +1,14 @@
 /**
  * Tests for the deferred diamond-cleanup queue store layer (parked-tasks.ts).
  *
- * The store persists `IParkedTask` rows in `sc_private.parkedTasks` and enforces
- * a partial unique index on `taskKey` (status ∈ {queued, proposed}) so a facet
- * can only be parked once per network while still open. Every pure helper takes
- * an injected `Collection<IParkedTask>` so the logic is exercised against an
+ * The store persists `IParkedTask` rows in `deferred-cleanup.parkedTasks` and
+ * enforces a partial unique index on `taskKey` (status ∈ {queued, proposed}) so a
+ * facet can only be parked once per network while still open. Every pure helper
+ * takes an injected `Collection<IParkedTask>` so the logic is exercised against an
  * in-memory fake that mirrors the partial-unique-index and atomic-flip semantics
- * MongoDB provides — no live cluster / VPN required. Only the thin live adapter
- * `getParkedTasksCollection()` (a `MongoClient` connect + VPN gate) is unit-test
- * exempt, exactly as its sibling `getSafeMongoCollection()` is.
+ * MongoDB provides — no live cluster required. Only the thin live adapter
+ * `getParkedTasksCollection()` (a `MongoClient` connect) is unit-test exempt,
+ * exactly as its sibling `getTimelockQueueCollection()` is.
  */
 
 import {
@@ -86,7 +86,7 @@ class FakeDuplicateKeyError extends Error {
   public code = 11000
   public constructor() {
     super(
-      'E11000 duplicate key error collection: sc_private.parkedTasks index: unique_open_task_key'
+      'E11000 duplicate key error collection: deferred-cleanup.parkedTasks index: unique_open_task_key'
     )
   }
 }

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -158,14 +158,21 @@ function createFakeCollection(
     },
     async findOneAndUpdate(
       filter: Filter<IParkedTask>,
-      update: UpdateFilter<IParkedTask>
+      update: UpdateFilter<IParkedTask>,
+      opts?: { returnDocument?: 'before' | 'after' }
     ): Promise<WithId<IParkedTask> | null> {
       const row = rows.find((r) => matchesFilter(r, filter))
       if (!row) return null
+      // Snapshot BEFORE mutating so the driver-default 'before' is honored — this
+      // is what forces production to pass returnDocument:'after' for the
+      // post-update assertions to hold.
+      const before = { ...row } as WithId<IParkedTask>
       Object.assign(row, update.$set ?? {})
       const record = row as unknown as Record<string, unknown>
       for (const field of Object.keys(update.$unset ?? {})) delete record[field]
-      return row as WithId<IParkedTask>
+      return opts?.returnDocument === 'after'
+        ? (row as WithId<IParkedTask>)
+        : before
     },
     async createIndex(spec: unknown, opts: unknown): Promise<string> {
       createIndexCalls.push({ spec, options: opts })
@@ -453,6 +460,12 @@ describe('status transitions', () => {
   it('markCancelled is a no-op (null) on a cancelled task', async () => {
     const coll = seedOne('cancelled')
     expect(await markCancelled(coll, KEY)).toBeNull()
+  })
+
+  it('markCancelled is a no-op (null) on a proposed task (avoids orphaning its proposal)', async () => {
+    const coll = seedOne('proposed')
+    expect(await markCancelled(coll, KEY)).toBeNull()
+    expect(coll.rows[0]?.status).toBe('proposed')
   })
 
   it('revertToQueued flips proposed→queued and clears proposedAt+safeTxHash', async () => {

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -1,0 +1,419 @@
+/**
+ * Deferred diamond-cleanup queue — store layer.
+ *
+ * Backs the "park a facet removal now, drain it opportunistically later" model
+ * (design: docs/DeferredDiamondCleanupQueue.md, PR #2049) with a durable queue
+ * in the same `sc_private` cluster the Safe proposals live in (`SC_MONGODB_URI`
+ * + VPN gate), collection `parkedTasks`. It mirrors the second durable queue the
+ * repo already runs on this plumbing (`timelock-operations/queue`,
+ * timelock-queue.ts) rather than introducing a new store type.
+ *
+ * This module is the *persistence* layer only — it does not mint Safe proposals,
+ * resolve selectors from the loupe, or hook the drain chokepoint (those depend on
+ * the #2047 removal engine and land separately). Every helper takes an injected
+ * `Collection<IParkedTask>` so the logic is unit-testable against an in-memory
+ * fake without a live cluster; only `getParkedTasksCollection()` touches Mongo.
+ *
+ * Dedup is enforced at the queue layer via a partial unique index on `taskKey`
+ * filtered to the *open* statuses {queued, proposed} — mirroring
+ * `unique_pending_intent_hash` — and the atomic `queued → proposed` flip in
+ * {@link claimForProposal}. The time-derived timelock salt makes the proposal
+ * `intentHash` non-deterministic, so it cannot dedup a re-proposed removal
+ * (spec Fact 9); the queue-layer flip is the guarantee instead.
+ */
+
+import { consola } from 'consola'
+import {
+  MongoClient,
+  type Collection,
+  type Filter,
+  type InsertOneResult,
+  type ObjectId,
+  type UpdateFilter,
+  type WithId,
+} from 'mongodb'
+import { type Address } from 'viem'
+
+import { type EnvironmentEnum } from '../../common/types'
+
+/** DB shared with Safe proposals (`pendingTransactions`) — same VPN-gated cluster. */
+const PARKED_TASKS_DB_NAME = 'sc_private'
+
+/** New collection holding the deferred diamond-cleanup queue. */
+const PARKED_TASKS_COLLECTION_NAME = 'parkedTasks'
+
+/** Kind of deferred diamond-maintenance task. Only `facet-removal` in v1 (spec §3). */
+export type ParkedTaskKind = 'facet-removal'
+
+/**
+ * Lifecycle states (spec §7). `queued`/`proposed` are the *open* states the dedup
+ * index covers; `executed`/`cancelled`/`superseded` are terminal.
+ */
+export type ParkedTaskStatus =
+  | 'queued'
+  | 'proposed'
+  | 'executed'
+  | 'cancelled'
+  | 'superseded'
+
+/** Statuses under which a `taskKey` is still active and must stay unique. */
+const OPEN_STATUSES: ParkedTaskStatus[] = ['queued', 'proposed']
+
+/**
+ * A deferred diamond-maintenance task, parked until the network is next touched.
+ * One record per (kind, network, environment, facetName) — the finest grain
+ * (spec §4). Selectors are intentionally NOT stored: they are resolved from the
+ * live loupe at drain time, so a stored list can never go stale.
+ */
+export interface IParkedTask {
+  _id?: ObjectId
+  /** Dedup key `${kind}|${network}|${environment}|${facetName}` (see {@link computeTaskKey}). */
+  taskKey: string
+  kind: ParkedTaskKind
+  /** Lowercased network name, matching the `pendingTransactions` convention. */
+  network: string
+  /** `production` in v1 — the queue is a production-mainnet construct (spec §12). */
+  environment: EnvironmentEnum
+  /** The facet identity; selectors are re-resolved from the loupe at drain. */
+  facetName: string
+  /** Diamond address snapshot from the deploy log at enqueue (sanity/fallback). */
+  diamondAddress: Address
+  /** Facet address snapshot; re-verified against the loupe at drain. */
+  facetAddress: Address
+  /** Originating deprecation PR — REQUIRED and first-class (spec §6). */
+  prUrl: string
+  status: ParkedTaskStatus
+  /** git user.email / actor that enqueued, for audit. */
+  enqueuer: string
+  createdAt: Date
+  /** Set when the drain claims the task (`queued → proposed`). */
+  proposedAt?: Date
+  /** Set at drain → links to the minted `pendingTransactions` proposal. */
+  safeTxHash?: string
+  /** Set on a terminal transition (executed / cancelled / superseded). */
+  resolvedAt?: Date
+  notes?: string
+}
+
+/**
+ * Fields a caller supplies to enqueue a task. `taskKey`, `status`, `createdAt`
+ * and the drain/resolution timestamps are derived by {@link enqueueParkedTask}.
+ */
+export type IParkedTaskInput = Omit<
+  IParkedTask,
+  | '_id'
+  | 'taskKey'
+  | 'status'
+  | 'createdAt'
+  | 'proposedAt'
+  | 'safeTxHash'
+  | 'resolvedAt'
+>
+
+/** Filters accepted by {@link listParkedTasks}. */
+export interface IListParkedTasksFilter {
+  network?: string
+  prUrl?: string
+  status?: ParkedTaskStatus
+}
+
+/**
+ * Computes the dedup key for a parked task: `${kind}|${network}|${environment}|${facetName}`.
+ * Only the network segment is lowercased, matching the stored `network` value.
+ *
+ * @param kind - Task kind (`facet-removal` in v1).
+ * @param network - Network slug (matches `networks.json` keys).
+ * @param environment - Deployment environment.
+ * @param facetName - The facet identity being parked for removal.
+ * @returns The pipe-joined task key.
+ */
+export function computeTaskKey(
+  kind: ParkedTaskKind,
+  network: string,
+  environment: EnvironmentEnum,
+  facetName: string
+): string {
+  return `${kind}|${network.toLowerCase()}|${environment}|${facetName}`
+}
+
+/**
+ * Ensures the partial unique index the queue depends on. Idempotent for an
+ * exact-match re-creation (Mongo no-ops); an index-*conflict* (codes 85/86 —
+ * a same-named index with a different definition) is surfaced as a clear error
+ * so an operator reconciles the drifted index rather than the queue proceeding
+ * against an unintended one.
+ *
+ * The index is unique on `taskKey` but only over the *open* statuses, so a facet
+ * can be re-parked once a prior task retires (executed/cancelled/superseded).
+ * `$in` in a partial filter requires MongoDB server ≥ 6.0.
+ *
+ * @param parkedTasks - The collection to index.
+ * @throws Error on an index definition conflict, or any other createIndex error.
+ */
+export async function ensureParkedTasksIndexes(
+  parkedTasks: Collection<IParkedTask>
+): Promise<void> {
+  try {
+    await parkedTasks.createIndex(
+      { taskKey: 1 },
+      {
+        unique: true,
+        partialFilterExpression: { status: { $in: OPEN_STATUSES } },
+        name: 'unique_open_task_key',
+      }
+    )
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      ((error as { code: number }).code === 85 ||
+        (error as { code: number }).code === 86)
+    )
+      throw new Error(
+        `Index conflict for "unique_open_task_key" on ${parkedTasks.collectionName}. ` +
+          `Existing index has a different definition; drop or reconcile it before retrying.`,
+        { cause: error }
+      )
+    throw error
+  }
+}
+
+/**
+ * Opens a short-lived MongoDB client and returns the `parkedTasks` collection.
+ *
+ * Mirrors `getSafeMongoCollection()`: same `SC_MONGODB_URI` + VPN gate, same
+ * `sc_private` DB, and ensures the queue's index on connect. The caller owns the
+ * returned client and must `close()` it.
+ *
+ * @returns The connected client and the `parkedTasks` collection.
+ * @throws Error if `SC_MONGODB_URI` is unset or the VPN check fails.
+ */
+export async function getParkedTasksCollection(): Promise<{
+  client: MongoClient
+  parkedTasks: Collection<IParkedTask>
+}> {
+  if (!process.env.SC_MONGODB_URI)
+    throw new Error('SC_MONGODB_URI environment variable is required')
+
+  try {
+    const response = await fetch('https://api.ipify.org?format=json')
+    const data = (await response.json()) as { ip: string }
+    if (data.ip !== '18.195.61.255') {
+      consola.warn(`VPN connection required! Current IP: ${data.ip}`)
+      throw new Error(
+        'VPN connection required to access Safe MongoDB collection'
+      )
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('VPN connection required')
+    )
+      throw error
+    consola.warn('Could not verify VPN connection:', error)
+    consola.warn(
+      'Proceeding with caution - ensure you are connected to the VPN'
+    )
+  }
+
+  const client = new MongoClient(process.env.SC_MONGODB_URI)
+  await client.connect()
+  const parkedTasks = client
+    .db(PARKED_TASKS_DB_NAME)
+    .collection<IParkedTask>(PARKED_TASKS_COLLECTION_NAME)
+  try {
+    await ensureParkedTasksIndexes(parkedTasks)
+    return { client, parkedTasks }
+  } catch (error) {
+    await client.close()
+    throw error
+  }
+}
+
+/**
+ * Enqueues a parked task. Fills `taskKey`, `status: 'queued'` and `createdAt`,
+ * then inserts. A duplicate open task (same `taskKey` while queued/proposed) hits
+ * the partial unique index → E11000 → returns `null` (a repeat deprecation of the
+ * same facet is a harmless no-op), mirroring `storeTransactionInMongoDB`.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param input - Task identity + snapshots + required `prUrl` + enqueuer.
+ * @returns The insert result, or `null` if a duplicate open task already exists.
+ * @throws Error if `prUrl` is missing or blank (the PR-link requirement, spec §6).
+ */
+export async function enqueueParkedTask(
+  parkedTasks: Collection<IParkedTask>,
+  input: IParkedTaskInput
+): Promise<InsertOneResult<IParkedTask> | null> {
+  if (!input.prUrl || input.prUrl.trim() === '')
+    throw new Error(
+      'prUrl is required to park a facet-removal task (reviewer must see the originating PR at signing)'
+    )
+
+  const network = input.network.toLowerCase()
+  const doc: IParkedTask = {
+    ...input,
+    network,
+    taskKey: computeTaskKey(
+      input.kind,
+      network,
+      input.environment,
+      input.facetName
+    ),
+    status: 'queued',
+    createdAt: new Date(),
+  }
+
+  try {
+    return await parkedTasks.insertOne(doc)
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: number }).code === 11000
+    ) {
+      consola.warn(
+        `Duplicate parked task detected - skipping enqueue.\n  Task key: ${doc.taskKey}`
+      )
+      return null
+    }
+    throw error
+  }
+}
+
+/**
+ * Reads parked tasks, optionally filtered by network / prUrl / status.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param filter - Optional network (lowercased), prUrl, and status filters.
+ * @returns The matching tasks.
+ */
+export async function listParkedTasks(
+  parkedTasks: Collection<IParkedTask>,
+  filter: IListParkedTasksFilter
+): Promise<WithId<IParkedTask>[]> {
+  const query: Filter<IParkedTask> = {}
+  if (filter.network) query.network = { $eq: filter.network.toLowerCase() }
+  if (filter.prUrl) query.prUrl = { $eq: filter.prUrl }
+  if (filter.status) query.status = { $eq: filter.status }
+  return parkedTasks.find(query).toArray()
+}
+
+/**
+ * Atomically transitions the single task matching `taskKey` whose current status
+ * is in `allowedFrom`, applying `set` (and optionally unsetting `unset` fields).
+ * Returns the updated document, or `null` if no task was in an allowed state —
+ * this is the dedup gate: only one caller can win a given flip.
+ */
+async function transition(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string,
+  allowedFrom: ParkedTaskStatus[],
+  set: Partial<IParkedTask>,
+  unset?: Partial<Record<keyof IParkedTask, ''>>
+): Promise<WithId<IParkedTask> | null> {
+  const update: UpdateFilter<IParkedTask> = { $set: set }
+  if (unset) update.$unset = unset
+  return parkedTasks.findOneAndUpdate(
+    { taskKey: { $eq: taskKey }, status: { $in: allowedFrom } },
+    update,
+    { returnDocument: 'after' }
+  )
+}
+
+/**
+ * Atomically claims a `queued` task for proposal (`queued → proposed`, stamping
+ * `proposedAt`). The `status: 'queued'` filter is the dedup gate: a concurrent
+ * drain finds nothing queued and gets `null`, so a removal is never double-proposed
+ * despite the non-deterministic timelock salt (spec Fact 9, §7).
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The task to claim.
+ * @returns The flipped task, or `null` if it was not `queued`.
+ */
+export async function claimForProposal(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  return transition(parkedTasks, taskKey, ['queued'], {
+    status: 'proposed',
+    proposedAt: new Date(),
+  })
+}
+
+/**
+ * Marks a `proposed` task `executed` (terminal, = done) — used once the linked
+ * proposal is confirmed executed and the loupe shows the facet gone.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The task to resolve.
+ * @returns The updated task, or `null` if it was not `proposed`.
+ */
+export async function markExecuted(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  return transition(parkedTasks, taskKey, ['proposed'], {
+    status: 'executed',
+    resolvedAt: new Date(),
+  })
+}
+
+/**
+ * Marks an open (`queued`/`proposed`) task `superseded` — the facet is already
+ * absent on-chain (removed via another route); self-healing reconcile.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The task to resolve.
+ * @returns The updated task, or `null` if it was not open.
+ */
+export async function markSuperseded(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  return transition(parkedTasks, taskKey, OPEN_STATUSES, {
+    status: 'superseded',
+    resolvedAt: new Date(),
+  })
+}
+
+/**
+ * Marks an open (`queued`/`proposed`) task `cancelled` — an operator explicitly
+ * cancels (deprecation reverted, facet re-added, or a protected facet was queued
+ * in error).
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The task to resolve.
+ * @returns The updated task, or `null` if it was not open.
+ */
+export async function markCancelled(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  return transition(parkedTasks, taskKey, OPEN_STATUSES, {
+    status: 'cancelled',
+    resolvedAt: new Date(),
+  })
+}
+
+/**
+ * Reverts a claimed (`proposed`) task back to `queued` when its minted proposal
+ * failed or was reverted, clearing the stale `proposedAt`/`safeTxHash` so the next
+ * drain re-proposes cleanly.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The task to re-open.
+ * @returns The reverted task, or `null` if it was not `proposed`.
+ */
+export async function revertToQueued(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  return transition(
+    parkedTasks,
+    taskKey,
+    ['proposed'],
+    { status: 'queued' },
+    { proposedAt: '', safeTxHash: '' }
+  )
+}

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -39,6 +39,7 @@ import {
 import { type Address } from 'viem'
 
 import { type EnvironmentEnum } from '../../common/types'
+import { fetchWithTimeout } from '../../utils/fetchWithTimeout'
 
 /** DB shared with Safe proposals (`pendingTransactions`) — same VPN-gated cluster. */
 const PARKED_TASKS_DB_NAME = 'sc_private'
@@ -200,7 +201,7 @@ export async function getParkedTasksCollection(): Promise<{
     throw new Error('SC_MONGODB_URI environment variable is required')
 
   try {
-    const response = await fetch('https://api.ipify.org?format=json')
+    const response = await fetchWithTimeout('https://api.ipify.org?format=json')
     const data = (await response.json()) as { ip: string }
     if (data.ip !== '18.195.61.255') {
       consola.warn(`VPN connection required! Current IP: ${data.ip}`)
@@ -240,10 +241,17 @@ export async function getParkedTasksCollection(): Promise<{
  * the partial unique index → E11000 → returns `null` (a repeat deprecation of the
  * same facet is a harmless no-op), mirroring `storeTransactionInMongoDB`.
  *
+ * Identity fields are normalised here (the single enqueue chokepoint) so every
+ * caller — CLI, `/deprecate-contract`, the future drain — dedups consistently:
+ * `network`/`facetName`/`prUrl` are trimmed and a blank `facetName` is rejected,
+ * because `taskKey` is built from `network`+`facetName` and a stray space would
+ * silently mint a distinct, undeduplicated task for the same facet.
+ *
  * @param parkedTasks - The queue collection.
  * @param input - Task identity + snapshots + required `prUrl` + enqueuer.
  * @returns The insert result, or `null` if a duplicate open task already exists.
- * @throws Error if `prUrl` is missing or blank (the PR-link requirement, spec §6).
+ * @throws Error if `prUrl` or `facetName` is missing or blank (prUrl is the
+ *   PR-link requirement, spec §6; facetName is the task identity).
  */
 export async function enqueueParkedTask(
   parkedTasks: Collection<IParkedTask>,
@@ -253,17 +261,17 @@ export async function enqueueParkedTask(
     throw new Error(
       'prUrl is required to park a facet-removal task (reviewer must see the originating PR at signing)'
     )
+  if (!input.facetName || input.facetName.trim() === '')
+    throw new Error('facetName is required to park a facet-removal task')
 
-  const network = input.network.toLowerCase()
+  const network = input.network.trim().toLowerCase()
+  const facetName = input.facetName.trim()
   const doc: IParkedTask = {
     ...input,
     network,
-    taskKey: computeTaskKey(
-      input.kind,
-      network,
-      input.environment,
-      input.facetName
-    ),
+    facetName,
+    prUrl: input.prUrl.trim(),
+    taskKey: computeTaskKey(input.kind, network, input.environment, facetName),
     status: 'queued',
     createdAt: new Date(),
   }

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -2,11 +2,15 @@
  * Deferred diamond-cleanup queue — store layer.
  *
  * Backs the "park a facet removal now, drain it opportunistically later" model
- * (design: docs/DeferredDiamondCleanupQueue.md, PR #2049) with a durable queue
- * in the same `sc_private` cluster the Safe proposals live in (`SC_MONGODB_URI`
- * + VPN gate), collection `parkedTasks`. It mirrors the second durable queue the
- * repo already runs on this plumbing (`timelock-operations/queue`,
- * timelock-queue.ts) rather than introducing a new store type.
+ * (design: docs/DeferredDiamondCleanupQueue.md, PR #2049) with a durable queue on
+ * the non-sensitive `MONGODB_URI` cluster (DB `deferred-cleanup`, collection
+ * `parkedTasks`) — the same plumbing the timelock execution queue already runs on
+ * (`timelock-operations/queue`, timelock-queue.ts), rather than introducing a new
+ * store type. Nothing parked is secret (public facet names, on-chain addresses,
+ * PR URLs) and the security boundary is on-chain (calldata verification, timelock
+ * delay, Safe quorum), so the queue is intentionally un-gated — which also lets
+ * non-interactive consumers (CI backlog reports, reconcile/TTL jobs, agent-driven
+ * `/deprecate-contract`) reach it without a tunnel.
  *
  * This module is the *persistence* layer only — it does not mint Safe proposals,
  * resolve selectors from the loupe, or hook the drain chokepoint (those depend on
@@ -39,10 +43,10 @@ import {
 import { type Address } from 'viem'
 
 import { type EnvironmentEnum } from '../../common/types'
-import { fetchWithTimeout } from '../../utils/fetchWithTimeout'
+import { getEnvVar } from '../../utils/utils'
 
-/** DB shared with Safe proposals (`pendingTransactions`) — same VPN-gated cluster. */
-const PARKED_TASKS_DB_NAME = 'sc_private'
+/** Database for the deferred diamond-cleanup queue inside the non-sensitive `MONGODB_URI` cluster. */
+const PARKED_TASKS_DB_NAME = 'deferred-cleanup'
 
 /** New collection holding the deferred diamond-cleanup queue. */
 const PARKED_TASKS_COLLECTION_NAME = 'parkedTasks'
@@ -184,45 +188,19 @@ export async function ensureParkedTasksIndexes(
 }
 
 /**
- * Opens a short-lived MongoDB client and returns the `parkedTasks` collection.
- *
- * Mirrors `getSafeMongoCollection()`: same `SC_MONGODB_URI` + VPN gate, same
- * `sc_private` DB, and ensures the queue's index on connect. The caller owns the
- * returned client and must `close()` it.
+ * Opens a MongoDB client and returns the `parkedTasks` collection, ensuring the
+ * dedup index on connect. Mirrors `getTimelockQueueCollection()`: the same
+ * non-sensitive `MONGODB_URI` cluster the timelock queue runs on, so no VPN /
+ * tunnel gate. The caller owns the returned client and must `close()` it.
  *
  * @returns The connected client and the `parkedTasks` collection.
- * @throws Error if `SC_MONGODB_URI` is unset or the VPN check fails.
+ * @throws Error if `MONGODB_URI` is not set.
  */
 export async function getParkedTasksCollection(): Promise<{
   client: MongoClient
   parkedTasks: Collection<IParkedTask>
 }> {
-  if (!process.env.SC_MONGODB_URI)
-    throw new Error('SC_MONGODB_URI environment variable is required')
-
-  try {
-    const response = await fetchWithTimeout('https://api.ipify.org?format=json')
-    const data = (await response.json()) as { ip: string }
-    if (data.ip !== '18.195.61.255') {
-      consola.warn(`VPN connection required! Current IP: ${data.ip}`)
-      throw new Error(
-        'VPN connection required to access Safe MongoDB collection'
-      )
-    }
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes('VPN connection required')
-    )
-      throw error
-    consola.warn('Could not verify VPN connection:', error)
-    consola.warn(
-      'Proceeding with caution - ensure you are connected to the VPN'
-    )
-  }
-
-  const client = new MongoClient(process.env.SC_MONGODB_URI)
-  await client.connect()
+  const client = new MongoClient(getEnvVar('MONGODB_URI'))
   const parkedTasks = client
     .db(PARKED_TASKS_DB_NAME)
     .collection<IParkedTask>(PARKED_TASKS_COLLECTION_NAME)

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -20,6 +20,10 @@
  * {@link claimForProposal}. The time-derived timelock salt makes the proposal
  * `intentHash` non-deterministic, so it cannot dedup a re-proposed removal
  * (spec Fact 9); the queue-layer flip is the guarantee instead.
+ *
+ * The drain (out of scope here) sets `safeTxHash` on a claimed record to link it
+ * to the minted `pendingTransactions` proposal (spec §6.3 step 4); that setter
+ * lands with the drain PR, so no `safeTxHash` writer is exposed yet by design.
  */
 
 import { consola } from 'consola'
@@ -378,19 +382,23 @@ export async function markSuperseded(
 }
 
 /**
- * Marks an open (`queued`/`proposed`) task `cancelled` — an operator explicitly
- * cancels (deprecation reverted, facet re-added, or a protected facet was queued
- * in error).
+ * Marks a `queued` task `cancelled` — an operator explicitly abandons the intent
+ * (deprecation reverted, facet re-added, or a protected facet was queued in
+ * error). Restricted to `queued`: a `proposed` task already has a live Safe
+ * removal proposal, and cancelling its record directly would orphan that proposal
+ * from its origin-PR linkage (the first-class requirement of spec §6). To abandon
+ * a claimed task, {@link revertToQueued} it first (which clears the proposal
+ * linkage), then cancel.
  *
  * @param parkedTasks - The queue collection.
  * @param taskKey - The task to resolve.
- * @returns The updated task, or `null` if it was not open.
+ * @returns The updated task, or `null` if it was not `queued`.
  */
 export async function markCancelled(
   parkedTasks: Collection<IParkedTask>,
   taskKey: string
 ): Promise<WithId<IParkedTask> | null> {
-  return transition(parkedTasks, taskKey, OPEN_STATUSES, {
+  return transition(parkedTasks, taskKey, ['queued'], {
     status: 'cancelled',
     resolvedAt: new Date(),
   })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Design source: **#2049** ([docs/DeferredDiamondCleanupQueue.md](https://github.com/lifinance/contracts/pull/2049)) — the deferred diamond-cleanup queue spec (park facet removals, drain opportunistically).

This PR implements **only the store layer** (spec phase 1 of the §13 estimate). It does **not** depend on the drain chokepoint or the #2047 removal engine, so it builds and merges independently of #2047.

# Why did I implement it this way?

The spec (§5) chooses a new `sc_private.parkedTasks` MongoDB collection over a git file or overloading `pendingTransactions`, because it wins **atomic dedup** (the time-derived timelock salt makes the proposal `intentHash` non-deterministic — Fact 9 — so intentHash dedup can't stop a re-proposed removal) and **on-chain-truth reconciliation**, while provably not being a parallel governance system (it mirrors the existing `timelock-operations/queue`).

New files (store layer only — nothing else touched):

- **`script/deploy/safe/parked-tasks.ts`** — the queue module, modelled on `timelock-queue.ts` and reusing the `getSafeMongoCollection` plumbing:
  - `IParkedTask` schema per spec §4 — selectors are **not** stored (resolved from the live loupe at drain, so a parked list can't go stale); `prUrl` is required and first-class.
  - `computeTaskKey(kind, network, environment, facetName)` — `${kind}|${network}|${environment}|${facetName}`, network lowercased.
  - `getParkedTasksCollection()` — mirrors `getSafeMongoCollection` (`sc_private`, `SC_MONGODB_URI` + VPN gate); new `parkedTasks` collection; ensures a **partial unique index** on `taskKey` filtered to the open statuses `{queued, proposed}`, so a facet can be re-parked once a prior task retires.
  - `enqueueParkedTask` — insert; duplicate open task → E11000 → `null` (mirrors `storeTransactionInMongoDB`); throws on a missing/blank `prUrl`.
  - `listParkedTasks`, `claimForProposal` (atomic `queued → proposed` flip — the dedup gate that replaces the unusable intentHash dedup), and the `markExecuted` / `markSuperseded` / `markCancelled` / `revertToQueued` transitions per the §7 state machine.
  - All I/O is injected (`Collection<IParkedTask>` args) so the logic is unit-tested against an in-memory fake — **100% coverage except the thin `getParkedTasksCollection` live adapter**.
- **`script/deploy/safe/list-parked-tasks.ts`** — read-only observability CLI (spec §9), mirroring `list-pending-proposals.ts`: `--network`/`--pr`/`--status`/`--json`, VPN + `SC_MONGODB_URI` gated, exit codes 0/1/2, grouped by network with per-network queued/proposed counts.
- **`script/deploy/safe/enqueue-parked-task.ts`** — write CLI that parks one facet-removal task; **refuses without `prUrl`**, validates addresses via viem, production-only in v1, resolves `enqueuer` from `git user.email`.

Out of scope (later PRs per §13): the drain helper + `sendOrPropose`/`runPropose` hook, `ISafeTxDocument.parkedTaskRefs` + signer-view surfacing, the `/deprecate-contract` rewrite, and reconcile/TTL jobs.

### ⚠️ One thing to verify before this is relied on in prod

The dedup guarantee rests on a **partial unique index** on `taskKey` filtered to `status ∈ {queued, proposed}` — `partialFilterExpression: { status: { $in: [...] } }`. `$in` inside a `partialFilterExpression` requires **MongoDB server ≥ 6.0**, and — unlike its sibling `unique_pending_intent_hash`, which uses plain equality — there's no existing index on `sc_private` that proves this cluster accepts a `$in` partial filter. It fails **loud** (throws at connect, so `enqueue`/`list` error visibly, never silent corruption) and a unit fake structurally can't validate a real index build, so please confirm the `sc_private` server is ≥ 6.0 before the drain PR relies on the index. Merging this draft is safe regardless — the index is only exercised once someone runs the CLIs against the live cluster.

### One decision flagged for confirmation

`markCancelled` is restricted to `queued` (an adversarial-review call): cancelling a `proposed` task would orphan its already-minted Safe removal proposal from the origin-PR linkage §6 makes first-class. A claimed task is abandoned via `revertToQueued` → `markCancelled`. Trivially widened to also accept `proposed` if the team prefers direct cancel-from-proposed. (`markSuperseded` intentionally still accepts both, matching §7's explicit "queued/proposed → superseded".)

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list — N/A (no Solidity / no facet)
- [x] I have updated any required documentation — N/A (design doc is #2049; no `.env` var or command added)

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted — N/A, no contract calls; TS store layer only
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted — N/A, no on-chain writes; MongoDB persistence only
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit — N/A, no Solidity in this PR
