### PR TITLE
feat(EXSC-408): reference IAccessGate implementation (S11)

### DIFF
--- a/src/VaultWrapper/access/ReferenceAccessGate.sol
+++ b/src/VaultWrapper/access/ReferenceAccessGate.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
+import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
+
+/// @title ReferenceAccessGate
+/// @author LI.FI (https://li.fi)
+/// @notice Reference `IAccessGate` implementation showing how to gate a LI.FI Earn vault
+///         wrapper. Combines an owner-managed allowlist, denylist, and sanction flags:
+///         - `isAllowed` (entry) folds in every check — an account is allowed only when it
+///           is neither denylisted nor sanctioned and, when the allowlist is enforced, is
+///           allowlisted.
+///         - `isTransferable` (share movement) keeps the perimeter sealed by requiring both
+///           endpoints to satisfy `isAllowed`; it does not soulbind shares.
+///         - `isSanctioned` (exit freeze) exposes the sanction flags directly.
+/// @dev This is a template, not a LI.FI-operated contract: each integrator deploys or forks
+///      its own instance. It custodies no funds. Sanction flags are owner-managed here to
+///      keep the example self-contained; an integrator wanting a live feed can instead back
+///      `isSanctioned` with a call to an external Chainalysis `SanctionsList`, whose
+///      `isSanctioned(address)` signature is identical.
+/// @custom:version 1.0.0
+contract ReferenceAccessGate is TransferrableOwnership, IAccessGate {
+    /// Storage ///
+
+    /// @notice Whether allowlisting is enforced; when false, every non-blocked account may enter.
+    bool public allowlistEnabled;
+    /// @notice Accounts explicitly permitted (only consulted when `allowlistEnabled`).
+    mapping(address => bool) public allowlisted;
+    /// @notice Accounts explicitly blocked, independent of the allowlist.
+    mapping(address => bool) public denylisted;
+    /// @notice Accounts flagged as sanctioned (hard exit freeze).
+    mapping(address => bool) public sanctioned;
+
+    /// Events ///
+
+    /// @notice Emitted when an account's allowlist membership changes.
+    event AllowlistedSet(address indexed account, bool allowed);
+    /// @notice Emitted when an account's denylist membership changes.
+    event DenylistedSet(address indexed account, bool denied);
+    /// @notice Emitted when an account's sanction flag changes.
+    event SanctionedSet(address indexed account, bool flagged);
+    /// @notice Emitted when allowlist enforcement is toggled.
+    event AllowlistEnabledSet(bool enabled);
+
+    /// @notice Initializes the gate with an owner and starting allowlist mode.
+    /// @param _owner The address that manages the lists and configuration.
+    /// @param _allowlistEnabled Whether allowlist enforcement starts on.
+    constructor(
+        address _owner,
+        bool _allowlistEnabled
+    ) TransferrableOwnership(_owner) {
+        allowlistEnabled = _allowlistEnabled;
+    }
+
+    /// Views ///
+
+    /// @inheritdoc IAccessGate
+    function isSanctioned(address _account) public view returns (bool) {
+        return sanctioned[_account];
+    }
+
+    /// @inheritdoc IAccessGate
+    function isAllowed(address _account) public view returns (bool) {
+        if (denylisted[_account] || sanctioned[_account]) return false;
+        return !allowlistEnabled || allowlisted[_account];
+    }
+
+    /// @inheritdoc IAccessGate
+    function isTransferable(
+        address _from,
+        address _to
+    ) external view returns (bool) {
+        return isAllowed(_from) && isAllowed(_to);
+    }
+
+    /// Configuration (owner) ///
+
+    /// @notice Toggle one account's allowlist membership.
+    function setAllowlisted(
+        address _account,
+        bool _allowed
+    ) external onlyOwner {
+        allowlisted[_account] = _allowed;
+        emit AllowlistedSet(_account, _allowed);
+    }
+
+    /// @notice Toggle several accounts' allowlist membership at once.
+    function setAllowlistedBatch(
+        address[] calldata _accounts,
+        bool _allowed
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            allowlisted[_accounts[i]] = _allowed;
+            emit AllowlistedSet(_accounts[i], _allowed);
+        }
+    }
+
+    /// @notice Toggle one account's denylist membership.
+    function setDenylisted(address _account, bool _denied) external onlyOwner {
+        denylisted[_account] = _denied;
+        emit DenylistedSet(_account, _denied);
+    }
+
+    /// @notice Toggle several accounts' denylist membership at once.
+    function setDenylistedBatch(
+        address[] calldata _accounts,
+        bool _denied
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            denylisted[_accounts[i]] = _denied;
+            emit DenylistedSet(_accounts[i], _denied);
+        }
+    }
+
+    /// @notice Toggle one account's sanction flag.
+    function setSanctioned(
+        address _account,
+        bool _flagged
+    ) external onlyOwner {
+        sanctioned[_account] = _flagged;
+        emit SanctionedSet(_account, _flagged);
+    }
+
+    /// @notice Toggle several accounts' sanction flags at once.
+    function setSanctionedBatch(
+        address[] calldata _accounts,
+        bool _flagged
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            sanctioned[_accounts[i]] = _flagged;
+            emit SanctionedSet(_accounts[i], _flagged);
+        }
+    }
+
+    /// @notice Enable or disable allowlist enforcement.
+    function setAllowlistEnabled(bool _enabled) external onlyOwner {
+        allowlistEnabled = _enabled;
+        emit AllowlistEnabledSet(_enabled);
+    }
+}

