### PR TITLE
chore(SupersetFacet): add TODO(EXSC-623) to defer refundRecipient rename

### DIFF
--- a/src/Facets/SupersetFacet.sol
+++ b/src/Facets/SupersetFacet.sol
@@ -100,6 +100,11 @@ contract SupersetFacet is ILiFi, ReentrancyGuard, SwapperV2, Validatable {
     struct SupersetData {
         bytes path;
         uint256 amountOutMin;
+        // TODO(EXSC-623): rename to the canonical `refundRecipient` per
+        // [CONV:FACET-REFUNDS]. Deferred so the name-only change rides the next
+        // audited change to this facet rather than forcing a standalone
+        // re-audit (selectors and runtime bytecode are unaffected). Reference
+        // implementation (rename + clear-signing regen + docs/tests): PR #2084.
         address refundAddress;
         address fallbackEoA;
         uint256 deadline;


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-658 — [SC] SupersetFacet: TODO breadcrumb deferring refundRecipient rename
(the deferred rename itself is tracked by EXSC-623, Backlog)

# Why did I implement it this way?

`SupersetFacet.SupersetData.refundAddress` should be renamed to the canonical
`refundRecipient` per [CONV:FACET-REFUNDS] (Slack convention call 2026-07-15).
The rename itself is **name-only** — verified by building both versions: function
selectors (`0x0691ff78` / `0xf26e657f`) and the executable runtime bytecode are
identical; only the human-readable ABI field name and the trailing metadata hash
change.

However, renaming the field forces a `@custom:version` bump, which makes
`versionControlAndAuditCheck` require a fresh `SupersetFacet@2.0.0` audit entry.
A full re-audit is not justified for a pure parameter rename, so instead of
paying that cost now we **defer the rename** and leave a `TODO(EXSC-623)`
breadcrumb at the struct field. The actual rename should ride the next
substantive (already-audited) change to this facet, folding the name change into
that change's audit.

This PR is **comment-only** — no version bump, no ABI change, no audit trigger.

The full rename is already implemented and verified in the reference PR #2084
(closed, branch kept): struct/usages/tests/docs/demo + regenerated
`config/clearSigningProposal.json`. EXSC-623 stays in Backlog to track landing it.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
