### PR TITLE
feat(healthcheck): per-network invariant exclusions with mandatory reason (stacks on #2078)

### DIFF
--- a/.github/workflows/healthCheckAllNetworks.yml
+++ b/.github/workflows/healthCheckAllNetworks.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false # read-only check; no git push/tag/submodule operations
+          fetch-depth: 0 # full history so a push run can diff which deployments/ changed
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
@@ -92,12 +93,29 @@ jobs:
       # continue-on-error so the Slack step below always reports; the "Fail if any network failed"
       # step restores the red check. The runner writes total / passed_count / failed_count /
       # failed_networks to $GITHUB_OUTPUT for the Slack composer.
-      - name: Run health check across all production networks
+      # On push it scopes to only the networks whose deploy logs changed (post-deploy drift is on
+      # those); on schedule/dispatch it sweeps the full production fleet.
+      - name: Run health check
         id: healthcheck
         continue-on-error: true
-        run: bunx tsx script/deploy/healthCheckAllNetworks.ts --environment production --concurrency 8
         env:
           MAX_CONCURRENT_JOBS: '8'
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          ARGS=(--environment production --concurrency 8)
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            # Only re-check networks whose deploy log changed in this push; fall back to the full
+            # fleet if the base commit is unavailable (e.g. first push / shallow history).
+            if git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+              CHANGED=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- 'deployments/*.json' | paste -sd, -)
+              if [[ -n "$CHANGED" ]]; then
+                ARGS+=(--changed-paths="$CHANGED")
+              fi
+            fi
+          fi
+          bunx tsx script/deploy/healthCheckAllNetworks.ts "${ARGS[@]}"
 
       - name: Fail if any network failed
         if: ${{ always() }}
@@ -119,6 +137,7 @@ jobs:
           TOTAL: ${{ steps.healthcheck.outputs.total }}
           PASSED_COUNT: ${{ steps.healthcheck.outputs.passed_count }}
           FAILED_COUNT: ${{ steps.healthcheck.outputs.failed_count }}
+          SKIPPED_COUNT: ${{ steps.healthcheck.outputs.skipped_count }}
           FAILED_NETWORKS: ${{ steps.healthcheck.outputs.failed_networks }}
         run: |
           # Deep-link straight to THIS job so the Slack link lands on the failing step; fall back to
@@ -133,7 +152,7 @@ jobs:
           RUN_URL="${RUN_URL:-$RUN_OVERVIEW}"
 
           if [[ "$OUTCOME" == "success" && "${FAILED_COUNT:-0}" == "0" ]]; then
-            HEADER=":white_check_mark: *Diamond health check — all ${TOTAL:-?} production networks passed*"
+            HEADER=":white_check_mark: *Diamond health check — ${PASSED_COUNT:-?}/${TOTAL:-?} networks passed (${SKIPPED_COUNT:-0} skipped)*"
             BODY="<${RUN_URL}|View workflow run>"
           else
             HEADER=":rotating_light: *Diamond health check — ACTION NEEDED*"

--- a/.github/workflows/healthCheckAllNetworks.yml
+++ b/.github/workflows/healthCheckAllNetworks.yml
@@ -18,8 +18,8 @@
 # - Slack: ONE consolidated status (pass = green, fail = red + the failing network list, plus a link to
 #   the run) on every trigger, so a green day is confirmed and a silently-broken cron shows up as a
 #   MISSING message.
-# - Known limitations: needs RPCs (MongoDB) + deploy logs; transient RPC errors are retried inside
-#   healthCheck.ts (execWithRateLimitRetry / viem transport retries) before a network is marked failed.
+# - Known limitations: needs RPCs (MongoDB) + deploy logs; transient RPC errors are absorbed by viem
+#   transport retries and a one-shot re-verify of each fatal invariant before a network is marked failed.
 
 name: Diamond Health Check (all networks)
 

--- a/script/deploy/healthCheck.ts
+++ b/script/deploy/healthCheck.ts
@@ -4,8 +4,10 @@
  * Reads the live on-chain configuration of one network's LiFiDiamond and its periphery
  * and asserts every invariant in {@link HEALTH_CHECK_INVARIANTS} holds. Invoke via
  * `bunx tsx ./script/deploy/healthCheck.ts --network <network> [--environment production|staging]`.
