### PR TITLE
fix: whitelist Composer VM proxy on Pharos diamond allowlist

### DIFF
--- a/config/composerWhitelist.json
+++ b/config/composerWhitelist.json
@@ -463,6 +463,17 @@
       ]
     }
   ],
+  "pharos": [
+    {
+      "address": "0x48eCDAA6aDA921f61357c1104829E9b1f4D1F75E",
+      "functionSelectors": [
+        {
+          "selector": "0x00a32e6c",
+          "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+        }
+      ]
+    }
+  ],
   "plume": [
     {
       "address": "0x125d9e76cDAF61B352548e39567382a2AAa1d378",

--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -9422,6 +9422,16 @@
             "signature": "validateNativeOutput(uint256,address)"
           }
         ]
+      },
+      {
+        "name": "Composer",
+        "address": "0x48eCDAA6aDA921f61357c1104829E9b1f4D1F75E",
+        "selectors": [
+          {
+            "selector": "0x00a32e6c",
+            "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+          }
+        ]
       }
     ],
     "plasma": [


### PR DESCRIPTION
# Which Linear task belongs to this PR?

<!-- No Linear task -->

# Why did I implement it this way?

Every zap routed through the LiFiDiamond on Pharos reverts with `ContractCallNotAllowed()` because the Composer (Yggdrasil) VM proxy was never added to the Diamond's `LibAllowList` when Pharos was deployed. This blocks all production zaps on Pharos, including the R25 Alipay/APC3M vault deposit whose pre-deposit window closes 2026-07-19. The fix adds the missing entry to `config/composerWhitelist.json` (the source config), and regenerates `config/whitelist.json` via `script/tasks/updateWhitelistPeriphery.ts` — matching how every other chain's Composer proxy is whitelisted (same `runVM` selector `0x00a32e6c`). Only the replay-verified Diamond-owned proxy `0x48eCDAA6aDA921f61357c1104829E9b1f4D1F75E` is added here; a manual `eth_call` replay of the failed tx with this contract + selector overridden to allowed executes the deposit end-to-end. Plasma has the same gap but is deferred as a follow-up per the triage thread.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>