### PR TITLE
fix(clear-signing): surface the real on-chain recipient for AcrossV4 + affected bridges

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -204,6 +204,12 @@
           "visible": "always"
         },
         {
+          "path": "_acrossData.receiverAddress",
+          "label": "Across Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -2945,6 +2951,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_acrossData.receiverAddress",
+          "label": "Across Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {

--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -360,6 +360,12 @@
           "visible": "always"
         },
         {
+          "path": "_allBridgeData.recipient",
+          "label": "AllBridge Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -644,6 +650,12 @@
           "visible": "always"
         },
         {
+          "path": "_chainflipData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -711,6 +723,12 @@
           "visible": "always"
         },
         {
+          "path": "_deBridgeData.receiver",
+          "label": "DeBridge Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -775,6 +793,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_ecoData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -912,6 +936,12 @@
           "visible": "always"
         },
         {
+          "path": "_gasZipData.receiverAddress",
+          "label": "GasZip Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -976,6 +1006,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_glacisData.receiverAddress",
+          "label": "Glacis Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1480,6 +1516,12 @@
           "visible": "always"
         },
         {
+          "path": "_layerSwapData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -1544,6 +1586,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_lifiIntentData.recipient",
+          "label": "Intent Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1614,6 +1662,12 @@
           "visible": "always"
         },
         {
+          "path": "_lifiIntentData.recipient",
+          "label": "Intent Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -1678,6 +1732,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_mayanData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1812,6 +1872,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_nearData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2214,6 +2280,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_polymerData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3152,6 +3224,12 @@
           "visible": "always"
         },
         {
+          "path": "_allBridgeData.recipient",
+          "label": "AllBridge Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3536,6 +3614,12 @@
           "visible": "always"
         },
         {
+          "path": "_chainflipData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3632,6 +3716,12 @@
           "visible": "always"
         },
         {
+          "path": "_deBridgeData.receiver",
+          "label": "DeBridge Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3725,6 +3815,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_ecoData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3920,6 +4016,12 @@
           "visible": "always"
         },
         {
+          "path": "_gasZipData.receiverAddress",
+          "label": "GasZip Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4013,6 +4115,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_glacisData.receiverAddress",
+          "label": "Glacis Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4688,6 +4796,12 @@
           "visible": "always"
         },
         {
+          "path": "_layerSwapData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4781,6 +4895,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_lifiIntentData.recipient",
+          "label": "Intent Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4880,6 +5000,12 @@
           "visible": "always"
         },
         {
+          "path": "_lifiIntentData.recipient",
+          "label": "Intent Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4973,6 +5099,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_mayanData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5165,6 +5297,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_nearData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5741,6 +5879,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_polymerData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {

--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -35,6 +35,20 @@ Reads on a hardware wallet as one sentence: *"Bridge 100 USDC via Across to chai
 
 Note the bridge name (`<Bridge>`) is a literal substituted at descriptor-generation time, not a `{path}` placeholder resolved by the wallet — it's constant per selector and doesn't change between transactions.
 
+#### Bridge-specific recipient (`BRIDGE_EXTRA_RECEIVERS`)
+
+For most bridges the on-chain recipient is `_bridgeData.receiver`, so the standard `Recipient` field is the whole story. A few bridges credit funds on the destination chain to a **bridge-specific** field instead, and `_bridgeData.receiver` is then a sentinel or an intermediary contract:
+
+- **AcrossV4** — `_startBridge` passes `_acrossData.receiverAddress` as the Across SpokePool `recipient` in every branch (see [`src/Facets/AcrossFacetV4.sol`](../src/Facets/AcrossFacetV4.sol)). `_bridgeData.receiver` only equals it for EVM transfers **without** a destination call (enforced on-chain). For non-EVM transfers it is the `NON_EVM_ADDRESS` sentinel; for destination calls it is our Receiver contract. A signer who only saw `_bridgeData.receiver` would not, in those two cases, see where the bridge actually sends the funds.
+
+For those bridges the generator appends an extra always-visible field (`Across Recipient` for AcrossV4) sourced from the bridge-specific struct field:
+
+```json
+{ "path": "_acrossData.receiverAddress", "label": "Across Recipient", "format": "raw", "visible": "always" }
+```
+
+The field is `bytes32` (it may hold a non-EVM address such as a Solana pubkey), and ERC-7730 v2 `addressName` only accepts `address` — there is no `bytes32`→EVM-address formatter — so the honest rendering is `raw` (hex). `interpolatedIntent` intentionally stays on `_bridgeData.receiver`: for the dominant EVM / no-destination-call path it resolves to a trusted name/ENS, and the raw field carries the ground truth for the rest. Only the `AcrossV4` identity is mapped, never the `AcrossV4Swap` opaque / EIP-712-gated variant (its `_acrossV4SwapFacetData` has no `receiverAddress`; its receiver is not on-chain-verifiable by design). The mapping is strict-by-default: if the referenced struct component is renamed or retyped, the generator fails and blocks CI rather than emit a dead display path. Mayan and LayerSwap carry the same `bytes32 nonEVMReceiver` pattern and are candidates for the same treatment in a follow-up.
+
 ### Swap-and-bridge: `swapAndStartBridgeTokensVia<Bridge>`
 
 Adds the head of the swap chain (`_swapData.[0]`) as a separate field:

--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -37,17 +37,25 @@ Note the bridge name (`<Bridge>`) is a literal substituted at descriptor-generat
 
 #### Bridge-specific recipient (`BRIDGE_EXTRA_RECEIVERS`)
 
-For most bridges the on-chain recipient is `_bridgeData.receiver`, so the standard `Recipient` field is the whole story. A few bridges credit funds on the destination chain to a **bridge-specific** field instead, and `_bridgeData.receiver` is then a sentinel or an intermediary contract:
-
-- **AcrossV4** — `_startBridge` passes `_acrossData.receiverAddress` as the Across SpokePool `recipient` in every branch (see [`src/Facets/AcrossFacetV4.sol`](../src/Facets/AcrossFacetV4.sol)). `_bridgeData.receiver` only equals it for EVM transfers **without** a destination call (enforced on-chain). For non-EVM transfers it is the `NON_EVM_ADDRESS` sentinel; for destination calls it is our Receiver contract. A signer who only saw `_bridgeData.receiver` would not, in those two cases, see where the bridge actually sends the funds.
-
-For those bridges the generator appends an extra always-visible field (`Across Recipient` for AcrossV4) sourced from the bridge-specific struct field:
+For most bridges the on-chain recipient is `_bridgeData.receiver`, so the standard `Recipient` field is the whole story. A number of bridges credit funds on the destination chain to a **bridge-specific** struct field instead, and `_bridgeData.receiver` is then a sentinel (`NON_EVM_ADDRESS`) or an intermediary contract. For those, the generator appends an extra **always-visible** field sourced from the bridge-specific field, e.g. for AcrossV4:
 
 ```json
 { "path": "_acrossData.receiverAddress", "label": "Across Recipient", "format": "raw", "visible": "always" }
 ```
 
-The field is `bytes32` (it may hold a non-EVM address such as a Solana pubkey), and ERC-7730 v2 `addressName` only accepts `address` — there is no `bytes32`→EVM-address formatter — so the honest rendering is `raw` (hex). `interpolatedIntent` intentionally stays on `_bridgeData.receiver`: for the dominant EVM / no-destination-call path it resolves to a trusted name/ENS, and the raw field carries the ground truth for the rest. Only the `AcrossV4` identity is mapped, never the `AcrossV4Swap` opaque / EIP-712-gated variant (its `_acrossV4SwapFacetData` has no `receiverAddress`; its receiver is not on-chain-verifiable by design). The mapping is strict-by-default: if the referenced struct component is renamed or retyped, the generator fails and blocks CI rather than emit a dead display path. Mayan and LayerSwap carry the same `bytes32 nonEVMReceiver` pattern and are candidates for the same treatment in a follow-up.
+The extra field is `bytes`/`bytes32` (it may hold a non-EVM address such as a Solana pubkey), and ERC-7730 v2 `addressName` only accepts `address` — there is no `bytes32`→EVM-address formatter — so the honest rendering is `raw` (hex). `interpolatedIntent` intentionally stays on `_bridgeData.receiver`: for the dominant EVM path it resolves to a trusted name/ENS, and the raw field carries the ground truth for the rest. The mapping is **strict-by-default**: if a referenced struct component is renamed or retyped, the generator fails and blocks CI rather than emit a dead display path.
+
+Two shapes, keyed by `bridgeFacetName()`:
+
+- **TYPE-A** — the field is the on-chain recipient in **every** branch (always populated). `AcrossV4` (`_acrossData.receiverAddress`) and `DeBridgeDln` (`_deBridgeData.receiver`) can differ from `_bridgeData.receiver` even on EVM (destination call → our Receiver contract; DeBridgeDln never cross-checks its `receiver`), so the field adds signal on EVM too. `Glacis`, `AllBridge`, `LiFiIntentEscrow`(+`V2`), `GasZip` enforce equality on plain EVM transfers, so there the field re-shows the recipient and carries the real value on non-EVM. Labelled `"<Bridge> Recipient"`.
+- **TYPE-B** — a `nonEVMReceiver`-style field only set on non-EVM transfers (`0x0` on EVM, where `_bridgeData.receiver` is the faithful recipient): `Mayan`, `LayerSwap`, `Chainflip`, `Eco`, `NEARIntents`, `PolymerCCTP`. Labelled `"Non-EVM Recipient"` so the `0x0` on an EVM transfer reads as "N/A".
+
+> **`GasZip` caveat:** its `receiverAddress` is a **right-padded** `bytes32` (`bytes32(bytes20(addr))`), unlike the left-padded convention elsewhere; `raw` shows the address in the high bytes.
+
+Deliberately **excluded** (no clean static fix — tracked as follow-up):
+
+- **Opaque / EIP-712-gated flows** — `AcrossV4Swap`, `Garden`, `ThorSwap`, `Symbiosis`, `RelayDepository`: the receiver lives in opaque calldata or an off-chain order and is not on-chain-verifiable by design.
+- **`Squid`** — the recipient is route-type-dependent (`_squidData.destinationAddress` for `BridgeCall`/`CallBridgeCall`, `_bridgeData.receiver` for `CallBridge`), so no single field is always correct; needs its own design.
 
 ### Swap-and-bridge: `swapAndStartBridgeTokensVia<Bridge>`
 

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -334,7 +334,7 @@ function bridgeFacetName(fnName: string): string {
 interface IExtraReceiver {
   paramName: string
   component: string
-  typePrefix: string
+  type: string
   label: string
 }
 
@@ -343,37 +343,37 @@ const BRIDGE_EXTRA_RECEIVERS: Record<string, IExtraReceiver> = {
   AcrossV4: {
     paramName: '_acrossData',
     component: 'receiverAddress',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Across Recipient',
   },
   DeBridgeDln: {
     paramName: '_deBridgeData',
     component: 'receiver',
-    typePrefix: 'bytes',
+    type: 'bytes',
     label: 'DeBridge Recipient',
   },
   Glacis: {
     paramName: '_glacisData',
     component: 'receiverAddress',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Glacis Recipient',
   },
   AllBridge: {
     paramName: '_allBridgeData',
     component: 'recipient',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'AllBridge Recipient',
   },
   LiFiIntentEscrow: {
     paramName: '_lifiIntentData',
     component: 'recipient',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Intent Recipient',
   },
   LiFiIntentEscrowV2: {
     paramName: '_lifiIntentData',
     component: 'recipient',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Intent Recipient',
   },
   GasZip: {
@@ -381,44 +381,44 @@ const BRIDGE_EXTRA_RECEIVERS: Record<string, IExtraReceiver> = {
     // left-padded convention elsewhere; `raw` shows the address in the high bytes.
     paramName: '_gasZipData',
     component: 'receiverAddress',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'GasZip Recipient',
   },
   // TYPE-B: nonEVMReceiver-style field, only set on non-EVM transfers (0x0 on EVM).
   Mayan: {
     paramName: '_mayanData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Non-EVM Recipient',
   },
   LayerSwap: {
     paramName: '_layerSwapData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Non-EVM Recipient',
   },
   Chainflip: {
     paramName: '_chainflipData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes',
+    type: 'bytes',
     label: 'Non-EVM Recipient',
   },
   Eco: {
     paramName: '_ecoData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes',
+    type: 'bytes',
     label: 'Non-EVM Recipient',
   },
   NEARIntents: {
     paramName: '_nearData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Non-EVM Recipient',
   },
   PolymerCCTP: {
     paramName: '_polymerData',
     component: 'nonEVMReceiver',
-    typePrefix: 'bytes32',
+    type: 'bytes32',
     label: 'Non-EVM Recipient',
   },
 }
@@ -435,15 +435,20 @@ function validateExtraReceiver(fn: IAbiFn): string | null {
   const spec = extraReceiverSpec(fn)
   if (!spec) return null
   const param = fn.inputs.find((p) => p.name === spec.paramName)
-  if (!param || !param.type.startsWith('tuple'))
+  // Exact `tuple`, not `startsWith('tuple')`: a `tuple[]` param would need an
+  // index in the path and must not silently satisfy a single-struct lookup.
+  if (!param || param.type !== 'tuple')
     return `expected param "${spec.paramName}" of tuple type for bridge-specific recipient; got name="${param?.name}" type="${param?.type}"`
   const comp = (
     param.components as { name: string; type: string }[] | undefined
   )?.find((c) => c.name === spec.component)
   if (!comp)
     return `${spec.paramName}: missing component "${spec.component}" (bridge-specific recipient)`
-  if (!comp.type.startsWith(spec.typePrefix))
-    return `${spec.paramName}: component "${spec.component}" has type "${comp.type}", expected prefix "${spec.typePrefix}"`
+  // Exact type match, not a prefix: `startsWith('bytes')` would wrongly accept
+  // `bytes32[]`/`bytes16`, and `startsWith('bytes32')` would accept `bytes32[]`
+  // — incompatible shapes that would pass CI but render the wrong value.
+  if (comp.type !== spec.type)
+    return `${spec.paramName}: component "${spec.component}" has type "${comp.type}", expected exactly "${spec.type}"`
   return null
 }
 

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -294,6 +294,86 @@ function bridgeFacetName(fnName: string): string {
   )
 }
 
+// ---------- bridge-specific "true recipient" fields ----------
+//
+// For most bridges the on-chain recipient is `_bridgeData.receiver`, so
+// RECEIVER_FIELD is the whole story. A few bridges credit funds on the
+// destination chain to a *bridge-specific* field instead, and
+// `_bridgeData.receiver` is then either a sentinel or an intermediary contract:
+//
+//   AcrossV4 — `_startBridge` passes `_acrossData.receiverAddress` as the Across
+//   SpokePool `recipient` in every branch (see src/Facets/AcrossFacetV4.sol).
+//   `_bridgeData.receiver` only equals it for EVM transfers *without* a
+//   destination call (enforced on-chain). For non-EVM transfers it is the
+//   NON_EVM_ADDRESS sentinel; for destination calls it is our Receiver contract.
+//   In those two cases a signer who only saw `_bridgeData.receiver` would not see
+//   where the bridge actually sends the funds.
+//
+// We surface that field as an extra always-visible entry. It is `bytes32` (it may
+// hold a non-EVM address such as a Solana pubkey), and ERC-7730 v2 `addressName`
+// only accepts `address` — there is no bytes32→EVM-address formatter — so the
+// honest rendering is `raw` (hex). `interpolatedIntent` intentionally stays on
+// `_bridgeData.receiver`: for the dominant EVM / no-destination-call path it
+// resolves to a trusted name/ENS, and the raw field carries the ground truth for
+// the rest.
+//
+// Keyed by bridge identity from bridgeFacetName() — "AcrossV4" only, never the
+// "AcrossV4Swap" opaque / EIP-712-gated variant (its `_acrossV4SwapFacetData` has
+// no receiverAddress; its receiver is not on-chain-verifiable by design).
+interface IExtraReceiver {
+  paramName: string
+  component: string
+  typePrefix: string
+  label: string
+}
+
+const BRIDGE_EXTRA_RECEIVERS: Record<string, IExtraReceiver> = {
+  AcrossV4: {
+    paramName: '_acrossData',
+    component: 'receiverAddress',
+    typePrefix: 'bytes32',
+    label: 'Across Recipient',
+  },
+}
+
+function extraReceiverSpec(fn: IAbiFn): IExtraReceiver | null {
+  return BRIDGE_EXTRA_RECEIVERS[bridgeFacetName(fn.name)] ?? null
+}
+
+// Strict-by-default: if a bridge declares an extra-receiver field above, the
+// referenced tuple component must exist in the ABI with the expected type. A
+// struct rename must fail the generator (and CI) loudly rather than emit a dead
+// display path that silently resolves to nothing in wallets.
+function validateExtraReceiver(fn: IAbiFn): string | null {
+  const spec = extraReceiverSpec(fn)
+  if (!spec) return null
+  const param = fn.inputs.find((p) => p.name === spec.paramName)
+  if (!param || !param.type.startsWith('tuple'))
+    return `expected param "${spec.paramName}" of tuple type for bridge-specific recipient; got name="${param?.name}" type="${param?.type}"`
+  const comp = (
+    param.components as { name: string; type: string }[] | undefined
+  )?.find((c) => c.name === spec.component)
+  if (!comp)
+    return `${spec.paramName}: missing component "${spec.component}" (bridge-specific recipient)`
+  if (!comp.type.startsWith(spec.typePrefix))
+    return `${spec.paramName}: component "${spec.component}" has type "${comp.type}", expected prefix "${spec.typePrefix}"`
+  return null
+}
+
+function extraReceiverFields(fn: IAbiFn): IField[] {
+  const spec = extraReceiverSpec(fn)
+  if (!spec) return []
+  return [
+    {
+      path: `${spec.paramName}.${spec.component}`,
+      label: spec.label,
+      // bytes32 recipient (may be non-EVM); addressName accepts `address` only.
+      format: 'raw',
+      visible: 'always',
+    },
+  ]
+}
+
 function variantTag(fnName: string): string | null {
   // Packed/Min disambiguator for the intent string.
   const native = /Native(Packed|Min)$/u.test(fnName)
@@ -334,6 +414,7 @@ function buildStartFormat(fn: IAbiFn): IFormatEntry {
       },
       CHAIN_FIELD,
       RECEIVER_FIELD,
+      ...extraReceiverFields(fn),
       ...HIDDEN_BRIDGE_FIELDS,
     ],
   }
@@ -363,6 +444,7 @@ function buildSwapAndStartFormat(fn: IAbiFn): IFormatEntry {
       },
       CHAIN_FIELD,
       RECEIVER_FIELD,
+      ...extraReceiverFields(fn),
       ...HIDDEN_BRIDGE_FIELDS,
       {
         path: '_swapData.[].callData',
@@ -748,12 +830,26 @@ function main() {
         )
         continue
       }
+      const extraErr = validateExtraReceiver(fn)
+      if (extraErr) {
+        failures.push(
+          `${sig}\n      reason: bridge-specific recipient mismatch — ${extraErr}\n      fix:    update the BRIDGE_EXTRA_RECEIVERS entry in buildClearSigningProposal.ts to match the facet's current struct field.`
+        )
+        continue
+      }
       out[sig] = buildSwapAndStartFormat(fn)
     } else if (fn.name.startsWith('startBridgeTokensVia')) {
       const err = validateStartFn(fn)
       if (err) {
         failures.push(
           `${sig}\n      reason: shape mismatch — ${err}\n      fix:    align the facet's _bridgeData struct with LiFi.BridgeData (canonical), OR teach buildClearSigningProposal.ts about the new shape.`
+        )
+        continue
+      }
+      const extraErr = validateExtraReceiver(fn)
+      if (extraErr) {
+        failures.push(
+          `${sig}\n      reason: bridge-specific recipient mismatch — ${extraErr}\n      fix:    update the BRIDGE_EXTRA_RECEIVERS entry in buildClearSigningProposal.ts to match the facet's current struct field.`
         )
         continue
       }

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -297,29 +297,40 @@ function bridgeFacetName(fnName: string): string {
 // ---------- bridge-specific "true recipient" fields ----------
 //
 // For most bridges the on-chain recipient is `_bridgeData.receiver`, so
-// RECEIVER_FIELD is the whole story. A few bridges credit funds on the
-// destination chain to a *bridge-specific* field instead, and
-// `_bridgeData.receiver` is then either a sentinel or an intermediary contract:
+// RECEIVER_FIELD is the whole story. A number of bridges instead credit funds on
+// the destination chain to a *bridge-specific* struct field, and
+// `_bridgeData.receiver` is then a sentinel or an intermediary contract. We
+// surface that field as an extra always-visible entry so the clear-signing text
+// reflects where the bridge actually sends the funds.
 //
-//   AcrossV4 — `_startBridge` passes `_acrossData.receiverAddress` as the Across
-//   SpokePool `recipient` in every branch (see src/Facets/AcrossFacetV4.sol).
-//   `_bridgeData.receiver` only equals it for EVM transfers *without* a
-//   destination call (enforced on-chain). For non-EVM transfers it is the
-//   NON_EVM_ADDRESS sentinel; for destination calls it is our Receiver contract.
-//   In those two cases a signer who only saw `_bridgeData.receiver` would not see
-//   where the bridge actually sends the funds.
+// The extra field is `bytes`/`bytes32` (it may hold a non-EVM address such as a
+// Solana pubkey), and ERC-7730 v2 `addressName` only accepts `address` — there is
+// no bytes32→EVM-address formatter — so the honest rendering is `raw` (hex).
+// `interpolatedIntent` intentionally stays on `_bridgeData.receiver`: for the
+// dominant EVM path it resolves to a trusted name/ENS, and the raw field carries
+// the ground truth for the rest.
 //
-// We surface that field as an extra always-visible entry. It is `bytes32` (it may
-// hold a non-EVM address such as a Solana pubkey), and ERC-7730 v2 `addressName`
-// only accepts `address` — there is no bytes32→EVM-address formatter — so the
-// honest rendering is `raw` (hex). `interpolatedIntent` intentionally stays on
-// `_bridgeData.receiver`: for the dominant EVM / no-destination-call path it
-// resolves to a trusted name/ENS, and the raw field carries the ground truth for
-// the rest.
+// Two shapes (both handled identically here; the difference is only in what the
+// field holds on an EVM transfer):
 //
-// Keyed by bridge identity from bridgeFacetName() — "AcrossV4" only, never the
-// "AcrossV4Swap" opaque / EIP-712-gated variant (its `_acrossV4SwapFacetData` has
-// no receiverAddress; its receiver is not on-chain-verifiable by design).
+//   TYPE-A — the field is the on-chain recipient in *every* branch, so it is
+//   always populated. AcrossV4/DeBridgeDln can even differ from
+//   `_bridgeData.receiver` on EVM (destination call → our Receiver contract;
+//   DeBridgeDln never cross-checks), so the field adds signal on EVM too. Glacis/
+//   AllBridge/LiFiIntentEscrow/GasZip enforce equality on plain EVM transfers, so
+//   there the field just re-shows the recipient and carries the real value on
+//   non-EVM.
+//
+//   TYPE-B — a `nonEVMReceiver`-style field that is only set on non-EVM transfers
+//   and is `0x0` on EVM (where `_bridgeData.receiver` is the faithful recipient).
+//   Labelled "Non-EVM Recipient" so the `0x0` on an EVM transfer reads as "N/A".
+//
+// Keyed by bridge identity from bridgeFacetName(). Deliberately excluded:
+//   - AcrossV4Swap / other opaque, EIP-712-gated flows — the receiver lives in
+//     opaque calldata and is not on-chain-verifiable by design.
+//   - Squid — the recipient is route-type-dependent (destinationAddress for some
+//     routes, _bridgeData.receiver for others); no single field is always right.
+// (See docs/ClearSigningProposal.md for the full audit + follow-up scope.)
 interface IExtraReceiver {
   paramName: string
   component: string
@@ -328,11 +339,87 @@ interface IExtraReceiver {
 }
 
 const BRIDGE_EXTRA_RECEIVERS: Record<string, IExtraReceiver> = {
+  // TYPE-A: field is the bridge's on-chain recipient in every branch.
   AcrossV4: {
     paramName: '_acrossData',
     component: 'receiverAddress',
     typePrefix: 'bytes32',
     label: 'Across Recipient',
+  },
+  DeBridgeDln: {
+    paramName: '_deBridgeData',
+    component: 'receiver',
+    typePrefix: 'bytes',
+    label: 'DeBridge Recipient',
+  },
+  Glacis: {
+    paramName: '_glacisData',
+    component: 'receiverAddress',
+    typePrefix: 'bytes32',
+    label: 'Glacis Recipient',
+  },
+  AllBridge: {
+    paramName: '_allBridgeData',
+    component: 'recipient',
+    typePrefix: 'bytes32',
+    label: 'AllBridge Recipient',
+  },
+  LiFiIntentEscrow: {
+    paramName: '_lifiIntentData',
+    component: 'recipient',
+    typePrefix: 'bytes32',
+    label: 'Intent Recipient',
+  },
+  LiFiIntentEscrowV2: {
+    paramName: '_lifiIntentData',
+    component: 'recipient',
+    typePrefix: 'bytes32',
+    label: 'Intent Recipient',
+  },
+  GasZip: {
+    // NOTE: this bytes32 is RIGHT-padded (bytes32(bytes20(addr))), unlike the
+    // left-padded convention elsewhere; `raw` shows the address in the high bytes.
+    paramName: '_gasZipData',
+    component: 'receiverAddress',
+    typePrefix: 'bytes32',
+    label: 'GasZip Recipient',
+  },
+  // TYPE-B: nonEVMReceiver-style field, only set on non-EVM transfers (0x0 on EVM).
+  Mayan: {
+    paramName: '_mayanData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes32',
+    label: 'Non-EVM Recipient',
+  },
+  LayerSwap: {
+    paramName: '_layerSwapData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes32',
+    label: 'Non-EVM Recipient',
+  },
+  Chainflip: {
+    paramName: '_chainflipData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes',
+    label: 'Non-EVM Recipient',
+  },
+  Eco: {
+    paramName: '_ecoData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes',
+    label: 'Non-EVM Recipient',
+  },
+  NEARIntents: {
+    paramName: '_nearData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes32',
+    label: 'Non-EVM Recipient',
+  },
+  PolymerCCTP: {
+    paramName: '_polymerData',
+    component: 'nonEVMReceiver',
+    typePrefix: 'bytes32',
+    label: 'Non-EVM Recipient',
   },
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-627](https://linear.app/lifi-linear/issue/EXSC-627/clear-signing-surface-bridge-specific-destination-recipient-for-non)

# Why did I implement it this way?

**Problem (raised by CodeRabbit on #2046; pre-existing, untouched by that PR).**
The generated ERC-7730 clear-signing entries surface `_bridgeData.receiver` as the
"Recipient". For a number of bridges that is **not** where the funds actually go on
the destination chain — the real recipient is a bridge-specific struct field, and
`_bridgeData.receiver` is a sentinel (`NON_EVM_ADDRESS`) or an intermediary contract.
The original flag was AcrossV4; an audit of every facet found the same class of gap
across many bridges.

**Fix — in the generator, not the JSON.** The entries are generated by
`tasks/buildClearSigningProposal.ts` (the `verifyClearSigning` CI gate regenerates +
diffs, so hand-editing the JSON is futile). Added a per-facet `BRIDGE_EXTRA_RECEIVERS`
map that appends an always-visible field sourced from the bridge's real recipient,
then regenerated `config/clearSigningProposal.json`.

**Design decisions:**

- **`format: "raw"`** — the fields are `bytes`/`bytes32` (may hold a non-EVM address
  such as a Solana pubkey). ERC-7730 v2 `addressName` accepts `address` only, and there
  is no `bytes32`→EVM-address formatter, so `raw` (hex) is the only honest rendering
  (same reason `destinationChainId` uses `raw`).
- **Additive** — `_bridgeData.receiver` stays as "Recipient" and `interpolatedIntent`
  keeps interpolating it, so the dominant EVM path still resolves to a trusted
  name/ENS; the raw field carries the ground truth for the rest.
- **Strict-by-default** — `validateExtraReceiver` fails the generator (and CI) if a
  referenced struct component is renamed/retyped, rather than emit a dead display path.

**Audit result — the affected facets fall into buckets:**

| Bucket | Facets (this PR) | Notes |
|---|---|---|
| **TYPE-A** — field is the on-chain recipient in *every* branch (always populated) | AcrossV4, DeBridgeDln, Glacis, AllBridge, LiFiIntentEscrow (+V2), GasZip | AcrossV4/DeBridgeDln can differ from `_bridgeData.receiver` even on EVM (dest-call → Receiver contract; DeBridgeDln never cross-checks). GasZip's `receiverAddress` is right-padded (documented). Labelled `"<Bridge> Recipient"`. |
| **TYPE-B** — `nonEVMReceiver`-style, only set on non-EVM (`0x0` on EVM) | Mayan, LayerSwap, Chainflip, Eco, NEARIntents, PolymerCCTP | On EVM the primary "Recipient" is already correct; this field is `0x0`, labelled `"Non-EVM Recipient"` so it reads as N/A. Fixes the non-EVM blind spot. |

**Excluded — no clean static fix (tracked as follow-up under EXSC-627):**

- **Opaque / EIP-712-gated flows** — AcrossV4Swap, Garden, ThorSwap, Symbiosis,
  RelayDepository: the receiver lives in opaque calldata / an off-chain order and is
  not on-chain-verifiable by design.
- **Squid** — recipient is route-type-dependent (`_squidData.destinationAddress` for
  BridgeCall/CallBridgeCall, `_bridgeData.receiver` for CallBridge); no single field is
  always correct. Needs its own design.

**Verification (beyond the `verifyClearSigning` CI gate):** regenerated the merged
registry descriptor locally (`generateLedgerClearSigning.ts`) and ran Ledger's own
`erc7730` reference tooling — `lint` reports the descriptor schema-valid, and the
`calldata` device serializer binds every new field to the correct ABI path (`type: RAW`)
for both `bytes32` and dynamic `bytes` fields. The visual on-device render is a
post-merge check once the registry PR lands.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

