### PR TITLE
fix(timelock-queue): tolerate MONGODB_URI createIndex authz failure (EXSC-670)

### DIFF
--- a/script/deploy/safe/timelock-queue.test.ts
+++ b/script/deploy/safe/timelock-queue.test.ts
@@ -319,17 +319,14 @@ describe('ensureTimelockQueueIndexes', () => {
     })
   })
 
-  it('surfaces an index-options conflict (code 85) as a clear error', async () => {
-    const err = Object.assign(new Error('conflict'), { code: 85 })
-    const coll = createFakeIndexCollection({ createIndexError: err })
-    await expectRejects(ensureTimelockQueueIndexes(coll), /Index conflict/)
-  })
-
-  it('surfaces an index-keyspec conflict (code 86) as a clear error', async () => {
-    const err = Object.assign(new Error('conflict'), { code: 86 })
-    const coll = createFakeIndexCollection({ createIndexError: err })
-    await expectRejects(ensureTimelockQueueIndexes(coll), /Index conflict/)
-  })
+  it.each([85, 86])(
+    'surfaces an index conflict (code %i) as a clear error',
+    async (code) => {
+      const err = Object.assign(new Error('conflict'), { code })
+      const coll = createFakeIndexCollection({ createIndexError: err })
+      await expectRejects(ensureTimelockQueueIndexes(coll), /Index conflict/)
+    }
+  )
 
   it('rethrows any other createIndex error unchanged', async () => {
     const err = Object.assign(new Error('network down'), { code: 6 })

--- a/script/deploy/safe/timelock-queue.test.ts
+++ b/script/deploy/safe/timelock-queue.test.ts
@@ -4,6 +4,7 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
+import { type Collection } from 'mongodb'
 import { encodeFunctionData, type Address, type Hex } from 'viem'
 
 import { TIMELOCK_SCHEDULE_BATCH_ABI } from './timelock-abi'
@@ -12,10 +13,70 @@ import {
   computeOperationIdBatch,
   decodeScheduleBatch,
   deserializeScheduleParams,
+  ensureTimelockQueueIndexes,
   isScheduleBatchCalldata,
   serializeScheduleParams,
   type IScheduleBatchParams,
+  type ITimelockQueueDoc,
 } from './timelock-queue'
+
+async function expectRejects(
+  promise: Promise<unknown>,
+  match: RegExp | string
+): Promise<void> {
+  let error: Error | undefined
+  try {
+    await promise
+  } catch (caught) {
+    error = caught as Error
+  }
+  expect(error).toBeInstanceOf(Error)
+  if (match instanceof RegExp) expect(error?.message).toMatch(match)
+  else expect(error?.message).toContain(match)
+}
+
+interface IFakeIndexOptions {
+  /** When set, every `createIndex` call rejects with this error. */
+  createIndexError?: Error
+  /** Index descriptors `listIndexes().toArray()` returns (default: none). */
+  existingIndexes?: { name: string }[]
+  /** When set, `listIndexes().toArray()` rejects with this error. */
+  listIndexesError?: Error
+}
+
+type IFakeIndexCollection = Collection<ITimelockQueueDoc> & {
+  createIndexCalls: { spec: unknown; options: unknown }[]
+}
+
+/**
+ * In-memory stand-in for the queue collection exercising the index path only:
+ * records every `createIndex` call and lets a test inject a `createIndex`
+ * failure, the `listIndexes` result, or a `listIndexes` failure — the three
+ * inputs `safeCreateIndex`'s authorization-degradation branch reads.
+ */
+function createFakeIndexCollection(
+  options: IFakeIndexOptions = {}
+): IFakeIndexCollection {
+  const createIndexCalls: { spec: unknown; options: unknown }[] = []
+  const api = {
+    collectionName: 'queue',
+    createIndexCalls,
+    async createIndex(spec: unknown, opts: unknown): Promise<string> {
+      createIndexCalls.push({ spec, options: opts })
+      if (options.createIndexError) throw options.createIndexError
+      return (opts as { name: string }).name
+    },
+    listIndexes() {
+      return {
+        async toArray(): Promise<{ name: string }[]> {
+          if (options.listIndexesError) throw options.listIndexesError
+          return options.existingIndexes ?? []
+        },
+      }
+    },
+  }
+  return api as unknown as IFakeIndexCollection
+}
 
 const ZERO_BYTES32 =
   // pre-commit-checker: not a secret — zero bytes32 sentinel used as test fixture
@@ -240,5 +301,100 @@ describe('serialize/deserialize round-trip', () => {
     expect(restored.predecessor).toBe(params.predecessor)
     expect(restored.salt).toBe(params.salt)
     expect(restored.delay).toBe(params.delay)
+  })
+})
+
+describe('ensureTimelockQueueIndexes', () => {
+  it('creates the unique and query indexes with expected specs', async () => {
+    const coll = createFakeIndexCollection()
+    await ensureTimelockQueueIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(2)
+    expect(coll.createIndexCalls[0]).toEqual({
+      spec: { network: 1, operationId: 1 },
+      options: { unique: true, name: 'unique_network_operation_id' },
+    })
+    expect(coll.createIndexCalls[1]).toEqual({
+      spec: { network: 1, status: 1 },
+      options: { name: 'network_status' },
+    })
+  })
+
+  it('surfaces an index-options conflict (code 85) as a clear error', async () => {
+    const err = Object.assign(new Error('conflict'), { code: 85 })
+    const coll = createFakeIndexCollection({ createIndexError: err })
+    await expectRejects(ensureTimelockQueueIndexes(coll), /Index conflict/)
+  })
+
+  it('surfaces an index-keyspec conflict (code 86) as a clear error', async () => {
+    const err = Object.assign(new Error('conflict'), { code: 86 })
+    const coll = createFakeIndexCollection({ createIndexError: err })
+    await expectRejects(ensureTimelockQueueIndexes(coll), /Index conflict/)
+  })
+
+  it('rethrows any other createIndex error unchanged', async () => {
+    const err = Object.assign(new Error('network down'), { code: 6 })
+    const coll = createFakeIndexCollection({ createIndexError: err })
+    await expectRejects(ensureTimelockQueueIndexes(coll), 'network down')
+  })
+
+  it('tolerates a not-authorized createIndex (code 13) when the indexes already exist', async () => {
+    const err = Object.assign(
+      new Error('not authorized on timelock-operations to execute command'),
+      { code: 13 }
+    )
+    const coll = createFakeIndexCollection({
+      createIndexError: err,
+      existingIndexes: [
+        { name: '_id_' },
+        { name: 'unique_network_operation_id' },
+        { name: 'network_status' },
+      ],
+    })
+    await ensureTimelockQueueIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(2)
+  })
+
+  it('tolerates a not-authorized createIndex matched by message when code is absent', async () => {
+    const err = new Error(
+      'not authorized on timelock-operations to execute command { createIndexes: ... }'
+    )
+    const coll = createFakeIndexCollection({
+      createIndexError: err,
+      existingIndexes: [
+        { name: 'unique_network_operation_id' },
+        { name: 'network_status' },
+      ],
+    })
+    await ensureTimelockQueueIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(2)
+  })
+
+  it('proceeds non-fatally when not authorized and the indexes are missing', async () => {
+    const err = Object.assign(
+      new Error('not authorized on timelock-operations'),
+      { code: 13 }
+    )
+    const coll = createFakeIndexCollection({
+      createIndexError: err,
+      existingIndexes: [{ name: '_id_' }],
+    })
+    await ensureTimelockQueueIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(2)
+  })
+
+  it('proceeds non-fatally when not authorized and listIndexes also fails', async () => {
+    const err = Object.assign(
+      new Error('not authorized on timelock-operations'),
+      { code: 13 }
+    )
+    const listErr = Object.assign(new Error('not authorized to listIndexes'), {
+      code: 13,
+    })
+    const coll = createFakeIndexCollection({
+      createIndexError: err,
+      listIndexesError: listErr,
+    })
+    await ensureTimelockQueueIndexes(coll)
+    expect(coll.createIndexCalls).toHaveLength(2)
   })
 })

