### PR TITLE
feat(deploy): warn when a deployed facet still refunds to msg.sender (EXSC-624)

### DIFF
--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -100,6 +100,7 @@ deploySingleContract() {
   # instead of a caller-supplied refundRecipient (EXSC-622, [CONV:FACET-REFUNDS]). Detection
   # reads the live facet source, so the reminder disappears automatically once a facet migrates.
   # Best-effort only - any failure here must never interrupt the deployment.
+  local REFUND_REMINDER
   REFUND_REMINDER=$(bunx tsx script/deploy/resources/facetRefundReminder.ts "$CONTRACT" 2>/dev/null || true)
   if [[ -n "$REFUND_REMINDER" ]]; then
     warning "$REFUND_REMINDER"

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -96,6 +96,15 @@ deploySingleContract() {
     echo -e "\n\n"
   fi
 
+  # Non-fatal reminder: warn if this facet still refunds source-side value to msg.sender
+  # instead of a caller-supplied refundRecipient (EXSC-622, [CONV:FACET-REFUNDS]). Detection
+  # reads the live facet source, so the reminder disappears automatically once a facet migrates.
+  # Best-effort only - any failure here must never interrupt the deployment.
+  REFUND_REMINDER=$(bunx tsx script/deploy/resources/facetRefundReminder.ts "$CONTRACT" 2>/dev/null || true)
+  if [[ -n "$REFUND_REMINDER" ]]; then
+    warning "$REFUND_REMINDER"
+  fi
+
   # check if deploy script exists
   if ! checkIfFileExists "$FULL_SCRIPT_PATH" >/dev/null; then
     error "could not find deploy script for $CONTRACT in this path: $FULL_SCRIPT_PATH". Aborting deployment.

--- a/script/deploy/resources/facetRefundReminder.test.ts
+++ b/script/deploy/resources/facetRefundReminder.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the facet source-side refund reminder (EXSC-624).
+ *
+ * Focus: detectMsgSenderRefundSites / buildMsgSenderRefundReminder, the pure detection
+ * used by deploySingleContract.sh to nudge migration off source-side refunds to msg.sender
+ * ([CONV:FACET-REFUNDS], EXSC-622). Covers both refund sites, the multi-line _depositAndSwap
+ * call shape used across the facets, the already-migrated refundRecipient form (must NOT flag),
+ * and comment-only mentions of msg.sender (must NOT flag).
+ */
+import {
+  describe,
+  it,
+  expect,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  detectMsgSenderRefundSites,
+  buildMsgSenderRefundReminder,
+} from './facetRefundReminder'
+
+describe('detectMsgSenderRefundSites', () => {
+  it('flags refundExcessNative(payable(msg.sender)) used as a modifier', () => {
+    const source = `
+      function startBridge(BridgeData calldata _bridgeData)
+        external
+        payable
+        refundExcessNative(payable(msg.sender))
+      {}
+    `
+    const sites = detectMsgSenderRefundSites(source)
+    expect(sites.refundExcessNative).toBe(true)
+    expect(sites.depositAndSwapLeftover).toBe(false)
+  })
+
+  it('flags a multi-line _depositAndSwap call whose leftover receiver is payable(msg.sender)', () => {
+    const source = `
+      _bridgeData.minAmount = _depositAndSwap(
+        _bridgeData.transactionId,
+        _bridgeData.minAmount,
+        _swapData,
+        payable(msg.sender)
+      );
+    `
+    const sites = detectMsgSenderRefundSites(source)
+    expect(sites.depositAndSwapLeftover).toBe(true)
+    expect(sites.refundExcessNative).toBe(false)
+  })
+
+  it('flags the _depositAndSwap overload with a trailing native-reserve arg', () => {
+    const source = `
+      _bridgeData.minAmount = _depositAndSwap(
+        _bridgeData.transactionId,
+        _bridgeData.minAmount,
+        _swapData,
+        payable(msg.sender),
+        _nativeReserve
+      );
+    `
+    expect(detectMsgSenderRefundSites(source).depositAndSwapLeftover).toBe(true)
+  })
+
+  it('does NOT flag a migrated facet that routes both refunds to refundRecipient', () => {
+    const source = `
+      function startBridge(BridgeData calldata _bridgeData, XData calldata _xData)
+        external
+        payable
+        refundExcessNative(payable(_xData.refundRecipient))
+      {
+        _bridgeData.minAmount = _depositAndSwap(
+          _bridgeData.transactionId,
+          _bridgeData.minAmount,
+          _swapData,
+          payable(_xData.refundRecipient),
+          _xData.nativeFee
+        );
+      }
+    `
+    const sites = detectMsgSenderRefundSites(source)
+    expect(sites.refundExcessNative).toBe(false)
+    expect(sites.depositAndSwapLeftover).toBe(false)
+  })
+
+  it('does NOT flag a comment that merely mentions msg.sender', () => {
+    const source = `
+      // msg.sender may be a relayer or the Permit2Proxy, so refundExcessNative(payable(msg.sender))
+      // is unsafe; route to refundRecipient instead. See _depositAndSwap( ... payable(msg.sender)).
+      refundExcessNative(payable(_xData.refundRecipient))
+    `
+    const sites = detectMsgSenderRefundSites(source)
+    expect(sites.refundExcessNative).toBe(false)
+    expect(sites.depositAndSwapLeftover).toBe(false)
+  })
+
+  it('does NOT let a payable(msg.sender) in a later statement leak into a preceding _depositAndSwap', () => {
+    const source = `
+      _bridgeData.minAmount = _depositAndSwap(
+        _bridgeData.transactionId,
+        _bridgeData.minAmount,
+        _swapData,
+        payable(_xData.refundRecipient)
+      );
+      someOtherCall(payable(msg.sender));
+    `
+    expect(detectMsgSenderRefundSites(source).depositAndSwapLeftover).toBe(
+      false
+    )
+  })
+
+  it('tolerates extra whitespace inside the refund patterns', () => {
+    const source = `refundExcessNative( payable(  msg.sender ) )`
+    expect(detectMsgSenderRefundSites(source).refundExcessNative).toBe(true)
+  })
+})
+
+describe('buildMsgSenderRefundReminder', () => {
+  it('returns null when the source has no source-side refund to msg.sender', () => {
+    expect(
+      buildMsgSenderRefundReminder('MigratedFacet', 'contract MigratedFacet {}')
+    ).toBeNull()
+  })
+
+  it('names the facet, both detected sites, the ticket and the convention anchor', () => {
+    const source = `
+      refundExcessNative(payable(msg.sender))
+      _depositAndSwap(id, min, swaps, payable(msg.sender));
+    `
+    const message = buildMsgSenderRefundReminder('AcrossFacet', source)
+    expect(message).not.toBeNull()
+    expect(message).toContain('AcrossFacet')
+    expect(message).toContain('refundExcessNative(payable(msg.sender))')
+    expect(message).toContain('_depositAndSwap leftovers')
+    expect(message).toContain('EXSC-622')
+    expect(message).toContain('[CONV:FACET-REFUNDS]')
+    expect(message).toContain('refundRecipient')
+  })
+
+  it('lists only the site that actually matched', () => {
+    const message = buildMsgSenderRefundReminder(
+      'DepositOnlyFacet',
+      '_depositAndSwap(id, min, swaps, payable(msg.sender));'
+    )
+    expect(message).toContain('_depositAndSwap leftovers')
+    expect(message).not.toContain('refundExcessNative(payable(msg.sender))')
+  })
+})

--- a/script/deploy/resources/facetRefundReminder.test.ts
+++ b/script/deploy/resources/facetRefundReminder.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   detectMsgSenderRefundSites,
   buildMsgSenderRefundReminder,
+  isValidContractName,
 } from './facetRefundReminder'
 
 describe('detectMsgSenderRefundSites', () => {
@@ -142,5 +143,21 @@ describe('buildMsgSenderRefundReminder', () => {
     )
     expect(message).toContain('_depositAndSwap leftovers')
     expect(message).not.toContain('refundExcessNative(payable(msg.sender))')
+  })
+})
+
+describe('isValidContractName', () => {
+  it('accepts plain Solidity contract identifiers', () => {
+    expect(isValidContractName('AcrossFacet')).toBe(true)
+    expect(isValidContractName('LiFiIntentEscrowFacetV2')).toBe(true)
+    expect(isValidContractName('Facet_1')).toBe(true)
+  })
+
+  it('rejects path-traversal and separator characters', () => {
+    expect(isValidContractName('../../.env')).toBe(false)
+    expect(isValidContractName('src/Facets/AcrossFacet')).toBe(false)
+    expect(isValidContractName('AcrossFacet.sol')).toBe(false)
+    expect(isValidContractName('Across Facet')).toBe(false)
+    expect(isValidContractName('')).toBe(false)
   })
 })

