### PR TITLE
docs(rules): flag GitHub Actions template injection in agent rules (EXSC-578)

### DIFF
--- a/.agents/rules/500-github-actions.md
+++ b/.agents/rules/500-github-actions.md
@@ -47,6 +47,7 @@ paths:
   - name: Check for authorized actor
     env:
       ACTOR_LOGIN: ${{ github.actor }}
+    shell: bash
     run: |
       if [[ "$ACTOR_LOGIN" == "lifi-action-bot" ]]; then echo "authorized"; fi
   ```

--- a/.agents/rules/500-github-actions.md
+++ b/.agents/rules/500-github-actions.md
@@ -36,6 +36,30 @@ paths:
   - uses: some-action@main
   ```
 
+### No template injection in `run:` scripts ([CONV:ACTIONS-NO-INJECTION])
+
+- **Never interpolate `${{ github.* }}` (or any other `${{ ... }}` expression carrying attacker-influenced data) directly into a `run:` shell script.** The expression is substituted into the script body **before** the shell runs, so a crafted value (e.g. a branch name, PR title, commit message, or actor login containing shell metacharacters) executes as code on the runner.
+- **Highest-risk contexts** (attacker-controllable on `pull_request`/`issue`/`issue_comment` triggers): `github.actor`, `github.event.*` (`.pull_request.title`, `.pull_request.body`, `.pull_request.head.ref`, `.issue.title`, `.comment.body`, `.label.name`, `.action`), `github.head_ref`. Treat every `github.event.*` field as untrusted.
+- **Fix**: bind the expression to an `env:` entry on the step, then reference the shell variable (quoted) inside `run:`. Values passed via `env:` reach the script as data, never as code.
+- **Example (correct)**:
+
+  ```yaml
+  - name: Check for authorized actor
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+    run: |
+      if [[ "$GITHUB_ACTOR" == "lifi-action-bot" ]]; then echo "authorized"; fi
+  ```
+
+- **Anti-pattern (forbidden)**:
+
+  ```yaml
+  - run: |
+      if [[ "${{ github.actor }}" == "lifi-action-bot" ]]; then echo "authorized"; fi
+  ```
+
+- `${{ secrets.* }}` and `${{ github.* }}` inside `if:`/`with:`/`env:` values are fine — only direct interpolation into the `run:` script body is the injection sink.
+
 ### Foundry installation ([CONV:FOUNDRY-SETUP])
 
 - **Always install foundry via the project's `./.github/actions/setup-foundry` composite action.** Do not call `foundry-rs/foundry-toolchain` directly from a workflow.

--- a/.agents/rules/500-github-actions.md
+++ b/.agents/rules/500-github-actions.md
@@ -40,15 +40,15 @@ paths:
 
 - **Never interpolate `${{ github.* }}` (or any other `${{ ... }}` expression carrying attacker-influenced data) directly into a `run:` shell script.** The expression is substituted into the script body **before** the shell runs, so a crafted value (e.g. a branch name, PR title, commit message, or actor login containing shell metacharacters) executes as code on the runner.
 - **Highest-risk contexts** (attacker-controllable on `pull_request`/`issue`/`issue_comment` triggers): `github.actor`, `github.event.*` (`.pull_request.title`, `.pull_request.body`, `.pull_request.head.ref`, `.issue.title`, `.comment.body`, `.label.name`, `.action`), `github.head_ref`. Treat every `github.event.*` field as untrusted.
-- **Fix**: bind the expression to an `env:` entry on the step, then reference the shell variable (quoted) inside `run:`. Values passed via `env:` reach the script as data, never as code.
+- **Fix**: bind the expression to an `env:` entry on the step, then reference the shell variable (quoted) inside `run:`. Values passed via `env:` reach the script as data, never as code. Use a **custom** env-var name — GitHub silently ignores assignments to names it reserves (`GITHUB_*`, `RUNNER_*`), so `env: GITHUB_ACTOR: ...` is dropped and `$GITHUB_ACTOR` falls back to the runner default (works only by coincidence when the values match).
 - **Example (correct)**:
 
   ```yaml
   - name: Check for authorized actor
     env:
-      GITHUB_ACTOR: ${{ github.actor }}
+      ACTOR_LOGIN: ${{ github.actor }}
     run: |
-      if [[ "$GITHUB_ACTOR" == "lifi-action-bot" ]]; then echo "authorized"; fi
+      if [[ "$ACTOR_LOGIN" == "lifi-action-bot" ]]; then echo "authorized"; fi
   ```
 
 - **Anti-pattern (forbidden)**:
@@ -58,7 +58,7 @@ paths:
       if [[ "${{ github.actor }}" == "lifi-action-bot" ]]; then echo "authorized"; fi
   ```
 
-- `${{ secrets.* }}` and `${{ github.* }}` inside `if:`/`with:`/`env:` values are fine — only direct interpolation into the `run:` script body is the injection sink.
+- The `run:` script body is the direct injection sink. `${{ ... }}` in `if:`/`with:`/`env:` is not that sink, but it is not automatically safe: `if:` cannot reference `secrets.*` at all (map to `env:` first), and a value handed to `with:` is only as safe as what the receiving action does with it. Always bind untrusted expressions through `env:` and reference the quoted shell variable in `run:`.
 
 ### Foundry installation ([CONV:FOUNDRY-SETUP])
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-578](https://linear.app/lifi-linear/issue/EXSC-578/review-and-update-pr-1984-template-injection-fix-add-ai-rule-to-catch)

Partial — this PR delivers the "add an AI-rule to catch it" half of EXSC-578 (the `Ref` keyword intentionally does not auto-close the ticket, since the PR #1984 review/merge half is tracked separately).

# Why did I implement it this way?

Follow-up to PR #1984, which fixed the last direct `${{ github.* }}` interpolations inside `run:` scripts in `protectAuditLabels.yml`. To stop this class of GitHub Actions template-injection bug from being reintroduced, this adds a `[CONV:ACTIONS-NO-INJECTION]` convention to the existing `500-github-actions.md` rule rather than a new rule file — that rule is already scoped to `.github/workflows/**`, so the guidance activates exactly when an agent edits a workflow (satisfying both of the ticket's AI-rule checkboxes). The convention states the rule (never interpolate untrusted `${{ ... }}` into a `run:` body), names the highest-risk attacker-controllable contexts (`github.actor`, `github.head_ref`, every `github.event.*` field), gives the correct `env:`-binding pattern plus the forbidden anti-pattern mirroring the #1984 fix, and clarifies that interpolation inside `if:`/`with:`/`env:` is safe — only the `run:` script body is the injection sink.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>