### PR TITLE
fix(parked-tasks): tolerate MONGODB_URI createIndex authz failure (EXSC-611)

### DIFF
--- a/.agents/commands/multisig-rollout.md
+++ b/.agents/commands/multisig-rollout.md
@@ -120,6 +120,15 @@ step is needed (design:
   **why** each facet is being removed.
 - **Best-effort**: a drain failure never blocks the primary proposal or the exit
   code.
+- **MongoDB privilege caveat**: the queue lives on the un-gated `MONGODB_URI`
+  cluster (DB `deferred-cleanup`), so the drain needs no tunnel — but it does need
+  the role to have `readWrite` **including index creation** on that DB. If the
+  role is `createIndex`-less (the grant drifted from `timelock-operations`), the
+  drain still runs (the adapter degrades non-fatally), but until an admin creates
+  the `unique_open_task_key` index, **enqueue dedup is unenforced** and you may see
+  a loud `DEDUP IS NOT ENFORCED` warning. Fix is infra (grant `readWrite`+index on
+  `deferred-cleanup`, or create the index once). See
+  [docs/DeferredDiamondCleanupQueue.md](../../docs/DeferredDiamondCleanupQueue.md) §5.
 - **Cold networks** (never touched by a rollout) are caught by the standalone
   `reconcile-parked-tasks` job + TTL alert and the `cleanUpProdDiamond --auto
   --all-networks` backstop (spec §8) — not by this skill. That backstop still

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -339,6 +339,44 @@ real signed transactions forces changes into `confirm-safe-tx` / `reconcile` /
 `getNextNonce` — exactly the code the constraints say to leave untouched — and it drags
 the queue back behind the `sc_private` tunnel gate.
 
+### Required MongoDB privilege on `deferred-cleanup` (operational prerequisite)
+
+The queue depends on one **partial unique index** — `unique_open_task_key` on `taskKey`
+filtered to the open statuses (§7) — which `getParkedTasksCollection()` ensures on
+connect via `createIndex`. Creating an index is a **`createIndex` privileged action**;
+plain `readWrite` does **not** grant it. So the `MONGODB_URI` role used by rollouts / CI
+/ `/deprecate-contract` must have **`readWrite` _plus_ index-creation on the
+`deferred-cleanup` DB** (equivalently: the built-in `readWrite` role already covers
+`createIndex`, but a **custom/scoped** role that only grants `find`/`insert`/`update`
+does not — that is the trap).
+
+- **Observed failure (EXSC-611 rollout, 2026-07-22).** Running a facet cut with
+  `DRAIN_PARKED_TASKS=true`, and independently `list-parked-tasks.ts`, both failed with
+  `not authorized on deferred-cleanup to execute command { createIndexes: "parkedTasks", … }`.
+  The `clusterTime` signature in the error proves `MONGODB_URI` **is** set and points at
+  a real cluster that has the `deferred-cleanup` DB — the role simply lacks
+  `createIndex` **on that DB**. The sibling `timelock-operations/queue` on the same
+  cluster works, so the grant almost certainly **drifted**: the newer `deferred-cleanup`
+  DB was added without extending the service role to it.
+- **Infra fix (preferred, durable).** Grant the `MONGODB_URI` service role
+  `readWrite` (with index privileges) on `deferred-cleanup`, mirroring its grant on
+  `timelock-operations`. Equivalently, create `unique_open_task_key` **once** via an
+  admin/migration; then every runtime consumer only needs `readWrite`, and even a
+  `createIndex`-less role degrades cleanly (below).
+- **Code robustness (already in place).** `ensureParkedTasksIndexes`
+  (`parked-tasks.ts`) treats an authorization failure (server code 13) as **non-fatal**:
+  it checks via `listIndexes` (a `read` action) whether `unique_open_task_key` already
+  exists. If it does, dedup is intact and the queue is fully functional on a
+  `readWrite`-only role; if it does not, it **warns loudly that enqueue dedup is
+  unenforced** but still lets reads / enqueue / claim / drain proceed. This keeps the
+  un-gated design promise (CI, rollouts, reconcile jobs reach the queue without a
+  tunnel) alive even before the infra grant lands — at the cost of dedup until the index
+  exists. **With this fix the drain and `list-parked-tasks` run to completion on a
+  `readWrite`-only role instead of aborting; the only degradation until the index exists
+  is that enqueue dedup is unenforced (duplicate open tasks are possible — harmless: the
+  drain processes each and a re-park whose facet is already gone resolves to
+  `superseded`). The cold-network reconcile backstop (§8) remains the catch-all.**
+
 ---
 
 ## 6. Drain: how a parked task becomes a proposal, and how the PR link reaches the reviewer (chokepoint Q2 → RESOLVED)

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -111,6 +111,10 @@ function matchesFilter(row: IParkedTask, filter: Filter<IParkedTask>): boolean {
 
 interface IFakeOptions {
   createIndexError?: Error
+  /** Index descriptors `listIndexes().toArray()` returns (default: none). */
+  existingIndexes?: { name: string }[]
+  /** When set, `listIndexes().toArray()` rejects with this error. */
+  listIndexesError?: Error
 }
 
 type IFakeCollection = Collection<IParkedTask> & {
@@ -179,6 +183,14 @@ function createFakeCollection(
       createIndexCalls.push({ spec, options: opts })
       if (options.createIndexError) throw options.createIndexError
       return (opts as { name: string }).name
+    },
+    listIndexes() {
+      return {
+        async toArray(): Promise<{ name: string }[]> {
+          if (options.listIndexesError) throw options.listIndexesError
+          return options.existingIndexes ?? []
+        },
+      }
     },
   }
   return api as unknown as IFakeCollection
@@ -582,5 +594,57 @@ describe('ensureParkedTasksIndexes', () => {
     const err = Object.assign(new Error('network down'), { code: 6 })
     const coll = createFakeCollection([], { createIndexError: err })
     await expectRejects(ensureParkedTasksIndexes(coll), 'network down')
+  })
+
+  it('tolerates a not-authorized createIndex (code 13) when the index already exists', async () => {
+    const err = Object.assign(
+      new Error('not authorized on deferred-cleanup to execute command'),
+      { code: 13 }
+    )
+    const coll = createFakeCollection([], {
+      createIndexError: err,
+      existingIndexes: [{ name: '_id_' }, { name: 'unique_open_task_key' }],
+    })
+    await ensureParkedTasksIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(1)
+  })
+
+  it('tolerates a not-authorized createIndex matched by message when code is absent', async () => {
+    const err = new Error(
+      'not authorized on deferred-cleanup to execute command { createIndexes: ... }'
+    )
+    const coll = createFakeCollection([], {
+      createIndexError: err,
+      existingIndexes: [{ name: 'unique_open_task_key' }],
+    })
+    await ensureParkedTasksIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(1)
+  })
+
+  it('proceeds non-fatally when not authorized and the index is missing', async () => {
+    const err = Object.assign(new Error('not authorized on deferred-cleanup'), {
+      code: 13,
+    })
+    const coll = createFakeCollection([], {
+      createIndexError: err,
+      existingIndexes: [{ name: '_id_' }],
+    })
+    await ensureParkedTasksIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(1)
+  })
+
+  it('proceeds non-fatally when not authorized and listIndexes also fails', async () => {
+    const err = Object.assign(new Error('not authorized on deferred-cleanup'), {
+      code: 13,
+    })
+    const listErr = Object.assign(new Error('not authorized to listIndexes'), {
+      code: 13,
+    })
+    const coll = createFakeCollection([], {
+      createIndexError: err,
+      listIndexesError: listErr,
+    })
+    await ensureParkedTasksIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(1)
   })
 })

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -68,6 +68,9 @@ export type ParkedTaskStatus =
 /** Statuses under which a `taskKey` is still active and must stay unique. */
 const OPEN_STATUSES: ParkedTaskStatus[] = ['queued', 'proposed']
 
