### PR TITLE
fix(helperFunctions): preserve date failure in timestamped loggers (EXSC-661 follow-up)

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3259,8 +3259,8 @@ function success() {
 function logWithTimestamp() {
   local MESSAGE="$1"
   local TIMESTAMP
-  TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
-  echo "[$TIMESTAMP] $MESSAGE"
+  TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S') || return 1
+  printf '[%s] %s\n' "$TIMESTAMP" "$MESSAGE"
 }
 # logNetworkResult: Print a per-network status line prefixed with a timestamp.
 #
@@ -3276,8 +3276,8 @@ function logNetworkResult() {
   local STATUS="$2"
   local MESSAGE="$3"
   local TIMESTAMP
-  TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
-  echo "[$TIMESTAMP] [$NETWORK] $STATUS: $MESSAGE"
+  TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S') || return 1
+  printf '[%s] [%s] %s: %s\n' "$TIMESTAMP" "$NETWORK" "$STATUS" "$MESSAGE"
 }
 # <<<<< output to console
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-661](https://linear.app/lifi-linear/issue/EXSC-661/non-interactive-deploys-abort-logwithtimestamp-not-source-visible-to) (follow-up hardening)

# Why did I implement it this way?

Addresses the remaining CodeRabbit finding from #2086 ([comment](https://github.com/lifinance/contracts/pull/2086#discussion_r3613944486)) that missed the merge: in `logWithTimestamp` and `logNetworkResult`, the `TIMESTAMP=$(date ...)` assignment swallowed a `date` failure, so the helper could emit an empty timestamp and still return success. Now the assignment returns on `date` failure, and output uses `printf` instead of `echo` (safer with arbitrary message content). Applied identically to both loggers since they were introduced together in #2089 and share the pattern.

Validated: `bash -n`, sourcing under `set -euo pipefail`, happy-path output unchanged, and a stubbed failing `date` propagates exit 1.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
