### PR TITLE
feat(clear-signing): surface bridge-specific destination recipient for non-EVM bridges (EXSC-627)

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -204,6 +204,12 @@
           "visible": "always"
         },
         {
+          "path": "_acrossData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -351,6 +357,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_allBridgeData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -638,6 +650,12 @@
           "visible": "always"
         },
         {
+          "path": "_chainflipData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -702,6 +720,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_deBridgeData.receiver",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -772,6 +796,12 @@
           "visible": "always"
         },
         {
+          "path": "_ecoData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -836,6 +866,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_gardenData.nonEvmReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -906,6 +942,12 @@
           "visible": "always"
         },
         {
+          "path": "_gasZipData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -970,6 +1012,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_glacisData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1474,6 +1522,12 @@
           "visible": "always"
         },
         {
+          "path": "_layerSwapData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -1538,6 +1592,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_lifiIntentData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1608,6 +1668,12 @@
           "visible": "always"
         },
         {
+          "path": "_lifiIntentData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -1672,6 +1738,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_mayanData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1806,6 +1878,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_nearData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2208,6 +2286,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_polymerData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2948,6 +3032,12 @@
           "visible": "always"
         },
         {
+          "path": "_acrossData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3137,6 +3227,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_allBridgeData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3524,6 +3620,12 @@
           "visible": "always"
         },
         {
+          "path": "_chainflipData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3617,6 +3719,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_deBridgeData.receiver",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3716,6 +3824,12 @@
           "visible": "always"
         },
         {
+          "path": "_ecoData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -3809,6 +3923,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_gardenData.nonEvmReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3908,6 +4028,12 @@
           "visible": "always"
         },
         {
+          "path": "_gasZipData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4001,6 +4127,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_glacisData.receiverAddress",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4676,6 +4808,12 @@
           "visible": "always"
         },
         {
+          "path": "_layerSwapData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4769,6 +4907,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_lifiIntentData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4868,6 +5012,12 @@
           "visible": "always"
         },
         {
+          "path": "_lifiIntentData.recipient",
+          "label": "Destination Recipient",
+          "format": "raw",
+          "visible": "always"
+        },
+        {
           "path": "_bridgeData.transactionId",
           "label": "Transaction Id",
           "visible": "never"
@@ -4961,6 +5111,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_mayanData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5153,6 +5309,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_nearData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5729,6 +5891,12 @@
               "ens"
             ]
           },
