### PR TITLE
feat(request-audit): auto-move linked ticket to In Audit + reliable Slack send signal (EXSC-647)

### DIFF
--- a/.agents/commands/request-audit.md
+++ b/.agents/commands/request-audit.md
@@ -9,8 +9,8 @@ usage: /request-audit <PR_NUMBER_OR_URL> [--urgent]
 > **Usage**: `/request-audit <PR_NUMBER_OR_URL> [--urgent]`
 
 Fetch a PR, extract scope + context, draft an audit request (parent post + thread reply),
-let the user pick the channel(s) and optionally edit, then post to Slack only after explicit
-confirmation.
+let the user pick the channel(s) and optionally edit, post to Slack only after explicit
+confirmation, then move the linked Linear ticket to **In Audit**.
 
 ---
 
@@ -192,6 +192,7 @@ Show the full preview using markdown code blocks so the user sees exactly what w
 **PR:** #{pr_number} — {pr_title_truncated_to_80_chars}
 **Commit:** `{latest_commit_oid}`
 **Urgent:** {Yes / No}
+**Linear:** {EXSC-1234 → In Audit on send, or "none linked"}
 
 ---
 
@@ -313,6 +314,30 @@ substituting `{webhook_var}` with the exact missing env var (`WEBHOOK_DEV_SC_AUD
    /tmp/audit-request-{pr_number}.md. Set the env var (URL in 1Password -> Developers
    Smart Contract -> Webhooks SC Channels) to post automatically next time.
 ```
+
+## Step 7 — Move the Linear ticket to "In Audit"
+
+Only if Step 1a found a linked `EXSC-\d+` ticket — otherwise skip silently. The **EXSC** team
+has a dedicated `In Audit` workflow state so the team can see at a glance which PRs are with the
+auditors; advance the ticket into it once the request is actually delivered.
+
+- **At least one channel posted successfully** (Step 6 exit `0`) — move it now:
+
+  ```
+  mcp__claude_ai_Linear__save_issue  id = EXSC-1234  state = "In Audit"
+  ```
+
+  Linear resolves the state by name. Report `✅ Moved EXSC-1234 to In Audit`.
+
+- **Ticket is already in `In Audit` or a later state** (`In Review`, `Done`, or any
+  completed/canceled state) — leave it; never move a ticket backward. Say so and skip.
+
+- **Every channel fell back to manual (no exit `0`) or the send errored** — don't move it
+  automatically; the request isn't delivered yet. Add a reminder to the output instead:
+  `↪️ Move EXSC-1234 to In Audit once you've posted the message manually.`
+
+If the `save_issue` call itself fails, report the error and tell the user to move the ticket
+by hand — the Slack post already succeeded, so never retry in a loop or treat it as fatal.
 
 ---
 

--- a/script/utils/send-slack-webhook-message.ts
+++ b/script/utils/send-slack-webhook-message.ts
@@ -56,7 +56,11 @@ async function main(): Promise<void> {
   }
 
   try {
-    await new SlackNotifier(webhookUrl).sendNotificationWithRetry({ text })
+    await new SlackNotifier(webhookUrl).sendNotificationWithRetry(
+      { text },
+      3,
+      true
+    )
     consola.success(`posted message to #${channel}`)
   } catch (err) {
     consola.error('Slack post failed:', err)

--- a/script/utils/slack-notifier.test.ts
+++ b/script/utils/slack-notifier.test.ts
@@ -126,3 +126,41 @@ describe('SlackNotifier payload safety', () => {
     expect(errorBlock).toBeDefined()
   })
 })
