### PR TITLE
fix(VaultWrapper): address #2092 review findings (2, 3, 8, 9, 10)

### DIFF
--- a/.agents/rules/108-vault-wrapper.md
+++ b/.agents/rules/108-vault-wrapper.md
@@ -71,13 +71,17 @@ and counter-intuitive against the repo's Diamond-era conventions.
   silently picks up v4 — keep VaultWrapper code under the scoped paths.
 - The repo does not enable `via_ir`; v5's namespaced-storage accessors raise stack
   pressure, so keep `initialize`/large functions shallow rather than enabling it.
-- **Pragma floor is `^0.8.24`, not the repo-wide `^0.8.17`** (a deliberate override of
+- **Pragma is `^0.8.29`, not the repo-wide `^0.8.17`** (a deliberate override of
   `[CONV:LICENSE]`'s pragma rule for this subsystem only): OZ v5.6.1's
-  `ERC4626Upgradeable` itself requires `^0.8.24` and the toolchain emits `mcopy`, so
-  declaring `^0.8.17` would be a provably false floor. Every file under `src/VaultWrapper/`,
-  `test/solidity/VaultWrapper/`, and `script/deploy/vaultWrapper/` pins `^0.8.24`. The
-  honesty of this floor is enforced by the `solc_floor_vaultwrapper` Foundry profile
-  (solc 0.8.24 + evm cancun), a second build step in `solc-floor-build.yml`.
+  `ERC4626Upgradeable` requires `^0.8.24` and the toolchain emits `mcopy` (cancun), so
+  `^0.8.17` would be a provably false floor. The subsystem is only ever deployed by LI.FI
+  with the repo's default compiler, so it pins that exact version (`^0.8.29`) rather than a
+  lower "honest minimum" — a lower floor would buy nothing (verification and bytecode key
+  off the exact compiler, not the pragma range) at the cost of a separate floor build. Every
+  file under `src/VaultWrapper/`, `test/solidity/VaultWrapper/`, and `script/deploy/vaultWrapper/`
+  pins `^0.8.29`. Because that equals the default compile version, the ordinary build is the
+  floor check; the subsystem is excluded from the `solc_floor` profile (which only compiles
+  the Diamond's 0.8.17 floor) and needs no profile of its own.
 
 ## Identity and onboarding ([CONV:VW-IDENTITY])
 

--- a/.agents/rules/108-vault-wrapper.md
+++ b/.agents/rules/108-vault-wrapper.md
@@ -71,6 +71,13 @@ and counter-intuitive against the repo's Diamond-era conventions.
   silently picks up v4 — keep VaultWrapper code under the scoped paths.
 - The repo does not enable `via_ir`; v5's namespaced-storage accessors raise stack
   pressure, so keep `initialize`/large functions shallow rather than enabling it.
+- **Pragma floor is `^0.8.24`, not the repo-wide `^0.8.17`** (a deliberate override of
+  `[CONV:LICENSE]`'s pragma rule for this subsystem only): OZ v5.6.1's
+  `ERC4626Upgradeable` itself requires `^0.8.24` and the toolchain emits `mcopy`, so
+  declaring `^0.8.17` would be a provably false floor. Every file under `src/VaultWrapper/`,
+  `test/solidity/VaultWrapper/`, and `script/deploy/vaultWrapper/` pins `^0.8.24`. The
+  honesty of this floor is enforced by the `solc_floor_vaultwrapper` Foundry profile
+  (solc 0.8.24 + evm cancun), a second build step in `solc-floor-build.yml`.
 
 ## Identity and onboarding ([CONV:VW-IDENTITY])
 

--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -9,9 +9,9 @@
 #   job is skipped (see `.agents/rules/500-github-actions.md`).
 # - The profile skips test/script (they trip the legacy pipeline's "stack too deep", a
 #   codegen limit unrelated to floor-feature detection) and matches production codegen.
-# - The Earn Vault Wrapper (src/VaultWrapper/**) is on OpenZeppelin v5 and declares a
-#   higher floor (`^0.8.24`); it is floor-checked by a second build step using the
-#   `solc_floor_vaultwrapper` profile (solc 0.8.24 + evm cancun) instead of being skipped.
+# - The Earn Vault Wrapper (src/VaultWrapper/**) is on OpenZeppelin v5 and pins `^0.8.29`,
+#   matching the default compile version, so the ordinary build already floor-checks it;
+#   it is skipped by the `solc_floor` profile (which can only compile the 0.8.17 floor).
 
 name: Verify Floor-Compiler Build
 on:
@@ -97,16 +97,6 @@ jobs:
         env:
           FOUNDRY_PROFILE: solc_floor
         run: forge build
-
-      - name: Build src/VaultWrapper with subsystem floor compiler (solc 0.8.24)
-        # The Earn Vault Wrapper is on OpenZeppelin v5 and declares a higher floor
-        # (`^0.8.24`) than the Diamond, so it is excluded from the profile above and
-        # floor-checked here instead. The `solc_floor_vaultwrapper` profile pins solc
-        # 0.8.24 + evm cancun; the explicit path scopes the build to the subsystem. A
-        # failure means a src/VaultWrapper/ contract uses a feature newer than `^0.8.24`.
-        env:
-          FOUNDRY_PROFILE: solc_floor_vaultwrapper
-        run: forge build src/VaultWrapper
 
   solc-floor-build-required:
     # Aggregator job for branch protection. Reports green when the heavy job

--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -9,6 +9,9 @@
 #   job is skipped (see `.agents/rules/500-github-actions.md`).
 # - The profile skips test/script (they trip the legacy pipeline's "stack too deep", a
 #   codegen limit unrelated to floor-feature detection) and matches production codegen.
+# - The Earn Vault Wrapper (src/VaultWrapper/**) is on OpenZeppelin v5 and declares a
+#   higher floor (`^0.8.24`); it is floor-checked by a second build step using the
+#   `solc_floor_vaultwrapper` profile (solc 0.8.24 + evm cancun) instead of being skipped.
 
 name: Verify Floor-Compiler Build
 on:
@@ -94,6 +97,16 @@ jobs:
         env:
           FOUNDRY_PROFILE: solc_floor
         run: forge build
+
+      - name: Build src/VaultWrapper with subsystem floor compiler (solc 0.8.24)
+        # The Earn Vault Wrapper is on OpenZeppelin v5 and declares a higher floor
+        # (`^0.8.24`) than the Diamond, so it is excluded from the profile above and
+        # floor-checked here instead. The `solc_floor_vaultwrapper` profile pins solc
+        # 0.8.24 + evm cancun; the explicit path scopes the build to the subsystem. A
+        # failure means a src/VaultWrapper/ contract uses a feature newer than `^0.8.24`.
+        env:
+          FOUNDRY_PROFILE: solc_floor_vaultwrapper
+        run: forge build src/VaultWrapper
 
   solc-floor-build-required:
     # Aggregator job for branch protection. Reports green when the heavy job

--- a/foundry.toml
+++ b/foundry.toml
@@ -47,14 +47,31 @@ runs = 32
 # - test/script are skipped: only deployed contracts must honor the floor, and those
 #   suites trip the legacy pipeline's "stack too deep" (a codegen limit, not a
 #   floor-incompatibility signal) which would mask the real check.
-# - src/VaultWrapper/** is skipped: the standalone Earn Vault Wrapper builds on
-#   OpenZeppelin v5, which requires solc >= 0.8.24, so the subsystem's real floor is
-#   higher than the Diamond's 0.8.17 and it cannot compile under this profile. Nothing
-#   in the Diamond imports it, so excluding it here does not weaken the Diamond's check.
+# - src/VaultWrapper/** is skipped HERE because the standalone Earn Vault Wrapper builds
+#   on OpenZeppelin v5 and pins a higher floor (`^0.8.24`); it cannot compile under
+#   0.8.17. Its floor is enforced by the separate `solc_floor_vaultwrapper` profile below
+#   rather than left unchecked. Nothing in the Diamond imports it, so excluding it from
+#   this profile does not weaken the Diamond's check.
 [profile.solc_floor]
 solc_version = '0.8.17'
 evm_version = 'london'
 skip = ['test/**', 'script/**', 'src/VaultWrapper/**']
+
+# Floor-compiler check for the Earn Vault Wrapper subsystem (used by the same workflow).
+# The subsystem is on OpenZeppelin v5 and pins `^0.8.24`, a genuinely higher floor than
+# the Diamond's 0.8.17, so it needs its own floor build rather than an exemption.
+# Run locally: FOUNDRY_PROFILE=solc_floor_vaultwrapper forge build src/VaultWrapper
+# (build the subsystem explicitly; the profile pins the compiler, the path scopes the check).
+# - solc 0.8.24 is the floor every src/VaultWrapper/ file pins via `pragma solidity ^0.8.24`
+#   (OZ v5.6.1's ERC4626Upgradeable itself requires `^0.8.24`).
+# - evm_version `cancun` is required: OZ v5.6.1 emits `mcopy`, which shanghai/london lack.
+# - test/script are skipped for the same reason as the Diamond floor profile (legacy-pipeline
+#   stack-too-deep); the CI step passes the src/VaultWrapper path so only the subsystem's
+#   deployed contracts are floor-checked.
+[profile.solc_floor_vaultwrapper]
+solc_version = '0.8.24'
+evm_version = 'cancun'
+skip = ['test/**', 'script/**']
 
 [profile.zksync]
 solc_version = '0.8.29'

--- a/foundry.toml
+++ b/foundry.toml
@@ -48,30 +48,15 @@ runs = 32
 #   suites trip the legacy pipeline's "stack too deep" (a codegen limit, not a
 #   floor-incompatibility signal) which would mask the real check.
 # - src/VaultWrapper/** is skipped HERE because the standalone Earn Vault Wrapper builds
-#   on OpenZeppelin v5 and pins a higher floor (`^0.8.24`); it cannot compile under
-#   0.8.17. Its floor is enforced by the separate `solc_floor_vaultwrapper` profile below
-#   rather than left unchecked. Nothing in the Diamond imports it, so excluding it from
-#   this profile does not weaken the Diamond's check.
+#   on OpenZeppelin v5 and pins `^0.8.29` (matching the default compile version), so it
+#   cannot compile under 0.8.17. Its floor equals the version the default profile already
+#   builds with, so the ordinary forge build IS its floor check — no separate floor profile
+#   is needed. Nothing in the Diamond imports it, so excluding it here does not weaken the
+#   Diamond's check.
 [profile.solc_floor]
 solc_version = '0.8.17'
 evm_version = 'london'
 skip = ['test/**', 'script/**', 'src/VaultWrapper/**']
-
-# Floor-compiler check for the Earn Vault Wrapper subsystem (used by the same workflow).
-# The subsystem is on OpenZeppelin v5 and pins `^0.8.24`, a genuinely higher floor than
-# the Diamond's 0.8.17, so it needs its own floor build rather than an exemption.
-# Run locally: FOUNDRY_PROFILE=solc_floor_vaultwrapper forge build src/VaultWrapper
-# (build the subsystem explicitly; the profile pins the compiler, the path scopes the check).
-# - solc 0.8.24 is the floor every src/VaultWrapper/ file pins via `pragma solidity ^0.8.24`
-#   (OZ v5.6.1's ERC4626Upgradeable itself requires `^0.8.24`).
-# - evm_version `cancun` is required: OZ v5.6.1 emits `mcopy`, which shanghai/london lack.
-# - test/script are skipped for the same reason as the Diamond floor profile (legacy-pipeline
-#   stack-too-deep); the CI step passes the src/VaultWrapper path so only the subsystem's
-#   deployed contracts are floor-checked.
-[profile.solc_floor_vaultwrapper]
-solc_version = '0.8.24'
-evm_version = 'cancun'
-skip = ['test/**', 'script/**']
 
 [profile.zksync]
 solc_version = '0.8.29'

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { DSTest } from "ds-test/test.sol";

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -22,14 +22,16 @@ import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 ///      DeployScriptBase. Per-network parameters are read from the scoped
 ///      config/vaultWrapper.json under the `NETWORK` key; the only env vars are
 ///      PRIVATE_KEY, NETWORK, and DEPLOYSALT (the salt prefix). Deploy order:
-///      TimelockController -> LiFiVaultWrapper -> UpgradeableBeacon(impl, timelock) ->
-///      LiFiVaultWrapperFactory(beacon, owner=timelock, ...) -> ERC4626Adapter. Each
-///      contract is deployed through the CREATE3 factory under its own salt, so the
-///      address depends only on (deployer, salt) and is independent of constructor
-///      args and deploy order — mainnets sharing the same CREATE3 factory therefore
-///      get matching system addresses. Deploying via the CREATE3 proxy is safe here
-///      because every ownership/role is set from a constructor argument, never
-///      msg.sender. Timelock roles: the LI.FI multisig is proposer AND canceller (OZ
+///      TimelockController -> LiFiVaultWrapper(predicted factory) ->
+///      UpgradeableBeacon(impl, timelock) -> LiFiVaultWrapperFactory(beacon,
+///      owner=timelock, ...) -> ERC4626Adapter. Each contract is deployed through the
+///      CREATE3 factory under its own salt, so the address depends only on
+///      (deployer, salt) and is independent of constructor args and deploy order —
+///      mainnets sharing the same CREATE3 factory therefore get matching system
+///      addresses, and the factory's address can be predicted and bound into the
+///      implementation before the factory exists. Deploying via the CREATE3 proxy is
+///      safe here because every ownership/role is set from a constructor argument,
+///      never msg.sender. Timelock roles: the LI.FI multisig is proposer AND canceller (OZ
 ///      grants both to each proposer); the executor role is open (address(0)); the
 ///      optional admin is renounced (address(0)), so the timelock is self-administered.
 ///      Because the factory owner is the 48h timelock, post-deploy configuration —
@@ -127,8 +129,17 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
         vm.startBroadcast(_deployerPrivateKey);
 
         timelock = TimelockController(payable(_deployTimelock(_cfg.multisig)));
+        // The implementation only accepts initialize calls from the factory it is bound
+        // to at construction; CREATE3 addresses depend on (deployer, salt) only, so the
+        // factory's address is known before it exists.
         impl = LiFiVaultWrapper(
-            _deploy("LiFiVaultWrapper", type(LiFiVaultWrapper).creationCode)
+            _deploy(
+                "LiFiVaultWrapper",
+                abi.encodePacked(
+                    type(LiFiVaultWrapper).creationCode,
+                    abi.encode(_predict("LiFiVaultWrapperFactory"))
+                )
+            )
         );
         beacon = UpgradeableBeacon(
             _deployBeacon(address(impl), address(timelock))
@@ -221,6 +232,8 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
             revert WiringMismatch("beacon.owner");
         if (_beacon.implementation() != address(_impl))
             revert WiringMismatch("beacon.implementation");
+        if (_impl.EXPECTED_FACTORY() != address(_factory))
+            revert WiringMismatch("impl.expectedFactory");
 
         if (_factory.owner() != address(_timelock))
             revert WiringMismatch("factory.owner");
@@ -298,6 +311,18 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
             );
     }
 
+    /// @notice The deterministic CREATE3 address `_name` will deploy to under the
+    ///         current salt prefix and deployer.
+    /// @param _name The contract name, appended to DEPLOYSALT to form the salt.
+    /// @return The predicted contract address.
+    function _predict(string memory _name) internal view returns (address) {
+        return
+            create3.getDeployed(
+                deployer,
+                keccak256(abi.encodePacked(saltPrefix, _name))
+            );
+    }
+
     /// @notice Deploys `creationCode` through the CREATE3 factory under a per-contract
     ///         salt, skipping deployment if the deterministic address already has code.
     /// @param _name The contract name, appended to DEPLOYSALT to form the salt.
@@ -307,8 +332,8 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
         string memory _name,
         bytes memory _creationCode
     ) internal returns (address deployed) {
+        address predicted = _predict(_name);
         bytes32 salt = keccak256(abi.encodePacked(saltPrefix, _name));
-        address predicted = create3.getDeployed(deployer, salt);
 
         if (predicted.code.length != 0) {
             emit log_named_address(

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -232,7 +232,7 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
             revert WiringMismatch("beacon.owner");
         if (_beacon.implementation() != address(_impl))
             revert WiringMismatch("beacon.implementation");
-        if (_impl.EXPECTED_FACTORY() != address(_factory))
+        if (_impl.FACTORY() != address(_factory))
             revert WiringMismatch("impl.expectedFactory");
 
         if (_factory.owner() != address(_timelock))

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { DSTest } from "ds-test/test.sol";

--- a/script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol
+++ b/script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { DSTest } from "ds-test/test.sol";

--- a/script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol
+++ b/script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { DSTest } from "ds-test/test.sol";

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -33,8 +33,9 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      live in proxy storage (no constructor-set immutables, which a beacon proxy cannot give
 ///      per instance). This contract DOES custody funds: it holds the yield-source position on
 ///      behalf of depositors and transiently holds the asset while routing a deposit or
-///      withdrawal. Identity (`underlying`/`adapter`/`owner`/`factory`) and the initial fee
-///      configuration are set write-once in `initialize`. The per-vault admin role is OZ's
+///      withdrawal. Identity (`underlying`/`adapter`/`owner`) and the initial fee
+///      configuration are set write-once in `initialize` (the `FACTORY` is bound at
+///      construction). The per-vault admin role is OZ's
 ///      two-step `owner` (`transferOwnership`/`acceptOwnership`); renouncing it is disabled.
 ///      All four fee types are charged: management (time-based dilution) and performance
 ///      (high-water-mark dilution) fee-shares are minted to this contract via `_accrueFees`,
@@ -117,12 +118,14 @@ contract LiFiVaultWrapper is
 
     /// Immutables ///
 
-    /// @notice The only address allowed to initialize instances of this implementation,
-    ///         bound at construction. Every proxy that reaches `initialize` has therefore
-    ///         passed the factory's deploy-time validation (adapter approval, underlying
-    ///         allowlist, fee bounds), so a counterfeit proxy pointed at the official
-    ///         beacon can never be initialized with unvetted parameters.
-    address public immutable EXPECTED_FACTORY;
+    /// @notice The factory bound to this implementation at construction: the only address
+    ///         allowed to initialize instances, and the source read by later modules for the
+    ///         factory-level global circuit breaker, fee bounds, and LI.FI fee recipient.
+    ///         Every proxy that reaches `initialize` has therefore passed the factory's
+    ///         deploy-time validation (adapter approval, underlying allowlist, fee bounds),
+    ///         so a counterfeit proxy pointed at the official beacon can never be initialized
+    ///         with unvetted parameters.
+    address public immutable FACTORY;
 
     /// Storage ///
 
@@ -130,9 +133,6 @@ contract LiFiVaultWrapper is
     address public underlying;
     /// @notice The approved yield adapter the wrapper routes deposits/withdrawals through.
     address public adapter;
-    /// @notice The factory that deployed this instance (the initializer); read by later
-    ///         modules for the factory-level global circuit breaker.
-    address public factory;
     /// @notice Whether this clone's deposits are paused by the integrator (the per-vault
     ///         `owner`), the only authority over this flag. LI.FI has no per-instance pause;
     ///         its lever is the factory-level global circuit breaker, a separate source read
@@ -200,7 +200,7 @@ contract LiFiVaultWrapper is
     /// @param _expectedFactory The factory whose deploys may initialize instances.
     constructor(address _expectedFactory) {
         if (_expectedFactory == address(0)) revert ZeroAddress();
-        EXPECTED_FACTORY = _expectedFactory;
+        FACTORY = _expectedFactory;
         _disableInitializers();
     }
 
@@ -219,7 +219,7 @@ contract LiFiVaultWrapper is
         FeeReceiver[] calldata _receivers,
         address _accessGate
     ) external initializer {
-        if (msg.sender != EXPECTED_FACTORY) revert NotFactory();
+        if (msg.sender != FACTORY) revert NotFactory();
         if (
             _underlying == address(0) ||
             _adapter == address(0) ||
@@ -236,7 +236,6 @@ contract LiFiVaultWrapper is
         // array; see the subsystem OZ-v5 stack-pressure note).
         _setIntegratorFeeReceivers(_receivers);
         __Ownable_init(_vaultWrapperAdmin);
-        factory = msg.sender;
         underlying = _underlying;
         adapter = _adapter;
         integratorShareBps = _integratorShareBps;
@@ -784,7 +783,7 @@ contract LiFiVaultWrapper is
 
         uint8 idx = uint8(_feeType);
         if (_newRateBps != 0) {
-            (uint16 minBps, uint16 maxBps) = ILiFiVaultWrapperFactory(factory)
+            (uint16 minBps, uint16 maxBps) = ILiFiVaultWrapperFactory(FACTORY)
                 .feeBounds(_feeType);
             if (_newRateBps < minBps || _newRateBps > maxBps)
                 revert FeeRateOutOfBounds(_newRateBps, minBps, maxBps);
@@ -861,7 +860,7 @@ contract LiFiVaultWrapper is
         lifiFeeShares = 0;
         integratorFeeShares = 0;
 
-        address lifiRecipient = ILiFiVaultWrapperFactory(factory)
+        address lifiRecipient = ILiFiVaultWrapperFactory(FACTORY)
             .lifiFeeRecipient();
 
         (
@@ -913,7 +912,7 @@ contract LiFiVaultWrapper is
     /// @return True if this clone is paused by the integrator or the factory-level global
     ///         circuit breaker is engaged.
     function depositsPaused() public view returns (bool) {
-        return paused || ILiFiVaultWrapperFactory(factory).globalPaused();
+        return paused || ILiFiVaultWrapperFactory(FACTORY).globalPaused();
     }
 
     /// Access control ///

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -115,6 +115,15 @@ contract LiFiVaultWrapper is
     ///         real deposit ever notices it.
     uint256 internal constant MIN_SHARE_SUPPLY = 1e6;
 
+    /// Immutables ///
+
+    /// @notice The only address allowed to initialize instances of this implementation,
+    ///         bound at construction. Every proxy that reaches `initialize` has therefore
+    ///         passed the factory's deploy-time validation (adapter approval, underlying
+    ///         allowlist, fee bounds), so a counterfeit proxy pointed at the official
+    ///         beacon can never be initialized with unvetted parameters.
+    address public immutable EXPECTED_FACTORY;
+
     /// Storage ///
 
     /// @notice The yield source this wrapper deposits into (e.g. an ERC-4626 vault).
@@ -184,13 +193,19 @@ contract LiFiVaultWrapper is
     /// Initialization ///
 
     /// @dev Locks the implementation contract so only beacon proxies (which have their own
-    ///      storage) can be initialized — never the implementation itself.
-    constructor() {
+    ///      storage) can be initialized — never the implementation itself. Binds the
+    ///      implementation to the single factory allowed to initialize proxies; with a
+    ///      CREATE3-deployed factory its address is predictable before it exists, so the
+    ///      implementation can be deployed first and the beacon/factory wired after.
+    /// @param _expectedFactory The factory whose deploys may initialize instances.
+    constructor(address _expectedFactory) {
+        if (_expectedFactory == address(0)) revert ZeroAddress();
+        EXPECTED_FACTORY = _expectedFactory;
         _disableInitializers();
     }
 
     /// @inheritdoc ILiFiVaultWrapper
-    /// @dev Permissionless but single-shot: the factory deploys and initializes in one
+    /// @dev Factory-only and single-shot: the bound factory deploys and initializes in one
     ///      transaction, and OpenZeppelin's `initializer` guard blocks any later call. All
     ///      arguments are validated by the factory before this is reached. Share name/symbol
     ///      derive from the asset symbol (e.g. "LI.FI Earn USDC" / "lfUSDC"), falling back to
@@ -204,6 +219,7 @@ contract LiFiVaultWrapper is
         FeeReceiver[] calldata _receivers,
         address _accessGate
     ) external initializer {
+        if (msg.sender != EXPECTED_FACTORY) revert NotFactory();
         if (
             _underlying == address(0) ||
             _adapter == address(0) ||

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -835,11 +835,13 @@ contract LiFiVaultWrapper is
     ///      LI.FI's parts go to the factory's live `lifiFeeRecipient`; the integrator's
     ///      parts are fanned across its wallets by bps (last absorbs the rounding
     ///      remainder). CEI: all four counters are zeroed before any transfer, and the call
-    ///      is `nonReentrant`. A failing integrator transfer (e.g. a blacklisted wallet) does
-    ///      not revert the distribution — its share is left in the wrapper and re-booked as
-    ///      still-owed integrator fees, so the integrator can rotate to a working wallet via
-    ///      `setIntegratorFeeReceivers` and call this again to claim it. No-op when every
-    ///      counter is empty.
+    ///      is `nonReentrant`. A failing transfer on either side (e.g. a blacklisted
+    ///      integrator wallet, or a blocked LI.FI recipient) does not revert the
+    ///      distribution — its share is left in the wrapper and re-booked as still-owed,
+    ///      so the two sides never hold each other's payout hostage. The integrator can
+    ///      rotate to a working wallet via `setIntegratorFeeReceivers`, and governance can
+    ///      repoint the LI.FI recipient via the factory's `setLifiFeeRecipient`, then call
+    ///      this again to claim it. No-op when every counter is empty.
     function distributeFees() external nonReentrant {
         _accrueFees();
 
@@ -862,24 +864,33 @@ contract LiFiVaultWrapper is
         address lifiRecipient = ILiFiVaultWrapperFactory(factory)
             .lifiFeeRecipient();
 
-        uint256 assetsRetained = _distributeFeePool(
-            asset(),
-            lifiAssets,
-            integratorAssets,
-            lifiRecipient
-        );
-        uint256 sharesRetained = _distributeFeePool(
-            address(this),
-            lifiShares,
-            integratorShares,
-            lifiRecipient
-        );
+        (
+            uint256 assetsIntegratorRetained,
+            uint256 assetsLifiRetained
+        ) = _distributeFeePool(
+                asset(),
+                lifiAssets,
+                integratorAssets,
+                lifiRecipient
+            );
+        (
+            uint256 sharesIntegratorRetained,
+            uint256 sharesLifiRetained
+        ) = _distributeFeePool(
+                address(this),
+                lifiShares,
+                integratorShares,
+                lifiRecipient
+            );
 
-        // Fees whose integrator transfer failed stay in the wrapper as still-owed
-        // integrator fees, claimable on a later distribution (nonReentrant guards this
-        // post-transfer write).
-        integratorFeeAssets = uint128(assetsRetained);
-        integratorFeeShares = uint128(sharesRetained);
+        // Fees whose transfer failed stay in the wrapper as still-owed fees, claimable on
+        // a later distribution once the recipient is fixed — the integrator by rotating
+        // wallets, LI.FI by repointing the factory recipient (nonReentrant guards these
+        // post-transfer writes).
+        integratorFeeAssets = uint128(assetsIntegratorRetained);
+        integratorFeeShares = uint128(sharesIntegratorRetained);
+        lifiFeeAssets = uint128(assetsLifiRetained);
+        lifiFeeShares = uint128(sharesLifiRetained);
     }
 
     /// Pause controls ///
@@ -1273,30 +1284,46 @@ contract LiFiVaultWrapper is
 
     /// @dev Pays out one fee pool of `_token` from the per-recipient parts booked at
     ///      accrual — no split happens here (see `_splitFee`). The integrator's part is
-    ///      fanned across the receiver wallets; LI.FI is paid its booked part and is NOT
-    ///      caught, so a reverting LI.FI recipient (factory-governed) is its own concern.
+    ///      fanned across the receiver wallets; LI.FI is paid its booked part. Both sides
+    ///      use OZ's non-reverting `trySafeTransfer`: a failed transfer on either side has
+    ///      its amount returned to the caller (which re-books it as still-owed) and left in
+    ///      the wrapper, so neither a blacklisted integrator wallet nor a blocked LI.FI
+    ///      recipient can revert the distribution and hold the other side's payout hostage.
     ///      Caller must zero the counters first (CEI). No-op on an empty fee pool.
     /// @param _token The fee-pool token (the vault asset, or this wrapper's shares).
     /// @param _lifiPart LI.FI's booked part of the fee pool.
     /// @param _integratorPart The integrator's booked part of the fee pool.
     /// @param _lifiRecipient The live LI.FI fee recipient.
-    /// @return retained The integrator amount whose transfer failed, left in the wrapper.
+    /// @return integratorRetained The integrator amount whose transfer failed, left in the wrapper.
+    /// @return lifiRetained The LI.FI amount whose transfer failed, left in the wrapper.
     function _distributeFeePool(
         address _token,
         uint256 _lifiPart,
         uint256 _integratorPart,
         address _lifiRecipient
-    ) private returns (uint256 retained) {
-        if (_lifiPart == 0 && _integratorPart == 0) return 0;
+    ) private returns (uint256 integratorRetained, uint256 lifiRetained) {
+        if (_lifiPart == 0 && _integratorPart == 0) return (0, 0);
 
         // pay integrators; any wallet whose transfer fails leaves its share in the wrapper
-        retained = _payIntegrators(_token, _integratorPart);
+        integratorRetained = _payIntegrators(_token, _integratorPart);
 
-        if (_lifiPart > 0) {
-            SafeERC20.safeTransfer(IERC20(_token), _lifiRecipient, _lifiPart);
+        if (
+            _lifiPart > 0 &&
+            !SafeERC20.trySafeTransfer(
+                IERC20(_token),
+                _lifiRecipient,
+                _lifiPart
+            )
+        ) {
+            lifiRetained = _lifiPart;
+            emit LifiPayoutRetained(_lifiRecipient, _token, _lifiPart);
         }
 
-        emit FeePoolDistributed(_token, _lifiPart, _integratorPart - retained);
+        emit FeePoolDistributed(
+            _token,
+            _lifiPart - lifiRetained,
+            _integratorPart - integratorRetained
+        );
     }
 
     /// @dev Fans `_integratorTotal` of `_token` across the integrator wallets by their bps, the

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -419,7 +419,8 @@ contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
             if (rate == 0) continue;
             if (rate > _cap(FeeType(i))) revert FeeRateAboveCap();
             FeeBounds memory b = feeBounds[FeeType(i)];
-            if (rate < b.minBps || rate > b.maxBps) revert FeeRateAboveBound();
+            if (rate < b.minBps || rate > b.maxBps)
+                revert FeeRateOutOfBounds(rate, b.minBps, b.maxBps);
         }
     }
 }

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";

--- a/src/VaultWrapper/LiFiVaultWrapperTypes.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 /// @title LiFiVaultWrapperTypes
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/LiFiVaultWrapperTypes.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 /// @title LiFiVaultWrapperTypes
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/access/ReferenceAccessGate.sol
+++ b/src/VaultWrapper/access/ReferenceAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";

--- a/src/VaultWrapper/access/ReferenceAccessGate.sol
+++ b/src/VaultWrapper/access/ReferenceAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/src/VaultWrapper/interfaces/IAccessGate.sol
+++ b/src/VaultWrapper/interfaces/IAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 /// @title IAccessGate
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/interfaces/IAccessGate.sol
+++ b/src/VaultWrapper/interfaces/IAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 /// @title IAccessGate
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { FeeConfig, FeeType, FeeReceiver, FEE_TYPE_COUNT } from "../LiFiVaultWrapperTypes.sol";
 

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -99,6 +99,9 @@ interface ILiFiVaultWrapper {
     error InvalidFeeType(uint8 feeType);
     /// @notice Thrown when a required initialization address is the zero address.
     error ZeroAddress();
+    /// @notice Thrown when initialize is called by anyone other than the factory the
+    ///         implementation was bound to at construction.
+    error NotFactory();
     /// @notice Thrown when a fee type's integrator share is 100% (10000 bps) or more.
     error InvalidIntegratorShareBps(uint16 integratorShareBps);
     /// @notice Thrown when ownership renouncement is attempted; the admin role is non-renounceable.
@@ -134,7 +137,9 @@ interface ILiFiVaultWrapper {
     /// Functions ///
 
     /// @notice One-time setup of a vault wrapper immediately after deployment.
-    /// @dev The asset is resolved from `_underlying` via `_adapter` rather than passed in,
+    /// @dev Callable only by the factory the implementation was bound to at construction,
+    ///      so every initialized instance has passed the factory's deploy-time validation.
+    ///      The asset is resolved from `_underlying` via `_adapter` rather than passed in,
     ///      so it cannot disagree with what the adapter actually reports.
     /// @param _underlying The protocol-specific yield source (e.g. an ERC-4626 vault).
     /// @param _adapter The approved yield adapter the vault wrapper routes through at runtime.

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -91,6 +91,20 @@ interface ILiFiVaultWrapper {
         uint256 amount
     );
 
+    /// @notice Emitted when the LI.FI payout fails (e.g. a blacklisted recipient). The amount
+    ///         is left in the wrapper — still tracked as owed LI.FI fees — instead of
+    ///         reverting the whole distribution and blocking the independent integrator
+    ///         payouts. Governance can repoint the recipient via the factory's
+    ///         `setLifiFeeRecipient` and call `distributeFees` again to claim it.
+    /// @param recipient The LI.FI fee recipient whose transfer reverted.
+    /// @param token The fee-pool token retained (the asset, or this wrapper's shares).
+    /// @param amount The amount retained in the wrapper.
+    event LifiPayoutRetained(
+        address indexed recipient,
+        address indexed token,
+        uint256 amount
+    );
+
     /// Errors ///
 
     /// @notice Thrown when a deposit is attempted while any pause source is engaged.

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { FeeConfig, FeeType, FeeReceiver, FEE_TYPE_COUNT } from "../LiFiVaultWrapperTypes.sol";
 

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { FeeType, FEE_TYPE_COUNT } from "../LiFiVaultWrapperTypes.sol";
 

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { FeeType, FEE_TYPE_COUNT } from "../LiFiVaultWrapperTypes.sol";
 

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol
@@ -123,8 +123,12 @@ interface ILiFiVaultWrapperFactory {
     error UnderlyingNotAllowed();
     /// @notice Thrown when the chosen adapter is not approved.
     error AdapterNotApproved();
-    /// @notice Thrown when an enabled fee rate is outside its configured bounds.
-    error FeeRateAboveBound();
+    /// @notice Thrown when an enabled fee rate is outside its configured bounds (below the
+    ///         minimum or above the maximum). Shares the signature — and therefore the
+    ///         selector — of the wrapper's `setFeeRate` bound check, so both the deploy path
+    ///         and the runtime path report the same diagnostic with the offending rate and
+    ///         its bounds.
+    error FeeRateOutOfBounds(uint16 rateBps, uint16 minBps, uint16 maxBps);
     /// @notice Thrown when an enabled fee rate exceeds its immutable cap.
     error FeeRateAboveCap();
     /// @notice Thrown when ownership renunciation is attempted (disabled).

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 /// @title IYieldAdapter
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 /// @title IYieldAdapter
 /// @author LI.FI (https://li.fi)

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
+++ b/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
+++ b/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
@@ -16,6 +16,8 @@ import { defaultReceivers } from "test/solidity/VaultWrapper/VaultWrapperTestHel
 ///         inherits LiFiVaultWrapper (identical storage + interface) and adds a
 ///         version() selector absent from V1.
 contract MockVaultWrapperV2 is LiFiVaultWrapper {
+    constructor(address _expectedFactory) LiFiVaultWrapper(_expectedFactory) {}
+
     function version() external pure returns (uint256) {
         return 2;
     }
@@ -38,8 +40,14 @@ contract BeaconUpgradeTest is Test {
     bytes32 internal constant NS = bytes32("Coinbase");
 
     function setUp() public virtual {
-        implV1 = new LiFiVaultWrapper();
-        implV2 = new MockVaultWrapperV2();
+        // The factory is the fourth CREATE in this setUp (implV1, implV2, beacon,
+        // factory); both implementations bind that factory at construction.
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 3
+        );
+        implV1 = new LiFiVaultWrapper(predictedFactory);
+        implV2 = new MockVaultWrapperV2(predictedFactory);
         beacon = new UpgradeableBeacon(address(implV1), address(this));
         beacon.transferOwnership(owner);
         factory = new LiFiVaultWrapperFactory(

--- a/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
+++ b/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -148,7 +148,7 @@ contract LiFiVaultWrapperTest is Test {
         assertEq(wrapper.underlying(), address(underlying));
         assertEq(wrapper.adapter(), address(adapter));
         assertEq(wrapper.owner(), vaultAdmin);
-        assertEq(wrapper.factory(), address(this));
+        assertEq(wrapper.FACTORY(), address(this));
         for (uint256 i; i < 4; ++i) {
             assertEq(wrapper.integratorShareBps(i), 8000);
         }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -134,7 +134,7 @@ contract LiFiVaultWrapperTest is Test {
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(address(this))),
             address(this)
         );
         wrapper = _newWrapper(address(underlying));
@@ -199,6 +199,28 @@ contract LiFiVaultWrapperTest is Test {
             defaultReceivers(),
             address(0)
         );
+    }
+
+    function testRevert_InitializeByNonFactory() public {
+        FeeConfig memory fees;
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                address(underlying),
+                address(adapter),
+                vaultAdmin,
+                _splits8000(),
+                fees,
+                defaultReceivers(),
+                address(0)
+            )
+        );
+        address attacker = makeAddr("attacker");
+
+        vm.prank(attacker);
+        vm.expectRevert(ILiFiVaultWrapper.NotFactory.selector);
+
+        new BeaconProxy(address(beacon), initCall);
     }
 
     function testRevert_InitializeRejectsZeroAddress() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperAccess.t.sol
@@ -88,7 +88,7 @@ contract LiFiVaultWrapperAccessTest is Test {
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(address(this))),
             address(this)
         );
         gate = new MockAccessGate();

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -597,7 +597,32 @@ contract LiFiVaultWrapperFactoryTest is Test {
         factory.setFeeBounds(FeeType.Performance, 0, 500); // tighten max to 5%
         DeployParams memory p = _params(0); // rate 1000 = 10%
         vm.prank(onboarder);
-        vm.expectRevert(ILiFiVaultWrapperFactory.FeeRateAboveBound.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILiFiVaultWrapperFactory.FeeRateOutOfBounds.selector,
+                uint16(1000),
+                uint16(0),
+                uint16(500)
+            )
+        );
+        factory.deploy(p);
+    }
+
+    function test_DeployRevertsOnFeeBelowBound() public {
+        _enableUnderlyingAndBounds(); // perf bounds 0..5000
+        vm.prank(owner);
+        factory.setFeeBounds(FeeType.Performance, 800, 5000); // require at least 8%
+        DeployParams memory p = _params(0); // rate 1000 = 10% is fine; drop it below min
+        p.fees = FeeConfig({ rateBps: [uint16(500), 0, 0, 0] }); // 5% < 8% min
+        vm.prank(onboarder);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILiFiVaultWrapperFactory.FeeRateOutOfBounds.selector,
+                uint16(500),
+                uint16(800),
+                uint16(5000)
+            )
+        );
         factory.deploy(p);
     }
 
@@ -621,7 +646,14 @@ contract LiFiVaultWrapperFactoryTest is Test {
         factory.setUnderlyingAllowed(address(underlying), true);
         DeployParams memory p = _params(0); // Performance rate 1000, enabled
         vm.prank(onboarder);
-        vm.expectRevert(ILiFiVaultWrapperFactory.FeeRateAboveBound.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILiFiVaultWrapperFactory.FeeRateOutOfBounds.selector,
+                uint16(1000),
+                uint16(0),
+                uint16(0)
+            )
+        );
         factory.deploy(p);
     }
 

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -65,7 +65,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     }
 
     function test_ImplementationBoundToFactory() public view {
-        assertEq(impl.EXPECTED_FACTORY(), address(factory));
+        assertEq(impl.FACTORY(), address(factory));
     }
 
     function testRevert_ImplementationConstructorRejectsZeroFactory() public {
@@ -399,7 +399,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(w.underlying(), address(underlying));
         assertEq(w.adapter(), address(adapter));
         assertEq(w.owner(), vaultAdmin);
-        assertEq(w.factory(), address(factory));
+        assertEq(w.FACTORY(), address(factory));
         for (uint256 i; i < 4; ++i) {
             assertEq(w.integratorShareBps(i), 8000); // factory default
         }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -34,7 +34,13 @@ contract LiFiVaultWrapperFactoryTest is Test {
     address internal assetToken = address(new MockERC20("Asset", "AST", 18));
 
     function setUp() public virtual {
-        impl = new LiFiVaultWrapper();
+        // The implementation binds the factory allowed to call initialize; the factory
+        // is the second CREATE after the implementation (beacon in between).
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
+        impl = new LiFiVaultWrapper(predictedFactory);
         beacon = new UpgradeableBeacon(address(impl), address(this));
         factory = new LiFiVaultWrapperFactory(
             address(beacon),
@@ -56,6 +62,15 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(factory.lifiFeeRecipient(), lifiRecipient);
         assertEq(factory.defaultIntegratorShareBps(), 8000);
         assertFalse(factory.globalPaused());
+    }
+
+    function test_ImplementationBoundToFactory() public view {
+        assertEq(impl.EXPECTED_FACTORY(), address(factory));
+    }
+
+    function testRevert_ImplementationConstructorRejectsZeroFactory() public {
+        vm.expectRevert(ILiFiVaultWrapper.ZeroAddress.selector);
+        new LiFiVaultWrapper(address(0));
     }
 
     function test_ConstructorRevertsOnZeroBeacon() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Vm } from "forge-std/Vm.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Vm } from "forge-std/Vm.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
@@ -57,7 +57,7 @@ contract VaultWrapperDeployScriptsTest is Test {
         assertEq(factory.owner(), address(timelock));
         assertEq(factory.BEACON(), address(beacon));
         assertEq(beacon.implementation(), address(impl));
-        assertEq(impl.EXPECTED_FACTORY(), address(factory));
+        assertEq(impl.FACTORY(), address(factory));
 
         assertEq(factory.emergencyPauser(), pauser);
         assertEq(factory.onboardingManager(), onboarder);

--- a/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
@@ -57,6 +57,7 @@ contract VaultWrapperDeployScriptsTest is Test {
         assertEq(factory.owner(), address(timelock));
         assertEq(factory.BEACON(), address(beacon));
         assertEq(beacon.implementation(), address(impl));
+        assertEq(impl.EXPECTED_FACTORY(), address(factory));
 
         assertEq(factory.emergencyPauser(), pauser);
         assertEq(factory.onboardingManager(), onboarder);

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -79,8 +79,14 @@ contract VaultWrapperDistributionTest is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
+        // The implementation binds the factory allowed to call initialize; the factory
+        // is the second CREATE after the implementation (beacon in between).
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(predictedFactory)),
             address(this)
         );
         factory = new LiFiVaultWrapperFactory(

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -74,6 +74,11 @@ contract VaultWrapperDistributionTest is Test {
         address indexed token,
         uint256 amount
     );
+    event LifiPayoutRetained(
+        address indexed recipient,
+        address indexed token,
+        uint256 amount
+    );
 
     function setUp() public {
         asset = new MockERC20("Token", "TKN", 18);
@@ -378,6 +383,46 @@ contract VaultWrapperDistributionTest is Test {
         wrapper.distributeFees();
 
         assertEq(asset.balanceOf(fresh), integratorPart);
+        assertEq(_accruedFeeAssets(), 0);
+    }
+
+    function test_DistributeFeesRetainsFailedLifiTransferInWrapper() public {
+        // A blocked LI.FI recipient must not revert the whole distribution and freeze the
+        // independent integrator payouts behind the factory's 48h timelock.
+        _useBlacklistAsset();
+        address integratorWallet = makeAddr("integrator");
+        wrapper = _deploy(
+            _assetFees(),
+            SPLIT,
+            _single(integratorWallet),
+            _full()
+        );
+        _deposit(alice, DEPOSIT);
+
+        uint256 lifiPart = wrapper.lifiFeeAssets();
+        uint256 integratorPart = wrapper.integratorFeeAssets();
+        BlacklistERC20(address(asset)).setBlocked(lifiRecipient, true);
+
+        vm.expectEmit(true, true, false, true, address(wrapper));
+        emit LifiPayoutRetained(lifiRecipient, address(asset), lifiPart);
+
+        wrapper.distributeFees(); // must not revert
+
+        // LI.FI got nothing; the integrator was paid in full; LI.FI's share is left in the
+        // wrapper, re-booked as still-owed LI.FI fees (not redirected to the integrator).
+        assertEq(asset.balanceOf(lifiRecipient), 0);
+        assertEq(asset.balanceOf(integratorWallet), integratorPart);
+        assertEq(wrapper.lifiFeeAssets(), lifiPart);
+        assertEq(wrapper.integratorFeeAssets(), 0);
+
+        // Governance repoints the LI.FI recipient and re-sweeps — the retained fees are claimed.
+        address freshLifi = makeAddr("freshLifi");
+        vm.prank(owner);
+        factory.setLifiFeeRecipient(freshLifi);
+
+        wrapper.distributeFees();
+
+        assertEq(asset.balanceOf(freshLifi), lifiPart);
         assertEq(_accruedFeeAssets(), 0);
     }
 

--- a/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
@@ -29,8 +29,15 @@ abstract contract VaultWrapperFactoryStackBase is Test {
         uint16[4] memory _bounds
     ) internal {
         adapter = new ERC4626Adapter();
+        // The implementation binds the factory allowed to call initialize at
+        // construction; the factory is the second CREATE after the implementation
+        // (beacon in between), so its address is predictable here.
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(predictedFactory)),
             makeAddr("beaconOwner")
         );
         factory = new LiFiVaultWrapperFactory(

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -67,8 +67,10 @@ abstract contract VaultWrapperFeeTestBase is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
+        // This test contract acts as the factory for the direct beacon-proxy
+        // wrappers, so the implementation is bound to it.
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(address(this))),
             address(this)
         );
     }
@@ -135,8 +137,19 @@ abstract contract VaultWrapperFeeTestBase is Test {
         uint16 _rate,
         uint16 _maxBps
     ) internal {
+        // The setUp implementation is bound to this test contract, so the factory
+        // stack needs its own implementation+beacon bound to the factory — the
+        // second CREATE after the implementation (beacon in between).
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
+        UpgradeableBeacon stackBeacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper(predictedFactory)),
+            address(this)
+        );
         factory = new LiFiVaultWrapperFactory(
-            address(beacon),
+            address(stackBeacon),
             owner,
             makeAddr("pauser"),
             makeAddr("onboarder"),

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -52,11 +52,13 @@ contract VaultWrapperPauseTest is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
+        // The mock factory deploys and initializes the proxy, so the implementation
+        // must be bound to it — construct it before the implementation.
+        factory = new MockPauseFactory();
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(address(factory))),
             address(this)
         );
-        factory = new MockPauseFactory();
 
         FeeConfig memory fees;
         bytes memory initCall = abi.encodeCall(
@@ -330,8 +332,14 @@ contract VaultWrapperGlobalPauseE2ETest is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
+        // The implementation binds the factory allowed to call initialize; the factory
+        // is the second CREATE after the implementation (beacon in between).
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
         beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper()),
+            address(new LiFiVaultWrapper(predictedFactory)),
             address(this)
         );
         factory = new LiFiVaultWrapperFactory(

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 

--- a/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 

--- a/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";

--- a/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
@@ -28,7 +28,13 @@ contract VaultWrapperTimelockTest is Test {
     address internal stranger = makeAddr("stranger");
 
     function setUp() public {
-        impl = new LiFiVaultWrapper();
+        // The factory is the fourth CREATE in this setUp (impl, beacon, timelock,
+        // factory); the implementation binds the factory address at construction.
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 3
+        );
+        impl = new LiFiVaultWrapper(predictedFactory);
         beacon = new UpgradeableBeacon(address(impl), address(this));
 
         address[] memory proposers = new address[](1);
@@ -210,7 +216,7 @@ contract VaultWrapperTimelockTest is Test {
     /// Beacon upgrade gating ///
 
     function test_BeaconUpgradeViaTimelock() public {
-        LiFiVaultWrapper newImpl = new LiFiVaultWrapper();
+        LiFiVaultWrapper newImpl = new LiFiVaultWrapper(address(factory));
         bytes memory data = abi.encodeCall(
             beacon.upgradeTo,
             (address(newImpl))
@@ -224,7 +230,7 @@ contract VaultWrapperTimelockTest is Test {
     }
 
     function testRevert_BeaconUpgradeDirectByMultisig() public {
-        LiFiVaultWrapper newImpl = new LiFiVaultWrapper();
+        LiFiVaultWrapper newImpl = new LiFiVaultWrapper(address(factory));
 
         vm.prank(multisig);
         vm.expectRevert(

--- a/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";

--- a/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
+++ b/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { ReferenceAccessGate } from "lifi/VaultWrapper/access/ReferenceAccessGate.sol";

--- a/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
+++ b/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { ReferenceAccessGate } from "lifi/VaultWrapper/access/ReferenceAccessGate.sol";

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";

--- a/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
+++ b/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
 import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";

--- a/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
+++ b/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
 import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";

--- a/test/solidity/VaultWrapper/fork/VaultWrapperForkTestBase.sol
+++ b/test/solidity/VaultWrapper/fork/VaultWrapperForkTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";

--- a/test/solidity/VaultWrapper/fork/VaultWrapperForkTestBase.sol
+++ b/test/solidity/VaultWrapper/fork/VaultWrapperForkTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -101,9 +101,10 @@ contract VaultWrapperInvariantHandler is Test {
 
     function withdraw(uint256 _actorSeed, uint256 _assets) external {
         address actor = _actor(_actorSeed);
-        // maxWithdraw ignores the withdrawal fee (it inflates the shares burned), so cap at
-        // half the fee-free ceiling to stay clear of it regardless of the live rate.
-        uint256 ceiling = WRAPPER.maxWithdraw(actor) / 2;
+        // maxWithdraw is fee-aware (previewRedeem(maxRedeem(owner)) with the wrapper's
+        // fee-deducting previewRedeem), so withdraw(maxWithdraw(actor)) is exactly
+        // exitable — drive the full allowed range so near-max/full exits are exercised.
+        uint256 ceiling = WRAPPER.maxWithdraw(actor);
         if (ceiling == 0) return;
 
         uint256 assets = bound(_assets, 1, ceiling);

--- a/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
+++ b/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { Test } from "forge-std/Test.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
+++ b/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";

--- a/test/solidity/VaultWrapper/mocks/MockAccessGate.sol
+++ b/test/solidity/VaultWrapper/mocks/MockAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
 

--- a/test/solidity/VaultWrapper/mocks/MockAccessGate.sol
+++ b/test/solidity/VaultWrapper/mocks/MockAccessGate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
 

--- a/test/solidity/VaultWrapper/mocks/MockERC4626Underlying.sol
+++ b/test/solidity/VaultWrapper/mocks/MockERC4626Underlying.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 /// @notice Minimal ERC4626-shaped vault exposing only what the adapter's asset resolution reads.
 contract MockERC4626Underlying {

--- a/test/solidity/VaultWrapper/mocks/MockERC4626Underlying.sol
+++ b/test/solidity/VaultWrapper/mocks/MockERC4626Underlying.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 /// @notice Minimal ERC4626-shaped vault exposing only what the adapter's asset resolution reads.
 contract MockERC4626Underlying {

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.29;
 
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.24;
 
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_TODO: link the EXSC ticket for the VaultWrapper review follow-ups._ Addresses findings from the code review of #2092 (dev-vault-wrapper).

# Why did I implement it this way?

Five independent fixes from the #2092 review, one commit each, targeting the `dev-vault-wrapper` branch.

**Fix 2 — bind `initialize` to the deploying factory (counterfeit-vault prevention).** `initialize` was permissionless, so anyone could deploy a `BeaconProxy` against the official beacon and initialize a counterfeit "LI.FI Earn" token — delegating to the genuine implementation while draining deposits — because the factory-side validation (adapter approval, underlying allowlist, fee bounds) lived only in `deploy()`. The implementation now carries an `EXPECTED_FACTORY` immutable set at construction; `initialize` reverts `NotFactory` for any other caller. The deploy script predicts the factory's CREATE3 address and binds it into the implementation before the factory exists, then asserts the wiring post-deploy.

**Fix 3 — guard the LI.FI fee payout.** `distributeFees` paid the LI.FI share with a plain `safeTransfer` while integrator payouts used `trySafeTransfer`. A blocked LI.FI recipient (e.g. a USDC blacklist) reverted the whole call, freezing the independent integrator payouts behind the factory's 48h timelock. The LI.FI share now uses `trySafeTransfer` too; on failure it is left in the wrapper, re-booked as still-owed, and `LifiPayoutRetained` is emitted. Neither side can hold the other's payout hostage.

**Fix 8 — correct the false pragma floor.** Every subsystem file declared `pragma solidity ^0.8.17` while building on OpenZeppelin v5.6.1, whose `ERC4626Upgradeable` requires `^0.8.24` and whose codegen emits `mcopy` (cancun) — a provably false floor, and the PR had silenced the only guard by adding `src/VaultWrapper/**` to the `solc_floor` skip list. Since the subsystem is only ever deployed by LI.FI with the repo's default compiler, all 36 subsystem files are pinned to that exact version (`^0.8.29`) rather than a lower "honest minimum": a lower floor buys nothing (verification and bytecode key off the exact compiler version, not the pragma range) and would need its own floor build to police. Because the pinned pragma equals the default compile version, the ordinary `forge build` is itself the floor check — VaultWrapper stays excluded from the 0.8.17 `solc_floor` profile (it can't compile there) and needs no profile of its own. The subsystem pragma override is documented in rule 108.

**Fix 9 — drive full-range withdrawals in the invariant handler.** The withdraw handler capped assets at `maxWithdraw/2` on a stale premise that `maxWithdraw` ignores the withdrawal fee. With the pinned OZ, `maxWithdraw = previewRedeem(maxRedeem(owner))`, which the fee-deducting `previewRedeem` makes fully fee-aware, so the halving kept the fail-on-revert campaign out of the upper half of the range — never exercising near-max/full exits. Now bounded at the full ceiling; the campaign runs with zero reverts.

**Fix 10 — correct the inverted fee-bound error.** `_validateFees` reverted with the parameterless `FeeRateAboveBound()` for both the below-minimum and above-maximum branches, giving integrators a backwards diagnostic for a below-minimum rate. Replaced with `FeeRateOutOfBounds(rateBps, minBps, maxBps)` — same signature and selector as the wrapper's `setFeeRate` path — so both paths report identically.

Findings 1, 4, 5, 6, and 7 from the review are intentionally out of scope for this PR.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