+          "visible": "always"
+        },
+        {
+          "path": "_polymerData.nonEVMReceiver",
+          "label": "Non-EVM Recipient",
+          "format": "raw",
           "visible": "always"
         },
         {

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -272,6 +272,117 @@ const RECEIVER_FIELD: IField = {
   visible: 'always',
 }
 
+// Bridge-specific destination recipient.
+//
+// `RECEIVER_FIELD` (`_bridgeData.receiver`) is the canonical recipient for EVM
+// destinations, but it does NOT carry the real recipient in every case: for a
+// non-EVM destination the facet passes the `NON_EVM_ADDRESS` sentinel in
+// `_bridgeData.receiver` and puts the actual recipient (a `bytes32`/`bytes`
+// value — a Solana/Bitcoin/NEAR address) in its own bridge-specific struct.
+// Surfacing only `_bridgeData.receiver` would therefore show a magic sentinel
+// instead of the recipient the signer is actually authorizing.
+//
+// ERC-7730 fields are static per selector — a descriptor cannot say "show A
+// unless it's the sentinel, then show B" — so we surface the bridge-specific
+// field ALONGSIDE `RECEIVER_FIELD` for every non-EVM-capable facet. `format`
+// is `raw` (not `addressName`): the value may be a non-EVM address that no EVM
+// address-book can resolve, so it must be shown as its literal bytes.
+//
+// Two label groups:
+//   - "Destination Recipient": the field is the authoritative recipient in ALL
+//     cases (it equals `_bridgeData.receiver` for EVM, and is the real
+//     recipient for non-EVM).
+//   - "Non-EVM Recipient": the field is populated only for non-EVM
+//     destinations (zero/empty for EVM, where `RECEIVER_FIELD` is authoritative).
+//
+// Each path is verified against the facet's `_startBridge` receiver handling.
+const BRIDGE_RECEIVER_FIELDS: Record<string, IField> = {
+  AcrossV4: {
+    path: '_acrossData.receiverAddress',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  AllBridge: {
+    path: '_allBridgeData.recipient',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  DeBridgeDln: {
+    path: '_deBridgeData.receiver',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  GasZip: {
+    path: '_gasZipData.receiverAddress',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  Glacis: {
+    path: '_glacisData.receiverAddress',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  LiFiIntentEscrow: {
+    path: '_lifiIntentData.recipient',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  LiFiIntentEscrowV2: {
+    path: '_lifiIntentData.recipient',
+    label: 'Destination Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  Chainflip: {
+    path: '_chainflipData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  Eco: {
+    path: '_ecoData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  Garden: {
+    path: '_gardenData.nonEvmReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  LayerSwap: {
+    path: '_layerSwapData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  Mayan: {
+    path: '_mayanData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  NEARIntents: {
+    path: '_nearData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+  PolymerCCTP: {
+    path: '_polymerData.nonEVMReceiver',
+    label: 'Non-EVM Recipient',
+    format: 'raw',
+    visible: 'always',
+  },
+}
+
 const CHAIN_FIELD: IField = {
   path: '_bridgeData.destinationChainId',
   label: 'Destination Chain',
@@ -314,6 +425,13 @@ function variantTag(fnName: string): string | null {
   return bits.length ? bits.join(', ') : null
 }
 
+// The generic recipient plus, for non-EVM-capable facets, the bridge-specific
+// destination recipient (see BRIDGE_RECEIVER_FIELDS).
+function receiverFields(facet: string): IField[] {
+  const extra = BRIDGE_RECEIVER_FIELDS[facet]
+  return extra ? [RECEIVER_FIELD, extra] : [RECEIVER_FIELD]
+}
+
 function buildStartFormat(fn: IAbiFn): IFormatEntry {
   const facet = bridgeFacetName(fn.name)
   return {
@@ -333,7 +451,7 @@ function buildStartFormat(fn: IAbiFn): IFormatEntry {
         visible: 'always',
       },
       CHAIN_FIELD,
-      RECEIVER_FIELD,
+      ...receiverFields(facet),
       ...HIDDEN_BRIDGE_FIELDS,
     ],
   }
@@ -362,7 +480,7 @@ function buildSwapAndStartFormat(fn: IAbiFn): IFormatEntry {
         visible: 'always',
       },
       CHAIN_FIELD,
-      RECEIVER_FIELD,
+      ...receiverFields(facet),
       ...HIDDEN_BRIDGE_FIELDS,
       {
         path: '_swapData.[].callData',


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-627](https://linear.app/lifi-linear/issue/EXSC-627/clear-signing-surface-bridge-specific-destination-recipient-for-non).

Follow-up from a CodeRabbit finding on [#2046](https://github.com/lifinance/contracts/pull/2046), which flagged AcrossV4 specifically. Investigation showed the issue is systemic, so it is fixed here in a dedicated PR rather than folded into that deprecation/audit PR.

# Why did I implement it this way?

**The problem.** `config/clearSigningProposal.json` (generated by `tasks/buildClearSigningProposal.ts`) surfaces only `_bridgeData.receiver` as the "Recipient" for every bridge. But `_bridgeData.receiver` is **not** the real recipient for non-EVM destinations: the facets pass the `NON_EVM_ADDRESS` sentinel (`0x1111…01`) in `_bridgeData.receiver` and carry the actual recipient — a `bytes32`/`bytes` non-EVM address (Solana / Bitcoin / NEAR / …) — in their own bridge-specific struct. So a hardware-wallet signer bridging to a non-EVM chain saw a magic sentinel constant where the recipient should be, instead of the address the funds actually go to.

This was verified against each facet's `_startBridge`: e.g. `AcrossFacetV4` passes `_acrossData.receiverAddress` as the `recipient` arg to `SPOKEPOOL.deposit` in all cases; `_bridgeData.receiver` is only a validation handle and is the sentinel for non-EVM.

**Why alongside, not replacing.** ERC-7730 `display.formats` fields are static per selector — a descriptor cannot express "show `_bridgeData.receiver`, unless it's the sentinel, then show the bridge-specific field". So the generator now emits the bridge-specific destination recipient **in addition to** the generic "Recipient" for every non-EVM-capable facet. The signer sees both.

**Why `format: raw`.** A non-EVM receiver is not an EVM address, so `addressName` (which resolves against EVM address books / ENS) cannot render it. `raw` shows the literal bytes the user is authorizing — the honest representation.

**Two label groups**, per how the field behaves:
- **"Destination Recipient"** — the field is authoritative in *all* cases (equals `_bridgeData.receiver` for EVM, holds the real recipient for non-EVM): `AcrossV4`, `AllBridge`, `DeBridgeDln`, `GasZip`, `Glacis`, `LiFiIntentEscrow`, `LiFiIntentEscrowV2`.
- **"Non-EVM Recipient"** — the field is populated only for non-EVM destinations (zero/empty for EVM, where the generic "Recipient" is authoritative): `Chainflip`, `Eco`, `Garden`, `LayerSwap`, `Mayan`, `NEARIntents`, `PolymerCCTP`.

14 non-EVM-capable facets × `startBridgeTokensVia…` + `swapAndStartBridgeTokensVia…` = 28 descriptor entries gain the extra field. Every path is verified against the facet's bridge-specific struct and its `_startBridge` receiver handling. This is a **behavioral-only change to a generated config** — no Solidity changes, external ABIs/selectors untouched, no audit or version bump required.

**Known limitations (deliberately out of scope):**
- The one-line `interpolatedIntent` summary still interpolates `{_bridgeData.receiver}`, so the headline for a non-EVM bridge still shows the sentinel; the authoritative recipient is now in the detailed fields. Reworking the summary per-bridge (interpolating a raw `bytes32`) is a larger, separate change.
- Packed/Min entrypoints and `AcrossV4Swap` are untouched — they either have no decodable params or carry no bridge-specific receiver field.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug — n/a: the generator has no unit-test harness; `verifyClearSigning` CI regenerates and diffs the committed output, which covers correctness of this change.
- [ ] For new facets: I have checked all points from this list — n/a (no facets; generator + generated config only)
- [x] I have updated any required documentation — the rationale lives in an in-code comment block on the new `BRIDGE_RECEIVER_FIELDS` map.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