--- a/script/deploy/resources/facetRefundReminder.ts
+++ b/script/deploy/resources/facetRefundReminder.ts
@@ -1,0 +1,134 @@
+/**
+ * Facet source-side refund reminder (EXSC-624).
+ *
+ * The team is standardizing source-side refunds on a caller-supplied `refundRecipient`
+ * field instead of `msg.sender`, retrofitting facets only when they are next touched
+ * (EXSC-622, [CONV:FACET-REFUNDS]). To keep that migration from becoming a forever-backlog,
+ * the deploy pipeline prints a NON-FATAL reminder whenever a facet being deployed still
+ * refunds to `msg.sender`.
+ *
+ * Detection is deliberately mechanical: it looks at the facet's Solidity source for the two
+ * refund sites that route value to `msg.sender`:
+ *   1. `refundExcessNative(payable(msg.sender))` — excess native refund
+ *   2. `_depositAndSwap(..., payable(msg.sender))` — swap leftover receiver
+ * Because it reads live source, the list of flagged facets stays correct as facets migrate;
+ * nothing is hard-coded.
+ *
+ * CLI (invoked from deploySingleContract.sh, best-effort — never blocks a deploy):
+ *   bunx tsx script/deploy/resources/facetRefundReminder.ts <ContractName>
+ * Prints the reminder to stdout when the facet source still refunds to msg.sender, otherwise
+ * prints nothing. Always exits 0.
+ */
+import { existsSync, readFileSync, realpathSync } from 'fs'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+export interface IMsgSenderRefundSites {
+  /** `refundExcessNative(payable(msg.sender))` is present */
+  refundExcessNative: boolean
+  /** a `_depositAndSwap(...)` call passes `payable(msg.sender)` as the leftover receiver */
+  depositAndSwapLeftover: boolean
+}
+
+/**
+ * Strip Solidity comments so a prose mention of `msg.sender` in NatSpec/inline comments
+ * (e.g. the "msg.sender may be a relayer" note in migrated facets) never triggers a reminder.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ')
+}
+
+/**
+ * Detect which source-side refund-to-msg.sender sites a facet's Solidity source still contains.
+ *
+ * The `_depositAndSwap` match is bounded to a single statement (`[^;]*`): argument lists cannot
+ * contain `;`, so a `payable(msg.sender)` in a *later* statement can never leak into a preceding,
+ * already-migrated `_depositAndSwap` call.
+ */
+export function detectMsgSenderRefundSites(
+  source: string
+): IMsgSenderRefundSites {
+  const code = stripComments(source)
+  return {
+    refundExcessNative:
+      /refundExcessNative\(\s*payable\(\s*msg\.sender\s*\)\s*\)/.test(code),
+    depositAndSwapLeftover:
+      /_depositAndSwap\([^;]*payable\(\s*msg\.sender\s*\)/.test(code),
+  }
+}
+
+/**
+ * Build the human-facing reminder for a facet, or null when its source no longer refunds to
+ * msg.sender. Only the sites that actually matched are named.
+ */
+export function buildMsgSenderRefundReminder(
+  contractName: string,
+  source: string
+): string | null {
+  const sites = detectMsgSenderRefundSites(source)
+  if (!sites.refundExcessNative && !sites.depositAndSwapLeftover) return null
+
+  const detail = [
+    sites.refundExcessNative ? 'refundExcessNative(payable(msg.sender))' : null,
+    sites.depositAndSwapLeftover ? '_depositAndSwap leftovers' : null,
+  ]
+    .filter(Boolean)
+    .join(' / ')
+
+  return (
+    `⚠️  ${contractName} still refunds to msg.sender (${detail}) — see EXSC-622 ` +
+    `[CONV:FACET-REFUNDS]. Consider migrating to a caller-supplied refundRecipient ` +
+    `while you're touching this facet.`
+  )
+}
+
+/**
+ * Resolve a facet's source path from its contract name. Source-side refunds only live in facets,
+ * so anything outside src/Facets/ (periphery, helpers) is intentionally not inspected.
+ */
+function resolveFacetSourcePath(
+  contractName: string,
+  repoRoot: string
+): string | null {
+  const path = join(repoRoot, 'src', 'Facets', `${contractName}.sol`)
+  return existsSync(path) ? path : null
+}
+
+/**
+ * CLI entry: read the facet source for the given contract name and print the reminder if it still
+ * refunds to msg.sender. Best-effort by design — any failure (missing file, read error) prints
+ * nothing rather than interfering with the deploy.
+ */
+function runCli(): void {
+  const contractName = process.argv[2]
+  if (!contractName) return
+
+  const sourcePath = resolveFacetSourcePath(contractName, process.cwd())
+  if (!sourcePath) return
+
+  let source: string
+  try {
+    source = readFileSync(sourcePath, 'utf8')
+  } catch {
+    return
+  }
+
+  const reminder = buildMsgSenderRefundReminder(contractName, source)
+  if (reminder) console.log(reminder)
+}
+
+/**
+ * Run the CLI only when this file is executed directly (bunx tsx ...), not when imported by tests.
+ * Compares the resolved entry script against this module's own path.
+ */
+function isDirectRun(): boolean {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+if (isDirectRun()) runCli()

--- a/script/deploy/resources/facetRefundReminder.ts
+++ b/script/deploy/resources/facetRefundReminder.ts
@@ -83,13 +83,24 @@ export function buildMsgSenderRefundReminder(
 }
 
 /**
+ * Solidity contract identifiers are alphanumeric/underscore only. Reject anything else so a
+ * caller-supplied name can never traverse outside src/Facets/ (e.g. `../../.env`) when composed
+ * into a file path.
+ */
+export function isValidContractName(name: string): boolean {
+  return /^[A-Za-z0-9_]+$/.test(name)
+}
+
+/**
  * Resolve a facet's source path from its contract name. Source-side refunds only live in facets,
- * so anything outside src/Facets/ (periphery, helpers) is intentionally not inspected.
+ * so anything outside src/Facets/ (periphery, helpers) is intentionally not inspected. Names that
+ * are not plain Solidity identifiers are rejected before touching the filesystem.
  */
 function resolveFacetSourcePath(
   contractName: string,
   repoRoot: string
 ): string | null {
+  if (!isValidContractName(contractName)) return null
   const path = join(repoRoot, 'src', 'Facets', `${contractName}.sol`)
   return existsSync(path) ? path : null
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-624](https://linear.app/lifi-linear/issue/EXSC-624) — [SC] Deploy scripts: warn when a deployed facet still refunds to `msg.sender`.

Related: [EXSC-622](https://linear.app/lifi-linear/issue/EXSC-622) (the `refundRecipient` migration this reminder keeps moving), convention [CONV:FACET-REFUNDS] in `.agents/rules/102-facets.md`.

# Why did I implement it this way?

The team agreed (Slack convention call, 2026-07-15) to standardize source-side refunds on a caller-supplied `refundRecipient` instead of `msg.sender`, retrofitting facets only when they're next touched. Goran's suggestion in that thread was to have the deploy scripts print a reminder when a facet still refunds to `msg.sender`, so the migration doesn't become a forever-backlog. This PR implements that reminder.

**Placement — mirror the existing reminder mechanism, don't invent a new one.** `deploySingleContract.sh` already prints per-contract reminders (the `contractSpecificReminders.sh` block). Since `deploySingleContract` is the single funnel every facet/periphery deploy passes through (`deployFacetAndAddToDiamond.sh`, `scriptMaster.sh`, `deployContractToNetworks.sh`, the `deploy-contract`/`multisig-rollout` skills all call it), the new reminder sits right beside the existing one, in the same warning style, before the zkEVM/CREATE3 branch so it covers every path.

**Non-fatal, by design.** The `bunx tsx` call is wrapped in `2>/dev/null || true` and only ever emits a `warning` — it can never change an exit code or block a deploy. `deploySingleContract`'s stdout is never captured by any caller (all invoke it directly and check `$?`), and the pre-existing reminder block already writes to stdout, so this adds nothing new to the contract of the function.

**Detect from source, never hard-code.** The reminder reads the live facet Solidity (`script/deploy/resources/facetRefundReminder.ts`) and flags the two sites that route value to `msg.sender`:
1. `refundExcessNative(payable(msg.sender))` — excess native refund
2. `_depositAndSwap(..., payable(msg.sender))` — swap leftover receiver

Because it reads source, the flagged set stays correct automatically as facets migrate — a facet that switches to `payable(_xData.refundRecipient)` (e.g. `PaxosTransitFacet`, `SupersetFacet`, `LayerSwapFacet`, `PolymerCCTPFacet`) stops being flagged with no code change here. Comments are stripped before matching so a prose mention of `msg.sender` never triggers a false reminder, and the `_depositAndSwap` match is statement-bounded so a `payable(msg.sender)` in a later line can't leak into a preceding already-migrated call.

As of `main`, detection flags **31 facets** = 30 live site-1 facets + `HopFacetOptimized` (site-2 only). EXSC-622's audit cites **32** at site-1, and reconciling the delta is itself the argument for source-based detection: that list already includes `AcrossFacetV3` (no longer in the tree) and `PolymerCCTPFacet` (migrated to `refundExcessNative(payable(_polymerData.refundRecipient))` in the recent v3.0.0 rollout). The audit is a point-in-time snapshot; reading live source means the flagged set self-corrects as facets are removed or migrated, rather than drifting.

**TypeScript helper + unit tests** rather than an inline bash grep: the multi-line `_depositAndSwap` + comment-stripping logic is exactly the kind of parsing the repo already tests (`bun test script/`), and the bash deploy path already shells out to `bunx tsx` helpers throughout `helperFunctions.sh`.

## Test plan

- `bun test ./script/deploy/resources/facetRefundReminder.test.ts` — 10 cases: both refund sites, multi-line `_depositAndSwap` (+ native-reserve overload), migrated `refundRecipient` (not flagged), comment-only mention (not flagged), later-statement leak guard, whitespace tolerance, message content/site-selection.
- CLI dry-run against real sources: `AcrossFacet`/`ThorSwapFacet` print; `PaxosTransitFacet`/`SupersetFacet` (migrated), `Executor` (periphery), a nonexistent name, and no-arg all stay silent and exit 0.
- `bash -n`, `tsc-files --noEmit`, `eslint` all clean.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
