### PR TITLE
feat(PolymerCCTPFacet): add Stellar as CCTP destination (EXSC-616)

### DIFF
--- a/config/polymercctp.json
+++ b/config/polymercctp.json
@@ -26,6 +26,7 @@
     { "chainId": 57073, "domainId": 21 },
     { "chainId": 98866, "domainId": 22 },
     { "chainId": 5042, "domainId": 26 },
+    { "chainId": 1201081091099710, "domainId": 27 },
     { "chainId": 2818, "domainId": 30 },
     { "chainId": 1672, "domainId": 31 },
     { "chainId": 25, "domainId": 32 }

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -27,12 +27,16 @@ import { CannotBridgeToSameNetwork, InvalidAmount, InvalidCallData, InvalidConfi
 ///      BridgeData.receiver is the NON_EVM_ADDRESS sentinel and the real recipient travels as a
 ///      Stellar strkey inside hookData, because a Stellar account can never be a CCTP mintRecipient
 ///      directly (see STELLAR_CCTP_FORWARDER). USDC is minted to the pinned Stellar forwarder,
-///      which forwards it to that strkey. Unlike HyperCore, the strkey is not a 20-byte EVM address,
-///      so it CANNOT be validated on-chain against BridgeData.receiver, nor against the
-///      nonEVMReceiver emitted in BridgeToNonEVMChainBytes32; the facet only enforces hookData's
-///      internal length consistency. Correctness of the Stellar recipient therefore relies on
-///      trusted (LI.FI API) calldata generation — integrators must treat it as not enforced on-chain.
-/// @custom:version 3.1.0
+///      which forwards it to that strkey.
+/// @dev SECURITY — UNVALIDATED RECEIVER (Stellar): unlike the HyperCore corridor, the Stellar
+///      strkey is not a 20-byte EVM address, so the facet CANNOT verify it on-chain against
+///      BridgeData.receiver, and it is NOT cross-checked against the nonEVMReceiver emitted in
+///      BridgeToNonEVMChainBytes32. The facet only enforces hookData's internal length consistency
+///      (see _startBridge). The strkey that actually receives the funds and the nonEVMReceiver used
+///      for off-chain tracking can therefore diverge. Correct routing relies entirely on trusted
+///      (LI.FI API) calldata generation — integrators MUST treat the Stellar receiver as NOT
+///      enforced on-chain.
+/// @custom:version 3.0.0
 contract PolymerCCTPFacet is
     ILiFi,
     ReentrancyGuard,
@@ -59,9 +63,7 @@ contract PolymerCCTPFacet is
     ///         is a contract and USDC minted to a bare account is unrecoverable. All Stellar
     ///         deposits therefore mint to this forwarder, which alone may execute the message and
     ///         forwards the USDC to the strkey recipient carried in the hook data (see _startBridge).
-    ///         Testnet forwarder is CA66Q2WFBND6V4UEB7RD4SAXSVIWMD6RA4X3U32ELVFGXV5PJK4T4VSZ
-    ///         (0x3de86ac50b47eaf2840fe23e48179551660fd1072fba6f445d4a6bd7af4ab93e) — swap the
-    ///         constant for staging deploys. Rotating the forwarder requires a facet upgrade.
+    ///         Rotating the forwarder requires a facet upgrade.
     ///         https://developers.circle.com/cctp/references/stellar-contracts
     bytes32 internal constant STELLAR_CCTP_FORWARDER =
         0x72bd20ff2f8281801bb05b7c29179026933256fabafeb13e94efd8ddbcfcf291;

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -91,7 +91,7 @@ contract PolymerCCTPFacet is
         // 1000 = fast path, 2000 = standard path
         uint32 minFinalityThreshold;
         // CctpForwarder hook data. For HyperCore it must encode bridgeData.receiver at bytes
-        // [32:52]. For Stellar it carries the forwardRecipient strkey: magic (24) + version (4) +
+        // [32:52]. For Stellar it carries the forward recipient strkey: magic (24) + version (4) +
         // length L (4) + strkey (L). Required iff destinationChainId is LIFI_CHAIN_ID_HYPERCORE
         // or LIFI_CHAIN_ID_STELLAR; must be empty otherwise.
         bytes hookData;

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -91,8 +91,8 @@ contract PolymerCCTPFacet is
         // 1000 = fast path, 2000 = standard path
         uint32 minFinalityThreshold;
         // CctpForwarder hook data. For HyperCore it must encode bridgeData.receiver at bytes
-        // [32:52]. For Stellar it carries the forward recipient strkey: magic (24) + version (4) +
-        // length L (4) + strkey (L). Required iff destinationChainId is LIFI_CHAIN_ID_HYPERCORE
+        // [32:52]. For Stellar it carries the forwardRecipient strkey: magic (24) + version (4) +
+        // length L (4) + strkey (L). Required if destinationChainId is LIFI_CHAIN_ID_HYPERCORE
         // or LIFI_CHAIN_ID_STELLAR; must be empty otherwise.
         bytes hookData;
     }

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -307,8 +307,8 @@ contract PolymerCCTPFacet is
         ILiFi.BridgeData memory _bridgeData,
         PolymerCCTPData calldata _polymerData
     ) internal {
-        // Corridor dispatch: HyperCore requires a forwarder hook; hooks toward any
-        // other destination are unsupported. Add new corridors (e.g. Stellar) as
+        // Corridor dispatch: HyperCore and Stellar require a forwarder hook; hooks
+        // toward any other destination are unsupported. Add new corridors as
         // additional arms.
         if (_bridgeData.destinationChainId == LIFI_CHAIN_ID_HYPERCORE) {
             // Without a valid hook the USDC would mint on HyperEVM and never

--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -23,7 +23,16 @@ import { CannotBridgeToSameNetwork, InvalidAmount, InvalidCallData, InvalidConfi
 ///      receiver encoded in hookData[32:52] equals BridgeData.receiver, so emitted events always
 ///      carry the real end user. Hooks toward any other destination are rejected. Rotating the
 ///      forwarder requires a facet upgrade.
-/// @custom:version 3.0.0
+/// @dev Stellar deposits (BridgeData.destinationChainId == LIFI_CHAIN_ID_STELLAR) are non-EVM:
+///      BridgeData.receiver is the NON_EVM_ADDRESS sentinel and the real recipient travels as a
+///      Stellar strkey inside hookData, because a Stellar account can never be a CCTP mintRecipient
+///      directly (see STELLAR_CCTP_FORWARDER). USDC is minted to the pinned Stellar forwarder,
+///      which forwards it to that strkey. Unlike HyperCore, the strkey is not a 20-byte EVM address,
+///      so it CANNOT be validated on-chain against BridgeData.receiver, nor against the
+///      nonEVMReceiver emitted in BridgeToNonEVMChainBytes32; the facet only enforces hookData's
+///      internal length consistency. Correctness of the Stellar recipient therefore relies on
+///      trusted (LI.FI API) calldata generation — integrators must treat it as not enforced on-chain.
+/// @custom:version 3.1.0
 contract PolymerCCTPFacet is
     ILiFi,
     ReentrancyGuard,
@@ -41,6 +50,21 @@ contract PolymerCCTPFacet is
     ///         https://developers.circle.com/cctp/references/hypercore-contract-addresses
     bytes32 internal constant HYPERCORE_CCTP_FORWARDER =
         bytes32(uint256(uint160(0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757)));
+
+    /// @notice Circle's CctpForwarder on Stellar mainnet
+    ///         (CBZL2IH7F6BIDAA3WBNXYKIXSATJGMSW7K5P5MJ6STX5RXN47TZJDF5T), pre-encoded as the
+    ///         bytes32 mintRecipient/destinationCaller (the forwarder's raw 32-byte contract id).
+    ///         A Stellar account can never be a CCTP mintRecipient directly: CCTP stores only the
+    ///         raw 32 bytes without the strkey type prefix, so the protocol assumes the recipient
+    ///         is a contract and USDC minted to a bare account is unrecoverable. All Stellar
+    ///         deposits therefore mint to this forwarder, which alone may execute the message and
+    ///         forwards the USDC to the strkey recipient carried in the hook data (see _startBridge).
+    ///         Testnet forwarder is CA66Q2WFBND6V4UEB7RD4SAXSVIWMD6RA4X3U32ELVFGXV5PJK4T4VSZ
+    ///         (0x3de86ac50b47eaf2840fe23e48179551660fd1072fba6f445d4a6bd7af4ab93e) — swap the
+    ///         constant for staging deploys. Rotating the forwarder requires a facet upgrade.
+    ///         https://developers.circle.com/cctp/references/stellar-contracts
+    bytes32 internal constant STELLAR_CCTP_FORWARDER =
+        0x72bd20ff2f8281801bb05b7c29179026933256fabafeb13e94efd8ddbcfcf291;
 
     bytes32 internal constant NAMESPACE =
         keccak256("com.lifi.facets.polymercctp");
@@ -64,8 +88,10 @@ contract PolymerCCTPFacet is
         // the minimum finality at which a burn message will be attested to, will be passed directly to tokenMessenger.depositForBurn method.
         // 1000 = fast path, 2000 = standard path
         uint32 minFinalityThreshold;
-        // CctpForwarder hook data for HyperCore deposits; must encode bridgeData.receiver at
-        // bytes [32:52]. Required iff destinationChainId == LIFI_CHAIN_ID_HYPERCORE.
+        // CctpForwarder hook data. For HyperCore it must encode bridgeData.receiver at bytes
+        // [32:52]. For Stellar it carries the forwardRecipient strkey: magic (24) + version (4) +
+        // length L (4) + strkey (L). Required iff destinationChainId is LIFI_CHAIN_ID_HYPERCORE
+        // or LIFI_CHAIN_ID_STELLAR; must be empty otherwise.
         bytes hookData;
     }
 
@@ -303,6 +329,29 @@ contract PolymerCCTPFacet is
             ) {
                 revert InvalidReceiver();
             }
+        } else if (_bridgeData.destinationChainId == LIFI_CHAIN_ID_STELLAR) {
+            // Stellar is non-EVM: the receiver is the NON_EVM_ADDRESS sentinel and the real
+            // recipient travels as a strkey in the hook data (a Stellar account can never be a
+            // CCTP mintRecipient; see STELLAR_CCTP_FORWARDER). The raw account is carried in
+            // nonEVMReceiver for off-chain relayer tracking. The strkey is not a 20-byte EVM
+            // address, so it cannot be validated against _bridgeData.receiver.
+            // Hook layout: magic (24) + version (4) + strkey length L (4) + strkey (L).
+            if (
+                _bridgeData.receiver != NON_EVM_ADDRESS ||
+                _polymerData.nonEVMReceiver == bytes32(0) ||
+                _polymerData.hookData.length < 32
+            ) {
+                revert InvalidCallData();
+            }
+
+            // Reject a hook whose declared payload length disagrees with its actual size,
+            // so a truncated or padded hook cannot reach the forwarder.
+            if (
+                uint32(bytes4(_polymerData.hookData[28:32])) !=
+                _polymerData.hookData.length - 32
+            ) {
+                revert InvalidCallData();
+            }
         } else if (_polymerData.hookData.length > 0) {
             revert InvalidCallData();
         }
