### PR TITLE
chore(PolymerCCTPFacet): TODO to remove temporary solanaReceiverATA param

### DIFF
--- a/src/Facets/PolymerCCTPFacet.sol
+++ b/src/Facets/PolymerCCTPFacet.sol
@@ -86,6 +86,9 @@ contract PolymerCCTPFacet is
         // Should only be nonzero if submitting to a nonEVM chain
         bytes32 nonEVMReceiver;
         // For Solana: the receiver's Associated Token Account (ATA) for USDC
+        // TODO: temporary param — the backend currently passes the receiver address here as a
+        // fixture. Update the facet to derive/handle the ATA on-chain so this field can be removed.
+        // https://linear.app/lifi-linear/issue/EXSC-662/sc-polymer-update-cctp-facet-to-remove-solanareceiverata-param
         bytes32 solanaReceiverATA;
         // the minimum finality at which a burn message will be attested to, will be passed directly to tokenMessenger.depositForBurn method.
         // 1000 = fast path, 2000 = standard path


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-662/sc-polymer-update-cctp-facet-to-remove-solanareceiverata-param

# Why did I implement it this way?

Comment-only change. The backend currently passes the receiver wallet address into `PolymerCCTPData.solanaReceiverATA` as a temporary fixture for Solana-destination CCTP transfers. This adds a tracked `TODO` on the struct field so the facet can be updated to derive/handle the receiver ATA on-chain and the param removed once that change lands. No logic, storage layout, ABI, or behavior changes.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
