### PR TITLE
docs(hyperevm): big-block enablement runbook for new wallets (EXSC-629)

### DIFF
--- a/.agents/commands/offboard-sc-dev.md
+++ b/.agents/commands/offboard-sc-dev.md
@@ -58,6 +58,8 @@ Run from the repo root. Confirm and report (don't fix silently):
 
 Nothing on-chain can proceed until the replacement keys exist. The human securely generates the new **deployer, dev, and pauser** keys and their replacement personal signer, and provides the addresses (never the keys, never via `global.json`). Fund the new deployer/dev/pauser enough to broadcast where each rotation needs gas — the individual rotate-* skills sweep the bulk from the old wallets, but the new deployer needs bootstrap gas *before* it can broadcast. Wait for the addresses before continuing.
 
+> **HyperEVM big blocks.** The new **deployer** and **dev** EOAs each need big blocks enabled on `hyperevm` before they can deploy there — an L1, per-address setting that does not carry over on rotation. `rotate-deployer-wallet` and `rotate-dev-wallet` each flag this in their funding phase; follow the runbook: `docs/HyperEVMBigBlocks.md`. (The **pauser** does not deploy, so it is exempt.)
+
 ### Phase 2 — Swap the multisig signer (remove departing, add replacement)
 
 Change the Safe ownership set on every production chain: remove the departing person's personal signer, add the replacement. This is a Safe owner change, so it runs through the production rollout lifecycle:

--- a/.agents/commands/rotate-deployer-wallet.md
+++ b/.agents/commands/rotate-deployer-wallet.md
@@ -73,6 +73,8 @@ Sweep native gas from the old deployer to the new one across all active EVM chai
 
 > Leave enough in the OLD deployer to sign the Safe/timelock txs it still needs to send in Phase 2 if any are broadcast by the old key — `sweep-wallet-funds`'s balance preview (read-only; the mover script has no dry-run flag) lets you judge this per network before committing.
 
+> **HyperEVM big blocks (manual, per-address).** The new deployer cannot broadcast contract deploys on `hyperevm` until big blocks are enabled for it — an L1 setting that does **not** carry over on rotation (register the address as a HyperCore Core user, then toggle big blocks ON). Follow the runbook: `docs/HyperEVMBigBlocks.md`.
+
 ### Phase 2 — Swap the Safe owner + move CANCELLER_ROLE (`multisig-rollout`)
 
 The governed changes — replace `safeOwners[0]` (old → new) on every production Safe and move the Timelock `CANCELLER_ROLE` (old removed, new granted) — run as timelock-wrapped Safe proposals via the production rollout skill:

--- a/.agents/commands/rotate-dev-wallet.md
+++ b/.agents/commands/rotate-dev-wallet.md
@@ -66,6 +66,8 @@ Sweep native gas from the old dev wallet to the new one across all active EVM ch
 
 `sweep-wallet-funds` previews balances first (read-only `cast balance` — the mover script has no dry-run flag), sweeps native **LAST** to avoid stranding gas, and reports per-network moved/skipped. It owns the human-confirmed pre-send report and secrets hygiene — do not reimplement `cast send` or `moveNativeFundsToNewWallet.ts` here.
 
+> **HyperEVM big blocks (manual, per-address).** The new dev EOA cannot deploy on `hyperevm` until big blocks are enabled for it — an L1 setting that does **not** carry over on rotation (register the address as a HyperCore Core user, then toggle big blocks ON). Follow the runbook: `docs/HyperEVMBigBlocks.md`.
+
 ### Phase 2 — Transfer staging diamond ownership (old → new)
 
 Staging diamonds are EOA-owned by the dev wallet, so this is a direct owner transfer per EVM network (the old dev key sets the new dev address as owner; the new wallet accepts if the diamond uses a two-step handover). Run the preview/dry-run first, confirm, then execute one network at a time.

--- a/config/networks.json
+++ b/config/networks.json
@@ -590,7 +590,7 @@
     "deployedWithEvmVersion": "cancun",
     "deployedWithSolcVersion": "0.8.29",
     "create3Factory": "0xf1469bEc8cDccEC511C0DdAaBa88B63f5841137a",
-    "devNotes": "To switch between smaller blocks (2M max gas limit, fast) and bigger blocks (30m gas limit, slow, for contract deployments, use this FE to toggle: https://hyperevm-block-toggle.vercel.app/"
+    "devNotes": "Dual-block architecture: contract deploys need big blocks (30M gas) instead of small blocks (~2-3M gas). Big blocks are opt-in PER ADDRESS via a gasless L1 action and do NOT carry over on wallet rotation - every new deployer/dev EOA must be enabled individually, and the address must first be a HyperCore Core user (receive USDC/HYPE on the Core/L1 side, NOT on HyperEVM). Full runbook: docs/HyperEVMBigBlocks.md. Toggle FE: https://hyperevm-block-toggle.vercel.app/"
   },
   "immutablezkevm": {
     "name": "immutablezkevm",

--- a/docs/HyperEVMBigBlocks.md
+++ b/docs/HyperEVMBigBlocks.md
@@ -1,0 +1,83 @@
+# HyperEVM Big Blocks
+
+## Why this matters
+
+HyperEVM has a [dual-block architecture](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture):
+transactions target either **small blocks** (fast, ~1s, ~2–3M gas) or **big
+blocks** (slow, ~1min, **30M gas**). Contract deployments exceed the small-block
+gas limit, so **any wallet that deploys on `hyperevm` must have big blocks
+enabled**.
+
+Big blocks are **opt-in per address** and the setting does **not** carry over
+when we rotate wallets — every new deployer / dev EOA must be enabled
+individually.
+
+## Prerequisite: the wallet must be a HyperCore "Core user"
+
+The toggle is a Hyperliquid **L1 action** (`evmUserModify`), and only an
+existing Core user can send an L1 action. An EOA becomes a Core user the first
+time it **receives a Core asset (USDC or HYPE) on HyperCore** — the L1 / spot
+side, **not** HyperEVM. Bridging funds to the HyperEVM side does not register a
+Core user.
+
+Registration is **permanent**: once an address has any Core state it stays a
+Core user even after the balance is withdrawn.
+
+## Runbook (validated)
+
+Do this once per new wallet. It needs **~5 USDC + a little ETH for Arbitrum
+gas**, which you recover at the end (minus the ~$1 Hyperliquid withdrawal fee).
+We don't keep standing balances on these wallets, so **source the USDC fresh
+each time** (e.g. swap/bridge via [Jumper](https://jumper.exchange) to the
+wallet on Arbitrum) — you can't rely on leftover funds from a previous run.
+
+1. Get **~5 USDC (+ gas ETH)** onto the wallet **on Arbitrum** (Hyperliquid's
+   native bridge is Arbitrum ↔ Hyperliquid).
+2. Connect the wallet at <https://app.hyperliquid.xyz/trade> → **Deposit** ≥ 5
+   USDC (5 is the minimum; smaller deposits are lost). This credits the wallet
+   on **HyperCore**, registering it as a Core user.
+3. Connect the wallet at <https://hyperevm-block-toggle.vercel.app/> and **enable
+   big blocks** (signs `evmUserModify` with `usingBigBlocks=true`). Toggle off to
+   revert.
+4. **Withdraw** the USDC back to Arbitrum (~$1 fee). The wallet stays a Core
+   user.
+
+The wallet's HyperEVM deploys now target the 30M-gas big blocks.
+
+## Shortcut when a funded Core account already exists
+
+If you already control a wallet that is a Core user with a spot balance (e.g. the
+outgoing deployer before it is drained), skip the bridge deposit: from that
+account, **Send** a dust spot transfer (USDC or HYPE) to the new address.
+Internal Hyperliquid sends are gasless and land on the recipient's Core balance,
+registering it. Then do step 3 above. This avoids sourcing 5 USDC but requires an
+already-registered, funded account to send from.
+
+## Gas note
+
+Registration and the toggle are **gasless** signed L1 actions — they cost no gas.
+The only HYPE you need is for the **actual contract deployment** (HyperEVM's
+native gas token is HYPE), which is the normal deployer-funding step. USDC is
+never gas on HyperEVM.
+
+## Verify (read-only)
+
+Confirm an address is a Core user via the Hyperliquid info API (no keys, no
+funds):
+
+```bash
+curl -s https://api.hyperliquid.xyz/info \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"spotClearinghouseState","user":"0xNEW"}'
+```
+
+A non-empty `balances` array (or an existing account) means the address is
+registered. Estimate gas on big blocks with the `bigBlockGasPrice` JSON-RPC
+method in place of `gasPrice`.
+
+## When this applies
+
+Every new deploying wallet on `hyperevm`, most commonly on **wallet rotations**.
+`rotate-deployer-wallet` and `rotate-dev-wallet` flag this in their funding
+phase, and `offboard-sc-dev` flags it in Phase 1. The **pauser is exempt** — it
+does not deploy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,3 +91,4 @@
 - [Adding a New Bridge Integration](./AddingANewBridge.md)
 - [Contract Deployment Checklist](./Deploy.md)
 - [ERC-7730 Clear-Signing Display Proposal](./ClearSigningProposal.md)
+- [HyperEVM Big Blocks — enabling big blocks for new deployer/dev wallets](./HyperEVMBigBlocks.md)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-629](https://linear.app/lifi-linear/issue/EXSC-629/document-hyperevm-big-block-enablement-for-new-deployerdev-wallets)

# Why did I implement it this way?

HyperEVM needs "big blocks" (30M gas) for contract deployments, but enabling them is a gasless per-address L1 action (`evmUserModify`) that does **not** carry over when we rotate deployer/dev wallets — and the address must first be a HyperCore "Core user" (receive USDC/HYPE on the Core/L1 side, not HyperEVM). This process kept getting re-derived from memory on each rotation, so this PR documents it once as the source of truth and points everything that needs it at that one place. I put the full runbook in a dedicated `docs/HyperEVMBigBlocks.md` (indexed under Guides) rather than cramming a procedure into a `networks.json` string; `networks.json` `devNotes` and the three rotation skills (`rotate-deployer-wallet`, `rotate-dev-wallet`, `offboard-sc-dev`) now carry short pointers to the runbook. The runbook captures the validated bridge-deposit method (deposit ≥5 USDC via Arbitrum → toggle → withdraw), the cheaper shortcut when a funded Core account already exists, the gas note (register + toggle are gasless; HYPE — not USDC — is the only gas, for the deploy itself), and a read-only verify command. The skill pointers use the repo's `docs/…` backtick convention rather than relative markdown links, since those command files are symlinked into `.claude/` and `.cursor/` where a relative link would break.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>