+
+describe('SlackNotifier retry failure signaling', () => {
+  /** Stub fetch so every attempt returns a non-2xx response. */
+  function mockFetchFailing(): void {
+    global.fetch = mock(
+      async () => new Response('boom', { status: 500 })
+    ) as unknown as typeof fetch
+  }
+
+  it('swallows a terminal failure by default so alerting paths never crash', async () => {
+    mockFetchFailing()
+    let threw = false
+    try {
+      await new SlackNotifier(WEBHOOK).sendNotificationWithRetry(
+        { text: 'hi' },
+        1
+      )
+    } catch {
+      threw = true
+    }
+    expect(threw).toBe(false)
+  })
+
+  it('rethrows the terminal failure when throwOnFailure is set', async () => {
+    mockFetchFailing()
+    let caught: unknown
+    try {
+      await new SlackNotifier(WEBHOOK).sendNotificationWithRetry(
+        { text: 'hi' },
+        1,
+        true
+      )
+    } catch (err) {
+      caught = err
+    }
+    expect(String(caught)).toContain('Slack API error: 500')
+  })
+})

--- a/script/utils/slack-notifier.ts
+++ b/script/utils/slack-notifier.ts
@@ -124,23 +124,31 @@ export class SlackNotifier {
   }
 
   /**
-   * Send notification with retry logic
+   * Send notification with retry logic.
+   *
+   * @param throwOnFailure - By default a terminal failure (all retries
+   *   exhausted) is logged and swallowed, so a transient Slack outage never
+   *   crashes a deploy/CI alerting path. Set true when the caller must act on
+   *   the outcome (e.g. a CLI wrapper that has to exit non-zero) — the final
+   *   error is then rethrown after logging.
    */
   public async sendNotificationWithRetry(
     message: ISlackMessage,
-    maxRetries = 3
+    maxRetries = 3,
+    throwOnFailure = false
   ): Promise<void> {
     for (let i = 0; i < maxRetries; i++)
       try {
         await this.sendNotification(message)
         return
       } catch (error) {
-        if (i === maxRetries - 1)
+        if (i === maxRetries - 1) {
           consola.warn(
             'Failed to send Slack notification after retries:',
             error
           )
-        else await sleep(1000 * (i + 1))
+          if (throwOnFailure) throw error
+        } else await sleep(1000 * (i + 1))
       }
   }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-647](https://linear.app/lifi-linear/issue/EXSC-647/sc-request-audit-skill-auto-move-linked-linear-ticket-to-in-audit-on)

# Why did I implement it this way?

**Primary change — `request-audit` skill Step 7.** The skill posted the Slack audit request but never advanced the linked Linear ticket, so a ticket stayed in its pre-audit state (`Todo` / `In Progress` / `Backlog`) while the PR was actually with the auditors — no team-wide signal of "which PRs are in audit". The **EXSC** team already has a dedicated `In Audit` workflow state; the skill just never used it. Step 7 (added to `.agents/commands/request-audit.md`, the canonical source — `.cursor/` and `.claude/` are symlinks and inherit it) transitions the linked `EXSC-\d+` ticket to `In Audit` **after a successful send**, with guards: never moves a ticket backward (`In Audit`/`In Review`/`Done`/canceled left untouched), skips silently when no ticket is linked, prints a reminder instead of moving on manual-fallback/error, and treats a `save_issue` failure as non-fatal. Intro summary and Step 4 preview updated to match.

**Supporting fix — reliable Slack delivery signal (found in review of the above).** Step 7 gates the ticket move on the webhook helper's exit `0`. But `SlackNotifier.sendNotificationWithRetry` *logged and swallowed* the final retry failure, so `send-slack-webhook-message.ts` always exited `0` — even when every send failed. That made exit `0` an unreliable "delivered" signal for both the new Step 7 **and** Step 6's existing "✅ Sent" report, and meant `multiNetworkExecution.sh`'s `|| logWithTimestamp "Warning: Failed…"` guard could never fire.

The fix adds an opt-in `throwOnFailure` flag to `sendNotificationWithRetry`:

- **Default `false`** — the 5 CI/alerting callers keep the intentional swallow (a transient Slack outage must not crash a deploy).
- **`true`** — set only in the CLI wrapper `send-slack-webhook-message.ts`, so a terminal failure now rethrows → the existing `catch` exits `1`. Exit `0` becomes a trustworthy success signal, and the `multiNetworkExecution.sh` warning guard works again.
- Unit tests added for both branches.

Docs + a narrowly-scoped scripts fix; no contract code, config, or shared-alerting behavior changed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