@@ -356,6 +405,26 @@ contract PolymerCCTPFacet is
                     _polymerData.minFinalityThreshold
                 );
             }
+        } else if (destinationChainId == LIFI_CHAIN_ID_STELLAR) {
+            // Mint to the pinned Stellar forwarder (never a Stellar account directly) and
+            // restrict execution to it; the forwarder credits the strkey recipient carried in
+            // the hook data validated above.
+            TOKEN_MESSENGER.depositForBurnWithHook(
+                bridgeAmount,
+                domainId,
+                STELLAR_CCTP_FORWARDER,
+                USDC,
+                STELLAR_CCTP_FORWARDER,
+                _polymerData.maxCCTPFee, // maxFee - 0 means no fee limit
+                _polymerData.minFinalityThreshold,
+                _polymerData.hookData
+            );
+
+            emit BridgeToNonEVMChainBytes32(
+                _bridgeData.transactionId,
+                destinationChainId,
+                _polymerData.nonEVMReceiver
+            );
         } else {
             // For Solana, CCTP expects the ATA as mintRecipient; for other non-EVM, use nonEVMReceiver.
             bool isSolanaDestination = destinationChainId ==

--- a/src/Helpers/LiFiData.sol
+++ b/src/Helpers/LiFiData.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 /// @title LiFiData
 /// @author LI.FI (https://li.fi)
 /// @notice A storage for LI.FI-internal config data (addresses, chainIDs, etc.)
-/// @custom:version 1.0.2
+/// @custom:version 1.0.1
 contract LiFiData {
     address internal constant NON_EVM_ADDRESS =
         0x11f111f111f111F111f111f111F111f111f111F1;

--- a/src/Helpers/LiFiData.sol
+++ b/src/Helpers/LiFiData.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 /// @title LiFiData
 /// @author LI.FI (https://li.fi)
 /// @notice A storage for LI.FI-internal config data (addresses, chainIDs, etc.)
-/// @custom:version 1.0.1
+/// @custom:version 1.0.2
 contract LiFiData {
     address internal constant NON_EVM_ADDRESS =
         0x11f111f111f111F111f111f111F111f111f111F1;
@@ -16,6 +16,7 @@ contract LiFiData {
     uint256 internal constant LIFI_CHAIN_ID_DGE = 20000000000004;
     uint256 internal constant LIFI_CHAIN_ID_LTC = 20000000000003;
     uint256 internal constant LIFI_CHAIN_ID_SOLANA = 1151111081099710;
+    uint256 internal constant LIFI_CHAIN_ID_STELLAR = 1201081091099710;
     uint256 internal constant LIFI_CHAIN_ID_SUI = 9270000000000000;
     uint256 internal constant LIFI_CHAIN_ID_TRON = 1885080386571452;
     uint256 internal constant LIFI_CHAIN_ID_HYPERCORE = 1337;

--- a/test/solidity/Facets/PolymerCCTPFacet.t.sol
+++ b/test/solidity/Facets/PolymerCCTPFacet.t.sol
@@ -42,6 +42,10 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
     bytes32 internal constant HYPERCORE_CCTP_FORWARDER =
         bytes32(uint256(uint160(0xb21D281DEdb17AE5B501F6AA8256fe38C4e45757)));
     uint32 internal constant HYPEREVM_CCTP_DOMAIN = 19;
+    // Must match PolymerCCTPFacet.STELLAR_CCTP_FORWARDER (Stellar mainnet CctpForwarder)
+    bytes32 internal constant STELLAR_CCTP_FORWARDER =
+        0x72bd20ff2f8281801bb05b7c29179026933256fabafeb13e94efd8ddbcfcf291;
+    uint32 internal constant STELLAR_CCTP_DOMAIN = 27;
     address internal polymerFeeReceiver = address(0x123);
 
     PolymerCCTPFacet.PolymerCCTPData internal validPolymerData;
@@ -56,7 +60,7 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
         pure
         returns (ChainMapping[] memory mappings)
     {
-        mappings = new ChainMapping[](21);
+        mappings = new ChainMapping[](22);
         mappings[0] = ChainMapping({ chainId: 1, domainId: 0 }); // Ethereum
         mappings[1] = ChainMapping({ chainId: 43114, domainId: 1 }); // Avalanche
         mappings[2] = ChainMapping({ chainId: 10, domainId: 2 }); // OP Mainnet
@@ -81,6 +85,10 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
             chainId: LIFI_CHAIN_ID_HYPERCORE,
             domainId: 19
         }); // HyperCore (same CCTP domain as HyperEVM)
+        mappings[21] = ChainMapping({
+            chainId: LIFI_CHAIN_ID_STELLAR,
+            domainId: STELLAR_CCTP_DOMAIN
+        }); // Stellar
     }
 
     function _toChainIdConfigs(
@@ -669,6 +677,21 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
             );
     }
 
+    /// @dev Stellar CctpForwarder hook data: magic (24) + version (4)
+    ///      + strkey length L (4) + strkey (L). The length field must equal the
+    ///      actual strkey length or the facet rejects the hook.
+    function _buildStellarHookData(
+        bytes memory strkey
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                bytes24("cctp-forward"),
+                uint32(0),
+                uint32(strkey.length),
+                strkey
+            );
+    }
+
     function _polymerDataWithHook(
         bytes memory hookData
     ) internal view returns (PolymerCCTPFacet.PolymerCCTPData memory) {
@@ -681,6 +704,206 @@ contract PolymerCCTPFacetTest is TestBaseFacet {
                 minFinalityThreshold: validPolymerData.minFinalityThreshold,
                 hookData: hookData
             });