+/** Name of the partial unique index the dedup guarantees depend on. */
+const OPEN_TASK_KEY_INDEX_NAME = 'unique_open_task_key'
+
 /**
  * A deferred diamond-maintenance task, parked until the network is next touched.
  * One record per (kind, network, environment, facetName) — the finest grain
@@ -146,18 +149,45 @@ export function computeTaskKey(
 }
 
 /**
- * Ensures the partial unique index the queue depends on. Idempotent for an
- * exact-match re-creation (Mongo no-ops); an index-*conflict* (codes 85/86 —
- * a same-named index with a different definition) is surfaced as a clear error
- * so an operator reconciles the drifted index rather than the queue proceeding
- * against an unintended one.
+ * True when `error` is a MongoDB authorization failure — the connected role lacks
+ * the `createIndex` action on the `deferred-cleanup` DB (server code 13,
+ * `Unauthorized`). Matched by code with a message fallback, since the queue's
+ * whole reason to exist on the un-gated `MONGODB_URI` cluster is to be reachable
+ * from readWrite-only, non-interactive consumers (CI, rollouts, reconcile jobs).
+ */
+function isUnauthorizedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (('code' in error && (error as { code: number }).code === 13) ||
+      /not authorized/i.test(error.message))
+  )
+}
+
+/**
+ * Ensures the partial unique index the queue depends on.
+ *
+ * Idempotent for an exact-match re-creation (Mongo no-ops). Two failure modes are
+ * handled so the shared adapter never takes the whole subsystem down:
+ *
+ * - **Index conflict** (codes 85/86 — a same-named index with a *different*
+ *   definition) is surfaced as a clear error so an operator reconciles the drifted
+ *   index rather than the queue proceeding against an unintended one.
+ * - **Authorization failure** (code 13) — the connected role has `readWrite` but
+ *   not `createIndex` on `deferred-cleanup`. Because every consumer (read, list,
+ *   enqueue, claim, drain, reconcile) connects through {@link getParkedTasksCollection}
+ *   → here, a hard throw would make the entire un-gated queue unusable from the
+ *   standard rollout / CI credential. Instead this degrades: if an admin already
+ *   created the index (`listIndexes`, a `read`-role action), dedup is intact and we
+ *   proceed silently; if not, we warn loudly (dedup is unenforced until an admin
+ *   creates it) but still proceed so reads/enqueue/claim work.
  *
  * The index is unique on `taskKey` but only over the *open* statuses, so a facet
  * can be re-parked once a prior task retires (executed/cancelled/superseded).
  * `$in` in a partial filter requires MongoDB server ≥ 6.0.
  *
  * @param parkedTasks - The collection to index.
- * @throws Error on an index definition conflict, or any other createIndex error.
+ * @throws Error on an index definition conflict, or any non-authorization
+ *   createIndex error.
  */
 export async function ensureParkedTasksIndexes(
   parkedTasks: Collection<IParkedTask>
@@ -168,9 +198,10 @@ export async function ensureParkedTasksIndexes(
       {
         unique: true,
         partialFilterExpression: { status: { $in: OPEN_STATUSES } },
-        name: 'unique_open_task_key',
+        name: OPEN_TASK_KEY_INDEX_NAME,
       }
     )
+    return
   } catch (error: unknown) {
     if (
       error instanceof Error &&
@@ -179,11 +210,46 @@ export async function ensureParkedTasksIndexes(
         (error as { code: number }).code === 86)
     )
       throw new Error(
-        `Index conflict for "unique_open_task_key" on ${parkedTasks.collectionName}. ` +
+        `Index conflict for "${OPEN_TASK_KEY_INDEX_NAME}" on ${parkedTasks.collectionName}. ` +
           `Existing index has a different definition; drop or reconcile it before retrying.`,
         { cause: error }
       )
-    throw error
+    if (!isUnauthorizedError(error)) throw error
+
+    let indexPresent = false
+    try {
+      const indexes = await parkedTasks.listIndexes().toArray()
+      indexPresent = indexes.some(
+        (index) => index.name === OPEN_TASK_KEY_INDEX_NAME
+      )
+    } catch (listError: unknown) {
+      consola.warn(
+        `Cannot create or verify the "${OPEN_TASK_KEY_INDEX_NAME}" index on ` +
+          `${parkedTasks.collectionName}: the MONGODB_URI role lacks createIndex on ` +
+          `the deferred-cleanup DB, and listIndexes also failed. Proceeding without ` +
+          `index verification — enqueue dedup may be unenforced.`,
+        listError
+      )
+      return
+    }
+
+    if (indexPresent) {
+      consola.debug(
+        `"${OPEN_TASK_KEY_INDEX_NAME}" already exists on ${parkedTasks.collectionName}; ` +
+          `the current MONGODB_URI role cannot create indexes but the dedup index is ` +
+          `present, so the queue is fully functional.`
+      )
+      return
+    }
+
+    consola.warn(
+      `The "${OPEN_TASK_KEY_INDEX_NAME}" index is MISSING on ${parkedTasks.collectionName} ` +
+        `and the current MONGODB_URI role lacks createIndex on the deferred-cleanup DB. ` +
+        `Reads/enqueue/claim will work, but enqueue DEDUP IS NOT ENFORCED — duplicate open ` +
+        `parked tasks can be inserted. Have an admin create the index once (readWrite + ` +
+        `createIndex on deferred-cleanup), then this warning clears. See ` +
+        `docs/DeferredDiamondCleanupQueue.md §5.`
+    )
   }
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-611 (surfaced during the GasZip+Garden → robinhood production rollout, 2026-07-22). This is a robustness follow-up to that rollout's parked-tasks authz failure, not part of its deploy scope.

