### PR TITLE
docs(tron): correct energy price to 100 SUN + real deploy-cost figures

### DIFF
--- a/docs/TronFork.md
+++ b/docs/TronFork.md
@@ -308,11 +308,21 @@ the TypeScript conventions that apply to everything under
 
 - **Energy**: Tron's equivalent to Ethereum gas, consumed by smart contract
   execution.
-- **Cost**: 1 Energy = 420 SUN (0.00042 TRX) when paying with rTRX.
+- **Cost**: 1 Energy = **100 SUN** (0.0001 TRX) since TRON governance
+  Proposal #104 (Aug 2025); it was 210 SUN before that and 420 SUN
+  earlier. This is a live governance parameter — always confirm the
+  current value via the `getEnergyFee` key in
+  `wallet/getchainparameters` before quoting deployment costs.
 - **Free Energy**: Users can stake TRX to get free daily Energy allocation
   (avoids TRX fees).
-- **Contract deployment**: Typically requires 200k–1M Energy depending on
-  contract size, roughly 200–1000 TRX total once Bandwidth is included.
+- **Contract deployment**: roughly **200 Energy per byte** of deployed
+  bytecode — so ~175k Energy for the tiny Diamond proxy up to ~2.3M for
+  a large facet, averaging ~1M per contract (measured against the live
+  `tron` diamond, 2026-07). At 100 SUN that is ~18–230 TRX per contract.
+  A full ~24-contract diamond deploy ≈ ~26M Energy (~2,600 TRX) for
+  energy, plus ~230 TRX bandwidth and ~350 TRX for the
+  diamondCut/registration calls — roughly **3,000–3,200 TRX (~$1,000 at
+  $0.33/TRX)** all-in.
 
 **Bandwidth**
 

--- a/docs/TronFork.md
+++ b/docs/TronFork.md
@@ -312,7 +312,9 @@ the TypeScript conventions that apply to everything under
   Proposal #104 (Aug 2025); it was 210 SUN before that and 420 SUN
   earlier. This is a live governance parameter — always confirm the
   current value via the `getEnergyFee` key in
-  `wallet/getchainparameters` before quoting deployment costs.
+  `wallet/getchainparameters` on a Tron **mainnet** node (the value is
+  network-specific — Shasta/Nile report different fees) before quoting
+  deployment costs.
 - **Free Energy**: Users can stake TRX to get free daily Energy allocation
   (avoids TRX fees).
 - **Contract deployment**: roughly **200 Energy per byte** of deployed


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None — doc-only correction (labelled `trivial` per the ticket-linkage
carve-out). Discovered while estimating a Tron staging-deploy cost: the
guide quoted a stale energy price that overstated cost by ~4.2x.

# Why did I implement it this way?

Two fixes to `docs/TronFork.md`, both grounded in live data rather than
the previously-hardcoded guesses:

1. **Energy burn price 420 → 100 SUN.** TRON governance Proposal #104
   (Aug 2025) cut the energy unit price to 100 SUN (was 210, and 420
   earlier). Confirmed live via the `getEnergyFee` key in
   `wallet/getchainparameters` (= 100). Added a note to always confirm
   the live value since it's a governance parameter.
2. **Per-contract deploy figures replaced with measured numbers.** The
   old "200k–1M energy / 200–1000 TRX per contract" was a rough guess.
   Replaced with figures measured against the live `tron` diamond's
   actual creation transactions: ~200 energy per byte of deployed
   bytecode (very consistent across the sampled facets), so ~175k–2.3M
   energy per contract, and ~26M energy / ~3,000–3,200 TRX (~$1,000 at
   current prices) for a full ~24-contract diamond deploy.

No code or behaviour change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
