### PR TITLE
docs(multisig-rollout): tag @diamond_multisig_signers for signing pings

### DIFF
--- a/.agents/commands/multisig-rollout.md
+++ b/.agents/commands/multisig-rollout.md
@@ -184,10 +184,10 @@ Top-level:
 
 (whitelist mode: `<N>x whitelist sync — <short PR title>`)
 
-Thread reply (capture `ts` from the top-level; `@smartcontract_core` MUST be the subteam syntax — plain text does not notify):
+Thread reply (capture `ts` from the top-level; `@diamond_multisig_signers` MUST be the subteam syntax — plain text does not notify). Signing pings the multisig-signer group, not the PR-review group `@smartcontract_core` — the signer set includes a non-core member:
 
 ```text
-<!subteam^S096X6MCB0C> please sign/execute :pray:
+<!subteam^S0BKA0JRY0G> please sign/execute :pray:
 
 PR with deployed addresses: <PR URL>
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None — trivial docs-only change (single-line skill update). Labelled `trivial` per the ticket-linkage carve-out.

# Why did I implement it this way?

A new Slack subteam `@diamond_multisig_signers` (Daniela, Goran, Daniel) now owns multisig **signing**, since the signer set includes a non-core member. The `multisig-rollout` skill's Phase 8 thread reply — the "please sign/execute" ping — is the only skill mention that targets signers, so it now uses `<!subteam^S0BKA0JRY0G>` (renders `@diamond_multisig_signers`) instead of `<!subteam^S096X6MCB0C>` (`@smartcontract_core`).

**PR review is unchanged**: `post-pr-for-review`, `check-open-prs`, and the README PR-review row still tag `@smartcontract_core` — reviews are still done by the core team; only signing has a non-core member. Added a one-line note in the skill so a future "consistency" edit doesn't accidentally re-sync the two tags.

Edited the canonical source at `.agents/commands/multisig-rollout.md`; the `.cursor/` and `.claude/` copies are symlinks.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
