### PR TITLE
fix: make `bun test:ts` run the TypeScript test suite

### DIFF
--- a/.agents/commands/create-pr.md
+++ b/.agents/commands/create-pr.md
@@ -145,7 +145,7 @@ The one gap pre-commit deliberately leaves is **tests** (`forge build --skip tes
 `bun test:ts`). Per `.agents/rules/099-finish.md`, run them now:
 
 - **Solidity changes**: `bun test:scoped -- <path-or-match>` during iteration; full `bun test` (or `forge test --match-path` if scope is clear) before opening a PR.
-- **TypeScript / JS changes**: `bun test:ts`.
+- **TypeScript / JS changes**: `bun test <path>` during iteration; full `bun test:ts` (runs every `script/**/*.test.ts`) before opening a PR.
 - **Docs / markdown / skill files only**: skip; note `N/A` in the summary.
 
 If anything fails, **stop and surface the failure** — do not push without explicit user

--- a/.github/workflows/ts-unit-tests.yml
+++ b/.github/workflows/ts-unit-tests.yml
@@ -1,0 +1,111 @@
+# Run TypeScript Unit Tests
+# - Runs the TypeScript/Bun test suite (`bun test:ts` → every `script/**/*.test.ts`).
+# - Path-gated: the test job runs only when files that can affect the outcome change
+#   (`script/**`, `package.json`, `bun.lock`, `tsconfig*.json`, this workflow).
+# - A `ts-tests-required` aggregator job always reports a final status so this workflow
+#   can remain a required check on `main` branch protection even when the test job is
+#   skipped (same pattern as `forge-unit-tests.yml`, see `.agents/rules/500-github-actions.md`).
+# - Lightweight: the suite is fully self-contained (no Foundry, submodules, MongoDB, RPC,
+#   or generated typechain bindings), so the job only installs Bun deps and runs the tests.
+
+name: Run TypeScript Unit Tests
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main # makes sure that it runs on main branch after a PR has been merged
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Default-deny at the workflow level; grant only what each job needs at the job level.
+permissions: {}
+
+# Cancel superseded in-progress runs on the same PR (force-push / rapid commits) so stale
+# runs stop burning runner minutes. Keyed per workflow, per event type, and per PR (falling
+# back to ref). cancel-in-progress is scoped to pull_request events so post-merge runs on
+# main and manual workflow_dispatch runs always complete and keep their signal.
+concurrency:
+  group: ts-unit-tests-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect-changes:
+    # Determines whether files that can influence `bun test:ts` outcomes were touched.
+    # Always runs (cheap) so the downstream ts-tests-required can report status.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to fetch repository contents
+      pull-requests: read # required by dorny/paths-filter to read changed files on PRs
+    outputs:
+      ts: ${{ steps.filter.outputs.ts }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            ts:
+              - 'script/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'tsconfig*.json'
+              - '.github/workflows/ts-unit-tests.yml'
+
+  run-ts-tests:
+    # Runs on PRs (once out of draft) and on push/workflow_dispatch.
+    # For non-PR events `github.event.pull_request` is null, so the draft check is gated
+    # behind an event-name guard to avoid `null == false` evaluating to false and silently
+    # skipping the job after a merge to main.
+    needs: detect-changes
+    if: >-
+      ${{
+        needs.detect-changes.outputs.ts == 'true' &&
+        (github.event_name != 'pull_request' ||
+         github.event.pull_request.draft == false)
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to fetch repository contents
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run TypeScript tests
+        run: bun test:ts
+
+  ts-tests-required:
+    # Aggregator job for branch protection. Reports green when the test job either
+    # succeeded or was skipped because no relevant files changed.
+    # Register THIS job (not `run-ts-tests`) as the required status check on `main`.
+    needs: [detect-changes, run-ts-tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate upstream result
+        # Validate `detect-changes` succeeded first. If it failed, `run-ts-tests` would be
+        # `skipped` due to the dependency failure — and treating that `skipped` as success
+        # would mask the infra failure from branch protection.
+        run: |
+          set -euo pipefail
+          detect_result="${{ needs.detect-changes.result }}"
+          test_result="${{ needs.run-ts-tests.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo -e "\033[31mts-tests-required FAILED (detect-changes=$detect_result)\033[0m" >&2
+            exit 1
+          fi
+          if [[ "$test_result" == "success" || "$test_result" == "skipped" ]]; then
+            echo -e "\033[32mts-tests-required OK (run-ts-tests=$test_result)\033[0m"
+            exit 0
+          fi
+          echo -e "\033[31mts-tests-required FAILED (run-ts-tests=$test_result)\033[0m" >&2
+          exit 1

--- a/.github/workflows/ts-unit-tests.yml
+++ b/.github/workflows/ts-unit-tests.yml
@@ -42,6 +42,8 @@ jobs:
       ts: ${{ steps.filter.outputs.ts }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Detect relevant changes
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -71,6 +73,8 @@ jobs:
       contents: read # required to fetch repository contents
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "test": "forge test --evm-version 'cancun'",
     "test:scoped": "bun script/utils/runScopedForgeTests.ts",
     "test:fix": "npm run lint:fix; npm run format:fix; npm run test",
-    "test:ts": "bun script/runTypescriptTests.ts",
+    "test:ts": "bun test script/",
     "troncast": "bun run script/troncast/index.ts",
     "typechain": "forge clean && rm -rf typechain/* && forge build src && bun abi:removeDuplicateEvents && typechain --target ethers-v5 'out/!(*.t).sol/*.json' --out-dir typechain",
     "typechain:incremental": "forge build src && bun abi:removeDuplicateEvents && typechain --target ethers-v5 'out/!(*.t).sol/*.json' --out-dir typechain",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-620](https://linear.app/lifi-linear/issue/EXSC-620/fix-bun-testts-script-points-at-a-nonexistent-runner)

# Why did I implement it this way?

**The problem:** `test:ts` was `bun script/runTypescriptTests.ts`, but that file has never existed (not in git history, no workflow invokes it), so `bun test:ts` failed immediately with `error: Module not found "script/runTypescriptTests.ts"`. On top of that, **no CI workflow ran the TypeScript suite at all** — 337 tests across 24 files had zero enforcement, so nothing stopped a change from silently breaking them.

**The fix (two coupled parts, one concern — "make the TS suite runnable and enforced"):**

1. Point `test:ts` at bun's built-in runner scoped to `script/` — `bun test script/` — since every TS test file lives under `script/` and they already use `bun:test`. I chose the `script/` substring filter over a shell glob (`script/**/*.test.ts`) so there's no dependency on shell globstar. Verified locally: discovers and runs all 24 files (337 tests) in ~2.7s, exits 0 on success, non-zero on failure — including when a broken filter matches nothing (bun has no implicit `--pass-with-no-tests`), so a future regression that stops discovering tests still fails loudly.
2. Add the `ts-unit-tests` workflow that runs `bun test:ts` on PRs (out of draft) and on `main`, mirroring `forge-unit-tests.yml`: a cheap `detect-changes` path filter, the test job gated on TS-relevant paths + draft state, and a `ts-tests-required` aggregator so branch protection stays green when the job is legitimately skipped. The suite is fully self-contained (the `typechain` imports are only in `demoScripts/*.ts`, never in test files; `MONGODB_URI`/RPC references are tests mocking their own env), so the job just installs Bun deps — no Foundry, submodules, MongoDB, RPC, or generated `typechain/`.

I also updated `create-pr` skill step 7 (which points engineers at `bun test:ts`) to reflect the now-working command.

**Follow-up required (not doable from a PR):** for `ts-tests-required` to actually *block* merges, an admin must add it to `main`'s required status checks in branch protection — same as every other `*-required` job. Until then the check runs and reports but is advisory.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