--- a/script/deploy/safe/timelock-queue.ts
+++ b/script/deploy/safe/timelock-queue.ts
@@ -131,6 +131,19 @@ export async function getTimelockQueueCollection(): Promise<{
 }
 
 /**
+ * Extracts the MongoDB server error code from an unknown thrown value, or
+ * `undefined` when the value is not an `Error` carrying a numeric `code`.
+ *
+ * @param error - The value thrown by a driver call.
+ * @returns The numeric server code, or `undefined`.
+ */
+function getMongoErrorCode(error: unknown): number | undefined {
+  return error instanceof Error && 'code' in error
+    ? (error as { code: number }).code
+    : undefined
+}
+
+/**
  * True when `error` is a MongoDB authorization failure — the connected role lacks
  * the `createIndex` action on the `timelock-operations` DB (server code 13,
  * `Unauthorized`). Matched by code with a message fallback, mirroring
@@ -143,9 +156,8 @@ export async function getTimelockQueueCollection(): Promise<{
  */
 function isUnauthorizedError(error: unknown): boolean {
   return (
-    error instanceof Error &&
-    (('code' in error && (error as { code: number }).code === 13) ||
-      /not authorized/i.test(error.message))
+    getMongoErrorCode(error) === 13 ||
+    (error instanceof Error && /not authorized/i.test(error.message))
   )
 }
 