+    }
+
+    function test_CanBridgeToStellarWithHookData() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildStellarHookData(
+                    bytes(
+                        "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+                    )
+                )
+            );
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0xABCD));
+
+        uint256 bridgeAmount = bridgeData.minAmount -
+            polymerDataWithHook.polymerTokenFee;
+
+        // Stellar (CCTP domain 27) is not yet registered on the forked mainnet
+        // TokenMessengerV2, so mock the burn to isolate the facet's dispatch/calldata.
+        vm.mockCall(
+            TOKEN_MESSENGER_V2_MAINNET,
+            abi.encodeWithSelector(
+                ITokenMessenger.depositForBurnWithHook.selector
+            ),
+            abi.encode()
+        );
+
+        vm.expectCall(
+            TOKEN_MESSENGER_V2_MAINNET,
+            abi.encodeCall(
+                ITokenMessenger.depositForBurnWithHook,
+                (
+                    bridgeAmount,
+                    STELLAR_CCTP_DOMAIN,
+                    STELLAR_CCTP_FORWARDER,
+                    ADDRESS_USDC,
+                    STELLAR_CCTP_FORWARDER,
+                    polymerDataWithHook.maxCCTPFee,
+                    polymerDataWithHook.minFinalityThreshold,
+                    polymerDataWithHook.hookData
+                )
+            )
+        );
+
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit ILiFi.BridgeToNonEVMChainBytes32(
+            bridgeData.transactionId,
+            LIFI_CHAIN_ID_STELLAR,
+            polymerDataWithHook.nonEVMReceiver
+        );
+
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit PolymerCCTPFeeSent(
+            bridgeData.minAmount,
+            polymerDataWithHook.polymerTokenFee,
+            polymerDataWithHook.minFinalityThreshold
+        );
+
+        ILiFi.BridgeData memory adjustedBridgeData = bridgeData;
+        adjustedBridgeData.minAmount = bridgeAmount;
+        vm.expectEmit(true, true, true, true, _facetTestContractAddress);
+        emit LiFiTransferStarted(adjustedBridgeData);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_StellarWithEVMReceiver() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        // receiver left as the default EVM address instead of NON_EVM_ADDRESS
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildStellarHookData(
+                    bytes(
+                        "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+                    )
+                )
+            );
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0xABCD));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_StellarWithoutNonEVMReceiver() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+
+        // nonEVMReceiver left as zero
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(
+                _buildStellarHookData(
+                    bytes(
+                        "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
+                    )
+                )
+            );
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_StellarWithoutHookData() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+        validPolymerData.nonEVMReceiver = bytes32(uint256(0xABCD));
+
+        // validPolymerData.hookData is empty -> length 0 < 32
+        vm.expectRevert(InvalidCallData.selector);
+
+        initiateBridgeTxWithFacet(false);
+
+        vm.stopPrank();
+    }
+
+    function testRevert_StellarHookDataTooShort() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+
+        // 31 bytes: one below the 32-byte header holding the length field
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(new bytes(31));
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0xABCD));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
+    }
+
+    function testRevert_StellarHookLengthMismatch() public {
+        vm.startPrank(USER_SENDER);
+
+        usdc.approve(_facetTestContractAddress, bridgeData.minAmount);
+
+        bridgeData.receiver = NON_EVM_ADDRESS;
+        bridgeData.destinationChainId = LIFI_CHAIN_ID_STELLAR;
+
+        // Declared strkey length (56) disagrees with the 10 trailing bytes present
+        bytes memory badHook = abi.encodePacked(
+            bytes24("cctp-forward"),
+            uint32(0),
+            uint32(56),
+            new bytes(10)
+        );
+        PolymerCCTPFacet.PolymerCCTPData
+            memory polymerDataWithHook = _polymerDataWithHook(badHook);
+        polymerDataWithHook.nonEVMReceiver = bytes32(uint256(0xABCD));
+
+        vm.expectRevert(InvalidCallData.selector);
+
+        polymerCCTPFacet.startBridgeTokensViaPolymerCCTP(
+            bridgeData,
+            polymerDataWithHook
+        );
+
+        vm.stopPrank();
     }
 
     function testRevert_NonEVMReceiverWithZeroBytes32() public {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-616](https://linear.app/lifi-linear/issue/EXSC-616/add-stellar-as-cctp-destination-to-polymercctpfacet-smart-contract)

# Why did I implement it this way?

Adds **Stellar** (non-EVM, CCTP domain 27) as a destination to `PolymerCCTPFacet`, porting the change prototyped in polymerdao/lifi-contracts@[545cac6](https://github.com/polymerdao/lifi-contracts/commit/545cac6f2b54faac8e4c7bb42aff8ed58ca7034d) ("add stellar support to polymerfacet").

> **⚠️ Stacked on #1652.** The fork commit is built on top of the HyperCore work (EXSC-169 / #1652), and reuses `depositForBurnWithHook` + the `hookData` field introduced there. This PR therefore targets `polymer-hypercore-ex-286` (the #1652 branch), **not `main`** — it cannot compile against `main`. Rebase onto `main` once #1652 merges.

## How Stellar works here

A Stellar `G...` account can never be a CCTP `mintRecipient` directly: CCTP stores only the raw 32 bytes without the strkey type prefix, so the protocol assumes the recipient is a contract, and USDC minted to a bare account is unrecoverable. All Stellar deposits therefore mint to Circle's pinned `CctpForwarder` (`mintRecipient == destinationCaller == STELLAR_CCTP_FORWARDER`), which alone may execute the message and forwards the USDC to the strkey recipient carried in the hook data. The raw account is emitted via `BridgeToNonEVMChainBytes32` for off-chain relayer tracking. Ref: https://developers.circle.com/cctp/references/stellar-contracts

- `validatePolymerData` corridor dispatch: a new `LIFI_CHAIN_ID_STELLAR` arm requires `receiver == NON_EVM_ADDRESS`, `nonEVMReceiver != 0`, `hookData.length >= 32`, and that the hook's self-declared payload length (`hookData[28:32]`) equals `hookData.length - 32` (rejects truncated/padded hooks).
- `_startBridge`: a new Stellar arm calls `depositForBurnWithHook` with the pinned forwarder and emits the non-EVM event.

## Deviations from the fork prototype (deliberate)

1. **Forwarder pinned to MAINNET.** The fork hardcoded the Stellar **testnet** forwarder (`CA66Q2…` = `0x3de8…b93e`). On a production deploy that would mint Stellar-bound USDC to a nonexistent recipient on Stellar mainnet → **fund loss**. This PR pins the **mainnet** forwarder `CBZL2IH7…DF5T` = `0x72bd20ff…f291`, verified against Circle's docs and by base32-decoding the strkey. No testnet value is carried in the facet.
2. **No version bump.** This change merges into the in-flight #1652 development line (facet `3.0.0`, `LiFiData 1.0.1`), which is versioned when that line finalizes — so no bump here.
3. **Config minimalism.** Only the `{ chainId: 1201081091099710, domainId: 27 }` mapping is added. The fork's ~130-line `testnets` block is fork-specific and not brought upstream.

## Trust assumption to review (⚠️ for audit)

Unlike HyperCore — where the facet validates `hookData[32:52] == bridgeData.receiver` so events can't misreport the beneficiary — Stellar's strkey recipient **cannot** be validated on-chain against `bridgeData.receiver` (it isn't a 20-byte EVM address), and it is **not** cross-checked against the emitted `nonEVMReceiver`. The facet only enforces the hook's internal length consistency. Correctness of the Stellar recipient therefore relies on trusted (LI.FI API) calldata generation.

This is called out as a dedicated **`SECURITY — UNVALIDATED RECEIVER (Stellar)`** note in the facet NatSpec (per rule 102 [CONV:FACET-REQS], opaque receiver). Suggested off-chain invariant: the relayer/backend should verify the strkey in `hookData` corresponds to the emitted `nonEVMReceiver`.

## Follow-ups (out of scope)

- `LIFI_CHAIN_ID_STELLAR = 1201081091099710` decodes to `"xlm"` + the shared non-EVM suffix (consistent with `SOLANA = "sol"` + suffix); please confirm it matches the backend chain-id registry.
- A Stellar path in `demoPolymerCCTP.ts` (the TS demo already carries `hookData`; no Stellar example added here).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
