### PR TITLE
fix(EXSC-657): derive --legacy from on-chain EIP-1559 support

### DIFF
--- a/config/networks.json
+++ b/config/networks.json
@@ -1375,7 +1375,6 @@
     "deployedWithSolcVersion": "0.8.29",
     "create3Factory": "0xDe367507f70A1f57a7203bD7A88ced24A79fb53d",
     "customDeployFlags": "--gas-limit 40000000",
-    "noLegacy": true,
     "devNotes": "In order to deploy contract its required to have GAS_MULTIPLIER set to 550 in .env file. If it's more than 550, the deployment for LiFiDEXAggregator will fail with gas limit exceeded error if less than 500 then the deployment for LiFiDEXAggregator will fail with out of gas error. Moreover we use dummy wrapped native address for AcrossFacetV4 because we don't activate the native path. Gas is paid in TIP-20 stablecoins (no native asset; eth_getBalance returns a sentinel): the default fee token is pathUSD (feeTokenAddress), and an account can override it via the FeeManager predeploy (feeManagerAddress) userTokens(account). eth_gasPrice is quoted in attodollars (1e18) per gas.",
     "skipHealthcheck": true
   },

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -276,15 +276,14 @@ deploySingleContract() {
     # Add network-specific deploy flags from networks.json (customDeployFlags)
     ADDITIONAL_FLAGS=""
     local NETWORKS_JSON="${NETWORKS_JSON_FILE_PATH:-./config/networks.json}"
-    local LEGACY_FLAG="--legacy"
     if [[ -f "$NETWORKS_JSON" ]]; then
       ADDITIONAL_FLAGS=$(jq -r --arg NETWORK "$NETWORK" '.[$NETWORK].customDeployFlags // ""' "$NETWORKS_JSON" 2>/dev/null || true)
-      # noLegacy:true means the chain requires EIP-1559 txs (e.g. AA chains) — omit --legacy
-      local NO_LEGACY
-      NO_LEGACY=$(jq -r --arg NETWORK "$NETWORK" '.[$NETWORK].noLegacy // false' "$NETWORKS_JSON" 2>/dev/null || echo "false")
-      if [[ "$NO_LEGACY" == "true" ]]; then
-        LEGACY_FLAG=""
-      fi
+    fi
+    # EIP-1559-capable chains must not get --legacy (a pinned legacy gasPrice loses
+    # the base-fee race on low-fee L2s); pre-1559 chains still require it.
+    local LEGACY_FLAG="--legacy"
+    if networkSupportsEip1559 "$NETWORK"; then
+      LEGACY_FLAG=""
     fi
     # If customDeployFlags contain --skip-simulation, force skip simulation (override env-based flag)
     if [[ -n "$ADDITIONAL_FLAGS" && "$ADDITIONAL_FLAGS" == *"--skip-simulation"* ]]; then

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3711,8 +3711,7 @@ function networkSupportsEip1559() {
   fi
 
   local BLOCK_JSON
-  BLOCK_JSON=$(cast block latest --json --rpc-url "$RPC_URL" 2>/dev/null)
-  if [[ $? -ne 0 || -z "$BLOCK_JSON" ]]; then
+  if ! BLOCK_JSON=$(cast block latest --json --rpc-url "$RPC_URL" 2>/dev/null) || [[ -z "$BLOCK_JSON" ]]; then
     warning "could not query latest block for '$NETWORK' to detect EIP-1559 support; assuming legacy transactions"
     return 1
   fi

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3688,6 +3688,39 @@ function getCurrentGasPrice() {
 
   echo "$GAS_PRICE"
 }
+# networkSupportsEip1559: Returns 0 (true) if NETWORK's latest block exposes a
+# baseFeePerGas field — the on-chain marker of EIP-1559 support — meaning forge
+# should send type-2 transactions and MUST NOT be passed --legacy. Returns 1 for
+# pre-EIP-1559 chains that require --legacy, and also on RPC failure, where the
+# type can't be determined and legacy is the safe fallback (a type-2 tx on a
+# pre-1559 chain is rejected outright, whereas legacy is the historical default).
+#
+# A --legacy tx pins one gasPrice quoted at build time; on low-base-fee L2s
+# (e.g. Arbitrum, ~0.02 gwei) the next block's base fee can rise above it and the
+# node rejects the tx ("max fee per gas less than block base fee"). A type-2 tx
+# sets maxFeePerGas with headroom and pays the actual base fee, surviving the race.
+#
+# Usage: if networkSupportsEip1559 "$NETWORK"; then LEGACY_FLAG=""; fi
+function networkSupportsEip1559() {
+  local NETWORK="$1"
+
+  local RPC_URL
+  if ! RPC_URL=$(getRPCUrl "$NETWORK"); then
+    warning "could not resolve RPC URL for '$NETWORK'; assuming legacy (pre-EIP-1559) transactions"
+    return 1
+  fi
+
+  local BLOCK_JSON
+  BLOCK_JSON=$(cast block latest --json --rpc-url "$RPC_URL" 2>/dev/null)
+  if [[ $? -ne 0 || -z "$BLOCK_JSON" ]]; then
+    warning "could not query latest block for '$NETWORK' to detect EIP-1559 support; assuming legacy transactions"
+    return 1
+  fi
+
+  local BASE_FEE
+  BASE_FEE=$(echo "$BLOCK_JSON" | jq -r '.baseFeePerGas // empty')
+  [[ -n "$BASE_FEE" && "$BASE_FEE" != "null" ]]
+}
 function getContractOwner() {
   # read function arguments into variables
   local network=$1

--- a/script/tasks/diamondUpdateFacet.sh
+++ b/script/tasks/diamondUpdateFacet.sh
@@ -139,6 +139,12 @@ diamondUpdateFacet() {
       DEPLOYER_ADDRESS=$(cast wallet address "$PRIVATE_KEY")
       echoDebug "Calculating facet cuts for $CONTRACT_NAME in path $SCRIPT_PATH..."
 
+      # EIP-1559-capable chains must not get --legacy; pre-1559 chains require it.
+      local LEGACY_FLAG="--legacy"
+      if networkSupportsEip1559 "$NETWORK"; then
+        LEGACY_FLAG=""
+      fi
+
       # Execute, parse, and check return code
       local COMMAND
       if isZkEvmNetwork "$NETWORK"; then
@@ -146,7 +152,7 @@ diamondUpdateFacet() {
         COMMAND="FOUNDRY_PROFILE=zksync NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
       else
         # PROD (normal mode): suggest diamondCut transaction to SAFE
-        COMMAND="NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json $SKIP_SIMULATION_FLAG --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
+        COMMAND="NO_BROADCAST=true NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$PRIVATE_KEY forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json $SKIP_SIMULATION_FLAG $LEGACY_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\""
       fi
       
       if ! executeAndParse \
@@ -248,12 +254,18 @@ diamondUpdateFacet() {
       # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
       DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
 
+      # EIP-1559-capable chains must not get --legacy; pre-1559 chains require it.
+      local LEGACY_FLAG="--legacy"
+      if networkSupportsEip1559 "$NETWORK"; then
+        LEGACY_FLAG=""
+      fi
+
       # Execute, parse, and check return code
       local COMMAND
       if isZkEvmNetwork "$NETWORK"; then
         COMMAND="FOUNDRY_PROFILE=zksync NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND ./foundry-zksync/forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --skip-simulation --slow --zksync --gas-limit 50000000 --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" --private-key $(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")"
       else
-        COMMAND="NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND NO_BROADCAST=false PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" $SKIP_SIMULATION_FLAG"
+        COMMAND="NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND NO_BROADCAST=false PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast $LEGACY_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\" $SKIP_SIMULATION_FLAG"
       fi
       
       if ! executeAndParse \

--- a/script/tasks/updateFacetConfig.sh
+++ b/script/tasks/updateFacetConfig.sh
@@ -81,9 +81,15 @@ updateFacetConfig() {
       # forge >=1.6 validates the simulation sender's balance; override to the funded deployer.
       DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
 
+      # EIP-1559-capable chains must not get --legacy; pre-1559 chains require it.
+      LEGACY_FLAG="--legacy"
+      if networkSupportsEip1559 "$NETWORK"; then
+        LEGACY_FLAG=""
+      fi
+
       # Execute, parse, and check return code
       if ! executeAndParse \
-        "NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --legacy $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
+        "NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX USE_DEF_DIAMOND=$USE_MUTABLE_DIAMOND PRIVATE_KEY=$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\") forge script \"$SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast $LEGACY_FLAG $SKIP_SIMULATION_FLAG --gas-estimate-multiplier \"$GAS_ESTIMATE_MULTIPLIER\"" \
         "true" \
         "forge script failed for $SCRIPT on network $NETWORK" \
         "continue"; then

--- a/script/tasks/updateFacetConfig.sh
+++ b/script/tasks/updateFacetConfig.sh
@@ -82,7 +82,7 @@ updateFacetConfig() {
       DEPLOYER_ADDRESS=$(getDeployerAddress "$NETWORK" "$ENVIRONMENT")
 
       # EIP-1559-capable chains must not get --legacy; pre-1559 chains require it.
-      LEGACY_FLAG="--legacy"
+      local LEGACY_FLAG="--legacy"
       if networkSupportsEip1559 "$NETWORK"; then
         LEGACY_FLAG=""
       fi


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-657](https://linear.app/lifi-linear/issue/EXSC-657/deploy-scripts-derive-legacy-from-on-chain-eip-1559-support)

# Why did I implement it this way?

The deploy/update pipeline decided whether to pass forge `--legacy` from a static source — hardcoded on the broadcast in `diamondUpdateFacet.sh` and `updateFacetConfig.sh`, and a hand-maintained `noLegacy` flag in `networks.json` for `deploySingleContract.sh`. A legacy (type-0) transaction pins a single `gasPrice` quoted at build time; on low-base-fee L2s such as Arbitrum (~0.02 gwei) the next block's base fee can rise above that pinned price and the node rejects the transaction with `max fee per gas less than block base fee`. This has been a recurring cause of diamond-cut failures on Arbitrum. The reliable signal for whether `--legacy` is needed is on-chain, not a config guess: a chain supports EIP-1559 exactly when its blocks carry a `baseFeePerGas` field, so I derive the decision at runtime from that instead of maintaining a per-chain list that will always drift. The new `networkSupportsEip1559()` helper probes `cast block latest`; when `baseFeePerGas` is present the scripts omit `--legacy` (forge sends a type-2 transaction with `maxFeePerGas` headroom that survives base-fee movement), and when it is absent — or the RPC can't be reached — it keeps `--legacy`, which is the safe historical default since a type-2 transaction on a genuinely pre-1559 chain is rejected outright. The helper is wired into all three pipeline broadcast paths, and the now-redundant `noLegacy` flag is removed from `networks.json` (only tempo carried it, and the probe derives the same answer for it), leaving a single source of truth. Chains with explicit gas-price flags in `customDeployFlags` (megaeth, robinhood) are unaffected because those flags already pin a price above base fee regardless of transaction type. Other one-off and emergency broadcast sites still on hardcoded `--legacy` (`emergencyPauseBreakGlass.sh`, `acceptOwnershipTransferPeriphery.sh`, `deployAndStoreCREATE3Factory.sh`, `universalCast.sh`) are left for a follow-up; this PR is scoped to the deploy/update pipeline that produced the failure.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>