@@ -197,12 +209,8 @@ async function safeCreateIndex(
     // hitting these codes means the deployed index has drifted from the spec
     // we want — surfacing it forces an operator to reconcile rather than
     // letting the runner proceed against an unintended index.
-    if (
-      error instanceof Error &&
-      'code' in error &&
-      ((error as { code: number }).code === 85 ||
-        (error as { code: number }).code === 86)
-    )
+    const code = getMongoErrorCode(error)
+    if (code === 85 || code === 86)
       throw new Error(
         `Index conflict for "${options.name}" on ${
           collection.collectionName

--- a/script/deploy/safe/timelock-queue.ts
+++ b/script/deploy/safe/timelock-queue.ts
@@ -131,8 +131,28 @@ export async function getTimelockQueueCollection(): Promise<{
 }
 
 /**
- * Ensures the indexes the queue depends on. Idempotent — duplicate-index
- * errors (Mongo error code 85/86) are swallowed.
+ * True when `error` is a MongoDB authorization failure — the connected role lacks
+ * the `createIndex` action on the `timelock-operations` DB (server code 13,
+ * `Unauthorized`). Matched by code with a message fallback, mirroring
+ * `parked-tasks.ts`: the queue runs on the un-gated `MONGODB_URI` cluster so it
+ * stays reachable from readWrite-only, non-interactive consumers (the execution
+ * runner, list/backfill scripts) without a tunnel.
+ *
+ * @param error - The error thrown by `createIndex`.
+ * @returns Whether the error is a MongoDB `Unauthorized` (code 13) failure.
+ */
+function isUnauthorizedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (('code' in error && (error as { code: number }).code === 13) ||
+      /not authorized/i.test(error.message))
+  )
+}
+
+/**
+ * Ensures the indexes the queue depends on. Idempotent — an exact-match
+ * re-creation is a Mongo no-op. Index-definition *conflicts* (codes 85/86) and
+ * authorization failures (code 13) are handled per-index by {@link safeCreateIndex}.
  *
  * @param timelockQueue - The collection to index.
  */
@@ -169,6 +189,7 @@ async function safeCreateIndex(
 ): Promise<void> {
   try {
     await collection.createIndex(spec, options)
+    return
   } catch (error: unknown) {
     // Codes 85 (IndexOptionsConflict) and 86 (IndexKeySpecsConflict) only fire
     // when an index with the same name already exists with a *different*
@@ -190,7 +211,49 @@ async function safeCreateIndex(
         )}). Existing index has a different definition; drop or reconcile it before retrying.`,
         { cause: error }
       )
-    throw error
+    if (!isUnauthorizedError(error)) throw error
+
+    // Authorization failure (code 13): the connected role has `readWrite` but not
+    // `createIndex` on `timelock-operations`. Every consumer connects through
+    // getTimelockQueueCollection() → here, so a hard throw would take the entire
+    // un-gated queue (runner, list, backfill) down. Degrade instead: if an admin
+    // already created this index (`listIndexes`, a read-role action), it is intact
+    // and we proceed silently; if not, warn and still proceed so reads/enqueue work.
+    let indexPresent = false
+    try {
+      const indexes = await collection.listIndexes().toArray()
+      indexPresent = indexes.some((index) => index.name === options.name)
+    } catch (listError: unknown) {
+      consola.warn(
+        `Cannot create or verify the "${options.name}" index on ` +
+          `${collection.collectionName}: the MONGODB_URI role lacks createIndex on ` +
+          `the timelock-operations DB, and listIndexes also failed. Proceeding without ` +
+          `index verification — enqueue dedup may be unenforced.`,
+        listError
+      )
+      return
+    }
+
+    if (indexPresent) {
+      consola.debug(
+        `"${options.name}" already exists on ${collection.collectionName}; the ` +
+          `current MONGODB_URI role cannot create indexes but this index is present, ` +
+          `so the queue is fully functional.`
+      )
+      return
+    }
+
+    consola.warn(
+      `The "${options.name}" index is MISSING on ${collection.collectionName} and ` +
+        `the current MONGODB_URI role lacks createIndex on the timelock-operations DB. ` +
+        (options.unique
+          ? `Reads/enqueue/execute will work, but enqueue DEDUP IS NOT ENFORCED — ` +
+            `duplicate queue rows can be inserted for the same (network, operationId). `
+          : `Reads/enqueue/execute will work, but this query index is absent, so ` +
+            `network+status lookups fall back to collection scans. `) +
+        `Have an admin create the index once (readWrite + createIndex on ` +
+        `timelock-operations), then this warning clears.`
+    )
   }
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-670](https://linear.app/lifi-linear/issue/EXSC-670/harden-timelock-queue-index-creation-against-mongodb-uri-createindex)

# Why did I implement it this way?

`ensureTimelockQueueIndexes` runs `createIndex` on connect via `getTimelockQueueCollection()`, so a `MONGODB_URI` role with `readWrite` but not `createIndex` on the un-gated `timelock-operations` DB would fail the *entire* timelock execution queue — `execute-pending-timelock-tx.ts`, `list-timelock-queue.ts`, `backfill-timelock-queue.ts` — on connect, before any read. Only index-definition conflicts (codes 85/86) were tolerated; an authorization failure (server code 13) was fatal. This is exactly the failure mode that took down the sibling `deferred-cleanup` queue during the EXSC-611 rollout, so this PR mirrors that fix (parked-tasks, PR #2101) on the timelock queue before it can bite in production.

The degradation lives in `safeCreateIndex` (the shared per-index helper) rather than in `ensureTimelockQueueIndexes`, because both the unique dedup index and the query index route through it — so each index degrades independently, keyed on its own name. On code 13 (matched by code, with a `not authorized` message fallback for drivers that drop the numeric code) the helper verifies via `listIndexes` — a read-role action — whether the named index already exists: if present it proceeds silently (dedup is intact on a readWrite-only role); if missing it warns loudly (the unique index warns that dedup is unenforced; the query index warns that lookups fall back to collection scans) but still proceeds, preserving the un-gated design promise that non-interactive consumers reach the queue without a tunnel. Any non-authorization error is still rethrown unchanged, and 85/86 conflicts still surface as before. `timelock-operations`' grant is fine today, so this is purely defensive.

Tests are colocated in `timelock-queue.test.ts`: a new `ensureTimelockQueueIndexes` block covers the happy path (both indexes created with expected specs), the 85/86 conflict surfacing, the non-authorization rethrow, and the three authz paths called out in the ticket — not-authorized-with-index-present (by code and by message fallback), not-authorized-with-index-missing, and listIndexes-also-fails.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>