### PR TITLE
feat(scripts): ERC20Proxy ownership remediation toolkit (EXSC-660)

### DIFF
--- a/script/tasks/confirmOwnershipForMax.ts
+++ b/script/tasks/confirmOwnershipForMax.ts
@@ -1,0 +1,254 @@
+/**
+ * confirmOwnershipForMax.ts — STEP 2 of the ERC20Proxy ownership remediation.
+ *
+ * For each of the two-step proxies it calls confirmOwnershipTransfer() from the
+ * refundWallet, finalising the transfer SC initiated in step 1 (which set
+ * pendingOwner = refundWallet). Reads the network + proxy list from the committed
+ * manifest and RPCs from config/networks.json (preferring ETH_NODE_URI_<NET> if set),
+ * so nothing sensitive is embedded.
+ *
+ * Idempotent & resumable: reads on-chain state first and skips anything already done
+ * or not yet ready (SC step 1 still pending). Re-run freely.
+ *
+ * SAFETY: dry-run by default; pass --broadcast to sign/send. Never prints the key or
+ * full RPC URLs. Reads the key from PRIVATE_KEY_REFUND_WALLET (override with --key-env NAME).
+ *
+ *   set -a; . ./.env; set +a          # must expose the refundWallet key
+ *   bunx tsx script/tasks/confirmOwnershipForMax.ts                 # dry-run
+ *   bunx tsx script/tasks/confirmOwnershipForMax.ts --broadcast     # finalise everything ready
+ *   bunx tsx script/tasks/confirmOwnershipForMax.ts --broadcast --only polygon,bsc
+ *
+ * NOTE: single-step chains (moonbeam et al.) are NOT here — they finalise in step 1.
+ * tron is a separate troncast stream. If confirm would revert NotPendingOwner, SC has
+ * not run step 1 on that chain yet — the script pre-checks and marks it NOT_READY.
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  defineChain,
+  getAddress,
+  parseAbi,
+  formatEther,
+  type Address,
+  type Hex,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const REPO = process.env.REPO_DIR || process.cwd()
+const argv = process.argv.slice(2)
+const BROADCAST = argv.includes('--broadcast')
+const KEY_ENV =
+  argv.find((a) => a.startsWith('--key-env='))?.split('=')[1] ||
+  'PRIVATE_KEY_REFUND_WALLET'
+const ONLY = (
+  argv.find((a) => a.startsWith('--only='))?.split('=')[1] ||
+  (argv.includes('--only') ? argv[argv.indexOf('--only') + 1] ?? '' : '')
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+const STATE_PATH =
+  argv.find((a) => a.startsWith('--state='))?.split('=')[1] ||
+  `${REPO}/confirm-ownership-state.json`
+
+const manifest = JSON.parse(
+  readFileSync(
+    `${REPO}/script/tasks/ownership-remediation-manifest.json`,
+    'utf8'
+  )
+)
+const networks = JSON.parse(
+  readFileSync(`${REPO}/config/networks.json`, 'utf8')
+)
+const REFUND = getAddress(manifest.refundWallet)
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+const firstLine = (m: string, n = 80): string =>
+  (m.split('\n')[0] ?? m).slice(0, n)
+const normKey = (k: string): Hex => {
+  const t = (k || '').trim()
+  return (t.startsWith('0x') ? t : `0x${t}`) as Hex
+}
+
+const rawKey = process.env[KEY_ENV] || ''
+if (!rawKey.trim())
+  throw new Error(
+    `${KEY_ENV} not set — source the .env that holds the refundWallet key`
+  )
+const ACCOUNT = privateKeyToAccount(normKey(rawKey))
+if (getAddress(ACCOUNT.address) !== REFUND)
+  throw new Error(
+    `${KEY_ENV} derives ${ACCOUNT.address}, expected refundWallet ${REFUND} — wrong key, aborting`
+  )
+
+const abi = parseAbi([
+  'function owner() view returns (address)',
+  'function pendingOwner() view returns (address)',
+  'function confirmOwnershipTransfer()',
+])
+
+interface IEntry {
+  network: string
+  erc20Proxy: string
+}
+const entries: IEntry[] = (manifest.evmTwoStep as IEntry[]).filter((e) =>
+  ONLY.length ? ONLY.includes(e.network) : true
+)
+
+type StateRecord = Record<string, unknown>
+const state: Record<string, StateRecord> = existsSync(STATE_PATH)
+  ? JSON.parse(readFileSync(STATE_PATH, 'utf8'))
+  : {}
+const save = () => writeFileSync(STATE_PATH, JSON.stringify(state, null, 2))
+const fmt = (w: bigint) => Number(formatEther(w)).toFixed(8)
+const NOW = process.env.RUN_TS || 'run'
+
+function clientsFor(net: string) {
+  const n = networks[net]
+  const rpc =
+    process.env[`ETH_NODE_URI_${net.toUpperCase()}`]?.trim() || n.rpcUrl
+  const chain = defineChain({
+    id: Number(n.chainId),
+    name: net,
+    nativeCurrency: {
+      name: n.nativeCurrency || 'ETH',
+      symbol: n.nativeCurrency || 'ETH',
+      decimals: 18,
+    },
+    rpcUrls: { default: { http: [rpc] } },
+  })
+  const transport = http(rpc, {
+    timeout: 20_000,
+    retryCount: 2,
+    retryDelay: 800,
+  })
+  return {
+    pub: createPublicClient({ chain, transport }),
+    wallet: createWalletClient({ account: ACCOUNT, chain, transport }),
+  }
+}
+
+async function processChain(e: IEntry) {
+  const proxy = getAddress(e.erc20Proxy)
+  const { pub, wallet } = clientsFor(e.network)
+  const rec: StateRecord = state[e.network] || {}
+
+  let owner: Address, pending: Address
+  try {
+    owner = getAddress(
+      await pub.readContract({ address: proxy, abi, functionName: 'owner' })
+    )
+    pending = getAddress(
+      await pub
+        .readContract({ address: proxy, abi, functionName: 'pendingOwner' })
+        .catch(() => ZERO)
+    )
+  } catch (err) {
+    console.log(
+      `✗ ${e.network}: unreachable (${firstLine((err as Error).message, 60)})`
+    )
+    rec.status = 'UNREACHABLE'
+    rec.updated = NOW
+    state[e.network] = rec
+    return save()
+  }
+
+  if (owner === REFUND) {
+    console.log(`✓ ${e.network}: already owned by refundWallet — done`)
+    rec.status = 'DONE'
+    rec.updated = NOW
+    state[e.network] = rec
+    return save()
+  }
+  if (pending !== REFUND) {
+    console.log(
+      `… ${e.network}: NOT READY (pendingOwner=${pending}) — SC step 1 not done yet`
+    )
+    rec.status = 'NOT_READY'
+    rec.updated = NOW
+    state[e.network] = rec
+    return save()
+  }
+
+  const gasPrice = await pub.getGasPrice().catch(() => 0n)
+  const bal = await pub.getBalance({ address: ACCOUNT.address })
+  if (gasPrice > 0n) {
+    const need = (60_000n * gasPrice * 15n) / 10n // ~confirm gas x1.5
+    if (bal < need) {
+      console.log(
+        `⚠ ${e.network}: refundWallet underfunded (${fmt(bal)} < ~${fmt(
+          need
+        )}) — fund refundWallet then re-run`
+      )
+      rec.status = 'REFUND_UNDERFUNDED'
+      rec.updated = NOW
+      state[e.network] = rec
+      return save()
+    }
+  }
+
+  console.log(`→ ${e.network}: confirmOwnershipTransfer()  proxy=${proxy}`)
+  if (BROADCAST) {
+    const h = await wallet.writeContract({
+      address: proxy,
+      abi,
+      functionName: 'confirmOwnershipTransfer',
+    })
+    await pub.waitForTransactionReceipt({ hash: h })
+    const o2 = getAddress(
+      await pub.readContract({ address: proxy, abi, functionName: 'owner' })
+    )
+    rec.confirmTx = h
+    rec.owner = o2
+    rec.status = o2 === REFUND ? 'DONE' : 'VERIFY_FAILED'
+    console.log(
+      `   ${e.network}: ${rec.status}${
+        rec.status === 'DONE' ? '' : ` (owner=${o2})`
+      }`
+    )
+  } else {
+    rec.status = 'DRYRUN_READY'
+  }
+  rec.updated = NOW
+  state[e.network] = rec
+  save()
+}
+
+;(async () => {
+  console.log(
+    `Mode: ${BROADCAST ? 'BROADCAST' : 'DRY-RUN'} | signer: refundWallet ${
+      ACCOUNT.address
+    } | chains: ${entries.length}\n`
+  )
+  for (const e of entries) {
+    try {
+      await processChain(e)
+    } catch (err) {
+      console.log(`✗ ${e.network}: ERROR ${firstLine((err as Error).message)}`)
+      state[e.network] = {
+        ...(state[e.network] || {}),
+        status: 'ERROR',
+        error: firstLine((err as Error).message, 120),
+        updated: NOW,
+      }
+      save()
+    }
+  }
+  console.log('\n════ SUMMARY ════')
+  const statusOf = (n: string): string =>
+    (state[n]?.status as string | undefined) ?? '—'
+  const by: Record<string, string[]> = {}
+  for (const e of entries) (by[statusOf(e.network)] ||= []).push(e.network)
+  for (const [s, ns] of Object.entries(by).sort())
+    console.log(`${s} (${ns.length}): ${ns.sort().join(' ')}`)
+  const pending = entries.filter((e) => statusOf(e.network) !== 'DONE')
+  if (pending.length && BROADCAST)
+    console.log(
+      `\nRe-run to finish ${pending.length}:  ... --broadcast --only ${pending
+        .map((e) => e.network)
+        .join(',')}`
+    )
+})()

--- a/script/tasks/ownership-remediation-manifest.json
+++ b/script/tasks/ownership-remediation-manifest.json
@@ -1,0 +1,455 @@
+{
+  "refundWallet": "0x156CeBba59DEB2cB23742F70dCb0a11cC775591F",
+  "transferOwnershipCalldata": "0xf2fde38b000000000000000000000000156cebba59deb2cb23742f70dcb0a11cc775591f",
+  "confirmOwnershipTransferCalldata": "0x7200b829",
+  "evmTwoStep": [
+    {
+      "network": "mainnet",
+      "erc20Proxy": "0x68E1Acfa805dcA813116Ed6507E01c38D44318f0",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "0g",
+      "erc20Proxy": "0x5DAf14730DdD0F102D6A826c11677efba090D7d7",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "abstract",
+      "erc20Proxy": "0x3C2b4f5916AFe9b9e7cA8F5944e776a713035e01",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "apechain",
+      "erc20Proxy": "0xDF28E193B15A366308fEdA4dA0D52855dC1fB5dF",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "arbitrumnova",
+      "erc20Proxy": "0x27139fC566d78e743Fb8B0E845069676DaA94aEd",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "berachain",
+      "erc20Proxy": "0x988764Fd9F705163c530388b42dD7181edA3F502",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "bob",
+      "erc20Proxy": "0xb1E9A462Bc38f62855662962c92Bf5C8aB67D699",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "botanix",
+      "erc20Proxy": "0xe5b95953a5769cB88595F66dfa3BA49b74cD2a79",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "etherlink",
+      "erc20Proxy": "0xDD103B009341a6eAE5fBb4667722Bf08B5b2afd1",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "flare",
+      "erc20Proxy": "0x82a00cB7D1FB1e1ad4ec2F344Bd1Ad2eAB338B73",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "flow",
+      "erc20Proxy": "0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "hemi",
+      "erc20Proxy": "0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "hyperevm",
+      "erc20Proxy": "0x3E8EDF9CC2591a7dB1A36DBB73A10d8746368D61",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "ink",
+      "erc20Proxy": "0xE16150617A4560925ef8e68E8efa3D68Bec3Bb7F",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "jovay",
+      "erc20Proxy": "0x6779c514999667B371d70844BAe96Cf782A3c54f",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "katana",
+      "erc20Proxy": "0xd45f6CaE2838A06D99C0Aceec201E7bd2003d567",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "lens",
+      "erc20Proxy": "0x6C251afA2ca69b53BF4588B63f2820a91672A6D3",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "megaeth",
+      "erc20Proxy": "0x6779c514999667B371d70844BAe96Cf782A3c54f",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "monad",
+      "erc20Proxy": "0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "morph",
+      "erc20Proxy": "0x1763A91609e4cad6c67148cC855B0aDa9b787b5F",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "nibiru",
+      "erc20Proxy": "0x7C25598d46593854904ec28c22A74a5C1d7f0c2A",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "optimism",
+      "erc20Proxy": "0x314bE5fcf0A204837896e6028C47A9e1FC2919c7",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "pharos",
+      "erc20Proxy": "0x27139fC566d78e743Fb8B0E845069676DaA94aEd",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "plasma",
+      "erc20Proxy": "0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "plume",
+      "erc20Proxy": "0xEb68ad34Af6150f840Bbc8d32E1cC09719Df9327",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "ronin",
+      "erc20Proxy": "0x38a7A06fEC3cA47105741605b3f52bbfeF5c9243",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "somnia",
+      "erc20Proxy": "0xE58c2CC78bA787bB8a549435bE6D31Ef92c150EF",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "soneium",
+      "erc20Proxy": "0x1f4613847c9F7Bd053c5229c65834c9231A83bF9",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "sophon",
+      "erc20Proxy": "0xEA6b5CDE78470740cdA435466EE38897225Bf7E8",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "stable",
+      "erc20Proxy": "0x6779c514999667B371d70844BAe96Cf782A3c54f",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "superposition",
+      "erc20Proxy": "0xC844DD1a2e26daD6FCb7AAb1Fe657ca14d139393",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "swellchain",
+      "erc20Proxy": "0xe670b3E309b8C867Df2559237884b4548cF69a41",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "telos",
+      "erc20Proxy": "0x7fa91e1F381Bc9000fD6D182c834137c9558E035",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "tempo",
+      "erc20Proxy": "0xB73D8c580b7fa3B583B2ADa5e106aD42220183C0",
+      "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3"
+    },
+    {
+      "network": "unichain",
+      "erc20Proxy": "0x1f4613847c9F7Bd053c5229c65834c9231A83bF9",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "vana",
+      "erc20Proxy": "0xF230cE59a3e7E026990c052b9c9416e8B707965C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "viction",
+      "erc20Proxy": "0x82a00cB7D1FB1e1ad4ec2F344Bd1Ad2eAB338B73",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    },
+    {
+      "network": "xdc",
+      "erc20Proxy": "0x7C25598d46593854904ec28c22A74a5C1d7f0c2A",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2"
+    }
+  ],
+  "evmSingleStep": [
+    {
+      "network": "base",
+      "erc20Proxy": "0x74a55CaDb12501A3707E9F3C5dfd8b563C6A5940",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "blast",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "celo",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "cronos",
+      "erc20Proxy": "0x9B112948F3c71eBFb59961657b37c21328cFb01e",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "fraxtal",
+      "erc20Proxy": "0xEd170C587Ccb4DaD6986798c8E7cC66fBb564AC5",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "gravity",
+      "erc20Proxy": "0x4307ca7Eca98daF86D4f65b4367B273C628A39B7",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "kaia",
+      "erc20Proxy": "0x6bb99Db9a03fa178F4F74F3A76204a4E9F9fD843",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "linea",
+      "erc20Proxy": "0x57ec2C57fA654aABAeCc63c8dad47cb6efaCCC24",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "lisk",
+      "erc20Proxy": "0x98750e70Cf1313D9702f0f57D399DD0bA05d16E0",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "mantle",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "metis",
+      "erc20Proxy": "0x88BFF60dFB4382dfb8da7dD5caC23397350D2078",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "mode",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "opbnb",
+      "erc20Proxy": "0x9B112948F3c71eBFb59961657b37c21328cFb01e",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "rootstock",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "scroll",
+      "erc20Proxy": "0xA950Ac46b0b844c0564d18A54A9685e614B9086C",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "sei",
+      "erc20Proxy": "0xEd170C587Ccb4DaD6986798c8E7cC66fBb564AC5",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "sonic",
+      "erc20Proxy": "0x55A5cE71307Ec425F0E533400A0bcEb136e6E800",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "taiko",
+      "erc20Proxy": "0x6bC43F95C5234aA749D18403753d60B91f972d3c",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "worldchain",
+      "erc20Proxy": "0x98750e70Cf1313D9702f0f57D399DD0bA05d16E0",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "xlayer",
+      "erc20Proxy": "0x32f9EBAEA88bfE6b965108A2315AC2bE6253cC82",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "zksync",
+      "erc20Proxy": "0x8E1cf39Df64D9DCAdA7831d90CC852e02663410a",
+      "currentOwner": "0x11F1022cA6AdEF6400e5677528a80d49a069C00c",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V2",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "avalanche",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "boba",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "bsc",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "fuse",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "gnosis",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "immutablezkevm",
+      "erc20Proxy": "0xB59Cb9E4087c841577ACE23B0168CCDdf9450290",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "polygon",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "arbitrum",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    },
+    {
+      "network": "moonbeam",
+      "erc20Proxy": "0x5741A7FfE7c39Ca175546a54985fA79211290b51",
+      "currentOwner": "0x11F11121DF7256C40339393b0FB045321022ce44",
+      "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V1",
+      "note": "OZ Ownable single-step: transferOwnership finalises IMMEDIATELY, no step-2, IRREVERSIBLE"
+    }
+  ],
+  "tron": {
+    "network": "tron",
+    "erc20Proxy": "TDCo8wrqwRVC7HaRAAsuCdbnS4AdAdtcn9",
+    "currentOwner": "0xb137683965ADC470f140df1a1D05B0D25C14E269",
+    "signerKey": "PRIVATE_KEY_PRODUCTION_OLD_V3",
+    "refundWalletTron": "TBvVg3Aam5QP2XE3XCatgatjefXvsYf6yD",
+    "note": "two-step via troncast/TronWeb, separate stream"
+  }
+}

--- a/script/tasks/ownershipRemediation.ts
+++ b/script/tasks/ownershipRemediation.ts
@@ -1,0 +1,401 @@
+/**
+ * ownershipRemediation.ts — one-shot, idempotent, resumable remediation of ERC20Proxy
+ * ownership from COMPROMISED old deployer wallets to refundWallet.
+ *
+ * Per network, done BACK-TO-BACK to minimise the funding-exposure window on the
+ * compromised wallet:
+ *   1. read on-chain state → skip if already remediated (resume/idempotency)
+ *   2. fund the old owner with the MINIMUM gas needed (transfer + sweep-back), only
+ *      the shortfall, and only if the current deployer has the gas to spare
+ *   3. transferOwnership(refundWallet) from the old owner key
+ *        - two-step proxies (38): sets pendingOwner (REVERSIBLE; Max confirms later)
+ *        - single-step OZ Ownable proxies (30, incl. moonbeam): finalises IMMEDIATELY (IRREVERSIBLE, no Max step)
+ *   4. sweep the old owner's remaining native back to the current deployer
+ *      (also rescues any pre-existing balance off the compromised wallet)
+ *   5. verify + persist per-network state; a re-run picks up only what's incomplete
+ *
+ * SAFETY: dry-run by default. Pass --broadcast to sign/send. Secrets hygiene: never
+ * prints private keys or full RPC URLs. Reads keys from the environment (source .env first).
+ *
+ *   set -a; . ./.env; set +a
+ *   NODE_PATH=./node_modules bunx tsx ownershipRemediation.ts            # dry-run
+ *   NODE_PATH=./node_modules bunx tsx ownershipRemediation.ts --broadcast
+ *   ... --only polygon,bsc     # restrict to specific networks
+ *   ... --state ./remediation-state.json
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  defineChain,
+  getAddress,
+  parseAbi,
+  formatEther,
+  type Address,
+  type Hex,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const REPO = process.env.REPO_DIR || process.cwd()
+const argv = process.argv.slice(2)
+const BROADCAST = argv.includes('--broadcast')
+const ONLY = (
+  argv.find((a) => a.startsWith('--only='))?.split('=')[1] ||
+  (argv.includes('--only') ? argv[argv.indexOf('--only') + 1] ?? '' : '')
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+
+// first line of an error message, safe against empty splits (strict TS)
+const firstLine = (m: string, n = 90): string =>
+  (m.split('\n')[0] ?? m).slice(0, n)
+const STATE_PATH =
+  argv.find((a) => a.startsWith('--state='))?.split('=')[1] ||
+  `${REPO}/ownership-remediation-state.json`
+const MANIFEST_PATH =
+  argv.find((a) => a.startsWith('--manifest='))?.split('=')[1] ||
+  `${REPO}/script/tasks/ownership-remediation-manifest.json`
+
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'))
+const networks = JSON.parse(
+  readFileSync(`${REPO}/config/networks.json`, 'utf8')
+)
+const REFUND = getAddress(manifest.refundWallet)
+
+const abi = parseAbi([
+  'function owner() view returns (address)',
+  'function pendingOwner() view returns (address)',
+  'function transferOwnership(address newOwner)',
+])
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+// keys in .env may lack the 0x prefix; viem requires it
+const normKey = (k: string): Hex => {
+  const t = (k || '').trim().replace(/^#.*$/, '')
+  return (t.startsWith('0x') ? t : `0x${t}`) as Hex
+}
+
+// funder = current (safe) deployer
+const rawFunder = process.env.PRIVATE_KEY_PRODUCTION || ''
+if (!rawFunder.trim())
+  throw new Error('PRIVATE_KEY_PRODUCTION (funder) not set — source .env')
+const FUNDER = privateKeyToAccount(normKey(rawFunder))
+
+interface IManifestEntry {
+  network: string
+  erc20Proxy: Address
+  currentOwner: Address
+  signerKey: string
+}
+interface IEntry extends IManifestEntry {
+  mode: 'two-step' | 'single-step'
+}
+const entries: IEntry[] = [
+  ...(manifest.evmTwoStep as IManifestEntry[]).map((e) => ({
+    ...e,
+    mode: 'two-step' as const,
+  })),
+  ...(manifest.evmSingleStep as IManifestEntry[]).map((e) => ({
+    ...e,
+    mode: 'single-step' as const,
+  })),
+].filter((e) => (ONLY.length ? ONLY.includes(e.network) : true))
+
+type StateRecord = Record<string, unknown>
+const state: Record<string, StateRecord> = existsSync(STATE_PATH)
+  ? JSON.parse(readFileSync(STATE_PATH, 'utf8'))
+  : {}
+const save = () => writeFileSync(STATE_PATH, JSON.stringify(state, null, 2))
+
+function clientsFor(net: string, ownerKey: Hex) {
+  const n = networks[net]
+  // prefer authenticated ETH_NODE_URI_<UPPER> (has API keys, more reliable) over public rpcUrl
+  const rpc =
+    process.env[`ETH_NODE_URI_${net.toUpperCase()}`]?.trim() || n.rpcUrl
+  const chain = defineChain({
+    id: Number(n.chainId),
+    name: net,
+    nativeCurrency: {
+      name: n.nativeCurrency || 'ETH',
+      symbol: n.nativeCurrency || 'ETH',
+      decimals: 18,
+    },
+    rpcUrls: { default: { http: [rpc] } },
+  })
+  const transport = http(rpc, {
+    timeout: 20_000,
+    retryCount: 2,
+    retryDelay: 800,
+  })
+  const pub = createPublicClient({ chain, transport })
+  const owner = createWalletClient({
+    account: privateKeyToAccount(ownerKey),
+    chain,
+    transport,
+  })
+  const funder = createWalletClient({ account: FUNDER, chain, transport })
+  return { pub, owner, funder }
+}
+
+async function processNetwork(e: IEntry) {
+  const label = `${e.network}/${e.mode}`
+  const rawOwnerKey = process.env[e.signerKey] || ''
+  if (!rawOwnerKey.trim()) {
+    console.log(`SKIP ${label}: $${e.signerKey} not set`)
+    return
+  }
+  const ownerKey = normKey(rawOwnerKey)
+  const oldOwnerAddr = privateKeyToAccount(ownerKey).address
+  if (getAddress(oldOwnerAddr) !== getAddress(e.currentOwner)) {
+    console.log(
+      `SKIP ${label}: key ${e.signerKey} derives ${oldOwnerAddr}, manifest expects ${e.currentOwner}`
+    )
+    state[e.network] = { status: 'KEY_MISMATCH', updated: NOW }
+    return save()
+  }
+
+  const { pub, owner, funder } = clientsFor(e.network, ownerKey)
+  const rec: StateRecord = state[e.network] || {}
+  rec.mode = e.mode
+  rec.proxy = e.erc20Proxy
+
+  // ---- 1. read on-chain state (source of truth for resume/idempotency) ----
+  let curOwner: Address,
+    pending: Address = ZERO as Address
+  try {
+    curOwner = getAddress(
+      await pub.readContract({
+        address: e.erc20Proxy,
+        abi,
+        functionName: 'owner',
+      })
+    )
+    if (e.mode === 'two-step')
+      pending = getAddress(
+        await pub
+          .readContract({
+            address: e.erc20Proxy,
+            abi,
+            functionName: 'pendingOwner',
+          })
+          .catch(() => ZERO)
+      )
+  } catch (err) {
+    console.log(
+      `✗ ${label}: unreachable (${firstLine((err as Error).message, 60)})`
+    )
+    rec.status = 'UNREACHABLE'
+    rec.updated = NOW
+    state[e.network] = rec
+    return save()
+  }
+
+  const ownedByRefund = curOwner === REFUND
+  const transferAlreadyDone =
+    ownedByRefund || (e.mode === 'two-step' && pending === REFUND)
+
+  // ---- 2+3. fund (minimal) + transferOwnership (skip if already initiated) ----
+  const gasPrice = await pub.getGasPrice().catch(() => 0n)
+  if (gasPrice === 0n) {
+    console.log(`✗ ${label}: gasPrice=0 / fee-token chain — handle manually`)
+    rec.status = 'MANUAL'
+    rec.updated = NOW
+    state[e.network] = rec
+    return save()
+  }
+
+  if (!transferAlreadyDone) {
+    let gasTransfer = 60_000n
+    try {
+      gasTransfer = await pub.estimateContractGas({
+        address: e.erc20Proxy,
+        abi,
+        functionName: 'transferOwnership',
+        args: [REFUND],
+        account: owner.account,
+      })
+    } catch {}
+    const sweepReserve = 21_000n * 3n // headroom for the later sweep tx (L2 L1-fee buffer)
+    const needed = ((gasTransfer + sweepReserve) * gasPrice * 15n) / 10n // 1.5x
+    const bal = await pub.getBalance({ address: oldOwnerAddr })
+
+    if (bal < needed) {
+      const topup = needed - bal
+      const srcBal = await pub.getBalance({ address: FUNDER.address })
+      if (srcBal < topup + needed) {
+        // funder needs its own gas too
+        console.log(
+          `⚠ ${label}: SOURCE UNDERFUNDED (funder has ${fmt(
+            srcBal
+          )}, needs ~${fmt(topup)}) — bridge gas to funder first`
+        )
+        rec.status = 'SOURCE_UNDERFUNDED'
+        rec.needTopup = topup.toString()
+        rec.updated = NOW
+        state[e.network] = rec
+        return save()
+      }
+      console.log(
+        `→ ${label}: fund old owner ${fmt(topup)} (bal ${fmt(
+          bal
+        )} < needed ${fmt(needed)})`
+      )
+      if (BROADCAST) {
+        const h = await funder.sendTransaction({
+          to: oldOwnerAddr,
+          value: topup,
+        })
+        await pub.waitForTransactionReceipt({ hash: h })
+        rec.fundTx = h
+      }
+    } else {
+      console.log(
+        `→ ${label}: old owner already funded (${fmt(bal)} ≥ ${fmt(
+          needed
+        )}) — no top-up`
+      )
+    }
+
+    console.log(
+      `→ ${label}: transferOwnership(refundWallet) from ${e.signerKey}${
+        e.mode === 'single-step' ? '  [IRREVERSIBLE]' : ''
+      }`
+    )
+    if (BROADCAST) {
+      const h = await owner.writeContract({
+        address: e.erc20Proxy,
+        abi,
+        functionName: 'transferOwnership',
+        args: [REFUND],
+      })
+      await pub.waitForTransactionReceipt({ hash: h })
+      rec.transferTx = h
+    }
+  } else {
+    console.log(
+      `✓ ${label}: transfer already ${
+        ownedByRefund
+          ? 'FINALISED (owner=refund)'
+          : 'initiated (pendingOwner=refund)'
+      } — skipping transfer`
+    )
+  }
+
+  // ---- 4. sweep remaining native back to current deployer ----
+  const bal2 = await pub.getBalance({ address: oldOwnerAddr })
+  const reserve = 21_000n * gasPrice * 3n
+  if (bal2 > reserve) {
+    const sweep = bal2 - reserve
+    console.log(`→ ${label}: sweep ${fmt(sweep)} back to current deployer`)
+    if (BROADCAST) {
+      const h = await owner.sendTransaction({
+        to: FUNDER.address,
+        value: sweep,
+      })
+      await pub.waitForTransactionReceipt({ hash: h })
+      rec.sweepTx = h
+    }
+  } else {
+    console.log(`   ${label}: nothing to sweep (bal ${fmt(bal2)} ≤ reserve)`)
+  }
+
+  // ---- 5. verify + record ----
+  if (BROADCAST) {
+    const o2 = getAddress(
+      await pub.readContract({
+        address: e.erc20Proxy,
+        abi,
+        functionName: 'owner',
+      })
+    )
+    const p2 =
+      e.mode === 'two-step'
+        ? getAddress(
+            await pub
+              .readContract({
+                address: e.erc20Proxy,
+                abi,
+                functionName: 'pendingOwner',
+              })
+              .catch(() => ZERO)
+          )
+        : (ZERO as Address)
+    const ok =
+      e.mode === 'single-step' ? o2 === REFUND : o2 === REFUND || p2 === REFUND
+    rec.status = ok
+      ? e.mode === 'single-step'
+        ? 'DONE_FINALISED'
+        : 'TRANSFER_INITIATED_AWAIT_MAX'
+      : 'VERIFY_FAILED'
+    rec.owner = o2
+    rec.pendingOwner = p2
+    console.log(`   ${label}: ${rec.status}`)
+  } else {
+    rec.status = transferAlreadyDone
+      ? 'DRYRUN_ALREADY_DONE'
+      : 'DRYRUN_WOULD_ACT'
+  }
+  rec.updated = NOW
+  state[e.network] = rec
+  save()
+}
+
+const fmt = (w: bigint) => `${Number(formatEther(w)).toFixed(8)}`
+let NOW = ''
+
+;(async () => {
+  NOW = process.env.RUN_TS || 'run' // avoid Date.* in some sandboxes; ts is cosmetic
+  console.log(
+    `Mode: ${BROADCAST ? 'BROADCAST' : 'DRY-RUN'} | networks: ${
+      entries.length
+    } | state: ${STATE_PATH}\n`
+  )
+  // sequential (per-network back-to-back) to minimise exposure on compromised wallets
+  for (const e of entries) {
+    try {
+      await processNetwork(e)
+    } catch (err) {
+      console.log(
+        `✗ ${e.network}: ERROR ${firstLine((err as Error).message, 80)}`
+      )
+      state[e.network] = {
+        ...(state[e.network] || {}),
+        status: 'ERROR',
+        error: (err as Error).message.slice(0, 120),
+        updated: NOW,
+      }
+      save()
+    }
+  }
+  // ---- final per-network report + what to re-run ----
+  console.log('\n════ SUMMARY ════')
+  const statusOf = (net: string): string =>
+    (state[net]?.status as string | undefined) ?? '—'
+  const by: Record<string, string[]> = {}
+  for (const e of entries) {
+    ;(by[statusOf(e.network)] ||= []).push(e.network)
+  }
+  for (const [s, ns] of Object.entries(by).sort())
+    console.log(`${s} (${ns.length}): ${ns.join(' ')}`)
+  const incomplete = entries.filter(
+    (e) =>
+      !['DONE_FINALISED', 'TRANSFER_INITIATED_AWAIT_MAX'].includes(
+        statusOf(e.network)
+      )
+  )
+  if (incomplete.length && BROADCAST)
+    console.log(
+      `\nRe-run to finish ${
+        incomplete.length
+      }:  ... --broadcast --only ${incomplete.map((e) => e.network).join(',')}`
+    )
+  console.log(
+    '\nNOTE: two-step chains still need Max to run confirmOwnershipTransfer() from refundWallet.'
+  )
+  console.log(
+    'NOTE: tron is separate (troncast). moonbeam is single-step (already finalised above).'
+  )
+})()

--- a/script/tasks/verifyOwnership.ts
+++ b/script/tasks/verifyOwnership.ts
@@ -1,0 +1,118 @@
+/**
+ * verifyOwnership.ts — READ-ONLY status of the ERC20Proxy ownership remediation.
+ * No keys, no writes. For every proxy it reads owner()/pendingOwner() and prints a
+ * verdict: DONE (owner==refundWallet) | AWAITING-MAX (pendingOwner==refundWallet, step-1
+ * done, step-2 pending) | NOT-STARTED (still the old owner) | UNREACHABLE.
+ *
+ *   bunx tsx script/tasks/verifyOwnership.ts            # all
+ *   bunx tsx script/tasks/verifyOwnership.ts --only polygon,bsc
+ */
+import { readFileSync } from 'node:fs'
+
+import {
+  createPublicClient,
+  http,
+  getAddress,
+  parseAbi,
+  type Address,
+} from 'viem'
+
+const REPO = process.env.REPO_DIR || process.cwd()
+const argv = process.argv.slice(2)
+const ONLY = (
+  argv.find((a) => a.startsWith('--only='))?.split('=')[1] ||
+  (argv.includes('--only') ? argv[argv.indexOf('--only') + 1] ?? '' : '')
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean)
+
+const manifest = JSON.parse(
+  readFileSync(
+    `${REPO}/script/tasks/ownership-remediation-manifest.json`,
+    'utf8'
+  )
+)
+const networks = JSON.parse(
+  readFileSync(`${REPO}/config/networks.json`, 'utf8')
+)
+const REFUND = getAddress(manifest.refundWallet)
+const ZERO = '0x0000000000000000000000000000000000000000'
+const abi = parseAbi([
+  'function owner() view returns (address)',
+  'function pendingOwner() view returns (address)',
+])
+
+interface IRow {
+  network: string
+  proxy: Address
+  mode: 'two-step' | 'single-step'
+}
+const rows: IRow[] = [
+  ...manifest.evmTwoStep.map((e: { network: string; erc20Proxy: string }) => ({
+    network: e.network,
+    proxy: getAddress(e.erc20Proxy),
+    mode: 'two-step' as const,
+  })),
+  ...manifest.evmSingleStep.map(
+    (e: { network: string; erc20Proxy: string }) => ({
+      network: e.network,
+      proxy: getAddress(e.erc20Proxy),
+      mode: 'single-step' as const,
+    })
+  ),
+].filter((r) => (ONLY.length ? ONLY.includes(r.network) : true))
+
+async function verdictFor(r: IRow): Promise<string> {
+  const n = networks[r.network]
+  const rpc =
+    process.env[`ETH_NODE_URI_${r.network.toUpperCase()}`]?.trim() || n.rpcUrl
+  const client = createPublicClient({
+    transport: http(rpc, { timeout: 15_000, retryCount: 2, retryDelay: 700 }),
+  })
+  try {
+    const owner = getAddress(
+      await client.readContract({
+        address: r.proxy,
+        abi,
+        functionName: 'owner',
+      })
+    )
+    if (owner === REFUND) return 'DONE'
+    if (r.mode === 'single-step') return 'NOT-STARTED'
+    const pending = getAddress(
+      await client
+        .readContract({ address: r.proxy, abi, functionName: 'pendingOwner' })
+        .catch(() => ZERO)
+    )
+    return pending === REFUND ? 'AWAITING-MAX' : 'NOT-STARTED'
+  } catch {
+    return 'UNREACHABLE'
+  }
+}
+
+;(async () => {
+  // bounded concurrency
+  const out: { network: string; verdict: string }[] = []
+  let i = 0
+  await Promise.all(
+    Array.from({ length: 8 }, async () => {
+      while (i < rows.length) {
+        const r = rows[i++]
+        if (!r) break
+        out.push({ network: r.network, verdict: await verdictFor(r) })
+      }
+    })
+  )
+  const by: Record<string, string[]> = {}
+  for (const o of out) (by[o.verdict] ||= []).push(o.network)
+  console.log(`refundWallet target: ${REFUND}\n`)
+  for (const v of ['DONE', 'AWAITING-MAX', 'NOT-STARTED', 'UNREACHABLE'])
+    if (by[v]) console.log(`${v} (${by[v].length}): ${by[v].sort().join(' ')}`)
+  const done = (by['DONE'] || []).length
+  console.log(
+    `\n${done}/${rows.length} fully transferred to refundWallet.` +
+      (done === rows.length ? ' ✅ COMPLETE' : ' — not complete yet.')
+  )
+  console.log('(tron is separate — verify via troncast.)')
+})()


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-660](https://linear.app/lifi-linear/issue/EXSC-660/remediate-erc20proxy-ownership-transfer-from-compromised-legacy) (related: EXSC-655)

# Why did I implement it this way?

Production `ERC20Proxy` on all prod chains is still owned by **legacy deployer EOAs that are compromised** (native gets swept by bots), instead of the `refundWallet` `0x156CeBba59DEB2cB23742F70dCb0a11cC775591F` that the health-check eval (PR #2078) expects. This PR adds the operational toolkit to remediate that safely and verifiably. **No contracts change — `script/tasks/` only.**

Sweep across all production networks found **68 EVM `ERC20Proxy`** needing transfer (every Receiver is already `refundWallet`-owned; tron is separate). Split by ownership mechanism:

- **38 two-step** (`TransferrableOwnership`): `transferOwnership` sets `pendingOwner`, then `refundWallet` calls `confirmOwnershipTransfer`. Reversible until confirmed.
- **30 single-step** legacy OZ `Ownable` (incl. moonbeam): `transferOwnership` finalises immediately — **irreversible, no step-2**.

Three keys (all now in `.env`) own them: `_OLD_V2` (`0x11F1022c…`, 51), `_OLD_V3` (`0xb1376839…`, 8 + tron), `_OLD_V1` (`0x11F11121DF…`, 9).

**Files (all `script/tasks/`, viem, dry-run by default):**

- `ownershipRemediation.ts` — **step 1**: per chain, fund the compromised owner minimally → `transferOwnership(refundWallet)` → sweep leftover gas back to the current deployer. Sequential per-network to minimise exposure; idempotent + resumable (reads on-chain state, `--only` to resume).
- `confirmOwnershipForMax.ts` — **step 2** (refundWallet key): `confirmOwnershipTransfer()` on the 38 two-step chains. Aborts if the key doesn't derive to `refundWallet`. Pre-checks readiness so it can be looped while SC works through step 1.
- `verifyOwnership.ts` — **read-only** status (`DONE` / `AWAITING-MAX` / `NOT-STARTED`); source of truth for progress. Complete when `68/68`.
- `ownership-remediation-manifest.json` — the 68-proxy list + mechanism split.

Design notes: RPCs resolve from `ETH_NODE_URI_<NET>` (fallback `networks.json`); keys read from env, never printed; single-network `send`/broadcast is opt-in via `--broadcast`. nibiru (`gasPrice=0`) is flagged `MANUAL`; tron handled via troncast separately. Per-network sequential (not parallel) is deliberate — it caps how long a compromised wallet holds funds.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

# ERC20Proxy addresses (target owner: refundWallet `0x156CeBba59DEB2cB23742F70dCb0a11cC775591F`)

These are the **existing** on-chain proxy addresses — this remediation transfers ownership in place, it does **not** redeploy, so no address changes. Source of truth: `deployments/<network>.json` `ERC20Proxy` and `script/tasks/ownership-remediation-manifest.json`.

| network | ERC20Proxy address | mechanism | current owner (key) → target |
|---|---|---|---|
| mainnet | `0x68E1Acfa805dcA813116Ed6507E01c38D44318f0` | two-step | 0x11F1022c…C00c → refundWallet |
| 0g | `0x5DAf14730DdD0F102D6A826c11677efba090D7d7` | two-step | 0xb1376839…E269 → refundWallet |
| abstract | `0x3C2b4f5916AFe9b9e7cA8F5944e776a713035e01` | two-step | 0x11F1022c…C00c → refundWallet |
| apechain | `0xDF28E193B15A366308fEdA4dA0D52855dC1fB5dF` | two-step | 0x11F1022c…C00c → refundWallet |
| arbitrumnova | `0x27139fC566d78e743Fb8B0E845069676DaA94aEd` | two-step | 0xb1376839…E269 → refundWallet |
| berachain | `0x988764Fd9F705163c530388b42dD7181edA3F502` | two-step | 0x11F1022c…C00c → refundWallet |
| bob | `0xb1E9A462Bc38f62855662962c92Bf5C8aB67D699` | two-step | 0x11F1022c…C00c → refundWallet |
| botanix | `0xe5b95953a5769cB88595F66dfa3BA49b74cD2a79` | two-step | 0x11F1022c…C00c → refundWallet |
| etherlink | `0xDD103B009341a6eAE5fBb4667722Bf08B5b2afd1` | two-step | 0x11F1022c…C00c → refundWallet |
| flare | `0x82a00cB7D1FB1e1ad4ec2F344Bd1Ad2eAB338B73` | two-step | 0x11F1022c…C00c → refundWallet |
| flow | `0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D` | two-step | 0x11F1022c…C00c → refundWallet |
| hemi | `0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D` | two-step | 0x11F1022c…C00c → refundWallet |
| hyperevm | `0x3E8EDF9CC2591a7dB1A36DBB73A10d8746368D61` | two-step | 0x11F1022c…C00c → refundWallet |
| ink | `0xE16150617A4560925ef8e68E8efa3D68Bec3Bb7F` | two-step | 0x11F1022c…C00c → refundWallet |
| jovay | `0x6779c514999667B371d70844BAe96Cf782A3c54f` | two-step | 0xb1376839…E269 → refundWallet |
| katana | `0xd45f6CaE2838A06D99C0Aceec201E7bd2003d567` | two-step | 0x11F1022c…C00c → refundWallet |
| lens | `0x6C251afA2ca69b53BF4588B63f2820a91672A6D3` | two-step | 0x11F1022c…C00c → refundWallet |
| megaeth | `0x6779c514999667B371d70844BAe96Cf782A3c54f` | two-step | 0x11F1022c…C00c → refundWallet |
| monad | `0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D` | two-step | 0x11F1022c…C00c → refundWallet |
| morph | `0x1763A91609e4cad6c67148cC855B0aDa9b787b5F` | two-step | 0xb1376839…E269 → refundWallet |
| nibiru | `0x7C25598d46593854904ec28c22A74a5C1d7f0c2A` | two-step | 0x11F1022c…C00c → refundWallet |
| optimism | `0x314bE5fcf0A204837896e6028C47A9e1FC2919c7` | two-step | 0x11F1022c…C00c → refundWallet |
| pharos | `0x27139fC566d78e743Fb8B0E845069676DaA94aEd` | two-step | 0xb1376839…E269 → refundWallet |
| plasma | `0xEF3D879e24741973d7f7E78858BFA4FBB9CFa74D` | two-step | 0x11F1022c…C00c → refundWallet |
| plume | `0xEb68ad34Af6150f840Bbc8d32E1cC09719Df9327` | two-step | 0x11F1022c…C00c → refundWallet |
| ronin | `0x38a7A06fEC3cA47105741605b3f52bbfeF5c9243` | two-step | 0x11F1022c…C00c → refundWallet |
| somnia | `0xE58c2CC78bA787bB8a549435bE6D31Ef92c150EF` | two-step | 0xb1376839…E269 → refundWallet |
| soneium | `0x1f4613847c9F7Bd053c5229c65834c9231A83bF9` | two-step | 0x11F1022c…C00c → refundWallet |
| sophon | `0xEA6b5CDE78470740cdA435466EE38897225Bf7E8` | two-step | 0x11F1022c…C00c → refundWallet |
| stable | `0x6779c514999667B371d70844BAe96Cf782A3c54f` | two-step | 0x11F1022c…C00c → refundWallet |
| superposition | `0xC844DD1a2e26daD6FCb7AAb1Fe657ca14d139393` | two-step | 0x11F1022c…C00c → refundWallet |
| swellchain | `0xe670b3E309b8C867Df2559237884b4548cF69a41` | two-step | 0x11F1022c…C00c → refundWallet |
| telos | `0x7fa91e1F381Bc9000fD6D182c834137c9558E035` | two-step | 0xb1376839…E269 → refundWallet |
| tempo | `0xB73D8c580b7fa3B583B2ADa5e106aD42220183C0` | two-step | 0xb1376839…E269 → refundWallet |
| unichain | `0x1f4613847c9F7Bd053c5229c65834c9231A83bF9` | two-step | 0x11F1022c…C00c → refundWallet |
| vana | `0xF230cE59a3e7E026990c052b9c9416e8B707965C` | two-step | 0x11F1022c…C00c → refundWallet |
| viction | `0x82a00cB7D1FB1e1ad4ec2F344Bd1Ad2eAB338B73` | two-step | 0x11F1022c…C00c → refundWallet |
| xdc | `0x7C25598d46593854904ec28c22A74a5C1d7f0c2A` | two-step | 0x11F1022c…C00c → refundWallet |
| base | `0x74a55CaDb12501A3707E9F3C5dfd8b563C6A5940` | **single-step** | 0x11F1022c…C00c → refundWallet |
| blast | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| celo | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| cronos | `0x9B112948F3c71eBFb59961657b37c21328cFb01e` | **single-step** | 0x11F1022c…C00c → refundWallet |
| fraxtal | `0xEd170C587Ccb4DaD6986798c8E7cC66fBb564AC5` | **single-step** | 0x11F1022c…C00c → refundWallet |
| gravity | `0x4307ca7Eca98daF86D4f65b4367B273C628A39B7` | **single-step** | 0x11F1022c…C00c → refundWallet |
| kaia | `0x6bb99Db9a03fa178F4F74F3A76204a4E9F9fD843` | **single-step** | 0x11F1022c…C00c → refundWallet |
| linea | `0x57ec2C57fA654aABAeCc63c8dad47cb6efaCCC24` | **single-step** | 0x11F1022c…C00c → refundWallet |
| lisk | `0x98750e70Cf1313D9702f0f57D399DD0bA05d16E0` | **single-step** | 0x11F1022c…C00c → refundWallet |
| mantle | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| metis | `0x88BFF60dFB4382dfb8da7dD5caC23397350D2078` | **single-step** | 0x11F1022c…C00c → refundWallet |
| mode | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| opbnb | `0x9B112948F3c71eBFb59961657b37c21328cFb01e` | **single-step** | 0x11F1022c…C00c → refundWallet |
| rootstock | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| scroll | `0xA950Ac46b0b844c0564d18A54A9685e614B9086C` | **single-step** | 0x11F1022c…C00c → refundWallet |
| sei | `0xEd170C587Ccb4DaD6986798c8E7cC66fBb564AC5` | **single-step** | 0x11F1022c…C00c → refundWallet |
| sonic | `0x55A5cE71307Ec425F0E533400A0bcEb136e6E800` | **single-step** | 0x11F1022c…C00c → refundWallet |
| taiko | `0x6bC43F95C5234aA749D18403753d60B91f972d3c` | **single-step** | 0x11F1022c…C00c → refundWallet |
| worldchain | `0x98750e70Cf1313D9702f0f57D399DD0bA05d16E0` | **single-step** | 0x11F1022c…C00c → refundWallet |
| xlayer | `0x32f9EBAEA88bfE6b965108A2315AC2bE6253cC82` | **single-step** | 0x11F1022c…C00c → refundWallet |
| zksync | `0x8E1cf39Df64D9DCAdA7831d90CC852e02663410a` | **single-step** | 0x11F1022c…C00c → refundWallet |
| avalanche | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| boba | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| bsc | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| fuse | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| gnosis | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| immutablezkevm | `0xB59Cb9E4087c841577ACE23B0168CCDdf9450290` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| polygon | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| arbitrum | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |
| moonbeam | `0x5741A7FfE7c39Ca175546a54985fA79211290b51` | **single-step** | 0x11F11121DF…ce44 → refundWallet |

tron (separate, troncast): `TDCo8wrqwRVC7HaRAAsuCdbnS4AdAdtcn9` → tron refundWallet `TBvVg3Aam5QP2XE3XCatgatjefXvsYf6yD`.
