### PR TITLE
docs(skills): remind to allow-list new deployer on Sophon in rotate-deployer-wallet

### DIFF
--- a/.agents/commands/rotate-deployer-wallet.md
+++ b/.agents/commands/rotate-deployer-wallet.md
@@ -75,6 +75,8 @@ Sweep native gas from the old deployer to the new one across all active EVM chai
 
 > **HyperEVM big blocks (manual, per-address).** The new deployer cannot broadcast contract deploys on `hyperevm` until big blocks are enabled for it — an L1 setting that does **not** carry over on rotation (register the address as a HyperCore Core user, then toggle big blocks ON). Follow the runbook: `docs/HyperEVMBigBlocks.md`.
 
+> **Sophon deployer allow-list (manual, per-address).** `sophon` gates contract deployment behind a per-EOA allow-list, so the new deployer is **rejected on every Sophon deploy** (`contract deployer address … is not in the allow list`) until the Sophon team adds it — funding the wallet is not enough, and the allow-listing does **not** carry over on rotation. It's an off-repo, async request, so start it **now** during bootstrap rather than discovering it at the next Sophon rollout: ask in the Sophon partner channel to allow-list the new deployer EOA. It doesn't block the other phases. (Other zkEVM chains like `abstract` and `zksync` have no such restriction.)
+
 ### Phase 2 — Swap the Safe owner + move CANCELLER_ROLE (`multisig-rollout`)
 
 The governed changes — replace `safeOwners[0]` (old → new) on every production Safe and move the Timelock `CANCELLER_ROLE` (old removed, new granted) — run as timelock-wrapped Safe proposals via the production rollout skill:


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-648](https://linear.app/lifi-linear/issue/EXSC-648/rotate-deployer-wallet-remind-to-allow-list-new-deployer-on-sophon)

# Why did I implement it this way?

During the LayerSwapFacet zkSync-family rollout the Sophon deploy failed with `contract deployer address … is not in the allow list`. Sophon gates contract deployment behind a per-EOA allow-list; the recently rotated deployer wasn't on it (the old deployer was — that's why Sophon already hosts our diamond). Funding the new wallet isn't enough, and the allow-listing doesn't carry over on rotation, so without a reminder this silently breaks every Sophon deploy until someone rediscovers it. This adds a "Sophon deployer allow-list" callout to the deployer-rotation skill's Phase 1 (bootstrap), placed right next to the existing HyperEVM big-blocks callout, since both are the same per-address enablement that a rotation must re-do. Edited the source-of-truth file under `.agents/commands/`; the `.claude/skills/` and `.cursor/commands/` entries are symlinks and pick it up automatically. Requested by Daniel in #dev-sc-multisig-proposals.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>