--- a/src/VaultWrapper/access/ReferenceAccessGate.sol
+++ b/src/VaultWrapper/access/ReferenceAccessGate.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
+import { InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 
 /// @title ReferenceAccessGate
 /// @author LI.FI (https://li.fi)
@@ -15,10 +16,12 @@ import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
 ///           endpoints to satisfy `isAllowed`; it does not soulbind shares.
 ///         - `isSanctioned` (exit freeze) exposes the sanction flags directly.
 /// @dev This is a template, not a LI.FI-operated contract: each integrator deploys or forks
-///      its own instance. It custodies no funds. Sanction flags are owner-managed here to
-///      keep the example self-contained; an integrator wanting a live feed can instead back
-///      `isSanctioned` with a call to an external Chainalysis `SanctionsList`, whose
-///      `isSanctioned(address)` signature is identical.
+///      its own instance. It custodies no funds. LI.FI does not guarantee the safety or
+///      correctness of this reference implementation; integrators are strongly advised to have
+///      their deployment audited by a reputable security firm before any mainnet use. Sanction
+///      flags are owner-managed here to keep the example self-contained; an integrator wanting a
+///      live feed can instead back `isSanctioned` with a call to an external Chainalysis
+///      `SanctionsList`, whose `isSanctioned(address)` signature is identical.
 /// @custom:version 1.0.0
 contract ReferenceAccessGate is TransferrableOwnership, IAccessGate {
     /// Storage ///
@@ -50,6 +53,8 @@ contract ReferenceAccessGate is TransferrableOwnership, IAccessGate {
         address _owner,
         bool _allowlistEnabled
     ) TransferrableOwnership(_owner) {
+        if (_owner == address(0)) revert InvalidConfig();
+
         allowlistEnabled = _allowlistEnabled;
     }
 

--- a/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
+++ b/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/Test.sol";
+import { ReferenceAccessGate } from "lifi/VaultWrapper/access/ReferenceAccessGate.sol";
+import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
+
+contract ReferenceAccessGateTest is Test {
+    ReferenceAccessGate internal gate;
+
+    address internal owner = makeAddr("owner");
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+
+    event AllowlistedSet(address indexed account, bool allowed);
+    event DenylistedSet(address indexed account, bool denied);
+    event SanctionedSet(address indexed account, bool flagged);
+    event AllowlistEnabledSet(bool enabled);
+
+    function setUp() public {
+        gate = new ReferenceAccessGate(owner, false);
+    }
+
+    /// Permissionless default ///
+
+    function test_PermissionlessWhenAllowlistDisabled() public view {
+        assertTrue(gate.isAllowed(alice));
+        assertTrue(gate.isTransferable(alice, bob));
+        assertFalse(gate.isSanctioned(alice));
+    }
+
+    /// Allowlist ///
+
+    function test_AllowlistBlocksUnlistedWhenEnabled() public {
+        vm.prank(owner);
+        gate.setAllowlistEnabled(true);
+
+        assertFalse(gate.isAllowed(alice));
+
+        vm.prank(owner);
+        gate.setAllowlisted(alice, true);
+        assertTrue(gate.isAllowed(alice));
+    }
+
+    function test_AllowlistBatchSetsMany() public {
+        vm.startPrank(owner);
+        gate.setAllowlistEnabled(true);
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+        gate.setAllowlistedBatch(accounts, true);
+        vm.stopPrank();
+
+        assertTrue(gate.isAllowed(alice));
+        assertTrue(gate.isAllowed(bob));
+    }
+
+    /// Denylist ///
+
+    function test_DenylistBlocksEvenWhenPermissionless() public {
+        vm.prank(owner);
+        gate.setDenylisted(alice, true);
+
+        assertFalse(gate.isAllowed(alice));
+        assertFalse(gate.isTransferable(alice, bob));
+    }
+
+    function test_DenylistOverridesAllowlist() public {
+        vm.startPrank(owner);
+        gate.setAllowlistEnabled(true);
+        gate.setAllowlisted(alice, true);
+        gate.setDenylisted(alice, true);
+        vm.stopPrank();
+
+        assertFalse(gate.isAllowed(alice));
+    }
+
+    /// Sanctions (exit freeze) ///
+
+    function test_SanctionFlagFreezesEntryAndTransferButIsReported() public {
+        vm.prank(owner);
+        gate.setSanctioned(alice, true);
+
+        assertTrue(gate.isSanctioned(alice));
+        assertFalse(gate.isAllowed(alice));
+        assertFalse(gate.isTransferable(alice, bob));
+    }
+
+    function test_SanctionBatchSetsMany() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+
+        vm.prank(owner);
+        gate.setSanctionedBatch(accounts, true);
+
+        assertTrue(gate.isSanctioned(alice));
+        assertTrue(gate.isSanctioned(bob));
+    }
+
+    /// Transferability perimeter ///
+
+    function test_TransferRequiresBothEndpointsAllowed() public {
+        vm.startPrank(owner);
+        gate.setAllowlistEnabled(true);
+        gate.setAllowlisted(alice, true);
+        vm.stopPrank();
+
+        assertFalse(gate.isTransferable(alice, bob));
+
+        vm.prank(owner);
+        gate.setAllowlisted(bob, true);
+        assertTrue(gate.isTransferable(alice, bob));
+    }
+
+    /// Ownership ///
+
+    function test_RevertWhen_NonOwnerConfigures() public {
+        vm.prank(alice);
+        vm.expectRevert(TransferrableOwnership.UnAuthorized.selector);
+        gate.setAllowlisted(bob, true);
+    }
+
+    /// Events ///
+
+    function test_EmitsOnConfiguration() public {
+        vm.startPrank(owner);
+
+        vm.expectEmit(true, false, false, true, address(gate));
+        emit AllowlistEnabledSet(true);
+        gate.setAllowlistEnabled(true);
+
+        vm.expectEmit(true, false, false, true, address(gate));
+        emit AllowlistedSet(alice, true);
+        gate.setAllowlisted(alice, true);
+
+        vm.expectEmit(true, false, false, true, address(gate));
+        emit DenylistedSet(bob, true);
+        gate.setDenylisted(bob, true);
+
+        vm.expectEmit(true, false, false, true, address(gate));
+        emit SanctionedSet(bob, true);
+        gate.setSanctioned(bob, true);
+
+        vm.stopPrank();
+    }
+}

--- a/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
+++ b/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17;
 import { Test } from "forge-std/Test.sol";
 import { ReferenceAccessGate } from "lifi/VaultWrapper/access/ReferenceAccessGate.sol";
 import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
+import { InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 
 contract ReferenceAccessGateTest is Test {
     ReferenceAccessGate internal gate;
@@ -19,6 +20,13 @@ contract ReferenceAccessGateTest is Test {
 
     function setUp() public {
         gate = new ReferenceAccessGate(owner, false);
+    }
+
+    /// Construction ///
+
+    function testRevert_ConstructedWithZeroOwner() public {
+        vm.expectRevert(InvalidConfig.selector);
+        new ReferenceAccessGate(address(0), false);
     }
 
     /// Permissionless default ///
@@ -55,6 +63,17 @@ contract ReferenceAccessGateTest is Test {
         assertTrue(gate.isAllowed(bob));
     }
 
+    function test_DisablingAllowlistRestoresPermissionless() public {
+        vm.startPrank(owner);
+        gate.setAllowlistEnabled(true);
+        assertFalse(gate.isAllowed(alice));
+
+        gate.setAllowlistEnabled(false);
+        vm.stopPrank();
+
+        assertTrue(gate.isAllowed(alice));
+    }
+
     /// Denylist ///
 
     function test_DenylistBlocksEvenWhenPermissionless() public {
@@ -73,6 +92,18 @@ contract ReferenceAccessGateTest is Test {
         vm.stopPrank();
 
         assertFalse(gate.isAllowed(alice));
+    }
+
+    function test_DenylistBatchSetsMany() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = bob;
+
+        vm.prank(owner);
+        gate.setDenylistedBatch(accounts, true);
+
+        assertFalse(gate.isAllowed(alice));
+        assertFalse(gate.isAllowed(bob));
     }
 
     /// Sanctions (exit freeze) ///


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-408 — S11: Reference IAccessGate implementation](https://linear.app/lifi-linear/issue/EXSC-408/s11-reference-iaccessgate-implementation)

**Based on `dev-vault-wrapper`**, not `main` — the VaultWrapper stack lives on the integration branch. Retarget as the stack merges.

# Why did I implement it this way?

S11 was originally scoped as two interfaces (`IVaultAccessControl` + `ISanctionsOracle`) plus a reference adapter (#1981, now closed). S4 (EXSC-412, #2032, merged) superseded the interface half by collapsing the access surface into the single `IAccessGate` hook, so all that remains of S11 is the integrator-facing reference gate — rewritten here against `IAccessGate`. It is a template each integrator forks/deploys, not a LI.FI-operated contract, and it custodies no funds. `isAllowed` (entry) folds in every check per the interface contract — blocked when denylisted or sanctioned, otherwise gated by the optional allowlist; `isTransferable` keeps the perimeter sealed by requiring both endpoints to pass `isAllowed` (deliberately not soulbound); `isSanctioned` exposes the flags directly for the wrapper's exit-freeze. Ownership is `TransferrableOwnership` to match the factory and the original adapter. Sanction flags are owner-managed to keep the example self-contained; the NatSpec notes an integrator can instead back `isSanctioned` with a live Chainalysis `SanctionsList` (identical signature) rather than resurrecting a dead wrapper-facing interface.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>