# Why did I implement it this way?

**The bug.** The deferred diamond-cleanup queue lives on the *un-gated* `MONGODB_URI` cluster (DB `deferred-cleanup`, collection `parkedTasks`) deliberately, so CI, reconcile/TTL jobs, and non-interactive rollout/agent runs can reach it without the `lifi-connect` tunnel. But `getParkedTasksCollection()` calls `ensureParkedTasksIndexes` → `createIndex` **on connect, before any read**. Creating an index is a privileged `createIndex` action that plain `readWrite` does not grant. During the EXSC-611 rollout, a facet cut with `DRAIN_PARKED_TASKS=true` **and** `list-parked-tasks.ts` both failed with:

```text
not authorized on deferred-cleanup to execute command { createIndexes: "parkedTasks", indexes: [ ... name: "unique_open_task_key" ... ] }
```

Because the index step runs before any read, this broke the **entire** subsystem — drain, `list-parked-tasks`, and `/deprecate-contract`'s enqueue — not just writes. The error carried a valid `clusterTime` signature, so `MONGODB_URI` *is* set and points at a real cluster with the `deferred-cleanup` DB; the role simply lacks `createIndex` **on that DB**. The sibling `timelock-operations/queue` on the same cluster works, so the grant almost certainly drifted: the newer `deferred-cleanup` DB was added without extending the service role to it.

