### PR TITLE
chore: sync foundry.lock forge-std rev to v1.16.1

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -9,7 +9,7 @@
     "rev": "e282159d5170298eb2455a6c05280ab5a73a4ef0"
   },
   "lib/forge-std": {
-    "rev": "7f7cb06aa55fc75d2280d7d54713dc4368d71fd3"
+    "rev": "620536fa5277db4e3fd46772d5cbc1ea0696fb43"
   },
   "lib/openzeppelin-contracts": {
     "rev": "e50c24f5839db17f46991478384bfda14acfb830"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

N/A — trivial lock-file sync. Follows up #1906 (forge-std → v1.16.1), which
bumped the submodule but left `foundry.lock` pointing at the old revision.
Labeled `trivial` per the ticket-linkage carve-out.

# Why did I implement it this way?

#1906 upgraded the `lib/forge-std` git submodule to v1.16.1
(`620536fa5277db4e3fd46772d5cbc1ea0696fb43`) but did not regenerate
`foundry.lock`, which still pinned the previous revision
(`7f7cb06aa55fc75d2280d7d54713dc4368d71fd3`). Foundry compares the lockfile
against the checked-out submodule on every build, so `forge build` emitted:

```text
Warning: Dependency 'lib/forge-std' revision mismatch: expected '7f7cb06...', found '620536f...'
```

Because `foundry.lock` is committed, the warning appeared on every branch.
The submodule itself is already correct; the one-line fix is to point the lock
entry at the committed submodule pin. No other dependency entries change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
