### PR TITLE
feat(deploy): deploy-network skill for staged new-network bring-up

### DIFF
--- a/.agents/commands/deploy-network.md
+++ b/.agents/commands/deploy-network.md
@@ -1,119 +1,154 @@
 ---
 name: deploy-network
-description: Brings a brand-new network fully on-chain by driving `deployAllContracts.sh` (scriptMaster use case 3) end to end — CREATE3 factory, core facets, diamond, non-core facets, periphery, whitelist sync, wallet funding, and health check — one stage at a time so it survives an agent's per-command time limit and needs no interactive terminal. Use after `add-network` has landed the config (networks.json, foundry.toml, target state) and the deployer is funded, when the user wants to "deploy the new network", "bring up <network> on-chain", "run the full deployment for <network>", or "deploy all contracts to <network>". This is the NEW-NETWORK bootstrap path and it runs production in direct-to-diamond mode (`SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`) because the Safe/timelock does not own the diamond yet. It stops after stage 11 (health check) and never performs stage 12 (ownership transfer) — that stays a deliberate step. NOT for deploying a single contract to existing networks (use `deploy-contract`), NOT for upgrading facets on networks that are already live and Safe-owned (use `multisig-rollout`), and NOT for Tron (`tron`/`tronshasta` — Foundry has no Tron support; there is no new-network bootstrap path there yet). Requires Foundry, gh, initialized submodules, and `MONGODB_URI` in `.env`.
+description: Brings a brand-new network fully on-chain by driving `deployAllContracts.sh` (scriptMaster use case 3) end to end — CREATE3 factory, Safe, diamond, core + non-core facets, periphery, whitelist sync, wallet funding, health check — one stage at a time so it survives an agent's per-command time limit and needs no interactive terminal. Use after `add-network` has landed the config (networks.json, foundry.toml, target state) and the deployer is funded, when the user wants to "deploy the new network", "bring up <network> on-chain", "run the full deployment for <network>", or "deploy all contracts to <network>". This is the NEW-NETWORK bootstrap path and it runs production in direct-to-diamond mode (`SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`) because the Safe/timelock does not own the diamond yet. It stops after stage 11 (health check) and never performs stage 12 (ownership transfer) — that stays a deliberate step. NOT for deploying a single contract to existing networks (use `deploy-contract`), NOT for upgrading facets on live Safe-owned networks (use `multisig-rollout`), and NOT for Tron (`tron`/`tronshasta` — Foundry has no Tron support). Requires Foundry, gh, and `MONGODB_URI` in `.env`.
 usage: /deploy-network <network> --production [--from-stage N] [--to-stage M]
 ---
 
 # Deploy Network (LI.FI Contracts)
 
 Drives a full new-network bring-up via the `deployAllContracts` function
-(`script/deploy/deployAllContracts.sh`, scriptMaster use case 3), **one stage per fresh
-shell**. Each of the 12 stages is idempotent (CREATE3 → deterministic addresses, plus
-`diamondCut`), so a stage that is interrupted or re-run resumes instead of duplicating work.
-This lets an agent complete a deploy that runs far longer than a single command's time budget,
-and with no TTY, by invoking the script once per stage with the stage range and non-interactive
-mode preset in the environment.
+(`script/deploy/deployAllContracts.sh`, scriptMaster use case 3), **one stage per fresh shell**.
+Every stage is idempotent (CREATE3 → deterministic addresses + `diamondCut`), so a stage that is
+interrupted or re-run resumes instead of duplicating work. This lets an agent complete a deploy
+that runs far longer than a single command's time budget, with no TTY, by invoking the script
+once per stage with the stage range and non-interactive mode preset in the environment.
 
 ## When to use this vs other deploy skills
 
 | Situation | Skill |
 |---|---|
-| Config for a new network (networks.json, foundry.toml, target state) | **`add-network`** (run first) |
-| Bring a **new** network fully on-chain (diamond + all contracts) | **this skill** |
+| Network *config* (networks.json, foundry.toml, target state) | **`add-network`** (run FIRST) |
+| Bring a **new** network fully on-chain | **this skill** |
 | Deploy/redeploy a **single** contract to existing network(s) | **`deploy-contract`** |
 | Upgrade facets/periphery on **existing, Safe-owned** networks | **`multisig-rollout`** |
-| Ownership transfer / post-rollout completion | done deliberately (`finish-rollout` / stage 12) |
+| Ownership transfer / post-rollout completion | deliberate (`finish-rollout` / stage 12) |
 
 ## Hard rails
 
-- **New-network bootstrap only.** This path sets `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`,
-  which bypasses the Safe. That is legitimate *only* before the diamond's ownership has been
-  transferred to the Safe/timelock. If the network is already Safe-owned, stop — use
-  `multisig-rollout`.
-- **Never runs stage 12 (ownership transfer).** The driver bounds the run to stage 11. Ownership
-  transfer is a deliberate, reviewed step performed after inspecting the health check.
-- **Never edits `.env` silently.** The production flags (`PRODUCTION=true`,
-  `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`) are shared, symlinked state — set them with the
-  user's explicit go, announce it, and restore afterward.
-- **Tron is out of scope.** No Foundry/CREATE3 support; there is no bootstrap path for
-  `tron`/`tronshasta` here.
+- **New-network bootstrap only.** Sets `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true` (bypasses the
+  Safe) — legitimate ONLY before ownership has moved to the Safe/timelock. If the network is
+  already Safe-owned, stop — use `multisig-rollout`.
+- **Never runs stage 12 (ownership transfer).** Bounded to stage 11. Ownership transfer is a
+  deliberate, reviewed step after the health check is clean.
+- **Never edits `.env` silently.** Production flags + any path/verify fixes are shared, symlinked
+  state — set them with the user's explicit go, announce it, restore afterward.
+- **Tron is out of scope** (no Foundry/CREATE3 support).
 
-## Phase 0 — Preflight (report, don't silently fix)
+## Execution mechanics (read before running anything)
 
-Run from the target network's worktree. Confirm:
+- **Run every command under `bash -c`.** The agent shell is zsh; the deploy scripts use bash-isms
+  (`read -a`, associative arrays). Under zsh you get `read: bad option: -a` and silent mis-parses.
+- **PATH**: prepend `export PATH="$HOME/.foundry/bin:$HOME/.bun/bin:$PATH"`.
+- **`dangerouslyDisableSandbox: true`** for anything doing network I/O (deploy, verify, cast, mongo).
+- **Env overrides that SURVIVE the script's `.env` re-source** (not set in `.env`): `START_STAGE`,
+  `END_STAGE`, `NON_INTERACTIVE`. Set these inline. Anything already in `.env` (`PRODUCTION`,
+  `VERIFY_CONTRACTS`, `GLOBAL_FILE_PATH`, `DO_NOT_VERIFY_IN_THESE_NETWORKS`) is re-sourced by the
+  script and CANNOT be overridden by an export — edit the `.env` file for those.
+- **Output is huge** (bytecode dumps on single lines) — pipe to a log file and `grep` for markers
+  (`STAGE N completed`, `successfully verified`, `Failed`, `Error:`), do NOT tail raw.
+- **10-min SIGTERM**: the agent's Bash tool hard-kills any command (incl. backgrounded) at ~10min.
+  Run one stage per shell; a stage that neither completes nor progresses across a re-run cap (~5)
+  → stop and surface, don't loop.
 
-- `add-network` config for the network is present (entry in `config/networks.json`, in
-  `foundry.toml`, and in `script/deploy/_targetState.json`).
-- `lib/` submodules initialized and `forge clean && forge build` is fresh (CREATE3 salt derives
-  from `out/`).
-- Deployer wallet funded on the network (stage 1 aborts on zero balance; the pauser/dev wallets
-  are funded automatically at stage 9 from the deployer).
-- `MONGODB_URI` set in `.env` (stage 1 auto-adds the RPC from `networks.json` → MongoDB →
-  `fetch-rpcs`; no premium RPC required).
-- For production: `PRODUCTION=true` and `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true` (set with the
-  user's go; see hard rails).
+## Phase 0 — Preflight (do IN THIS ORDER; report, don't silently fix)
+
+1. **`add-network` landed**: network present in `config/networks.json`, `foundry.toml`
+   (`[rpc_endpoints]` + `[etherscan]`), and `script/deploy/_targetState.json`.
+2. **Submodules**: `git submodule update --init --recursive` (fresh worktrees have none → forge
+   import resolution fails).
+3. **node_modules**: symlink the main checkout's `node_modules` (avoids `bun.lock` churn) or
+   `bun install` — needed for TS tooling + lint-staged.
+4. **typechain**: `bun typechain:incremental` — TS deploy helpers (`deploy-safe.ts`, etc.) crash
+   `ERR_MODULE_NOT_FOUND … /typechain` without it. `forge build` does NOT generate it.
+5. **Fresh build**: `forge clean && forge build` (CREATE3 salt derives from `out/`).
+6. **`GLOBAL_FILE_PATH` sanity**: `source .env` and assert `GLOBAL_FILE_PATH` resolves to an
+   existing file from repo root (framework default `config/global.json`). A stale relative value
+   like `./../config/global.json` silently breaks stage 2. Empty `NETWORKS_JSON_FILE_PATH` is fine
+   (falls back to default).
+7. **Verifier endpoint probe**: for blockscout networks the verify API is often a SEPARATE
+   subdomain (e.g. `blockscout-api.<chain>` not the explorer UI `blockscout.<chain>`). Probe the
+   `explorerApiUrl` returns JSON, not HTML — a wrong URL makes verification 404, which the deploy
+   misreads as a gateway timeout and RETRIES WITH BACKOFF, throttling everything.
+8. **RPC**: prefer a **premium RPC** (Alchemy/Quicknode). Public RPCs can be ~1.4s/call → 30-60s
+   of forking PER contract; a premium RPC is ~2x+ faster. Add via `bun add-network-rpc --network
+   <net> --rpc-url <url>` then `bun fetch-rpcs` (RPC Mongo is separate/unprotected — no
+   lifi-connect needed). Stage 1 auto-adds the `networks.json` public rpcUrl if none is set.
+9. **corePeriphery ↔ target-state reconciliation** (prevents silent gaps): diff
+   `config/global.json` `corePeriphery` against the parsed target-state periphery. Flag
+   (a) corePeriphery items MISSING from the target state → they won't deploy (add to the sheet),
+   and (b) deprecated items still in corePeriphery → they'll fail the health check forever (remove
+   from corePeriphery). Account for legitimate per-chain skips: GasZip* (no gaszip config),
+   Permit2Proxy (no Permit2 on chain).
+10. **Version currency**: check the target-state parse warnings for "differs from current" — a
+    stale sheet deploys old versions. Critically, ERC20Proxy must be **>= 1.2.0** or the Executor
+    is NOT pre-authorized (forces a manual `setAuthorizedCaller`). Update the sheet + re-parse if stale.
+11. **Deployer funded** (stage 1 aborts on 0). Pauser/Dev are funded automatically at stage 9 via
+    `NON_INTERACTIVE` defaults — do NOT pre-require them.
+12. **Production flags**: edit `.env` → `PRODUCTION=true` and `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`.
 
 ## The stages
 