**The fix (code robustness — direction 2).** `ensureParkedTasksIndexes` now treats a MongoDB authorization failure (server code 13, `Unauthorized`, matched by code with a message fallback) as **non-fatal**:

- It checks via `listIndexes` (a `read`-role action) whether `unique_open_task_key` already exists.
- **Index present** → dedup is intact; proceed silently (debug log). The queue is fully functional on a `readWrite`-only role.
- **Index missing** → warn loudly that enqueue dedup is unenforced, but still let read / enqueue / claim / drain proceed.
- **`listIndexes` also fails** → warn and proceed non-fatally rather than take the subsystem down.

Index-conflict handling (codes 85/86) is unchanged and still surfaces a clear error. This keeps the un-gated design promise alive even before the infra grant lands; the only degradation until then is unenforced dedup (duplicate open tasks are harmless — the drain processes each, and a re-park whose facet is already gone resolves to `superseded`; the §8 cold-network reconcile remains the catch-all).

**Still needs infra (direction 1 — durable dedup).** Grant the `MONGODB_URI` service role `readWrite`+index on `deferred-cleanup` (mirroring its grant on `timelock-operations`), **or** create the `unique_open_task_key` index once via an admin/migration so runtime consumers only need `readWrite`. This is a MongoDB-side change outside this repo; documented in `docs/DeferredDiamondCleanupQueue.md` §5 and flagged to infra.

**Docs/skill.** `DeferredDiamondCleanupQueue.md` §5 gains a "Required MongoDB privilege" subsection (observed failure, infra fix, code degradation). The `multisig-rollout` skill's Phase 3.5 gains a privilege caveat so a rollout operator understands why a `DEDUP IS NOT ENFORCED` warning can appear and that the durable fix is infra.

**Not in scope:** the same latent `createIndex`-authz risk exists in `ensureTimelockQueueIndexes` (works today because that DB's grant is fine). Flagged as a separate defensive-hardening follow-up rather than expanding this PR into the critical timelock execution path.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