- * The check layer (what is asserted) lives in `healthCheckInvariants.ts`; this file only
- * builds the per-network context, runs the registry, and maps the result to an exit code.
+ * The check layer (what is asserted) lives in `healthCheckInvariants.ts`; this file builds
+ * the per-network context and runs the registry. The reusable entry point is
+ * {@link runHealthCheckForNetwork} (returns a result, never exits) so the multi-network
+ * runner can fan it out in-process; the CLI wrapper maps that result to an exit code.
  */
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
@@ -34,47 +36,44 @@ import {
 
 const targetState = targetStateImport as TargetState
 
-const main = defineCommand({
-  meta: {
-    name: 'LIFI Diamond Health Check',
-    description: 'Check that the diamond is configured correctly',
-  },
-  args: {
-    network: {
-      type: 'string',
-      description: 'EVM network to check',
-      required: true,
-    },
-    environment: {
-      type: 'string',
-      description: 'Environment to check (production or staging)',
-      default: 'production',
-    },
-  },
-  async run({ args }) {
-    const { network, environment } = args
-    const networkStr = Array.isArray(network) ? network[0] : network
-    const networkLower = (networkStr as string).toLowerCase()
+/** Outcome of a single network's health check. */
+export interface IHealthCheckNetworkResult {
+  network: string
+  status: 'passed' | 'failed' | 'skipped'
+  errors: string[]
+  warnings: string[]
+  /** Set when status is 'skipped'. */
+  skipReason?: string
+}
 
-    // Reject typos early: an unsupported value would load production deploy logs
-    // (anything but 'staging') while skipping production-only checks (anything but
-    // 'production'), silently running reduced coverage against production data.
-    if (environment !== 'production' && environment !== 'staging') {
-      consola.error(
-        `Unsupported environment '${String(
-          environment
-        )}'; expected 'production' or 'staging'`
-      )
-      process.exit(1)
+/**
+ * Run the health check for one network and return its result. Never calls `process.exit`
+ * and never throws — any failure (including a missing deploy log) is captured as a failed
+ * result — so it is safe to fan out concurrently in a single process.
+ *
+ * @param networkStr - Network key (as in config/networks.json).
+ * @param environment - 'production' or 'staging' (validated by the caller).
+ */
+export async function runHealthCheckForNetwork(
+  networkStr: string,
+  environment: string
+): Promise<IHealthCheckNetworkResult> {
+  const networkLower = networkStr.toLowerCase()
+
+  // Skip tronshasta testnet but allow tron mainnet.
+  if (networkLower === 'tronshasta')
+    return {
+      network: networkStr,
+      status: 'skipped',
+      errors: [],
+      warnings: [],
+      skipReason: 'Health checks are not implemented for Tron Shasta testnet',
     }
 
-    // Skip tronshasta testnet but allow tron mainnet
-    if (networkLower === 'tronshasta') {
-      consola.info('Health checks are not implemented for Tron Shasta testnet.')
-      consola.info('Skipping all tests.')
-      process.exit(0)
-    }
+  const errors: string[] = []
+  const warnings: string[] = []
 
+  try {
     const isTron = networkLower === 'tron'
 
     // Testnet networks have an EOA-owned diamond (deployerWallet) with no Safe
@@ -99,12 +98,14 @@ const main = defineCommand({
         { skipHealthcheck?: boolean } | undefined
       >
     )[networkLower]
-    if (networkEntry?.skipHealthcheck === true) {
-      consola.info(
-        `Health check bypassed for network '${networkLower}' (skipHealthcheck: true in config/networks.json).`
-      )
-      process.exit(0)
-    }
+    if (networkEntry?.skipHealthcheck === true)
+      return {
+        network: networkStr,
+        status: 'skipped',
+        errors: [],
+        warnings: [],
+        skipReason: 'skipHealthcheck: true in config/networks.json',
+      }
 
     // Skip GasZip checks for networks where the integration is intentionally unsupported.
     const networkGasZipConfig = (
@@ -115,15 +116,14 @@ const main = defineCommand({
     const coreFacetExclusions = supportsGasZip ? [] : ['GasZipFacet']
     const coreFacetsToCheck = getCoreFacets({ exclude: coreFacetExclusions })
 
-    // For staging, skip targetState checks as targetState is only for production
+    // For staging, skip targetState checks as targetState is only for production.
     let nonCoreFacets: string[] = []
     let missingProductionTargetState = false
     if (environment === 'production') {
       const networkTarget = targetState[networkLower]?.production
       if (!networkTarget?.LiFiDiamond)
         // Surface (not silence): a production network with no target state means the
-        // non-core facet comparison is skipped, i.e. reduced coverage. Recorded as a
-        // warning below so it shows in the report rather than passing silently.
+        // non-core facet comparison is skipped, i.e. reduced coverage.
         missingProductionTargetState = true
       else
         nonCoreFacets = Object.keys(networkTarget.LiFiDiamond).filter(
@@ -199,13 +199,10 @@ const main = defineCommand({
       pauserWalletAddress = globalConfig.pauserWallet
     }
 
-    const errors: string[] = []
-    const warnings: string[] = []
-
     const ctx: IHealthCheckContext = {
-      network: networkStr as string,
+      network: networkStr,
       networkLower,
-      environment: environment as string,
+      environment,
       isTron,
       isTestnet,
       supportsGasZip,
@@ -241,29 +238,76 @@ const main = defineCommand({
         `Network '${networkLower}' has no production target state; non-core facet coverage is reduced`
       )
 
-    consola.info('Running post deployment checks...\n')
+    consola.info(`[${networkLower}] Running post deployment checks...\n`)
 
     await runHealthCheckInvariants(ctx)
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    errors.push(`[${networkLower}] health check aborted: ${errorMessage}`)
+  }
 
-    finish(ctx)
-  },
-})
-
-const finish = (ctx: IHealthCheckContext) => {
-  // this line ensures that all logs are actually written before the script ends
-  process.stdout.write('', () => process.stdout.end())
-  if (ctx.warnings.length)
-    consola.warn(
-      `${ctx.warnings.length} warning(s) found (non-fatal, review recommended)`
-    )
-  if (ctx.errors.length) {
-    consola.error(`${ctx.errors.length} Errors found in deployment`)
-    process.exit(1)
-  } else {
-    consola.success('Deployment checks passed')
-    process.exit(0)
+  return {
+    network: networkStr,
+    status: errors.length ? 'failed' : 'passed',
+    errors,
+    warnings,
   }
 }
+
+const main = defineCommand({
+  meta: {
+    name: 'LIFI Diamond Health Check',
+    description: 'Check that the diamond is configured correctly',
+  },
+  args: {
+    network: {
+      type: 'string',
+      description: 'EVM network to check',
+      required: true,
+    },
+    environment: {
+      type: 'string',
+      description: 'Environment to check (production or staging)',
+      default: 'production',
+    },
+  },
+  async run({ args }) {
+    const { network, environment } = args
+    const networkStr = Array.isArray(network) ? network[0] : (network as string)
+
+    // Reject typos early: an unsupported value would load production deploy logs
+    // (anything but 'staging') while skipping production-only checks (anything but
+    // 'production'), silently running reduced coverage against production data.
+    if (environment !== 'production' && environment !== 'staging') {
+      consola.error(
+        `Unsupported environment '${String(
+          environment
+        )}'; expected 'production' or 'staging'`
+      )
+      process.exit(1)
+    }
+
+    const result = await runHealthCheckForNetwork(networkStr, environment)
+
+    // this line ensures that all logs are actually written before the script ends
+    process.stdout.write('', () => process.stdout.end())
+
+    if (result.status === 'skipped') {
+      consola.info(`Skipping all tests: ${result.skipReason}`)
+      process.exit(0)
+    }
+    if (result.warnings.length)
+      consola.warn(
+        `${result.warnings.length} warning(s) found (non-fatal, review recommended)`
+      )
+    if (result.status === 'failed') {
+      consola.error(`${result.errors.length} Errors found in deployment`)
+      process.exit(1)
+    }
+    consola.success('Deployment checks passed')
+    process.exit(0)
+  },
+})
 
 // Guard so importing this module does not execute the CLI (entry-point-only run).
 if (import.meta.main) runMain(main)

--- a/script/deploy/healthCheck.ts
+++ b/script/deploy/healthCheck.ts
@@ -178,7 +178,6 @@ export async function runHealthCheckForNetwork(
     let deployerWallet: string
     let refundWallet: string
     let feeCollectorOwner: string
-    let pauserWalletAddress: string
 
     if (isTron) {
       if (!tronWeb) throw new Error('TronWeb not initialized')
@@ -186,7 +185,6 @@ export async function runHealthCheckForNetwork(
       deployerWallet = getTronWallet('deployerWallet', { tronWeb })
       refundWallet = getTronWallet('refundWallet', { tronWeb })
       feeCollectorOwner = getTronWallet('feeCollectorOwner', { tronWeb })
-      pauserWalletAddress = getTronWallet('pauserWallet', { tronWeb })
     } else {
       // Testnets are owned by deployerWallet regardless of environment.
       deployerWallet = getAddress(
@@ -196,7 +194,6 @@ export async function runHealthCheckForNetwork(
       )
       refundWallet = getAddress(globalConfig.refundWallet)
       feeCollectorOwner = getAddress(globalConfig.feeCollectorOwner)
-      pauserWalletAddress = globalConfig.pauserWallet
     }
 
     const ctx: IHealthCheckContext = {
@@ -219,7 +216,6 @@ export async function runHealthCheckForNetwork(
       deployerWallet,
       refundWallet,
       feeCollectorOwner,
-      pauserWalletAddress,
       onChainFacets: [],
       errors,
       warnings,

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -8,6 +8,7 @@ import {
 import type { INetwork } from '../common/types'
 
 import {
+  deploymentPathsToNetworks,
   getProductionNetworkNames,
   summarizeHealthChecks,
 } from './healthCheckAllNetworks'
@@ -35,21 +36,49 @@ describe('getProductionNetworkNames', () => {
   })
 })
 
-describe('summarizeHealthChecks', () => {
-  it('splits passed and failed and counts the total', () => {
-    const summary = summarizeHealthChecks([
-      { network: 'polygon', passed: true, detail: '' },
-      { network: 'optimism', passed: false, detail: 'boom' },
-      { network: 'arbitrum', passed: true, detail: '' },
+describe('deploymentPathsToNetworks', () => {
+  it('extracts production network keys, ignoring staging/diamond/non-network files', () => {
+    const result = deploymentPathsToNetworks([
+      'deployments/optimism.json',
+      'deployments/opbnb.json',
+      'deployments/base.staging.json',
+      'deployments/polygon.diamond.json',
+      'deployments/_deployments_log_file.json',
+      'src/Periphery/Executor.sol',
     ])
-    expect(summary.total).toBe(3)
+    expect(result).toEqual(['opbnb', 'optimism'])
+  })
+
+  it('dedupes and returns empty when no network file changed', () => {
+    expect(
+      deploymentPathsToNetworks([
+        'deployments/arbitrum.json',
+        'deployments/arbitrum.json',
+      ])
+    ).toEqual(['arbitrum'])
+    expect(deploymentPathsToNetworks(['deployments/x.diamond.json'])).toEqual(
+      []
+    )
+  })
+})
+
+describe('summarizeHealthChecks', () => {
+  it('splits passed / failed / skipped and counts the total', () => {
+    const summary = summarizeHealthChecks([
+      { network: 'polygon', status: 'passed', detail: '' },
+      { network: 'optimism', status: 'failed', detail: 'boom' },
+      { network: 'arbitrum', status: 'passed', detail: '' },
+      { network: 'tron', status: 'skipped', detail: 'skipHealthcheck' },
+    ])
+    expect(summary.total).toBe(4)
     expect(summary.passed).toEqual(['arbitrum', 'polygon'])
     expect(summary.failed).toEqual(['optimism'])
+    expect(summary.skipped).toEqual(['tron'])
   })
 
   it('handles the all-passed case', () => {
     const summary = summarizeHealthChecks([
-      { network: 'polygon', passed: true, detail: '' },
+      { network: 'polygon', status: 'passed', detail: '' },
     ])
     expect(summary.failed).toEqual([])
     expect(summary.passed).toEqual(['polygon'])
@@ -57,6 +86,11 @@ describe('summarizeHealthChecks', () => {
 
   it('handles the empty case', () => {
     const summary = summarizeHealthChecks([])
-    expect(summary).toEqual({ total: 0, passed: [], failed: [] })
+    expect(summary).toEqual({
+      total: 0,
+      passed: [],
+      failed: [],
+      skipped: [],
+    })
   })
 })

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -1,15 +1,13 @@
 /**
- * Fan the single-network health check across every production network.
+ * Fan the single-network health check across every production network — in one process.
  *
- * Runs `script/deploy/healthCheck.ts` once per production network (mainnet + active) with
- * bounded concurrency, collects a pass/fail per network, and (in GitHub Actions) writes a
- * consolidated summary to `$GITHUB_OUTPUT` for the Slack report. Exits non-zero if any
- * network fails. Invoke via
- * `bunx tsx ./script/deploy/healthCheckAllNetworks.ts [--environment production] [--concurrency 5] [--networks a,b]`.
- * This is the runner behind the scheduled `healthCheckAllNetworks` workflow; the invariants
- * it enforces live in `healthCheckInvariants.ts`.
+ * Calls {@link runHealthCheckForNetwork} per production network (mainnet + active) with
+ * bounded concurrency (no subprocess-per-network), collects a pass/fail/skip per network,
+ * and (in GitHub Actions) writes a consolidated summary to `$GITHUB_OUTPUT` for the Slack
+ * report. Exits non-zero if any network fails. Invoke via
+ * `bunx tsx ./script/deploy/healthCheckAllNetworks.ts [--environment production] [--concurrency 8] [--networks a,b] [--changed-paths deployments/x.json,...]`.
+ * The invariants it enforces live in `healthCheckInvariants.ts`.
  */
-import { spawn } from 'child_process'
 import { appendFileSync } from 'fs'
 
 import { defineCommand, runMain } from 'citty'
@@ -18,16 +16,17 @@ import { consola } from 'consola'
 import type { INetwork } from '../common/types'
 import { getAllActiveNetworks } from '../utils/viemScriptHelpers'
 
-/** Per-network health-check deadline. One diamond's multicall reads finish well within this;
- * a stalled RPC connection past it is killed so it cannot starve the whole sweep. */
+import { runHealthCheckForNetwork } from './healthCheck'
+
+/** Per-network deadline. A network whose reads stall past this is recorded as failed so one
+ * hung RPC cannot block the consolidated report (the dangling read is abandoned, not killed). */
 const PER_NETWORK_TIMEOUT_MS = 5 * 60_000 // 5 minutes
-const KILL_GRACE_MS = 5_000 // 5 seconds between SIGTERM and SIGKILL
 
 /** Outcome of a single network's health check. */
 export interface IHealthCheckResult {
   network: string
-  passed: boolean
-  /** Trimmed error output when the check failed (empty on success). */
+  status: 'passed' | 'failed' | 'skipped'
+  /** Trimmed detail when failed/skipped (empty on pass). */
   detail: string
 }
 
@@ -45,21 +44,39 @@ export function getProductionNetworkNames(networks: INetwork[]): string[] {
     .sort()
 }
 
+/**
+ * Map changed `deployments/**` file paths to the production network keys they belong to.
+ * Only `deployments/<network>.json` counts — `<network>.staging.json`, `<network>.diamond.json`
+ * and non-network files (e.g. `_deployments_log_file.json`) are ignored. Pure; used by the
+ * push-to-main trigger to check only the networks a deploy actually touched.
+ */
+export function deploymentPathsToNetworks(paths: string[]): string[] {
+  const networks = new Set<string>()
+  for (const path of paths) {
+    const match = path.trim().match(/^deployments\/([a-z0-9]+)\.json$/)
+    if (match?.[1]) networks.add(match[1])
+  }
+  return [...networks].sort()
+}
+
 /** Aggregate per-network results into a consolidated report. Pure. */
 export function summarizeHealthChecks(results: IHealthCheckResult[]): {
   total: number
   passed: string[]
   failed: string[]
+  skipped: string[]
 } {
-  const passed = results
-    .filter((r) => r.passed)
-    .map((r) => r.network)
-    .sort()
-  const failed = results
-    .filter((r) => !r.passed)
-    .map((r) => r.network)
-    .sort()
-  return { total: results.length, passed, failed }
+  const byStatus = (status: IHealthCheckResult['status']) =>
+    results
+      .filter((r) => r.status === status)
+      .map((r) => r.network)
+      .sort()
+  return {
+    total: results.length,
+    passed: byStatus('passed'),
+    failed: byStatus('failed'),
+    skipped: byStatus('skipped'),
+  }
 }
 
 /**
@@ -91,62 +108,65 @@ async function mapWithConcurrency<T, R>(
   return results
 }
 
-/**
- * Run the single-network health check as a child process with a hard deadline; never
- * throws. On timeout the child is SIGTERM'd (then SIGKILL'd after a grace period) so one
- * stalled RPC cannot leave the sweep pending and block the consolidated report.
- */
-function runOneNetwork(
+/** Run one network's health check in-process, bounded by a deadline; never throws. */
+async function runOneNetwork(
   network: string,
   environment: string,
   timeoutMs: number = PER_NETWORK_TIMEOUT_MS
 ): Promise<IHealthCheckResult> {
-  return new Promise((resolve) => {
-    const child = spawn(
-      'bunx',
-      [
-        'tsx',
-        'script/deploy/healthCheck.ts',
-        '--network',
-        network,
-        '--environment',
-        environment,
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<IHealthCheckResult>((resolve) => {
+    timer = setTimeout(
+      () =>
+        resolve({
+          network,
+          status: 'failed',
+          detail: `TIMEOUT after ${Math.round(timeoutMs / 1000)}s`,
+        }),
+      timeoutMs
     )
-
-    let output = ''
-    let timedOut = false
-    const capture = (data: Buffer) => {
-      output += data.toString()
-    }
-    child.stdout?.on('data', capture)
-    child.stderr?.on('data', capture)
-
-    const timer = setTimeout(() => {
-      timedOut = true
-      child.kill('SIGTERM')
-      setTimeout(() => child.kill('SIGKILL'), KILL_GRACE_MS)
-    }, timeoutMs)
-
-    const finalize = (passed: boolean, note: string) => {
-      clearTimeout(timer)
-      // Keep only the tail so a single network cannot flood the consolidated report.
-      const detail = passed
-        ? ''
-        : [note, output.trim().split('\n').slice(-5).join('\n')]
-            .filter(Boolean)
-            .join('\n')
-      resolve({ network, passed, detail })
-    }
-
-    child.on('close', (code) => {
-      if (timedOut)
-        finalize(false, `TIMEOUT after ${Math.round(timeoutMs / 1000)}s`)
-      else finalize(code === 0, code === 0 ? '' : `exit code ${code}`)
-    })
-    child.on('error', (error) => finalize(false, String(error)))
   })
+
+  const check = runHealthCheckForNetwork(network, environment).then(
+    (result): IHealthCheckResult => ({
+      network,
+      status: result.status,
+      // Keep only the tail so a single network cannot flood the consolidated report.
+      detail:
+        result.status === 'failed'
+          ? result.errors.slice(-5).join('\n')
+          : result.status === 'skipped'
+          ? result.skipReason ?? 'skipped'
+          : '',
+    })
+  )
+
+  try {
+    return await Promise.race([check, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/** Append the consolidated per-run summary to $GITHUB_OUTPUT for the Slack composer (no-op locally). */
+function writeConsolidatedOutput(summary: {
+  total: number
+  passed: string[]
+  failed: string[]
+  skipped: string[]
+}): void {
+  if (!process.env.GITHUB_OUTPUT) return
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    [
+      `total=${summary.total}`,
+      `passed_count=${summary.passed.length}`,
+      `failed_count=${summary.failed.length}`,
+      `skipped_count=${summary.skipped.length}`,
+      `failed_networks=${summary.failed.join(', ')}`,
+      '',
+    ].join('\n')
+  )
 }
 
 const main = defineCommand({
@@ -164,7 +184,7 @@ const main = defineCommand({
     concurrency: {
       type: 'string',
       description: 'Maximum health checks to run in parallel',
-      default: process.env.MAX_CONCURRENT_JOBS ?? '5',
+      default: process.env.MAX_CONCURRENT_JOBS ?? '8',
     },
     networks: {
       type: 'string',
@@ -172,20 +192,44 @@ const main = defineCommand({
         'Optional comma-separated network override (defaults to all production networks)',
       required: false,
     },
+    'changed-paths': {
+      type: 'string',
+      description:
+        'Comma-separated changed deployments/** paths; checks only the networks they map to (post-deploy trigger)',
+      required: false,
+    },
   },
   async run({ args }) {
     const environment = String(args.environment)
     const concurrency = Math.max(
       1,
-      Number.parseInt(String(args.concurrency), 10) || 5
+      Number.parseInt(String(args.concurrency), 10) || 8
     )
 
-    const networks = args.networks
-      ? String(args.networks)
-          .split(',')
-          .map((n) => n.trim().toLowerCase())
-          .filter(Boolean)
-      : getProductionNetworkNames(getAllActiveNetworks())
+    // Precedence: explicit --networks override, else --changed-paths (post-deploy), else full fleet.
+    let networks: string[]
+    if (args.networks)
+      networks = String(args.networks)
+        .split(',')
+        .map((n) => n.trim().toLowerCase())
+        .filter(Boolean)
+    else if (args['changed-paths'] !== undefined) {
+      networks = deploymentPathsToNetworks(
+        String(args['changed-paths']).split(',')
+      )
+      if (networks.length === 0) {
+        consola.success(
+          'No production network deployment files changed; nothing to check.'
+        )
+        writeConsolidatedOutput({
+          total: 0,
+          passed: [],
+          failed: [],
+          skipped: [],
+        })
+        process.exit(0)
+      }
+    } else networks = getProductionNetworkNames(getAllActiveNetworks())
 
     if (networks.length === 0) {
       consola.error('No production networks resolved; nothing to check.')
@@ -200,33 +244,26 @@ const main = defineCommand({
       runOneNetwork(network, environment)
     )
 
-    const { total, passed, failed } = summarizeHealthChecks(results)
+    const { total, passed, failed, skipped } = summarizeHealthChecks(results)
 
     consola.box(
-      `Health check summary: ${passed.length}/${total} passed, ${failed.length} failed`
+      `Health check summary: ${passed.length}/${total} passed, ${failed.length} failed, ${skipped.length} skipped`
     )
     for (const result of results)
-      if (result.passed) consola.success(result.network)
-      else consola.error(`${result.network}\n${result.detail}`)
+      if (result.status === 'failed')
+        consola.error(`${result.network}\n${result.detail}`)
+      else if (result.status === 'skipped')
+        consola.info(`${result.network} (skipped: ${result.detail})`)
+      else consola.success(result.network)
 
     // Publish a consolidated result for the workflow's Slack step.
-    if (process.env.GITHUB_OUTPUT)
-      appendFileSync(
-        process.env.GITHUB_OUTPUT,
-        [
-          `total=${total}`,
-          `passed_count=${passed.length}`,
-          `failed_count=${failed.length}`,
-          `failed_networks=${failed.join(', ')}`,
-          '',
-        ].join('\n')
-      )
+    writeConsolidatedOutput({ total, passed, failed, skipped })
 
     if (failed.length > 0) {
       consola.error(`Health check failed on: ${failed.join(', ')}`)
       process.exit(1)
     }
-    consola.success('All production networks passed the health check.')
+    consola.success('All checked networks passed the health check.')
     process.exit(0)
   },
 })

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -5,11 +5,16 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
+import networksConfig from '../../config/networks.json'
+
 import {
+  HEALTH_CHECK_EXCLUSIONS,
   HEALTH_CHECK_INVARIANTS,
   findDuplicateSelectors,
+  getInvariantExclusion,
   isInvariantApplicable,
   type IHealthCheckInvariant,
+  type IInvariantExclusion,
 } from './healthCheckInvariants'
 
 /** Minimal invariant descriptor for exercising the pure applicability logic. */
@@ -176,5 +181,59 @@ describe('HEALTH_CHECK_INVARIANTS registry', () => {
     const names = HEALTH_CHECK_INVARIANTS.map((i) => i.name)
     expect(names).toContain('executor-erc20proxy-binding')
     expect(names).toContain('receiver-executor-binding')
+  })
+})
+
+describe('getInvariantExclusion', () => {
+  const sample: IInvariantExclusion[] = [
+    {
+      invariant: 'safe-config',
+      network: 'somechain',
+      reason: 'no Safe on somechain',
+    },
+  ]
+
+  it('returns the matching exclusion', () => {
+    const result = getInvariantExclusion('safe-config', 'somechain', sample)
+    expect(result?.reason).toBe('no Safe on somechain')
+  })
+
+  it('matches the network case-insensitively', () => {
+    const result = getInvariantExclusion('safe-config', 'SomeChain', sample)
+    expect(result?.reason).toBe('no Safe on somechain')
+  })
+
+  it('returns undefined for a non-excluded invariant/network', () => {
+    expect(
+      getInvariantExclusion('safe-config', 'otherchain', sample)
+    ).toBeUndefined()
+    expect(
+      getInvariantExclusion('whitelist-integrity', 'somechain', sample)
+    ).toBeUndefined()
+  })
+
+  it('defaults to the real exclusion table', () => {
+    // Smoke: the default arg is HEALTH_CHECK_EXCLUSIONS (empty today → always undefined).
+    expect(getInvariantExclusion('safe-config', 'somechain')).toBeUndefined()
+  })
+})
+
+describe('HEALTH_CHECK_EXCLUSIONS table integrity', () => {
+  const invariantNames = new Set(HEALTH_CHECK_INVARIANTS.map((i) => i.name))
+  const knownNetworks = new Set(Object.keys(networksConfig))
+
+  it('every exclusion targets a real invariant name (guards stale carve-outs)', () => {
+    for (const exclusion of HEALTH_CHECK_EXCLUSIONS)
+      expect(invariantNames).toContain(exclusion.invariant)
+  })
+
+  it('every exclusion targets a known network', () => {
+    for (const exclusion of HEALTH_CHECK_EXCLUSIONS)
+      expect(knownNetworks).toContain(exclusion.network.toLowerCase())
+  })
+
+  it('every exclusion carries a non-empty reason', () => {
+    for (const exclusion of HEALTH_CHECK_EXCLUSIONS)
+      expect(exclusion.reason.trim().length).toBeGreaterThan(0)
   })
 })

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -13,9 +13,50 @@ import {
   findDuplicateSelectors,
   getInvariantExclusion,
   isInvariantApplicable,
+  runHealthCheckInvariants,
+  scriptEval,
+  type IHealthCheckContext,
   type IHealthCheckInvariant,
   type IInvariantExclusion,
 } from './healthCheckInvariants'
+
+/** Minimal in-scope context for driving the runner without any RPC. */
+function makeCtx(): IHealthCheckContext {
+  const errors: string[] = []
+  const warnings: string[] = []
+  return {
+    networkLower: 'testnet1',
+    environment: 'production',
+    isTron: false,
+    isTestnet: false,
+    supportsGasZip: true,
+    onChainFacets: [],
+    errors,
+    warnings,
+    logError: (msg: string) => {
+      errors.push(msg)
+    },
+    logWarn: (msg: string) => {
+      warnings.push(msg)
+    },
+  } as unknown as IHealthCheckContext
+}
+
+/** Build a synthetic invariant with a given run body. */
+function inv(
+  name: string,
+  run: IHealthCheckInvariant['run'],
+  extra: Partial<IHealthCheckInvariant> = {}
+): IHealthCheckInvariant {
+  return {
+    name,
+    description: name,
+    severity: 'error',
+    scope: {},
+    run,
+    ...extra,
+  }
+}
 
 /** Minimal invariant descriptor for exercising the pure applicability logic. */
 function makeInvariant(
@@ -235,5 +276,123 @@ describe('HEALTH_CHECK_EXCLUSIONS table integrity', () => {
   it('every exclusion carries a non-empty reason', () => {
     for (const exclusion of HEALTH_CHECK_EXCLUSIONS)
       expect(exclusion.reason.trim().length).toBeGreaterThan(0)
+  })
+})
+
+describe('runHealthCheckInvariants (runner)', () => {
+  it('merges concurrent invariants without clobbering each other errors', async () => {
+    const ctx = makeCtx()
+    await runHealthCheckInvariants(ctx, [
+      inv('a', async (c) => c.logError('err-a')),
+      inv('b', async (c) => c.logError('err-b')),
+    ])
+    expect(ctx.errors.sort()).toEqual(['err-a', 'err-b'])
+  })
+
+  it('clears a transient error that does not reproduce on re-verify', async () => {
+    const ctx = makeCtx()
+    let calls = 0
+    await runHealthCheckInvariants(ctx, [
+      inv('flaky', async (c) => {
+        calls++
+        if (calls === 1) c.logError('transient blip')
+      }),
+    ])
+    expect(calls).toBe(2) // ran once, then re-verified
+    expect(ctx.errors).toEqual([]) // transient failure not recorded
+  })
+
+  it('records a persistent error that reproduces on re-verify', async () => {
+    const ctx = makeCtx()
+    await runHealthCheckInvariants(ctx, [
+      inv('broken', async (c) => c.logError('real drift')),
+    ])
+    expect(ctx.errors).toEqual(['real drift'])
+  })
+
+  it('does not re-verify a warning (only fatal errors)', async () => {
+    const ctx = makeCtx()
+    let calls = 0
+    await runHealthCheckInvariants(ctx, [
+      inv(
+        'warner',
+        async (c) => {
+          calls++
+          c.logWarn('heads up')
+        },
+        { severity: 'warning' }
+      ),
+    ])
+    expect(calls).toBe(1)
+    expect(ctx.warnings).toEqual(['heads up'])
+  })
+
+  it('propagates onChainFacets from a phase-1 writer to a phase-2 reader', async () => {
+    const ctx = makeCtx()
+    await runHealthCheckInvariants(ctx, [
+      inv('writer', async (c) => {
+        c.onChainFacets.push({ address: '0xA', selectors: ['0x11111111'] })
+      }),
+      inv(
+        'reader',
+        async (c) => {
+          if (c.onChainFacets.length === 0) c.logError('reader saw no facets')
+        },
+        { readsOnChainFacets: true }
+      ),
+    ])
+    expect(ctx.errors).toEqual([])
+    expect(ctx.onChainFacets).toHaveLength(1)
+  })
+
+  it('halts remaining invariants when a haltIfFailed prerequisite fails', async () => {
+    const ctx = makeCtx()
+    let laterRan = false
+    await runHealthCheckInvariants(ctx, [
+      inv('prereq', async (c) => c.logError('diamond missing'), {
+        haltIfFailed: true,
+      }),
+      inv('later', async () => {
+        laterRan = true
+      }),
+    ])
+    expect(laterRan).toBe(false)
+    expect(ctx.errors).toEqual(['diamond missing'])
+  })
+
+  it('skips an out-of-scope invariant', async () => {
+    const ctx = makeCtx() // environment: production
+    let ran = false
+    await runHealthCheckInvariants(ctx, [
+      inv(
+        'staging-only',
+        async () => {
+          ran = true
+        },
+        { scope: { environments: ['staging'] } }
+      ),
+    ])
+    expect(ran).toBe(false)
+  })
+})
+
+describe('scriptEval', () => {
+  it('passes when the script exits 0', async () => {
+    const ctx = makeCtx()
+    await scriptEval('true')(ctx)
+    expect(ctx.errors).toEqual([])
+  })
+
+  it('records an error when the script exits non-zero', async () => {
+    const ctx = makeCtx()
+    await scriptEval('false')(ctx)
+    expect(ctx.errors.length).toBe(1)
+  })
+
+  it('reports as a warning when severity is warning', async () => {
+    const ctx = makeCtx()
+    await scriptEval('false', 'warning')(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(ctx.warnings.length).toBe(1)
   })
 })

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -18,11 +18,9 @@ import path from 'path'
 import { consola } from 'consola'
 import type { TronWeb } from 'tronweb'
 import {
-  formatEther,
   getAddress,
   getContract,
   parseAbi,
-  type Abi,
   type Address,
   type Hex,
   type PublicClient,
@@ -118,7 +116,48 @@ export interface IHealthCheckInvariant {
   scope: IHealthCheckScope
   /** When this invariant fails, skip all remaining invariants (e.g. diamond not deployed). */
   haltIfFailed?: boolean
+  /**
+   * Reads `ctx.onChainFacets` (populated by `facets-registered`). The runner defers these to
+   * a second phase so the first phase's concurrent reads finish (and populate it) first.
+   */
+  readsOnChainFacets?: boolean
+  /** Actionable fix shown after this invariant fails (e.g. the command to re-sync). */
+  remediation?: string
   run: (ctx: IHealthCheckContext) => Promise<void>
+}
+
+/**
+ * Adapt an external check script into an invariant `run()`: the script is spawned with the
+ * network + environment, and the invariant passes iff it exits 0. Non-zero exit records a
+ * failure (error/warning per `severity`) with the script's output tail as the detail. Use
+ * sparingly — a subprocess per (eval × network) loses the shared viem client/batching, so
+ * it is for reusing authoritative external checks, not for checks that belong in-process.
+ *
+ * @param scriptPath - Repo-relative path to an executable check (exit 0 = pass).
+ * @param severity - How a non-zero exit is reported.
+ * @param argsFromCtx - Builds the script args from the network context.
+ */
+export function scriptEval(
+  scriptPath: string,
+  severity: HealthCheckSeverity = 'error',
+  argsFromCtx: (ctx: IHealthCheckContext) => string[] = (ctx) => [
+    '--network',
+    ctx.networkLower,
+    '--environment',
+    ctx.environment,
+  ]
+): (ctx: IHealthCheckContext) => Promise<void> {
+  return async (ctx) => {
+    try {
+      await spawnAndCapture(scriptPath, argsFromCtx(ctx))
+      consola.success(`${scriptPath} passed`)
+    } catch (error: unknown) {
+      const detail = error instanceof Error ? error.message : String(error)
+      const tail = detail.split('\n').slice(-5).join('\n')
+      const report = severity === 'warning' ? ctx.logWarn : ctx.logError
+      report(`${scriptPath} failed: ${tail}`)
+    }
+  }
 }
 
 /**
@@ -565,62 +604,71 @@ async function checkWhitelistIntegrity(
         }
       }
     } else if (hasEvmContext) {
-      const whitelistManager = getContract({
-        address: diamondAddress as Address,
-        abi: parseAbi([
-          'function isContractSelectorWhitelisted(address,bytes4) external view returns (bool)',
-        ]),
-        client: publicClient,
-      })
+      const abi = parseAbi([
+        'function isContractSelectorWhitelisted(address,bytes4) external view returns (bool)',
+      ])
       const hasMulticall3 =
         publicClient.chain?.contracts?.multicall3 !== undefined
 
-      for (const expectedPair of expectedPairs) {
-        try {
-          let isWhitelisted: boolean
-          if (hasMulticall3) {
-            const result = await publicClient.multicall({
-              contracts: [
-                {
-                  address: whitelistManager.address,
-                  abi: whitelistManager.abi as Abi,
-                  functionName: 'isContractSelectorWhitelisted',
-                  args: [
-                    expectedPair.contract as Address,
-                    expectedPair.selector,
-                  ],
-                },
-              ],
-              allowFailure: false,
-            })
-            isWhitelisted = result[0] as boolean
-          } else {
-            const manager = whitelistManager as unknown as {
-              read: {
-                isContractSelectorWhitelisted: (
-                  args: [Address, Hex]
-                ) => Promise<boolean>
-              }
-            }
-            isWhitelisted = await manager.read.isContractSelectorWhitelisted([
-              expectedPair.contract as Address,
-              expectedPair.selector,
-            ])
-          }
-          if (!isWhitelisted) {
+      if (hasMulticall3) {
+        // One multicall over ALL pairs (viem auto-chunks) instead of a round-trip per pair.
+        const results = await publicClient.multicall({
+          contracts: expectedPairs.map((pair) => ({
+            address: diamondAddress as Address,
+            abi,
+            functionName: 'isContractSelectorWhitelisted' as const,
+            args: [pair.contract as Address, pair.selector] as const,
+          })),
+          allowFailure: true,
+        })
+        expectedPairs.forEach((pair, i) => {
+          const result = results[i]
+          if (!result || result.status !== 'success') {
             logError(
-              `Source of Truth FAILED: ${expectedPair.contract} / ${expectedPair.selector} is 'false'.`
+              `Failed to check ${pair.contract}/${pair.selector}: ${
+                result?.error?.message ?? 'call failed'
+              }`
+            )
+            granularFails++
+          } else if (!result.result) {
+            logError(
+              `Source of Truth FAILED: ${pair.contract} / ${pair.selector} is 'false'.`
             )
             granularFails++
           }
-        } catch (error: unknown) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error)
-          logError(
-            `Failed to check ${expectedPair.contract}/${expectedPair.selector}: ${errorMessage}`
-          )
-          granularFails++
-        }
+        })
+      } else {
+        // No multicall3 on this chain: fire the reads concurrently (still one round-trip each,
+        // but parallel) rather than sequentially.
+        const manager = getContract({
+          address: diamondAddress as Address,
+          abi,
+          client: publicClient,
+        })
+        await Promise.all(
+          expectedPairs.map(async (pair) => {
+            try {
+              const isWhitelisted =
+                await manager.read.isContractSelectorWhitelisted([
+                  pair.contract as Address,
+                  pair.selector,
+                ])
+              if (!isWhitelisted) {
+                logError(
+                  `Source of Truth FAILED: ${pair.contract} / ${pair.selector} is 'false'.`
+                )
+                granularFails++
+              }
+            } catch (error: unknown) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error)
+              logError(
+                `Failed to check ${pair.contract}/${pair.selector}: ${errorMessage}`
+              )
+              granularFails++
+            }
+          })
+        )
       }
     }
 
@@ -746,9 +794,25 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     description: 'All expected facets are registered in the diamond',
     severity: 'error',
     scope: {},
+    remediation:
+      'Add/verify the facet via diamondCut (see script/deploy/facets) and confirm it is verified on the explorer.',
     run: async (ctx) => {
       let registeredFacets: string[] = []
       let facetCheckSkipped = false
+      // Populated in place so the shared ctx.onChainFacets reference (see runner) is visible
+      // to the phase-2 selector/facet-set invariants.
+      const setOnChainFacets = (facets: IOnChainFacet[]) => {
+        ctx.onChainFacets.length = 0
+        ctx.onChainFacets.push(...facets)
+      }
+      const configFacetsByAddress = Object.fromEntries(
+        Object.entries(ctx.deployedContracts).map(
+          ([name, address]: [string, unknown]) => [
+            String(address).toLowerCase(),
+            name,
+          ]
+        )
+      )
       try {
         if (ctx.isTron && ctx.tronRpcUrl) {
           const rawString = await callTronContract(
@@ -761,86 +825,37 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           const onChainFacets = parseTroncastFacetsOutput(rawString)
 
           if (Array.isArray(onChainFacets)) {
-            ctx.onChainFacets = onChainFacets.map(
-              ([address, selectors]: [string, unknown]) => ({
+            setOnChainFacets(
+              onChainFacets.map(([address, selectors]: [string, unknown]) => ({
                 address: String(address),
                 selectors: (Array.isArray(selectors) ? selectors : []).map(
                   (s) => String(s)
                 ),
-              })
+              }))
             )
-
-            const configFacetsByAddress = Object.fromEntries(
-              Object.entries(ctx.deployedContracts).map(
-                ([name, address]: [string, unknown]) => [
-                  String(address).toLowerCase(),
-                  name,
-                ]
-              )
-            )
-
-            registeredFacets = onChainFacets
-              .map(
-                ([tronAddress]: [string, unknown]) =>
-                  configFacetsByAddress[String(tronAddress).toLowerCase()]
-              )
+            registeredFacets = ctx.onChainFacets
+              .map((f) => configFacetsByAddress[f.address.toLowerCase()])
               .filter((name): name is string => typeof name === 'string')
           }
-        } else if (
-          ctx.networkConfig.rpcUrl &&
-          ctx.publicClient &&
-          ctx.publicClient.chain
-        ) {
-          const rpcUrl: string =
-            ctx.publicClient.chain.rpcUrls.default.http[0] ||
-            ctx.networkConfig.rpcUrl
-          const rawString = await execWithRateLimitRetry(
-            [
-              'cast',
-              'call',
-              ctx.diamondAddress,
-              'facets() returns ((address,bytes4[])[])',
-              '--rpc-url',
-              rpcUrl,
-            ],
-            0,
-            3,
-            RETRY_DELAY
+        } else if (ctx.publicClient) {
+          // viem read (not `cast`): folds into the batched multicall client and drops a subprocess.
+          const diamond = getContract({
+            address: ctx.diamondAddress as Address,
+            abi: parseAbi([
+              'function facets() view returns ((address facetAddress, bytes4[] functionSelectors)[])',
+            ]),
+            client: ctx.publicClient,
+          })
+          const facets = await diamond.read.facets()
+          setOnChainFacets(
+            facets.map((f) => ({
+              address: f.facetAddress,
+              selectors: [...f.functionSelectors],
+            }))
           )
-
-          const jsonCompatibleString = rawString
-            .replace(/\(/g, '[')
-            .replace(/\)/g, ']')
-            .replace(/0x[0-9a-fA-F]+/g, '"$&"')
-
-          const onChainFacets = JSON.parse(jsonCompatibleString)
-
-          if (Array.isArray(onChainFacets)) {
-            ctx.onChainFacets = onChainFacets.map(
-              ([address, selectors]: [string, unknown]) => ({
-                address: String(address),
-                selectors: (Array.isArray(selectors) ? selectors : []).map(
-                  (s) => String(s)
-                ),
-              })
-            )
-
-            const configFacetsByAddress = Object.fromEntries(
-              Object.entries(ctx.deployedContracts).map(
-                ([name, address]: [string, unknown]) => [
-                  String(address).toLowerCase(),
-                  name,
-                ]
-              )
-            )
-
-            registeredFacets = onChainFacets
-              .map(
-                ([address]: [string, unknown]) =>
-                  configFacetsByAddress[String(address).toLowerCase()]
-              )
-              .filter((name): name is string => typeof name === 'string')
-          }
+          registeredFacets = ctx.onChainFacets
+            .map((f) => configFacetsByAddress[f.address.toLowerCase()])
+            .filter((name): name is string => typeof name === 'string')
         }
       } catch (error: unknown) {
         facetCheckSkipped = true
@@ -855,7 +870,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           const errorMessage =
             error instanceof Error ? error.message : String(error)
           consola.warn(
-            'Unable to parse output - skipping facet registration check'
+            'Unable to read facets() - skipping facet registration check'
           )
           consola.warn('Error:', errorMessage)
         }
@@ -899,6 +914,8 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       'Executor is bound to the deployed ERC20Proxy and that proxy authorizes it (bug bounty #292)',
     severity: 'error',
     scope: { environments: ['production'] },
+    remediation:
+      'Executor bound to a stale proxy: redeploy the Executor against the deployed ERC20Proxy, re-register it, and authorize it on the proxy.',
     run: async (ctx) => {
       const erc20ProxyAddress = ctx.deployedContracts['ERC20Proxy']
       const executorAddress = ctx.deployedContracts['Executor']
@@ -1231,6 +1248,8 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     description: 'ERC20Proxy owner is the refund wallet',
     severity: 'error',
     scope: { environments: ['production'] },
+    remediation:
+      'Transfer ERC20Proxy ownership to refundWallet: current owner calls transferOwnership(refundWallet), then refundWallet calls confirmOwnershipTransfer().',
     run: async (ctx) => {
       if (ctx.isTron && ctx.tronWeb && ctx.tronRpcUrl)
         await checkOwnershipTron(
@@ -1357,42 +1376,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         )
     },
   },
-  {
-    name: 'pauser-wallet-funded',
-    description: 'Pauser wallet holds a non-zero native balance',
-    severity: 'error',
-    scope: {},
-    run: async (ctx) => {
-      if (ctx.isTron && ctx.tronWeb) {
-        try {
-          const pauserTronAddress = ensureTronAddress(
-            ctx.pauserWalletAddress,
-            ctx.tronWeb
-          )
-          const balanceSun = await ctx.tronWeb.trx.getBalance(pauserTronAddress)
-          const balanceTrx = ctx.tronWeb.fromSun(balanceSun)
-          const balanceStr = String(balanceTrx)
-
-          if (!balanceTrx || balanceStr === '0')
-            ctx.logError('PauserWallet does not have any native balance')
-          else consola.success(`PauserWallet is funded: ${balanceTrx} TRX`)
-        } catch (error: unknown) {
-          const errorMessage =
-            error instanceof Error ? error.message : String(error)
-          ctx.logError(`Failed to check pauser wallet balance: ${errorMessage}`)
-        }
-      } else if (ctx.publicClient) {
-        const pauserBalance = formatEther(
-          await ctx.publicClient.getBalance({
-            address: ctx.pauserWalletAddress as Address,
-          })
-        )
-        if (!pauserBalance || pauserBalance === '0')
-          ctx.logError('PauserWallet does not have any native balance')
-        else consola.success(`PauserWallet is funded: ${pauserBalance}`)
-      }
-    },
-  },
+  // NOTE: pauser-wallet-funded was intentionally removed. Pauser funding is owned by
+  // verifyEmergencyPauseReadiness.yml (checkPauserFunds.sh), which checks the stronger
+  // "can afford a pauseDiamond()" rather than mere non-zero balance. Keeping a weaker
+  // daily duplicate here wasted RPC and split ownership of that check.
   {
     name: 'refund-wallet-access',
     description:
@@ -1469,6 +1456,9 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     description: 'No function selector is registered by more than one facet',
     severity: 'error',
     scope: {},
+    readsOnChainFacets: true,
+    remediation:
+      'A selector maps to two facets — a broken diamondCut; remove the duplicate registration.',
     run: async (ctx) => {
       if (ctx.onChainFacets.length === 0) {
         consola.info(
@@ -1493,6 +1483,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     description: 'Every on-chain facet address is a known deployed contract',
     severity: 'warning',
     scope: {},
+    readsOnChainFacets: true,
     run: async (ctx) => {
       if (ctx.onChainFacets.length === 0) {
         consola.info(
@@ -1630,48 +1621,125 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
 ]
 
 /**
- * Run the given invariants against one network's context, in registry order.
- * Applicability is decided by {@link isInvariantApplicable}; a thrown invariant is
- * recorded as an error (never aborts the run) unless it is marked `haltIfFailed`, in
- * which case a prerequisite failure (e.g. diamond not deployed) stops the remaining
- * checks. Results accumulate in `ctx.errors` / `ctx.warnings`.
+ * Execute one invariant against an isolated view of the context, then merge its result.
+ *
+ * Each invariant logs into its own `errors`/`warnings` arrays (not the shared ones) so that
+ * (a) invariants can run concurrently without clobbering each other's error accounting, and
+ * (b) a fatal failure can be cleanly re-verified once: read-only checks are idempotent, so a
+ * failure that does not reproduce on a second run was a transient RPC blip, not real drift.
+ * `onChainFacets` stays shared (same array reference) — `facets-registered` mutates it in
+ * place so the phase-2 consumers see it.
+ *
+ * @returns true if the invariant failed (an error persisted after re-verification).
+ */
+async function executeInvariant(
+  baseCtx: IHealthCheckContext,
+  invariant: IHealthCheckInvariant
+): Promise<boolean> {
+  consola.box(
+    `[${invariant.severity}] ${invariant.name} — ${invariant.description}`
+  )
+  const errors: string[] = []
+  const warnings: string[] = []
+  const localCtx: IHealthCheckContext = {
+    ...baseCtx,
+    errors,
+    warnings,
+    logError: (msg: string) => {
+      consola.error(msg)
+      errors.push(msg)
+    },
+    logWarn: (msg: string) => {
+      consola.warn(msg)
+      warnings.push(msg)
+    },
+  }
+
+  const runOnce = async () => {
+    try {
+      await invariant.run(localCtx)
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      localCtx.logError(`[${invariant.name}] threw: ${errorMessage}`)
+    }
+  }
+
+  await runOnce()
+
+  // Re-verify a fatal failure once before recording it — guards against transient RPC errors
+  // paging on a green fleet. Only error-severity failures are re-checked (warnings are non-fatal).
+  if (invariant.severity === 'error' && errors.length > 0) {
+    errors.length = 0
+    warnings.length = 0
+    await runOnce()
+    if (errors.length === 0)
+      consola.info(`↻ [${invariant.name}] recovered on re-verify (transient)`)
+  }
+
+  const failed = errors.length > 0
+  if (failed && invariant.remediation)
+    consola.info(`💡 ${invariant.name}: ${invariant.remediation}`)
+
+  baseCtx.errors.push(...errors)
+  baseCtx.warnings.push(...warnings)
+  return failed
+}
+
+/**
+ * Run the given invariants against one network's context. Applicability is decided by
+ * {@link isInvariantApplicable} and per-network carve-outs by {@link getInvariantExclusion}.
+ *
+ * Execution is phased for both correctness and efficiency:
+ * - Phase 0: `haltIfFailed` prerequisites (e.g. diamond deployed) run first, sequentially;
+ *   if one fails the run stops (nothing else is meaningful).
+ * - Phase 1: every other invariant that does NOT read `onChainFacets` runs concurrently —
+ *   their on-chain reads overlap so the viem client (batch: multicall) aggregates them into
+ *   a few multicall round-trips instead of dozens of sequential calls.
+ * - Phase 2: invariants that read `onChainFacets` run concurrently after phase 1's barrier,
+ *   by which point `facets-registered` has populated it.
+ *
+ * Results accumulate in `ctx.errors` / `ctx.warnings`.
  */
 export async function runHealthCheckInvariants(
   ctx: IHealthCheckContext,
   invariants: IHealthCheckInvariant[] = HEALTH_CHECK_INVARIANTS
 ): Promise<void> {
-  for (const invariant of invariants) {
+  const active = invariants.filter((invariant) => {
     if (!isInvariantApplicable(invariant, ctx)) {
       consola.info(`⏭  Skipping [${invariant.name}] (out of scope)`)
-      continue
+      return false
     }
-
     const exclusion = getInvariantExclusion(invariant.name, ctx.networkLower)
     if (exclusion) {
       // Surface the carve-out (never a silent skip) so it is visible in the run output.
       consola.info(
         `⏭  Skipping [${invariant.name}] on ${ctx.networkLower} — excluded: ${exclusion.reason}`
       )
-      continue
+      return false
     }
+    return true
+  })
 
-    consola.box(
-      `[${invariant.severity}] ${invariant.name} — ${invariant.description}`
-    )
-    const errorsBefore = ctx.errors.length
-    try {
-      await invariant.run(ctx)
-    } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error)
-      ctx.logError(`[${invariant.name}] threw: ${errorMessage}`)
-    }
-
-    if (invariant.haltIfFailed && ctx.errors.length > errorsBefore) {
+  for (const invariant of active.filter((i) => i.haltIfFailed)) {
+    const failed = await executeInvariant(ctx, invariant)
+    if (failed) {
       consola.warn(
         `Halting further checks: prerequisite invariant '${invariant.name}' failed.`
       )
       return
     }
   }
+
+  const rest = active.filter((i) => !i.haltIfFailed)
+  await Promise.all(
+    rest
+      .filter((i) => !i.readsOnChainFacets)
+      .map((i) => executeInvariant(ctx, i))
+  )
+  await Promise.all(
+    rest
+      .filter((i) => i.readsOnChainFacets)
+      .map((i) => executeInvariant(ctx, i))
+  )
 }

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -27,11 +27,10 @@ import {
 } from 'viem'
 
 import type { IWhitelistConfig, TargetState } from '../common/types'
-import { sleep } from '../utils/delay'
 import { spawnAndCapture } from '../utils/spawnAndCapture'
 import { normalizeSelector } from '../utils/utils'
 
-import { RETRY_DELAY, SAFE_THRESHOLD } from './shared/constants'
+import { SAFE_THRESHOLD } from './shared/constants'
 import { getCorePeriphery } from './shared/globalContractLists'
 import { isRateLimitError } from './shared/rateLimit'
 import { parseTroncastFacetsOutput } from './tron/helpers/parseTroncastFacetsOutput'
@@ -99,7 +98,6 @@ export interface IHealthCheckContext {
   deployerWallet: string
   refundWallet: string
   feeCollectorOwner: string
-  pauserWalletAddress: string
   /** Populated by the `facets-registered` invariant; reused by selector/facet-set invariants. */
   onChainFacets: IOnChainFacet[]
   errors: string[]
@@ -205,54 +203,6 @@ export function getInvariantExclusion(
     (e) =>
       e.invariant === invariantName && e.network.toLowerCase() === networkLower
   )
-}
-
-/**
- * Execute a command with retry logic for rate limit errors (429).
- * Uses spawn to avoid shell interpretation issues with special characters.
- *
- * NOTE: For Tron contract calls, prefer using callTronContract() from tron/tronUtils.ts
- * which is specialized for troncast and includes proper delay handling.
- *
- * @param commandParts - Array of command parts (e.g., ['cast', 'call', ...])
- * @param initialDelay - Initial delay before first attempt (ms)
- * @param maxRetries - Maximum number of retries
- * @param retryDelay - Delay in ms for all retry attempts (default: RETRY_DELAY)
- * @returns The command output string
- * @throws The last error if all retries fail
- */
-export async function execWithRateLimitRetry(
-  commandParts: string[],
-  initialDelay = 0,
-  maxRetries = 3,
-  retryDelay = RETRY_DELAY
-): Promise<string> {
-  if (initialDelay > 0) {
-    await sleep(initialDelay)
-  }
-
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      consola.warn(
-        `Rate limit (429). Retrying in ${
-          retryDelay / 1000
-        }s... (attempt ${attempt}/${maxRetries})`
-      )
-      await sleep(retryDelay)
-    }
-    try {
-      const [command, ...args] = commandParts
-      if (!command) {
-        throw new Error('No command provided')
-      }
-      return await spawnAndCapture(command, args)
-    } catch (error: unknown) {
-      const shouldRetry = isRateLimitError(error) && attempt < maxRetries
-      if (!shouldRetry) throw error
-    }
-  }
-
-  throw new Error('Max retries exceeded')
 }
 
 /**

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -122,6 +122,53 @@ export interface IHealthCheckInvariant {
 }
 
 /**
+ * A deliberate, documented carve-out: skip one invariant on one network. Use ONLY when an
+ * invariant genuinely does not apply to a chain (e.g. an integration is deprecated there) —
+ * NOT to silence a real failure you should fix. Every entry MUST carry a `reason`, which is
+ * printed when the invariant is skipped so the carve-out is never invisible, and every entry
+ * is validated in tests to reference a real invariant name and a real network.
+ */
+export interface IInvariantExclusion {
+  /** `name` of the invariant to skip (must exist in HEALTH_CHECK_INVARIANTS). */
+  invariant: string
+  /** Network key to skip it on (as in config/networks.json; compared case-insensitively). */
+  network: string
+  /** Why this invariant does not apply on this network. Shown in the run output. */
+  reason: string
+}
+
+/**
+ * Per-network invariant carve-outs. Empty by default — the correct response to a failing
+ * invariant is almost always to fix the on-chain/config drift, not to exclude the check.
+ * Add an entry only for a genuine, permanent non-applicability, and link the ticket that
+ * documents the decision in `reason`.
+ *
+ * Example (do not uncomment without a real case):
+ *   {
+ *     invariant: 'executor-erc20proxy-binding',
+ *     network: 'somechain',
+ *     reason: 'ERC20Proxy path deprecated on somechain; token pulls route via Permit2 (EXSC-000)',
+ *   },
+ */
+export const HEALTH_CHECK_EXCLUSIONS: IInvariantExclusion[] = []
+
+/**
+ * Return the carve-out for a given invariant on a given network, or undefined if the
+ * invariant is not excluded there. Pure; network match is case-insensitive.
+ */
+export function getInvariantExclusion(
+  invariantName: string,
+  network: string,
+  exclusions: IInvariantExclusion[] = HEALTH_CHECK_EXCLUSIONS
+): IInvariantExclusion | undefined {
+  const networkLower = network.toLowerCase()
+  return exclusions.find(
+    (e) =>
+      e.invariant === invariantName && e.network.toLowerCase() === networkLower
+  )
+}
+
+/**
  * Execute a command with retry logic for rate limit errors (429).
  * Uses spawn to avoid shell interpretation issues with special characters.
  *
@@ -1596,6 +1643,15 @@ export async function runHealthCheckInvariants(
   for (const invariant of invariants) {
     if (!isInvariantApplicable(invariant, ctx)) {
       consola.info(`⏭  Skipping [${invariant.name}] (out of scope)`)
+      continue
+    }
+
+    const exclusion = getInvariantExclusion(invariant.name, ctx.networkLower)
+    if (exclusion) {
+      // Surface the carve-out (never a silent skip) so it is visible in the run output.
+      consola.info(
+        `⏭  Skipping [${invariant.name}] on ${ctx.networkLower} — excluded: ${exclusion.reason}`
+      )
       continue
     }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-655](https://linear.app/lifi-linear/issue/EXSC-655/prevention-layer-for-bug-bounty-292-assert-executorerc20proxy-binding) (same effort as #2078)

# Why did I implement it this way?

**Stacks on #2078** (base branch `healthcheck-binding-invariants`, not `main`) — it extends the invariant registry added there, and is intended to consolidate into that PR.

Adds a per-network carve-out layer so a specific eval can be excluded on a specific chain **when it genuinely doesn't apply** (e.g. a deprecated integration on one chain), without weakening the check everywhere. Chosen shape: a single declarative `HEALTH_CHECK_EXCLUSIONS` table of `{ invariant, network, reason }` rather than flags scattered across invariants or `skipHealthcheck`-style booleans in `networks.json`, because:

- **One auditable place** to see every carve-out across all chains.
- **`reason` is mandatory** and printed when the eval is skipped — a carve-out is never a silent skip.
- **Validated in tests**: every entry must reference a real invariant name AND a real network AND a non-empty reason, so a stale carve-out (renamed/removed invariant, deprecated chain) fails CI. This keeps the table honest as the registry evolves.

The table starts **empty** — the default response to a failing invariant is to fix the on-chain/config drift, not to exclude the check. (Alternative considered: a `healthCheckExclusions` map in `config/networks.json`, consistent with `skipHealthcheck`; rejected because it couples network config to invariant names, scatters carve-outs across networks, and can't be type/name-validated as cheaply.)

Runner change: `runHealthCheckInvariants` consults `getInvariantExclusion(name, network)` after scope gating and skips + logs the reason.

# Verification

- `bunx tsc-files --noEmit` — pass; `bunx eslint` — pass; `bun test` — 24 pass / 0 fail (adds `getInvariantExclusion` match/case-insensitivity/no-match + table-integrity: valid invariant name, valid network, non-empty reason).
- Module remains side-effect-free on import (`--help` loads).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