-| # | Stage |
-|---|---|
-| 1 | Initial setup + CREATE3Factory (+ Safe deploy on production) |
-| 2 | Deploy core facets |
-| 3 | Deploy diamond + add core facets |
-| 4 | Approve refund wallet |
-| 5 | Deploy non-core facets + add to diamond *(heavy — may exceed one command's budget)* |
-| 6 | Deploy periphery contracts |
-| 7 | Add periphery to diamond |
-| 8 | Whitelist sync |
-| 9 | Fund PauserWallet + DevWallet |
-| 10 | Verify ERC20Proxy (Executor) authorization |
-| 11 | Health check |
-| 12 | Ownership transfer — **skipped by this skill** |
+| # | Stage | Notes |
+|---|---|---|
+| 1 | Setup + CREATE3Factory (+ Safe on production) | RPC self-heals here |
+| 2 | Deploy core facets | GasZipFacet skipped if no gaszip config |
+| 3 | Deploy diamond + cut in core facets | |
+| 4 | Approve refund wallet | |
+| 5 | Deploy non-core facets + cut | empty for a core-only setup |
+| 6 | Deploy periphery | Permit2Proxy/GasZipPeriphery skipped if unconfigured |
+| 7 | Register periphery in diamond | |
+| 8 | Whitelist sync | writes `config/whitelist.json` (deploy-generated, commit it) |
+| 9 | Fund Pauser + Dev | `NON_INTERACTIVE` uses computed defaults |
+| 10 | Verify Executor authorization | "already authorized" when ERC20Proxy >= 1.2.0 |
+| 11 | Health check | bounded stop here |
+| 12 | Ownership transfer | **skipped by this skill** |
 
 ## Phase 1 — Drive the stages
 
-`deployAllContracts` reads three environment overrides (added for this skill; unset preserves the
-original interactive behavior):
-
-- `START_STAGE` / `END_STAGE` — bound the run to `[START_STAGE, END_STAGE]` and skip the
-  interactive `gum` stage menu.
-- `NON_INTERACTIVE=true` — accept computed defaults at the stage-9 funding prompts and
-  auto-confirm the stage-10 ERC20Proxy owner-funding prompt (in
-  `script/tasks/verifyERC20ProxyAuthorization.sh`).
-
-Run **each stage as its own command** (fresh shell, stays under the time limit):
+Deploy with **verification OFF** for speed (verify in Phase 2 instead). One stage per shell:
 
 ```bash
 export PATH="$HOME/.foundry/bin:$HOME/.bun/bin:$PATH"
 cd <network-worktree>
-START_STAGE=<N> END_STAGE=<N> NON_INTERACTIVE=true \
-  bash -c 'source script/deploy/deployAllContracts.sh; deployAllContracts <network> production'
+START_STAGE=<N> END_STAGE=<N> NON_INTERACTIVE=true VERIFY_CONTRACTS=false \
+  bash -c 'source script/deploy/deployAllContracts.sh; deployAllContracts <network> production' \
+  2>&1 | sed 's/\x1b\[[0-9;]*m//g' > /tmp/stage<N>.log
+grep -c "STAGE <N> completed" /tmp/stage<N>.log   # 1 = advance; 0 = inspect/re-run
 ```
 
-After each stage, confirm the log contains `STAGE <N> completed` before advancing:
+(`VERIFY_CONTRACTS=false` is in `.env`, so to truly disable inline verification either edit `.env`
+for the run or rely on the Phase-2 sweep; deploying verification-off avoids inline `--watch`
+blocking and Blockscout indexing-lag failures.)
 
-- **Marker present** → advance to stage N+1.
-- **Marker absent** (timed out / interrupted) → re-run the *same* stage. Idempotency means it
-  resumes; the heavy stage 5 typically needs a few re-runs to deploy all facets. Cap at ~5
-  re-runs per stage — if a stage still never completes, stop and surface the failure with the
-  log; do not loop indefinitely.
+- **Marker present** → advance to N+1. **Absent** → re-run the same stage (idempotent; heavy
+  stage 5 may need a few re-runs). Cap ~5; then stop + surface with the log.
+- **Transient RPC/DNS**: a stage may fail once with `could not instantiate forked environment …
+  dns error`; a plain re-run usually succeeds. Retry before deep diagnosis.
+- Runs auto-stop after stage 11 (`END_STAGE < 12`), leaving the deployer as diamond owner — the
+  correct resumable pre-ownership-transfer state.
 
-Advance 1 → 11. The run auto-stops after stage 11 (`END_STAGE < 12`), leaving the deployer as
-diamond owner — the correct, resumable pre-ownership-transfer state.
+## Phase 2 — Verify all contracts (parallel, rate-limit-aware)
 
-## Phase 2 — Land the results
+Run ONCE after all deploys (Blockscout has had time to index → avoids "address is not a smart
+contract" races). The master log is in **MongoDB** — `bun mongo-logs:sync` refreshes the local
+cache (`_deployments_log_file.json`) so logged `constructorArgs`/`solc`/`evm` are available.
 
-- **Commit the deploy artifacts** (`deployments/<network>.json`, diamond log files) to the
-  network's `add-network` PR — this is what turns the `check-new-network-health` CI gate green.
-- **Restore `.env`** if production flags were set for the run (`PRODUCTION=false`,
-  `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=` empty).
-- **Verify** contracts on the explorer and re-check the PR checks.
-- **Executor authorization follow-up:** if `ERC20Proxy < 1.2.0`, stage 10 only funds the owner
-  (refundWallet) — the actual `setAuthorizedCaller(Executor, true)` is a manual owner-key tx.
-  Surface it; swaps routed through the Executor fail until it lands.
+Use `verifyNetworkContractsParallel <network> <environment>` (ships with this skill): verifies all
+unverified contracts for the network concurrently (capped at `MAX_CONCURRENT_JOBS`), with
+**Blockscout rate-limit backoff** (429/gateway → exponential retry), then pushes `verified:true`
+back to MongoDB. Confirm with `bun mongo-logs:query`. Re-run to mop up any left by rate limits.
+
+## Phase 3 — Land results
+
+- Commit `deployments/<net>.json`, `<net>.diamond.json`, and the stage-8 `config/whitelist.json`
+  additions → turns `check-new-network-health` green.
+- Restore `.env` (`PRODUCTION=false`, `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=` empty; keep
+  `GLOBAL_FILE_PATH` fixed).
+- Health check will still note, by design: GasZip/Permit2 (unconfigured/N-A) and diamond ownership
+  (stage 12 deferred). Those are expected, not failures.
 
 ## Hand-offs
 
-- **Ownership transfer** (stage 12) → deliberate step / `finish-rollout` once the health check is
-  clean (only diamond-ownership errors remain).
-- **Bridge integrations** (Stargate, Across, etc.) → their own follow-up deploys after bring-up.
+- **Ownership transfer** (stage 12) → deliberate step / `finish-rollout` once the health check
+  shows only ownership errors.
+- **Bridge integrations** → their own follow-up deploys.

--- a/.agents/commands/deploy-network.md
+++ b/.agents/commands/deploy-network.md
@@ -41,9 +41,12 @@ once per stage with the stage range and non-interactive mode preset in the envir
 - **PATH**: prepend `export PATH="$HOME/.foundry/bin:$HOME/.bun/bin:$PATH"`.
 - **`dangerouslyDisableSandbox: true`** for anything doing network I/O (deploy, verify, cast, mongo).
 - **Env overrides that SURVIVE the script's `.env` re-source** (not set in `.env`): `START_STAGE`,
-  `END_STAGE`, `NON_INTERACTIVE`. Set these inline. Anything already in `.env` (`PRODUCTION`,
-  `VERIFY_CONTRACTS`, `GLOBAL_FILE_PATH`, `DO_NOT_VERIFY_IN_THESE_NETWORKS`) is re-sourced by the
-  script and CANNOT be overridden by an export — edit the `.env` file for those.
+  `END_STAGE`, `NON_INTERACTIVE`. Set these inline. `VERIFY_CONTRACTS` also survives despite being
+  in `.env`: the deploy scripts promote a caller-provided value into an exported
+  `VERIFY_CONTRACTS_OVERRIDE` before every `source .env`, and the verify gate consults that override
+  — so an inline `VERIFY_CONTRACTS=false` reliably disables inline verification. The other `.env`
+  vars (`PRODUCTION`, `GLOBAL_FILE_PATH`, `DO_NOT_VERIFY_IN_THESE_NETWORKS`) are re-sourced and
+  CANNOT be overridden by an export — edit the `.env` file for those.
 - **Output is huge** (bytecode dumps on single lines) — pipe to a log file and `grep` for markers
   (`STAGE N completed`, `successfully verified`, `Failed`, `Error:`), do NOT tail raw.
 - **10-min SIGTERM**: the agent's Bash tool hard-kills any command (incl. backgrounded) at ~10min.
@@ -116,10 +119,12 @@ START_STAGE=<N> END_STAGE=<N> NON_INTERACTIVE=true VERIFY_CONTRACTS=false \
 grep -c "STAGE <N> completed" /tmp/stage<N>.log   # 1 = advance; 0 = inspect/re-run
 ```
 
-(`deployAllContracts` preserves a caller-provided `VERIFY_CONTRACTS` across its `source .env`, so
-the inline `VERIFY_CONTRACTS=false` above genuinely disables verification even when `.env` sets it
-to `true` — no need to edit `.env`. Deploying verification-off avoids inline `--watch` blocking and
-Blockscout indexing-lag failures; verify in the Phase-2 sweep instead.)
+(The deploy scripts promote the caller-provided `VERIFY_CONTRACTS` into an exported
+`VERIFY_CONTRACTS_OVERRIDE` before every `source .env`, and the verify gate in `deploySingleContract`
+consults that override — so the inline `VERIFY_CONTRACTS=false` above genuinely disables verification
+even when `.env` sets it to `true`, and even though each deploy stage re-sources `.env`. No need to
+edit `.env`. Deploying verification-off avoids inline `--watch` blocking and Blockscout indexing-lag
+failures; verify in the Phase-2 sweep instead.)
 
 - **Marker present** → advance to N+1. **Absent** → re-run the same stage (idempotent; heavy
   stage 5 may need a few re-runs). Cap ~5; then stop + surface with the log.

--- a/.agents/commands/deploy-network.md
+++ b/.agents/commands/deploy-network.md
@@ -1,0 +1,119 @@
+---
+name: deploy-network
+description: Brings a brand-new network fully on-chain by driving `deployAllContracts.sh` (scriptMaster use case 3) end to end — CREATE3 factory, core facets, diamond, non-core facets, periphery, whitelist sync, wallet funding, and health check — one stage at a time so it survives an agent's per-command time limit and needs no interactive terminal. Use after `add-network` has landed the config (networks.json, foundry.toml, target state) and the deployer is funded, when the user wants to "deploy the new network", "bring up <network> on-chain", "run the full deployment for <network>", or "deploy all contracts to <network>". This is the NEW-NETWORK bootstrap path and it runs production in direct-to-diamond mode (`SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`) because the Safe/timelock does not own the diamond yet. It stops after stage 11 (health check) and never performs stage 12 (ownership transfer) — that stays a deliberate step. NOT for deploying a single contract to existing networks (use `deploy-contract`), NOT for upgrading facets on networks that are already live and Safe-owned (use `multisig-rollout`), and NOT for Tron (`tron`/`tronshasta` — Foundry has no Tron support; there is no new-network bootstrap path there yet). Requires Foundry, gh, initialized submodules, and `MONGODB_URI` in `.env`.
+usage: /deploy-network <network> --production [--from-stage N] [--to-stage M]
+---
+
+# Deploy Network (LI.FI Contracts)
+
+Drives a full new-network bring-up via the `deployAllContracts` function
+(`script/deploy/deployAllContracts.sh`, scriptMaster use case 3), **one stage per fresh
+shell**. Each of the 12 stages is idempotent (CREATE3 → deterministic addresses, plus
+`diamondCut`), so a stage that is interrupted or re-run resumes instead of duplicating work.
+This lets an agent complete a deploy that runs far longer than a single command's time budget,
+and with no TTY, by invoking the script once per stage with the stage range and non-interactive
+mode preset in the environment.
+
+## When to use this vs other deploy skills
+
+| Situation | Skill |
+|---|---|
+| Config for a new network (networks.json, foundry.toml, target state) | **`add-network`** (run first) |
+| Bring a **new** network fully on-chain (diamond + all contracts) | **this skill** |
+| Deploy/redeploy a **single** contract to existing network(s) | **`deploy-contract`** |
+| Upgrade facets/periphery on **existing, Safe-owned** networks | **`multisig-rollout`** |
+| Ownership transfer / post-rollout completion | done deliberately (`finish-rollout` / stage 12) |
+
+## Hard rails
+
+- **New-network bootstrap only.** This path sets `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`,
+  which bypasses the Safe. That is legitimate *only* before the diamond's ownership has been
+  transferred to the Safe/timelock. If the network is already Safe-owned, stop — use
+  `multisig-rollout`.
+- **Never runs stage 12 (ownership transfer).** The driver bounds the run to stage 11. Ownership
+  transfer is a deliberate, reviewed step performed after inspecting the health check.
+- **Never edits `.env` silently.** The production flags (`PRODUCTION=true`,
+  `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true`) are shared, symlinked state — set them with the
+  user's explicit go, announce it, and restore afterward.
+- **Tron is out of scope.** No Foundry/CREATE3 support; there is no bootstrap path for
+  `tron`/`tronshasta` here.
+
+## Phase 0 — Preflight (report, don't silently fix)
+
+Run from the target network's worktree. Confirm:
+
+- `add-network` config for the network is present (entry in `config/networks.json`, in
+  `foundry.toml`, and in `script/deploy/_targetState.json`).
+- `lib/` submodules initialized and `forge clean && forge build` is fresh (CREATE3 salt derives
+  from `out/`).
+- Deployer wallet funded on the network (stage 1 aborts on zero balance; the pauser/dev wallets
+  are funded automatically at stage 9 from the deployer).
+- `MONGODB_URI` set in `.env` (stage 1 auto-adds the RPC from `networks.json` → MongoDB →
+  `fetch-rpcs`; no premium RPC required).
+- For production: `PRODUCTION=true` and `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=true` (set with the
+  user's go; see hard rails).
+
+## The stages
+
+| # | Stage |
+|---|---|
+| 1 | Initial setup + CREATE3Factory (+ Safe deploy on production) |
+| 2 | Deploy core facets |
+| 3 | Deploy diamond + add core facets |
+| 4 | Approve refund wallet |
+| 5 | Deploy non-core facets + add to diamond *(heavy — may exceed one command's budget)* |
+| 6 | Deploy periphery contracts |
+| 7 | Add periphery to diamond |
+| 8 | Whitelist sync |
+| 9 | Fund PauserWallet + DevWallet |
+| 10 | Verify ERC20Proxy (Executor) authorization |
+| 11 | Health check |
+| 12 | Ownership transfer — **skipped by this skill** |
+
+## Phase 1 — Drive the stages
+
+`deployAllContracts` reads three environment overrides (added for this skill; unset preserves the
+original interactive behavior):
+
+- `START_STAGE` / `END_STAGE` — bound the run to `[START_STAGE, END_STAGE]` and skip the
+  interactive `gum` stage menu.
+- `NON_INTERACTIVE=true` — accept computed defaults at the stage-9 funding prompts and
+  auto-confirm the stage-10 ERC20Proxy owner-funding prompt (in
+  `script/tasks/verifyERC20ProxyAuthorization.sh`).
+
+Run **each stage as its own command** (fresh shell, stays under the time limit):
+
+```bash
+export PATH="$HOME/.foundry/bin:$HOME/.bun/bin:$PATH"
+cd <network-worktree>
+START_STAGE=<N> END_STAGE=<N> NON_INTERACTIVE=true \
+  bash -c 'source script/deploy/deployAllContracts.sh; deployAllContracts <network> production'
+```
+
+After each stage, confirm the log contains `STAGE <N> completed` before advancing:
+
+- **Marker present** → advance to stage N+1.
+- **Marker absent** (timed out / interrupted) → re-run the *same* stage. Idempotency means it
+  resumes; the heavy stage 5 typically needs a few re-runs to deploy all facets. Cap at ~5
+  re-runs per stage — if a stage still never completes, stop and surface the failure with the
+  log; do not loop indefinitely.
+
+Advance 1 → 11. The run auto-stops after stage 11 (`END_STAGE < 12`), leaving the deployer as
+diamond owner — the correct, resumable pre-ownership-transfer state.
+
+## Phase 2 — Land the results
+
+- **Commit the deploy artifacts** (`deployments/<network>.json`, diamond log files) to the
+  network's `add-network` PR — this is what turns the `check-new-network-health` CI gate green.
+- **Restore `.env`** if production flags were set for the run (`PRODUCTION=false`,
+  `SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=` empty).
+- **Verify** contracts on the explorer and re-check the PR checks.
+- **Executor authorization follow-up:** if `ERC20Proxy < 1.2.0`, stage 10 only funds the owner
+  (refundWallet) — the actual `setAuthorizedCaller(Executor, true)` is a manual owner-key tx.
+  Surface it; swaps routed through the Executor fail until it lands.
+
+## Hand-offs
+
+- **Ownership transfer** (stage 12) → deliberate step / `finish-rollout` once the health check is
+  clean (only diamond-ownership errors remain).
+- **Bridge integrations** (Stargate, Across, etc.) → their own follow-up deploys after bring-up.

--- a/.agents/commands/deploy-network.md
+++ b/.agents/commands/deploy-network.md
@@ -116,9 +116,10 @@ START_STAGE=<N> END_STAGE=<N> NON_INTERACTIVE=true VERIFY_CONTRACTS=false \
 grep -c "STAGE <N> completed" /tmp/stage<N>.log   # 1 = advance; 0 = inspect/re-run
 ```
 
-(`VERIFY_CONTRACTS=false` is in `.env`, so to truly disable inline verification either edit `.env`
-for the run or rely on the Phase-2 sweep; deploying verification-off avoids inline `--watch`
-blocking and Blockscout indexing-lag failures.)
+(`deployAllContracts` preserves a caller-provided `VERIFY_CONTRACTS` across its `source .env`, so
+the inline `VERIFY_CONTRACTS=false` above genuinely disables verification even when `.env` sets it
+to `true` — no need to edit `.env`. Deploying verification-off avoids inline `--watch` blocking and
+Blockscout indexing-lag failures; verify in the Phase-2 sweep instead.)
 
 - **Marker present** → advance to N+1. **Absent** → re-run the same stage (idempotent; heavy
   stage 5 may need a few re-runs). Cap ~5; then stop + surface with the log.

--- a/.agents/commands/deploy-network.md
+++ b/.agents/commands/deploy-network.md
@@ -140,7 +140,8 @@ contract" races). The master log is in **MongoDB** — `bun mongo-logs:sync` ref
 cache (`_deployments_log_file.json`) so logged `constructorArgs`/`solc`/`evm` are available.
 
 Use `verifyNetworkContractsParallel <network> <environment>` (ships with this skill): verifies all
-unverified contracts for the network concurrently (capped at `MAX_CONCURRENT_JOBS`), with
+unverified contracts for the network concurrently (`VERIFICATION_MAX_CONCURRENT_JOBS`, default 4,
+never above `MAX_CONCURRENT_JOBS`), with
 **Blockscout rate-limit backoff** (429/gateway → exponential retry), then pushes `verified:true`
 back to MongoDB. Confirm with `bun mongo-logs:query`. Re-run to mop up any left by rate limits.
 

--- a/.claude/skills/deploy-network/SKILL.md
+++ b/.claude/skills/deploy-network/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agents/commands/deploy-network.md

--- a/.cursor/commands/deploy-network.md
+++ b/.cursor/commands/deploy-network.md
@@ -1,0 +1,1 @@
+../../.agents/commands/deploy-network.md

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/danielblaecker/Documents/GitHub/contracts/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/danielblaecker/Documents/GitHub/contracts/node_modules

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -20,8 +20,14 @@ deployAllContracts() {
   local NETWORK="$1"
   local ENVIRONMENT="$2"
 
+  # Preserve a caller-provided VERIFY_CONTRACTS override before sourcing .env: otherwise a
+  # `VERIFY_CONTRACTS=true` in .env silently re-enables inline verification that the caller
+  # (e.g. the deploy-network Phase-1 command) explicitly asked to turn off.
+  local VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS:-}"
+
   # load env variables
   source .env
+  [[ -n "$VERIFY_CONTRACTS_OVERRIDE" ]] && VERIFY_CONTRACTS="$VERIFY_CONTRACTS_OVERRIDE"
 
   # get file suffix based on value in variable ENVIRONMENT
   local FILE_SUFFIX=$(getFileSuffix "$ENVIRONMENT")
@@ -119,6 +125,7 @@ deployAllContracts() {
       bun fetch-rpcs
       # reload .env file to have the new RPC URL available
       source .env
+      [[ -n "$VERIFY_CONTRACTS_OVERRIDE" ]] && VERIFY_CONTRACTS="$VERIFY_CONTRACTS_OVERRIDE"
     fi
 
     # get deployer wallet balance

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -20,14 +20,18 @@ deployAllContracts() {
   local NETWORK="$1"
   local ENVIRONMENT="$2"
 
-  # Preserve a caller-provided VERIFY_CONTRACTS override before sourcing .env: otherwise a
-  # `VERIFY_CONTRACTS=true` in .env silently re-enables inline verification that the caller
-  # (e.g. the deploy-network Phase-1 command) explicitly asked to turn off.
-  local VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS:-}"
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported VERIFY_CONTRACTS_OVERRIDE
+  # BEFORE sourcing .env. This override — never set by .env — is what the verify gate in
+  # deploySingleContract actually consults. Restoring VERIFY_CONTRACTS itself is not enough:
+  # every deploy stage calls same-shell functions (deployCoreFacets, deploySingleContract,
+  # deployFacetAndAddToDiamond) that each re-`source .env` and reset VERIFY_CONTRACTS back to
+  # its .env value before the gate runs. The `:-` guard captures the caller value exactly
+  # once (outermost entry wins), so a `VERIFY_CONTRACTS=false` from the deploy-network Phase-1
+  # command genuinely disables inline verification even when .env sets VERIFY_CONTRACTS=true.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
 
   # load env variables
   source .env
-  [[ -n "$VERIFY_CONTRACTS_OVERRIDE" ]] && VERIFY_CONTRACTS="$VERIFY_CONTRACTS_OVERRIDE"
 
   # get file suffix based on value in variable ENVIRONMENT
   local FILE_SUFFIX=$(getFileSuffix "$ENVIRONMENT")
@@ -124,8 +128,8 @@ deployAllContracts() {
       bun add-network-rpc --network "$NETWORK" --rpc-url "$(getRpcUrlFromNetworksJson "$NETWORK")"
       bun fetch-rpcs
       # reload .env file to have the new RPC URL available
+      # (VERIFY_CONTRACTS_OVERRIDE is unaffected by source .env, so no restore needed)
       source .env
-      [[ -n "$VERIFY_CONTRACTS_OVERRIDE" ]] && VERIFY_CONTRACTS="$VERIFY_CONTRACTS_OVERRIDE"
     fi
 
     # get deployer wallet balance

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -5,6 +5,7 @@ deployAllContracts() {
 
   # load required resources
   source script/helperFunctions.sh
+  source script/deploy/deploySingleContract.sh
   source script/deploy/deployAndStoreCREATE3Factory.sh
   source script/deploy/deployCoreFacets.sh
   source script/deploy/deployFacetAndAddToDiamond.sh

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -52,46 +52,61 @@ deployAllContracts() {
     fi
   fi
 
-  # Ask user where to start the deployment process
-  echo "Which stage would you like to start from?"
-  START_FROM=$(
-    gum choose \
-      "1) Initial setup and CREATE3Factory deployment" \
-      "2) Deploy core facets" \
-      "3) Deploy diamond and update with core facets" \
-      "4) Set approval for refund wallet" \
-      "5) Deploy non-core facets and add to diamond" \
-      "6) Deploy periphery contracts" \
-      "7) Add periphery to diamond" \
-      "8) Update whitelist.json and execute sync whitelist script" \
-      "9) Fund PauserWallet and DevWallet" \
-      "10) Verify ERC20Proxy authorization" \
-      "11) Run health check only" \
-      "12) Ownership transfer to timelock (production only)"
-  )
-
-  # Extract the stage number from the selection (e.g. "12) ...")
-  # Important: do NOT substring-match "1)" as it would also match "10)", "11)", "12)".
-  if [[ "$START_FROM" =~ ^([0-9]+)\) ]]; then
-    START_STAGE="${BASH_REMATCH[1]}"
+  # Stage range selection.
+  # Interactive use: ask via gum, run from the chosen stage through stage 12.
+  # Automated use (e.g. the deploy-network skill): preset START_STAGE (and optionally
+  # END_STAGE) in the environment to bound the run and skip the prompt entirely. This
+  # lets a caller run one stage per invocation to stay under process time limits; every
+  # stage is idempotent (CREATE3 + diamondCut) so a bounded/re-run range is safe.
+  END_STAGE="${END_STAGE:-12}"
+  if [[ -n "${START_STAGE:-}" ]]; then
+    echo "[info] START_STAGE=$START_STAGE END_STAGE=$END_STAGE preset in environment; skipping interactive stage selection"
   else
-    error "invalid selection: $START_FROM - exiting script now"
-    exit 1
+    echo "Which stage would you like to start from?"
+    START_FROM=$(
+      gum choose \
+        "1) Initial setup and CREATE3Factory deployment" \
+        "2) Deploy core facets" \
+        "3) Deploy diamond and update with core facets" \
+        "4) Set approval for refund wallet" \
+        "5) Deploy non-core facets and add to diamond" \
+        "6) Deploy periphery contracts" \
+        "7) Add periphery to diamond" \
+        "8) Update whitelist.json and execute sync whitelist script" \
+        "9) Fund PauserWallet and DevWallet" \
+        "10) Verify ERC20Proxy authorization" \
+        "11) Run health check only" \
+        "12) Ownership transfer to timelock (production only)"
+    )
+
+    # Extract the stage number from the selection (e.g. "12) ...")
+    # Important: do NOT substring-match "1)" as it would also match "10)", "11)", "12)".
+    if [[ "$START_FROM" =~ ^([0-9]+)\) ]]; then
+      START_STAGE="${BASH_REMATCH[1]}"
+    else
+      error "invalid selection: $START_FROM - exiting script now"
+      exit 1
+    fi
   fi
 
   if [[ "$START_STAGE" -lt 1 || "$START_STAGE" -gt 12 ]]; then
-    error "invalid selection (stage out of range): $START_FROM - exiting script now"
+    error "invalid START_STAGE (out of range 1-12): $START_STAGE - exiting script now"
     exit 1
   fi
 
-  echo "Starting from stage $START_STAGE: $START_FROM"
+  if [[ "$END_STAGE" -lt "$START_STAGE" || "$END_STAGE" -gt 12 ]]; then
+    error "invalid END_STAGE ($END_STAGE): must be between START_STAGE ($START_STAGE) and 12 - exiting script now"
+    exit 1
+  fi
+
+  echo "Starting from stage $START_STAGE through stage $END_STAGE"
   echo ""
 
   # since we only support mutable diamonds, no need to ask user to select diamond type
   local DIAMOND_CONTRACT_NAME="LiFiDiamond"
 
   # Stage 1: Initial setup and CREATE3Factory deployment
-  if [[ $START_STAGE -le 1 ]]; then
+  if [[ $START_STAGE -le 1 && $END_STAGE -ge 1 ]]; then
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 1: Initial setup and CREATE3Factory deployment"
 
     # add RPC URL to MongoDB (only if not already in .env)
@@ -154,7 +169,7 @@ deployAllContracts() {
   fi
 
   # Stage 2: Deploy core facets
-  if [[ $START_STAGE -le 2 ]]; then
+  if [[ $START_STAGE -le 2 && $END_STAGE -ge 2 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 2: Deploy core facets"
 
@@ -166,7 +181,7 @@ deployAllContracts() {
   fi
 
   # Stage 3: Deploy diamond and update with core facets
-  if [[ $START_STAGE -le 3 ]]; then
+  if [[ $START_STAGE -le 3 && $END_STAGE -ge 3 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 3: Deploy diamond and update with core facets"
 
@@ -203,7 +218,7 @@ deployAllContracts() {
   fi
 
   # Stage 4: Set approval for refund wallet
-  if [[ $START_STAGE -le 4 ]]; then
+  if [[ $START_STAGE -le 4 && $END_STAGE -ge 4 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 4: Set approval for refund wallet"
 
@@ -218,7 +233,7 @@ deployAllContracts() {
   fi
 
   # Stage 5: Deploy non-core facets and add to diamond
-  if [[ $START_STAGE -le 5 ]]; then
+  if [[ $START_STAGE -le 5 && $END_STAGE -ge 5 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 5: Deploy non-core facets and add to diamond"
 
@@ -256,7 +271,7 @@ deployAllContracts() {
   fi
 
   # Stage 6: Deploy periphery contracts
-  if [[ $START_STAGE -le 6 ]]; then
+  if [[ $START_STAGE -le 6 && $END_STAGE -ge 6 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 6: Deploy periphery contracts"
 
@@ -267,7 +282,7 @@ deployAllContracts() {
   fi
 
   # Stage 7: Add periphery to diamond
-  if [[ $START_STAGE -le 7 ]]; then
+  if [[ $START_STAGE -le 7 && $END_STAGE -ge 7 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 7: Add periphery to diamond"
 
@@ -280,7 +295,7 @@ deployAllContracts() {
   fi
 
   # Stage 8: Update whitelist.json and execute sync whitelist script
-  if [[ $START_STAGE -le 8 ]]; then
+  if [[ $START_STAGE -le 8 && $END_STAGE -ge 8 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 8: Update whitelist.json and execute sync whitelist script"
 
@@ -293,7 +308,7 @@ deployAllContracts() {
   fi
 
   # Stage 9: Fund PauserWallet and DevWallet
-  if [[ $START_STAGE -le 9 ]]; then
+  if [[ $START_STAGE -le 9 && $END_STAGE -ge 9 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 9: Fund PauserWallet and DevWallet"
 
@@ -348,8 +363,13 @@ deployAllContracts() {
         DEFAULT_FUND_AMOUNT=$FALLBACK_FUND_AMOUNT
         warning "could not estimate pause cost for $NETWORK; falling back to default $DEFAULT_FUND_AMOUNT wei"
       fi
-      echo "PauserWallet balance is 0. Enter wei to send to $PAUSER_WALLET_ADDRESS (edit or press Enter to confirm default):"
-      FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+      if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
+        echo "[info] NON_INTERACTIVE: funding PauserWallet with computed default $DEFAULT_FUND_AMOUNT wei"
+        FUNDING_AMOUNT="$DEFAULT_FUND_AMOUNT"
+      else
+        echo "PauserWallet balance is 0. Enter wei to send to $PAUSER_WALLET_ADDRESS (edit or press Enter to confirm default):"
+        FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+      fi
       FUNDING_AMOUNT="${FUNDING_AMOUNT:-$DEFAULT_FUND_AMOUNT}"
 
       # Validate that FUNDING_AMOUNT is a numeric value
@@ -383,8 +403,13 @@ deployAllContracts() {
 
       if [[ "$BALANCE" == "0" ]]; then
         local DEFAULT_FUND_AMOUNT=2000000000000000
-        echo "DevWallet balance is 0. Enter wei to send to $DEV_WALLET_ADDRESS (edit or press Enter to confirm default):"
-        FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+        if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
+          echo "[info] NON_INTERACTIVE: funding DevWallet with default $DEFAULT_FUND_AMOUNT wei"
+          FUNDING_AMOUNT="$DEFAULT_FUND_AMOUNT"
+        else
+          echo "DevWallet balance is 0. Enter wei to send to $DEV_WALLET_ADDRESS (edit or press Enter to confirm default):"
+          FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+        fi
         FUNDING_AMOUNT="${FUNDING_AMOUNT:-$DEFAULT_FUND_AMOUNT}"
 
         # Validate that FUNDING_AMOUNT is a numeric value
@@ -405,7 +430,7 @@ deployAllContracts() {
   fi
 
   # Stage 10: Verify ERC20Proxy authorization
-  if [[ $START_STAGE -le 10 ]]; then
+  if [[ $START_STAGE -le 10 && $END_STAGE -ge 10 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 10: Verify ERC20Proxy authorization"
 
@@ -426,7 +451,7 @@ deployAllContracts() {
   fi
 
   # Stage 11: Run health check only
-  if [[ $START_STAGE -le 11 ]]; then
+  if [[ $START_STAGE -le 11 && $END_STAGE -ge 11 ]]; then
     echo ""
     echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 11: Run health check only"
     bun run healthcheck --network "$NETWORK" --environment "$ENVIRONMENT"
@@ -435,7 +460,13 @@ deployAllContracts() {
 
     # Pause and ask user if they want to continue with ownership transfer.
     # Testnets keep deployerWallet as the owner, so Stage 12 is skipped entirely.
-    if [[ "$ENVIRONMENT" == "production" ]] && ! isTestnetNetwork "$NETWORK"; then
+    # Bounded runs (END_STAGE < 12) stop here without prompting — ownership transfer is
+    # a deliberate step outside an automated bring-up.
+    if [[ "$END_STAGE" -lt 12 ]]; then
+      echo "[info] END_STAGE=$END_STAGE: stopping after stage 11 (ownership transfer not in requested range)"
+      echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< deployAllContracts completed"
+      return
+    elif [[ "$ENVIRONMENT" == "production" ]] && ! isTestnetNetwork "$NETWORK"; then
       echo ""
       echo "Health check completed. Do you want to continue with ownership transfer to timelock?"
       echo "This should only be done if the health check shows only diamond ownership errors."
@@ -454,7 +485,7 @@ deployAllContracts() {
   fi
 
   # Stage 12: Ownership transfer to timelock (production only; skipped on testnet)
-  if [[ $START_STAGE -le 12 ]]; then
+  if [[ $START_STAGE -le 12 && $END_STAGE -ge 12 ]]; then
     if [[ "$ENVIRONMENT" == "production" ]] && ! isTestnetNetwork "$NETWORK"; then
       echo ""
       echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> STAGE 12: Ownership transfer to timelock (production only)"

--- a/script/deploy/deployAllContracts.sh
+++ b/script/deploy/deployAllContracts.sh
@@ -3,6 +3,19 @@
 deployAllContracts() {
   echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> start deployAllContracts"
 
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported VERIFY_CONTRACTS_OVERRIDE
+  # BEFORE anything re-sources .env — including `source script/helperFunctions.sh` below,
+  # which sources .env at file level and would reset VERIFY_CONTRACTS to its .env value
+  # before a later promotion could capture the caller's. This override — never set by .env —
+  # is what the verify gate in deploySingleContract actually consults. Restoring
+  # VERIFY_CONTRACTS itself is not enough: every deploy stage calls same-shell functions
+  # (deployCoreFacets, deploySingleContract, deployFacetAndAddToDiamond) that each
+  # re-`source .env` and reset VERIFY_CONTRACTS back to its .env value before the gate runs.
+  # The `:-` guard captures the caller value exactly once (outermost entry wins), so a
+  # `VERIFY_CONTRACTS=false` from the deploy-network Phase-1 command genuinely disables
+  # inline verification even when .env sets VERIFY_CONTRACTS=true.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load required resources
   source script/helperFunctions.sh
   source script/deploy/deploySingleContract.sh
@@ -19,16 +32,6 @@ deployAllContracts() {
   # read function arguments into variables
   local NETWORK="$1"
   local ENVIRONMENT="$2"
-
-  # Promote a caller-provided VERIFY_CONTRACTS into an exported VERIFY_CONTRACTS_OVERRIDE
-  # BEFORE sourcing .env. This override — never set by .env — is what the verify gate in
-  # deploySingleContract actually consults. Restoring VERIFY_CONTRACTS itself is not enough:
-  # every deploy stage calls same-shell functions (deployCoreFacets, deploySingleContract,
-  # deployFacetAndAddToDiamond) that each re-`source .env` and reset VERIFY_CONTRACTS back to
-  # its .env value before the gate runs. The `:-` guard captures the caller value exactly
-  # once (outermost entry wins), so a `VERIFY_CONTRACTS=false` from the deploy-network Phase-1
-  # command genuinely disables inline verification even when .env sets VERIFY_CONTRACTS=true.
-  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
 
   # load env variables
   source .env

--- a/script/deploy/deployCoreFacets.sh
+++ b/script/deploy/deployCoreFacets.sh
@@ -15,6 +15,11 @@ deployCoreFacets() {
   local NETWORK="$1"
   local ENVIRONMENT="$2"
 
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported override before sourcing .env
+  # so it survives this same-shell re-source and reaches deploySingleContract's verify gate
+  # (see deployAllContracts). The `:-` guard preserves a value already set by an outer caller.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load env variables
   source .env
 

--- a/script/deploy/deployCoreFacets.sh
+++ b/script/deploy/deployCoreFacets.sh
@@ -7,6 +7,13 @@ deployCoreFacets() {
   echo ""
   echo "[info] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> deploying core facets now...."
 
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported override before any sourcing:
+  # helperFunctions.sh below re-sources .env at file level, so a later promotion would capture
+  # the .env value instead of the caller's (see deployAllContracts). The override survives all
+  # same-shell re-sources and reaches deploySingleContract's verify gate. The `:-` guard
+  # preserves a value already set by an outer caller.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load helper functions
   source script/helperFunctions.sh
   source script/deploy/deploySingleContract.sh
@@ -14,11 +21,6 @@ deployCoreFacets() {
   # read function arguments into variables
   local NETWORK="$1"
   local ENVIRONMENT="$2"
-
-  # Promote a caller-provided VERIFY_CONTRACTS into an exported override before sourcing .env
-  # so it survives this same-shell re-source and reaches deploySingleContract's verify gate
-  # (see deployAllContracts). The `:-` guard preserves a value already set by an outer caller.
-  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
 
   # load env variables
   source .env

--- a/script/deploy/deployFacetAndAddToDiamond.sh
+++ b/script/deploy/deployFacetAndAddToDiamond.sh
@@ -2,6 +2,11 @@
 
 # deploys a facet contract and adds it to a diamond contract
 function deployFacetAndAddToDiamond() {
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported override before sourcing .env
+  # so it survives this same-shell re-source and reaches deploySingleContract's verify gate
+  # (see deployAllContracts). The `:-` guard preserves a value already set by an outer caller.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load env variables
   source .env
 

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -263,20 +263,31 @@ deploySingleContract() {
   # execute script
   attempts=1
   ADDRESS_COLLISION_DETECTED=false
-  # Reset before the loop so a value leaked from a previous contract can never wrongly trigger the
-  # short-circuit below (deploySingleContract is called in a loop by deployFacetAndAddToDiamond).
+  # Reset before the loop so values leaked from a previous contract can never (a) wrongly trigger the
+  # short-circuit below, or (b) feed the constructor-arg extraction if the loop is skipped
+  # (deploySingleContract is called in a loop by deployFacetAndAddToDiamond; RAW_RETURN_DATA is global).
   ADDRESS=""
+  RAW_RETURN_DATA=""
+  CONSTRUCTOR_ARGS_FROM_LOG=""
 
   # Short-circuit already-deployed contracts (opt out with SKIP_IF_ALREADY_DEPLOYED=false).
   # DEPLOYSALT includes the compiled bytecode, so the predicted CREATE3 address is version-specific:
   # if it already has code (NEW_DEPLOYMENT=="true"), this exact contract+version is already deployed
   # and running the forge script would only fork the RPC (~dozens of calls) to no-op. Reuse the
-  # deployed address and skip the loop; the log-matching further below supplies the constructor args.
+  # deployed address and skip the loop.
   # A version bump changes the bytecode -> a different salt/address with no code -> deploys normally.
   # (Only the non-zkEVM CREATE3 path sets NEW_DEPLOYMENT, so this naturally never fires on zkEVM.)
   if [[ "${SKIP_IF_ALREADY_DEPLOYED:-true}" == "true" && "$NEW_DEPLOYMENT" == "true" ]]; then
     echo "[info] $CONTRACT already deployed at $CONTRACT_ADDRESS (version-specific CREATE3 salt) - skipping forge deployment"
     ADDRESS="$CONTRACT_ADDRESS"
+    # No forge run means no fresh RAW_RETURN_DATA to parse; recover this contract's constructor args
+    # from its existing log entry so a still-pending verification uses the correct args (not a stale
+    # blob from the previous contract, nor an empty fallback that would fail verification).
+    local SKIP_LOG_ENTRY
+    SKIP_LOG_ENTRY=$(findContractInMasterLog "$CONTRACT" "$NETWORK" "$ENVIRONMENT" "$VERSION")
+    if [[ $? -eq 0 ]]; then
+      CONSTRUCTOR_ARGS_FROM_LOG=$(echo "$SKIP_LOG_ENTRY" | jq -r ".CONSTRUCTOR_ARGS // empty")
+    fi
   fi
 
   while [ $attempts -le "$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" ] && [[ -z "$ADDRESS" ]]; do
@@ -432,16 +443,21 @@ deploySingleContract() {
   fi
 
   # extract constructor arguments from return data
-  # Use sed to handle multi-line JSON (critical for large hex strings that cause forge to output multi-line JSON)
-  local JSON_DATA
-  JSON_DATA=$(echo "$RAW_RETURN_DATA" | sed -n '/{"logs":/,/}$/p' | tr -d '\n' | sed 's/} *$/}/')
-  
-  # Fallback: if sed method fails, try grep method (but this may truncate multi-line JSON)
-  if [[ -z "$JSON_DATA" || "$JSON_DATA" == "" ]]; then
-    JSON_DATA=$(echo "$RAW_RETURN_DATA" | grep -o '{"logs":.*}' | tail -1)
+  # A skipped deployment has no fresh RAW_RETURN_DATA; use the args recovered from the log entry.
+  if [[ -z "$RAW_RETURN_DATA" ]]; then
+    CONSTRUCTOR_ARGS="${CONSTRUCTOR_ARGS_FROM_LOG:-0x}"
+  else
+    # Use sed to handle multi-line JSON (critical for large hex strings that cause forge to output multi-line JSON)
+    local JSON_DATA
+    JSON_DATA=$(echo "$RAW_RETURN_DATA" | sed -n '/{"logs":/,/}$/p' | tr -d '\n' | sed 's/} *$/}/')
+
+    # Fallback: if sed method fails, try grep method (but this may truncate multi-line JSON)
+    if [[ -z "$JSON_DATA" || "$JSON_DATA" == "" ]]; then
+      JSON_DATA=$(echo "$RAW_RETURN_DATA" | grep -o '{"logs":.*}' | tail -1)
+    fi
+
+    CONSTRUCTOR_ARGS=$(echo "$JSON_DATA" | jq -r '.returns.constructorArgs.value // .returns[1].value // "0x"' 2>/dev/null | head -1 | tr -d '\n')
   fi
-  
-  CONSTRUCTOR_ARGS=$(echo "$JSON_DATA" | jq -r '.returns.constructorArgs.value // .returns[1].value // "0x"' 2>/dev/null | head -1 | tr -d '\n')
   # Validate extracted constructor args before verify/log: 0x + hex only, even-length payload
   CONSTRUCTOR_ARGS=$(echo "$CONSTRUCTOR_ARGS" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   local CA_HEX_PAYLOAD="${CONSTRUCTOR_ARGS#0x}"

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -15,6 +15,12 @@ deploySingleContract() {
   local VERSION="$4"
   local EXIT_ON_ERROR="$5"
 
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported override BEFORE sourcing .env
+  # (see deployAllContracts). The verify gate below consults VERIFY_CONTRACTS_OVERRIDE, which
+  # .env never sets, so an inline `VERIFY_CONTRACTS=false` survives this (and any parent's)
+  # re-source. The `:-` guard preserves a value already promoted by an outer caller.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load env variables
   source .env
 
@@ -288,6 +294,15 @@ deploySingleContract() {
     if [[ $? -eq 0 ]]; then
       CONSTRUCTOR_ARGS_FROM_LOG=$(echo "$SKIP_LOG_ENTRY" | jq -r ".CONSTRUCTOR_ARGS // empty")
     fi
+    # If no constructor args could be recovered — no master-log entry (e.g. a prior run crashed
+    # after broadcast but before logging, or Mongo was unreachable), or the entry has none — the
+    # extraction below falls back to CONSTRUCTOR_ARGS="0x" and the log write persists that
+    # placeholder. That is fine for a contract with no constructor args, but for one WITH args the
+    # Phase-2 verification sweep (which reads args from the log) then fails forever with no hint.
+    # Warn loudly so the operator can correct the logged args before verifying.
+    if [[ -z "$CONSTRUCTOR_ARGS_FROM_LOG" ]]; then
+      warning "$CONTRACT is already deployed at $CONTRACT_ADDRESS but no constructor args could be recovered from the master log (missing or incomplete log entry). A placeholder CONSTRUCTOR_ARGS=0x will be logged for this address. If $CONTRACT has constructor args, its Phase-2 verification will FAIL until you correct CONSTRUCTOR_ARGS in the deployment log."
+    fi
   fi
 
   while [ $attempts -le "$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" ] && [[ -z "$ADDRESS" ]]; do
@@ -507,8 +522,11 @@ deploySingleContract() {
     ZK_SOLC_VERSION=""
   fi
 
-  # check if contract verification is enabled in config and contract not yet verified according to log file
-  if [[ $VERIFY_CONTRACTS == "true" && ("$VERIFIED_LOG" == "false" || -z "$VERIFIED_LOG") ]]; then
+  # check if contract verification is enabled in config and contract not yet verified according to log file.
+  # VERIFY_CONTRACTS_OVERRIDE (a caller value promoted before any `source .env`) wins over .env's
+  # VERIFY_CONTRACTS, which same-shell re-sources keep resetting; fall back to VERIFY_CONTRACTS when unset.
+  local EFFECTIVE_VERIFY_CONTRACTS="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+  if [[ "$EFFECTIVE_VERIFY_CONTRACTS" == "true" && ("$VERIFIED_LOG" == "false" || -z "$VERIFIED_LOG") ]]; then
     # For zkEVM networks, add delay before verification to allow API to index the contract
     # This helps avoid "504 Gateway Time-out" errors when API tries to fetch contract ABI
     if isZkEvmNetwork "$NETWORK"; then

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -263,8 +263,23 @@ deploySingleContract() {
   # execute script
   attempts=1
   ADDRESS_COLLISION_DETECTED=false
+  # Reset before the loop so a value leaked from a previous contract can never wrongly trigger the
+  # short-circuit below (deploySingleContract is called in a loop by deployFacetAndAddToDiamond).
+  ADDRESS=""
 
-  while [ $attempts -le "$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" ]; do
+  # Short-circuit already-deployed contracts (opt out with SKIP_IF_ALREADY_DEPLOYED=false).
+  # DEPLOYSALT includes the compiled bytecode, so the predicted CREATE3 address is version-specific:
+  # if it already has code (NEW_DEPLOYMENT=="true"), this exact contract+version is already deployed
+  # and running the forge script would only fork the RPC (~dozens of calls) to no-op. Reuse the
+  # deployed address and skip the loop; the log-matching further below supplies the constructor args.
+  # A version bump changes the bytecode -> a different salt/address with no code -> deploys normally.
+  # (Only the non-zkEVM CREATE3 path sets NEW_DEPLOYMENT, so this naturally never fires on zkEVM.)
+  if [[ "${SKIP_IF_ALREADY_DEPLOYED:-true}" == "true" && "$NEW_DEPLOYMENT" == "true" ]]; then
+    echo "[info] $CONTRACT already deployed at $CONTRACT_ADDRESS (version-specific CREATE3 salt) - skipping forge deployment"
+    ADDRESS="$CONTRACT_ADDRESS"
+  fi
+
+  while [ $attempts -le "$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" ] && [[ -z "$ADDRESS" ]]; do
     echo "[info] trying to deploy $CONTRACT now - attempt ${attempts} (max attempts: $MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT) "
 
     # ensure that gas price is below maximum threshold (for mainnet only)

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -4,6 +4,14 @@
 # should be called like this:
 # $(deploySingleContract "Executor" "BSC" "staging" "1.0.0" true)
 deploySingleContract() {
+  # Promote a caller-provided VERIFY_CONTRACTS into an exported override BEFORE any sourcing —
+  # helperFunctions.sh below re-sources .env at file level, so promoting later would capture
+  # the .env value instead of the caller's (see deployAllContracts). The verify gate below
+  # consults VERIFY_CONTRACTS_OVERRIDE, which .env never sets, so an inline
+  # `VERIFY_CONTRACTS=false` survives this (and any parent's) re-source. The `:-` guard
+  # preserves a value already promoted by an outer caller.
+  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
+
   # load helper functions
   source script/helperFunctions.sh
   source script/deploy/resources/contractSpecificReminders.sh # pre-commit-checker: not a secret
@@ -14,12 +22,6 @@ deploySingleContract() {
   local ENVIRONMENT="$3"
   local VERSION="$4"
   local EXIT_ON_ERROR="$5"
-
-  # Promote a caller-provided VERIFY_CONTRACTS into an exported override BEFORE sourcing .env
-  # (see deployAllContracts). The verify gate below consults VERIFY_CONTRACTS_OVERRIDE, which
-  # .env never sets, so an inline `VERIFY_CONTRACTS=false` survives this (and any parent's)
-  # re-source. The `:-` guard preserves a value already promoted by an outer caller.
-  export VERIFY_CONTRACTS_OVERRIDE="${VERIFY_CONTRACTS_OVERRIDE:-${VERIFY_CONTRACTS:-}}"
 
   # load env variables
   source .env
@@ -140,6 +142,14 @@ deploySingleContract() {
   echoDebug "DIAMOND_TYPE=$DIAMOND_TYPE"
   echoDebug "GAS_ESTIMATE_MULTIPLIER=$GAS_ESTIMATE_MULTIPLIER (default value: 130, set in .env for example to 200 for doubling Foundry's estimate)"
   echo ""
+
+  # Reset before the CREATE3/zkEVM split: NEW_DEPLOYMENT and CONTRACT_ADDRESS are globals set
+  # only on the non-zkEVM path below. Without this reset, values leaked from a previous
+  # deploySingleContract call in the same shell (e.g. a multi-network loop mixing zkEVM and
+  # non-zkEVM targets) could wrongly trigger the already-deployed short-circuit further down —
+  # reusing another network's address.
+  NEW_DEPLOYMENT=""
+  CONTRACT_ADDRESS=""
 
   # the following is only applicable for networks where we use CREATE3 (= non-zkEVM)
   if ! isZkEvmNetwork "$NETWORK"; then

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -292,7 +292,16 @@ deploySingleContract() {
     local SKIP_LOG_ENTRY
     SKIP_LOG_ENTRY=$(findContractInMasterLog "$CONTRACT" "$NETWORK" "$ENVIRONMENT" "$VERSION")
     if [[ $? -eq 0 ]]; then
-      CONSTRUCTOR_ARGS_FROM_LOG=$(echo "$SKIP_LOG_ENTRY" | jq -r ".CONSTRUCTOR_ARGS // empty")
+      # findContractInMasterLog keys only on contract/network/environment/version, so a same-version
+      # entry can point at a DIFFERENT address than the one we're short-circuiting (e.g. after a salt
+      # change). Only trust its constructor args when the entry's ADDRESS matches CONTRACT_ADDRESS
+      # (case-insensitive); otherwise leave CONSTRUCTOR_ARGS_FROM_LOG empty so the warning + placeholder
+      # fallback below runs rather than writing another address's args against CONTRACT_ADDRESS.
+      local SKIP_LOG_ADDRESS
+      SKIP_LOG_ADDRESS=$(echo "$SKIP_LOG_ENTRY" | jq -r ".ADDRESS // empty")
+      if [[ -n "$SKIP_LOG_ADDRESS" && "$(echo "$SKIP_LOG_ADDRESS" | tr '[:upper:]' '[:lower:]')" == "$(echo "$CONTRACT_ADDRESS" | tr '[:upper:]' '[:lower:]')" ]]; then
+        CONSTRUCTOR_ARGS_FROM_LOG=$(echo "$SKIP_LOG_ENTRY" | jq -r ".CONSTRUCTOR_ARGS // empty")
+      fi
     fi
     # If no constructor args could be recovered — no master-log entry (e.g. a prior run crashed
     # after broadcast but before logging, or Mongo was unreachable), or the entry has none — the

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2566,9 +2566,18 @@ function verifyNetworkContractsParallel() {
 
   # Verification concurrency is intentionally lower than MAX_CONCURRENT_JOBS: block explorers
   # rate-limit aggressively. Each verifyContract already retries with backoff on 429/gateway.
-  local CONCURRENCY=${VERIFICATION_MAX_CONCURRENT_JOBS:-4}
-  if [[ -n "$MAX_CONCURRENT_JOBS" && "$MAX_CONCURRENT_JOBS" -lt "$CONCURRENCY" ]]; then
-    CONCURRENCY=$MAX_CONCURRENT_JOBS
+  local CONCURRENCY="${VERIFICATION_MAX_CONCURRENT_JOBS:-4}"
+  local MAX_JOBS="${MAX_CONCURRENT_JOBS:-}"
+  if ! [[ "$CONCURRENCY" =~ ^[1-9][0-9]*$ ]]; then
+    error "VERIFICATION_MAX_CONCURRENT_JOBS must be a positive integer"
+    return 1
+  fi
+  if [[ -n "$MAX_JOBS" ]]; then
+    if ! [[ "$MAX_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+      error "MAX_CONCURRENT_JOBS must be a positive integer"
+      return 1
+    fi
+    (( MAX_JOBS < CONCURRENCY )) && CONCURRENCY="$MAX_JOBS"
   fi
 
   local WORK_DIR
@@ -2631,8 +2640,13 @@ function verifyNetworkContractsParallel() {
       SOLC_VERSION=$(echo "$ENTRY" | jq -r '.SOLC_VERSION // empty')
       EVM_VERSION=$(echo "$ENTRY" | jq -r '.EVM_VERSION // empty')
       ZK_SOLC_VERSION=$(echo "$ENTRY" | jq -r '.ZK_SOLC_VERSION // empty')
-      logContractDeploymentInfo "$CONTRACT" "$NETWORK" "$TIMESTAMP" "$VERSION" "$OPTIMIZER_RUNS" "$ARGS" "$ENVIRONMENT" "$ADDRESS" "true" "$SALT" "$SOLC_VERSION" "$EVM_VERSION" "$ZK_SOLC_VERSION"
-      OK=$((OK + 1))
+      if logContractDeploymentInfo "$CONTRACT" "$NETWORK" "$TIMESTAMP" "$VERSION" "$OPTIMIZER_RUNS" "$ARGS" "$ENVIRONMENT" "$ADDRESS" "true" "$SALT" "$SOLC_VERSION" "$EVM_VERSION" "$ZK_SOLC_VERSION"; then
+        OK=$((OK + 1))
+      else
+        # Contract is verified on-chain, but the log's VERIFIED flag didn't persist (e.g. MongoDB
+        # unavailable) — surface it so the summary doesn't claim success while state stays stale.
+        FAILED+=("$CONTRACT ($ADDRESS): verified but log update failed")
+      fi
     else
       FAILED+=("$CONTRACT ($ADDRESS)")
     fi

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2314,7 +2314,8 @@ function verifyContract() {
     # Check if command failed with non-zero exit code
     if [ $VERIFY_EXIT_CODE -ne 0 ]; then
       # Check for specific error types that should trigger retry with longer delay
-      if echo "$VERIFY_OUTPUT" | grep -qi "504\|Gateway Time-out\|timeout\|Failed to obtain contract ABI"; then
+      # (includes explorer rate-limiting, which parallel verification is prone to hit)
+      if echo "$VERIFY_OUTPUT" | grep -qi "504\|Gateway Time-out\|timeout\|Failed to obtain contract ABI\|429\|rate limit\|too many requests"; then
         warning "API timeout or gateway error detected. This may be temporary - will retry with longer delay..."
         error "Verification command failed with exit code $VERIFY_EXIT_CODE (API timeout/gateway error)"
         if [ -n "$VERIFY_OUTPUT" ]; then
@@ -2543,6 +2544,107 @@ function verifyAllUnverifiedContractsInLogFile() {
   done
 
   echo "[info] done (verified contracts: $COUNTER)"
+}
+function verifyNetworkContractsParallel() {
+  # Parallel, network-scoped verification sweep with explorer rate-limit backoff.
+  # Verifies every not-yet-verified contract for ONE network/environment concurrently, then
+  # updates the deployment log SEQUENTIALLY afterwards (parallel log writes would corrupt it).
+  # Meant to run AFTER a full deploy (deploy stages with VERIFY_CONTRACTS=false) so the explorer
+  # has indexed everything. Requires the log to be synced first: `bun mongo-logs:sync`.
+  # Args: $1 NETWORK, $2 ENVIRONMENT
+  local NETWORK="$1"
+  local ENVIRONMENT="$2"
+
+  if [[ -z "$NETWORK" || -z "$ENVIRONMENT" ]]; then
+    error "verifyNetworkContractsParallel requires NETWORK and ENVIRONMENT"
+    return 1
+  fi
+  if [ ! -f "$LOG_FILE_PATH" ]; then
+    error "log file not found at $LOG_FILE_PATH (run 'bun mongo-logs:sync' first)"
+    return 1
+  fi
+
+  # Verification concurrency is intentionally lower than MAX_CONCURRENT_JOBS: block explorers
+  # rate-limit aggressively. Each verifyContract already retries with backoff on 429/gateway.
+  local CONCURRENCY=${VERIFICATION_MAX_CONCURRENT_JOBS:-4}
+  if [[ -n "$MAX_CONCURRENT_JOBS" && "$MAX_CONCURRENT_JOBS" -lt "$CONCURRENCY" ]]; then
+    CONCURRENCY=$MAX_CONCURRENT_JOBS
+  fi
+
+  local WORK_DIR
+  WORK_DIR=$(mktemp -d)
+  local WORK_LIST="$WORK_DIR/worklist"
+  : >"$WORK_LIST"
+
+  # Collect all unverified entries for this network/environment into a tab-separated work list.
+  local CONTRACT
+  for CONTRACT in $(jq -r 'keys[]' "$LOG_FILE_PATH"); do
+    jq -e --arg c "$CONTRACT" --arg n "$NETWORK" '.[$c][$n]' "$LOG_FILE_PATH" >/dev/null 2>&1 || continue
+    local VERSION
+    for VERSION in $(jq -r --arg c "$CONTRACT" --arg n "$NETWORK" --arg e "$ENVIRONMENT" '.[$c][$n][$e] // {} | keys[]' "$LOG_FILE_PATH" 2>/dev/null); do
+      local ENTRY
+      ENTRY=$(jq -r --arg c "$CONTRACT" --arg n "$NETWORK" --arg e "$ENVIRONMENT" --arg v "$VERSION" '.[$c][$n][$e][$v][0]' "$LOG_FILE_PATH")
+      [[ -z "$ENTRY" || "$ENTRY" == "null" ]] && continue
+      [[ "$(echo "$ENTRY" | jq -r '.VERIFIED // "false"')" == "true" ]] && continue
+      local ADDRESS ARGS
+      ADDRESS=$(echo "$ENTRY" | jq -r '.ADDRESS // empty')
+      ARGS=$(echo "$ENTRY" | jq -r '.CONSTRUCTOR_ARGS // empty')
+      [[ -z "$ADDRESS" ]] && continue
+      printf '%s\t%s\t%s\t%s\n' "$CONTRACT" "$VERSION" "$ADDRESS" "$ARGS" >>"$WORK_LIST"
+    done
+  done
+
+  local TOTAL
+  TOTAL=$(wc -l <"$WORK_LIST" | tr -d ' ')
+  if [[ "$TOTAL" -eq 0 ]]; then
+    echo "[info] no unverified contracts for $NETWORK/$ENVIRONMENT"
+    rm -rf "$WORK_DIR"
+    return 0
+  fi
+  echo "[info] verifying $TOTAL contract(s) for $NETWORK/$ENVIRONMENT (concurrency: $CONCURRENCY)"
+
+  # Dispatch parallel verification jobs. Each writes only its own result file; no job touches the
+  # shared log. Small stagger between dispatches to avoid a thundering herd against the explorer.
+  while IFS=$'\t' read -r CONTRACT VERSION ADDRESS ARGS; do
+    while [[ $(jobs -r | wc -l | tr -d ' ') -ge $CONCURRENCY ]]; do sleep 1; done
+    (
+      if verifyContract "$NETWORK" "$CONTRACT" "$ADDRESS" "$ARGS" >/dev/null 2>&1; then
+        echo "ok" >"$WORK_DIR/$CONTRACT.$VERSION.result"
+      else
+        echo "fail" >"$WORK_DIR/$CONTRACT.$VERSION.result"
+      fi
+    ) &
+    sleep 2
+  done <"$WORK_LIST"
+  wait
+
+  # Sequentially flip VERIFIED=true in the log for the successes (preserving all other fields).
+  local OK=0
+  local FAILED=()
+  while IFS=$'\t' read -r CONTRACT VERSION ADDRESS ARGS; do
+    if [[ "$(cat "$WORK_DIR/$CONTRACT.$VERSION.result" 2>/dev/null)" == "ok" ]]; then
+      local ENTRY TIMESTAMP OPTIMIZER_RUNS SALT SOLC_VERSION EVM_VERSION ZK_SOLC_VERSION
+      ENTRY=$(jq -r --arg c "$CONTRACT" --arg n "$NETWORK" --arg e "$ENVIRONMENT" --arg v "$VERSION" '.[$c][$n][$e][$v][0]' "$LOG_FILE_PATH")
+      TIMESTAMP=$(echo "$ENTRY" | jq -r '.TIMESTAMP // empty')
+      OPTIMIZER_RUNS=$(echo "$ENTRY" | jq -r '.OPTIMIZER_RUNS // empty')
+      SALT=$(echo "$ENTRY" | jq -r '.SALT // empty')
+      SOLC_VERSION=$(echo "$ENTRY" | jq -r '.SOLC_VERSION // empty')
+      EVM_VERSION=$(echo "$ENTRY" | jq -r '.EVM_VERSION // empty')
+      ZK_SOLC_VERSION=$(echo "$ENTRY" | jq -r '.ZK_SOLC_VERSION // empty')
+      logContractDeploymentInfo "$CONTRACT" "$NETWORK" "$TIMESTAMP" "$VERSION" "$OPTIMIZER_RUNS" "$ARGS" "$ENVIRONMENT" "$ADDRESS" "true" "$SALT" "$SOLC_VERSION" "$EVM_VERSION" "$ZK_SOLC_VERSION"
+      OK=$((OK + 1))
+    else
+      FAILED+=("$CONTRACT ($ADDRESS)")
+    fi
+  done <"$WORK_LIST"
+
+  rm -rf "$WORK_DIR"
+  echo "[info] verified $OK/$TOTAL for $NETWORK/$ENVIRONMENT"
+  if [[ ${#FAILED[@]} -gt 0 ]]; then
+    warning "still unverified (explorer rate-limit/indexing lag — re-run to retry): ${FAILED[*]}"
+    return 1
+  fi
+  return 0
 }
 function removeFacetFromDiamond() {
   # read function arguments into variables

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2617,7 +2617,15 @@ function verifyNetworkContractsParallel() {
   while IFS=$'\t' read -r CONTRACT VERSION ADDRESS ARGS; do
     while [[ $(jobs -r | wc -l | tr -d ' ') -ge $CONCURRENCY ]]; do sleep 1; done
     (
-      if verifyContract "$NETWORK" "$CONTRACT" "$ADDRESS" "$ARGS" >/dev/null 2>&1; then
+      # Pass the logged toolchain (solc/EVM version, optimizer runs) so verification compiles
+      # with what the contract was BUILT with, not whatever foundry.toml currently pins —
+      # matching the sequential sweep (verifyAllUnverifiedContractsInLogFile). Read-only jq
+      # lookups are parallel-safe. Empty values leave verifyContract's default behavior intact.
+      JOB_ENTRY=$(jq -r --arg c "$CONTRACT" --arg n "$NETWORK" --arg e "$ENVIRONMENT" --arg v "$VERSION" '.[$c][$n][$e][$v][0]' "$LOG_FILE_PATH")
+      JOB_SOLC_VERSION=$(echo "$JOB_ENTRY" | jq -r '.SOLC_VERSION // empty')
+      JOB_EVM_VERSION=$(echo "$JOB_ENTRY" | jq -r '.EVM_VERSION // empty')
+      JOB_OPTIMIZER_RUNS=$(echo "$JOB_ENTRY" | jq -r '.OPTIMIZER_RUNS // empty')
+      if verifyContract "$NETWORK" "$CONTRACT" "$ADDRESS" "$ARGS" "$JOB_SOLC_VERSION" "$JOB_EVM_VERSION" "$JOB_OPTIMIZER_RUNS" >/dev/null 2>&1; then
         echo "ok" >"$WORK_DIR/$CONTRACT.$VERSION.result"
       else
         echo "fail" >"$WORK_DIR/$CONTRACT.$VERSION.result"

--- a/script/tasks/verifyERC20ProxyAuthorization.sh
+++ b/script/tasks/verifyERC20ProxyAuthorization.sh
@@ -107,11 +107,23 @@ authorizeExecutorOnZkEvm() {
   OWNER_BALANCE=$(cast balance "$OWNER" --rpc-url "$RPC_URL")
   echo "[info] Owner ($OWNER) native balance: $OWNER_BALANCE wei"
 
-  if gum confirm "Fund owner with gas for the setAuthorizedCaller tx now?"; then
-    local DEFAULT_FUND_AMOUNT=1000000000000000 # 0.001 native; one cheap state-setting tx
-    echo "Enter wei to send to $OWNER (edit or press Enter to confirm default):"
+  local DEFAULT_FUND_AMOUNT=1000000000000000 # 0.001 native; one cheap state-setting tx
+  local DO_FUND_OWNER=false
+  if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
+    echo "[info] NON_INTERACTIVE: auto-funding owner with default $DEFAULT_FUND_AMOUNT wei for the setAuthorizedCaller tx"
+    DO_FUND_OWNER=true
+  elif gum confirm "Fund owner with gas for the setAuthorizedCaller tx now?"; then
+    DO_FUND_OWNER=true
+  fi
+
+  if [[ "$DO_FUND_OWNER" == "true" ]]; then
     local FUNDING_AMOUNT
-    FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+    if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
+      FUNDING_AMOUNT="$DEFAULT_FUND_AMOUNT"
+    else
+      echo "Enter wei to send to $OWNER (edit or press Enter to confirm default):"
+      FUNDING_AMOUNT=$(gum input --value "$DEFAULT_FUND_AMOUNT" --placeholder "wei amount" --width 40)
+    fi
     FUNDING_AMOUNT="${FUNDING_AMOUNT:-$DEFAULT_FUND_AMOUNT}"
     if ! [[ "$FUNDING_AMOUNT" =~ ^[0-9]+$ ]]; then
       error "Invalid funding amount. Please provide a valid wei amount (numeric value)."

--- a/script/tasks/verifyERC20ProxyAuthorization.sh
+++ b/script/tasks/verifyERC20ProxyAuthorization.sh
@@ -109,9 +109,22 @@ authorizeExecutorOnZkEvm() {
 
   local DEFAULT_FUND_AMOUNT=1000000000000000 # 0.001 native; one cheap state-setting tx
   local DO_FUND_OWNER=false
+
+  # Only top up when the owner can't cover the tx. Compare with bc: wei balances routinely exceed
+  # 2^63 and would overflow bash integer arithmetic. Without this gate, every NON_INTERACTIVE rerun
+  # (e.g. before the manual authorization lands) would send another DEFAULT_FUND_AMOUNT.
+  local OWNER_NEEDS_FUNDING=false
+  if [[ -z "$OWNER_BALANCE" ]] || (( $(echo "$OWNER_BALANCE < $DEFAULT_FUND_AMOUNT" | bc -l) )); then
+    OWNER_NEEDS_FUNDING=true
+  fi
+
   if [[ "${NON_INTERACTIVE:-}" == "true" ]]; then
-    echo "[info] NON_INTERACTIVE: auto-funding owner with default $DEFAULT_FUND_AMOUNT wei for the setAuthorizedCaller tx"
-    DO_FUND_OWNER=true
+    if [[ "$OWNER_NEEDS_FUNDING" == "true" ]]; then
+      echo "[info] NON_INTERACTIVE: owner balance below $DEFAULT_FUND_AMOUNT wei; auto-funding for the setAuthorizedCaller tx"
+      DO_FUND_OWNER=true
+    else
+      echo "[info] NON_INTERACTIVE: owner already has sufficient native balance; skipping automatic funding"
+    fi
   elif gum confirm "Fund owner with gas for the setAuthorizedCaller tx now?"; then
     DO_FUND_OWNER=true
   fi

--- a/script/tasks/verifyERC20ProxyAuthorization.sh
+++ b/script/tasks/verifyERC20ProxyAuthorization.sh
@@ -103,18 +103,28 @@ authorizeExecutorOnZkEvm() {
   local PRIVATE_KEY_TO_USE
   PRIVATE_KEY_TO_USE=$(getPrivateKey "$NETWORK" "$ENVIRONMENT") || { error "no private key for $NETWORK"; return 1; }
 
-  local OWNER_BALANCE
-  OWNER_BALANCE=$(cast balance "$OWNER" --rpc-url "$RPC_URL")
-  echo "[info] Owner ($OWNER) native balance: $OWNER_BALANCE wei"
+  # Capture the balance and the lookup's exit status separately: a transient RPC failure yields an
+  # empty string, which must NOT be mistaken for "balance is zero" and trigger auto-funding. Fail
+  # closed — on any failed/empty lookup, skip funding and leave the balance unknown.
+  local OWNER_BALANCE OWNER_BALANCE_OK=true
+  OWNER_BALANCE=$(cast balance "$OWNER" --rpc-url "$RPC_URL") || OWNER_BALANCE_OK=false
+  if [[ "$OWNER_BALANCE_OK" != "true" || -z "$OWNER_BALANCE" ]]; then
+    warning "Could not read owner ($OWNER) native balance on $NETWORK (RPC error?); skipping automatic funding (fail closed). Fund the owner manually if it lacks gas for the setAuthorizedCaller tx."
+    OWNER_BALANCE=""
+  else
+    echo "[info] Owner ($OWNER) native balance: $OWNER_BALANCE wei"
+  fi
 
   local DEFAULT_FUND_AMOUNT=1000000000000000 # 0.001 native; one cheap state-setting tx
   local DO_FUND_OWNER=false
 
-  # Only top up when the owner can't cover the tx. Compare with bc: wei balances routinely exceed
-  # 2^63 and would overflow bash integer arithmetic. Without this gate, every NON_INTERACTIVE rerun
-  # (e.g. before the manual authorization lands) would send another DEFAULT_FUND_AMOUNT.
+  # Only top up when we successfully read a balance AND it can't cover the tx. A missing/failed balance
+  # fails closed (no funding) rather than being treated as insufficient funds. Compare with bc: wei
+  # balances routinely exceed 2^63 and would overflow bash integer arithmetic. Without the sufficiency
+  # gate, every NON_INTERACTIVE rerun (e.g. before the manual authorization lands) would send another
+  # DEFAULT_FUND_AMOUNT.
   local OWNER_NEEDS_FUNDING=false
-  if [[ -z "$OWNER_BALANCE" ]] || (( $(echo "$OWNER_BALANCE < $DEFAULT_FUND_AMOUNT" | bc -l) )); then
+  if [[ -n "$OWNER_BALANCE" ]] && (( $(echo "$OWNER_BALANCE < $DEFAULT_FUND_AMOUNT" | bc -l) )); then
     OWNER_NEEDS_FUNDING=true
   fi
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-631 — https://linear.app/lifi-linear/issue/EXSC-631/deploy-network-skill-agent-driven-staged-new-network-bring-up

# Why did I implement it this way?

Adds a **`deploy-network`** skill so an agent can drive a full new-network production bring-up
(`deployAllContracts.sh` / scriptMaster use case 3) end to end — the gap between `add-network`
(config) and `multisig-rollout` (upgrades to existing chains). Built and hardened during the live
Injective (chainId 1776) production deploy, which is its shakedown.

**Two things blocked agent-driven use of `deployAllContracts`:** the agent Bash tool hard-kills any
command at ~10 min, and the script is interactive (`gum`/`read`). This PR makes it drivable
**one stage per fresh shell**, non-interactively, relying on the deploy's existing CREATE3 +
`diamondCut` idempotency for safe per-stage re-runs.

### Script changes (additive, backward-compatible — default interactive behavior unchanged)

- **`script/deploy/deployAllContracts.sh`**
  - Optional `START_STAGE`/`END_STAGE` env bounds the stage range and skips the interactive `gum`
    stage menu when preset. Each stage guard is bounded to `[START_STAGE, END_STAGE]`; a bounded
    run ending at 11 stops cleanly without the stage-12 ownership-transfer prompt.
  - `NON_INTERACTIVE=true` accepts the computed defaults at the stage-9 funding prompts.
  - Sources `deploySingleContract.sh` itself (was relying on scriptMaster to source it → stage 3
    failed `deploySingleContract: command not found` under direct invocation). Now self-contained.
- **`script/tasks/verifyERC20ProxyAuthorization.sh`**: `NON_INTERACTIVE=true` auto-confirms owner
  funding with the default (stage 10).

### The skill (`.agents/commands/deploy-network.md` + `.cursor`/`.claude` symlinks)

New-network bootstrap only (direct-to-diamond, pre-ownership-transfer); stops after stage 11. The
body encodes every rough edge the Injective deploy surfaced so the next one is turnkey:

- **Ordered preflight**: submodules → node_modules → **typechain** (TS deploy helpers crash
  without it) → `forge clean && forge build` → **`GLOBAL_FILE_PATH` sanity** (a stale
  `./../config/global.json` silently broke stage 2) → **verifier-subdomain probe** (blockscout
  verify API is often a separate `*-api` host; wrong URL → 404s misread as gateway timeouts →
  retry-throttling) → **premium RPC** (public Injective RPC ≈1.4s/call → 30-60s forking per
  contract; Alchemy ≈2× faster) → **corePeriphery ↔ target-state reconciliation** (caught
  OutputValidator missing from the sheet and deprecated FeeCollector still expected) → **version
  currency** (ERC20Proxy must be ≥1.2.0 or the Executor isn't pre-authorized).
- **Execution mechanics**: run under `bash -c` (agent shell is zsh; scripts use `read -a`), which
  env overrides survive the script's `.env` re-source vs. which need a file edit, idempotent
  per-stage re-run with a cap, huge-output handling.
- **Verification**: deploy with verification off, then a **parallel, rate-limit-aware** sweep
  (Blockscout indexes lag inline verification; a post-deploy sweep is faster and more reliable).
  Master log is in MongoDB — `bun mongo-logs:sync` refreshes the local cache.

### Still to land on this branch before marking ready

- **#2** `verifyNetworkContractsParallel` helper (parallel, network-scoped, Blockscout
  rate-limit backoff) — referenced by the skill's Phase 2.
- **#3** short-circuit already-deployed contracts (skip the `forge script` fork via `getDeployed`
  + `cast code` + version check) — biggest win on re-runs.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

