### PR TITLE
feat(tron): deploy staging diamond to Tron mainnet (EXSC-311)

### DIFF
--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -28,6 +28,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import { deployContractWithLogging, validateBalance } from './tronUtils'
 
 /**
@@ -50,9 +51,7 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
   }
 
   // Get network configuration from networks.json
-  // Use tronshasta for staging/testnet, tron for production
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
 
   const network = networkName as SupportedChain
 

--- a/script/deploy/tron/deploy-and-register-eco-facet.ts
+++ b/script/deploy/tron/deploy-and-register-eco-facet.ts
@@ -29,6 +29,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import { deployContractWithLogging, validateBalance } from './tronUtils'
 
 async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
@@ -43,8 +44,7 @@ async function deployAndRegisterEcoFacet(options: { dryRun?: boolean }) {
     verbose = getEnvVar('VERBOSE') !== 'false'
   } catch {}
 
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
 
   const network = networkName as SupportedChain
 

--- a/script/deploy/tron/deploy-and-register-near-intents-facet.ts
+++ b/script/deploy/tron/deploy-and-register-near-intents-facet.ts
@@ -29,6 +29,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import { deployContractWithLogging, validateBalance } from './tronUtils'
 
 async function deployAndRegisterNEARIntentsFacet(options: {
@@ -45,8 +46,7 @@ async function deployAndRegisterNEARIntentsFacet(options: {
     verbose = getEnvVar('VERBOSE') !== 'false'
   } catch {}
 
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
 
   const network = networkName as SupportedChain
 

--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -40,6 +40,7 @@ import { ZERO_ADDRESS } from '../shared/constants.js'
 import { getContractVersion } from '../shared/getContractVersion'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import { getTronCorePeriphery } from './helpers/tronContractLists.js'
 import { getTronWallet } from './tronUtils.js'
 
@@ -143,9 +144,7 @@ async function deployAndRegisterPeripheryImpl(options: {
   const onlyContracts = options.onlyContracts
 
   // Get network configuration from networks.json
-  // Use tronshasta for staging/testnet, tron for production
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
   let tronConfig
   try {
     tronConfig = getNetworkConfig(networkName as SupportedChain)

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -30,6 +30,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import { deployContractWithLogging, validateBalance } from './tronUtils'
 
 /**
@@ -51,9 +52,7 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
   }
 
   // Get network configuration from networks.json
-  // Use tronshasta for staging/testnet, tron for production
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
 
   const network = networkName as SupportedChain
 

--- a/script/deploy/tron/deploy-core-facets.ts
+++ b/script/deploy/tron/deploy-core-facets.ts
@@ -29,6 +29,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { getCoreFacets } from '../shared/globalContractLists'
 
+import { TRON_DEPLOY_NETWORK } from './constants'
 import {
   deployContractWithLogging,
   validateBalance,
@@ -100,9 +101,7 @@ async function deployCoreFacetsImpl(options: {
   const networksConfig = await Bun.file('config/networks.json').json()
 
   // Get network configuration from networks.json
-  // Use tronshasta for staging/testnet, tron for production
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  const networkName = TRON_DEPLOY_NETWORK
 
   const tronConfig = networksConfig[networkName]
   if (!tronConfig) {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-311](https://linear.app/lifi-linear/issue/EXSC-311/deploy-tron-staging-setup) — Deploy Tron staging setup.

# Why did I implement it this way?

The Tron facet/periphery deploy scripts derived the **target network** from the environment:

```ts
const networkName = environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
```

That forced every non-production (staging) deploy onto **Shasta testnet**, so we could never stand up a staging diamond on **Tron mainnet** — which is what BE/QA actually need (Shasta USDT is a different, working token and can't exercise the broken-mainnet-USDT path the `contracts-tron` fork exists for).

Fix: point the six scripts at the existing `TRON_DEPLOY_NETWORK` constant (`= 'tron'`) already defined in `constants.ts` and already used by `deploy-safe-tron.ts` — so this also removes an inconsistency rather than adding a mechanism.

`PRODUCTION` is now the sole staging/prod switch, exactly like EVM (and already wired for the deployment-file suffix via `getEnvironment()` and the wallet key via `getPrivateKeyForEnvironment()`):

| `.env` | Network | Deploy file | Wallet |
|---|---|---|---|
| `PRODUCTION=true` | tron (mainnet) | `tron.json` | prod key |
| `PRODUCTION=false` | tron (mainnet) | `tron.staging.json` | staging key |

No new env var, no flags. **Shasta is dropped** as a deploy target (unused — `tronshasta.json` is empty — and untestable for the USDT path). If a testnet escape hatch is ever needed it's a one-line `process.env.TRON_NETWORK ?? TRON_DEPLOY_NETWORK`.

Scoped, non-behavioural for production (prod already resolved to `tron`); only the staging branch changes.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
