### PR TITLE
feat(deploy): DB-driven contract verification using recorded solc/evm (EXSC-656)

### DIFF
--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -932,6 +932,66 @@ const updateCommand = defineCommand({
   },
 })
 
+// Define list-unverified command
+const listUnverifiedCommand = defineCommand({
+  meta: {
+    name: 'list-unverified',
+    description:
+      'Print TSV rows for deployment records not marked verified, so a caller can re-run block-explorer verification with the recorded toolchain.',
+  },
+  args: {
+    environment: {
+      type: 'string',
+      description: 'Environment (staging or production)',
+      default: 'production',
+    },
+  },
+  async run({ args }) {
+    if (args.environment !== 'staging' && args.environment !== 'production') {
+      consola.error('Environment must be either "staging" or "production"')
+      process.exit(1)
+    }
+
+    const manager = new DeploymentLogManager(
+      config,
+      args.environment as keyof typeof EnvironmentEnum
+    )
+
+    let exitCode = 0
+    try {
+      await manager.connect()
+      const records = await manager.queryDeployments({})
+      const unverified = records.filter((record) => record.verified !== true)
+
+      consola.info(
+        `Found ${unverified.length} unverified record(s) out of ${records.length} in ${args.environment}`
+      )
+
+      // TSV rows go to stdout so a shell caller can read them field-by-field;
+      // all diagnostics above/below use consola. Columns:
+      // network, contractName, address, constructorArgs, solcVersion, evmVersion, optimizerRuns
+      for (const record of unverified) {
+        const row = [
+          record.network,
+          record.contractName,
+          record.address,
+          record.constructorArgs ?? '',
+          record.solcVersion ?? '',
+          record.evmVersion ?? '',
+          record.optimizerRuns ?? '',
+        ].join('\t')
+        process.stdout.write(`${row}\n`)
+      }
+    } catch (error) {
+      consola.error('list-unverified failed:', error)
+      exitCode = 1
+    } finally {
+      await manager.disconnect()
+    }
+    if (exitCode !== 0) process.exit(exitCode)
+  },
+})
+
 // Define create-indexes command
 const createIndexesCommand = defineCommand({
   meta: {
@@ -985,6 +1045,7 @@ const main = defineCommand({
     sync: syncCommand,
     add: addCommand,
     update: updateCommand,
+    'list-unverified': listUnverifiedCommand,
     'create-indexes': createIndexesCommand,
   },
 })

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2115,6 +2115,10 @@ function verifyContract() {
   local CONTRACT=$2
   local ADDRESS=$3
   local ARGS=$4
+  # Optional toolchain overrides, sourced from the recorded per-contract values in
+  # the Mongo 'contract-deployments' DB. When empty, forge falls back to foundry.toml
+  # [profile.default], which is only correct for contracts compiled with the current config.
+  local SOLC_VERSION="${5:-}" EVM_VERSION="${6:-}" OPTIMIZER_RUNS="${7:-}"
 
   if [[ -n "$DO_NOT_VERIFY_IN_THESE_NETWORKS" ]]; then
     case ",$DO_NOT_VERIFY_IN_THESE_NETWORKS," in
@@ -2208,6 +2212,15 @@ function verifyContract() {
     VERIFY_CMD+=("--constructor-args" "$ARGS")
   else
     warning "Skipping invalid constructor args for verify-contract (expected 0x-prefixed hex with an even number of hex digits); not passing --constructor-args."
+  fi
+
+  # Pin the toolchain to the recorded per-contract values so re-verifying an old
+  # deployment recompiles with the solc/evm/optimizer it was built with, not the
+  # current foundry.toml config. zkEVM (--zksync) is left to its own pinning path.
+  if ! isZkEvmNetwork "$NETWORK"; then
+    [[ -n "$SOLC_VERSION" ]] && VERIFY_CMD+=("--compiler-version" "$SOLC_VERSION")
+    [[ -n "$EVM_VERSION" ]] && VERIFY_CMD+=("--evm-version" "$EVM_VERSION")
+    [[ -n "$OPTIMIZER_RUNS" ]] && VERIFY_CMD+=("--num-of-optimizations" "$OPTIMIZER_RUNS")
   fi
 
   # Get API key and determine verification method
@@ -2385,6 +2398,55 @@ function verifyContract() {
   # If we get here, verification failed after all retries
   echo "[error] Failed to verify $CONTRACT on $NETWORK after $MAX_RETRIES attempts"
   return 1
+}
+
+# verifyUnverifiedContractsFromMongo: Re-verify every deployment the Mongo
+# 'contract-deployments' DB has not marked verified, recompiling each with its
+# recorded solc/evm/optimizer instead of the foundry.toml defaults. This keeps
+# re-verification correct after a network's config group changes (e.g. london->cancun).
+#
+# Usage: verifyUnverifiedContractsFromMongo [ENVIRONMENT]
+#   ENVIRONMENT - Optional: "production" (default) or "staging"
+#
+# Behavior:
+#   - Rows with BOTH solc and evm empty cannot pin a compile and are skipped.
+#   - Each remaining row is verified via verifyContract with the recorded toolchain.
+#
+# Returns: 0 if no verification failed, 1 otherwise. Prints verified/skipped/failed totals.
+# Example: verifyUnverifiedContractsFromMongo "production"
+function verifyUnverifiedContractsFromMongo() {
+  local ENVIRONMENT="${1:-production}"
+
+  local ROWS
+  if ! ROWS=$(bunx tsx script/deploy/update-deployment-logs.ts list-unverified --environment "$ENVIRONMENT"); then
+    error "failed to list unverified contracts from MongoDB ($ENVIRONMENT)"
+    return 1
+  fi
+
+  local VERIFIED_COUNT=0 SKIPPED_COUNT=0 FAILED_COUNT=0
+
+  local NETWORK CONTRACT ADDRESS CONSTRUCTOR_ARGS SOLC EVM OPT
+  while IFS=$'\t' read -r NETWORK CONTRACT ADDRESS CONSTRUCTOR_ARGS SOLC EVM OPT; do
+    # Only whole TSV rows drive verification; consola diagnostics on stdout lack the address column.
+    [[ -z "$NETWORK" || -z "$CONTRACT" || -z "$ADDRESS" ]] && continue
+
+    # Without a recorded solc or evm we cannot pin the compile; foundry.toml defaults would
+    # reintroduce the config-drift bug this function exists to avoid, so skip such records.
+    if [[ -z "$SOLC" && -z "$EVM" ]]; then
+      echo "[skip] $CONTRACT@$NETWORK: no recorded solc/evm"
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      continue
+    fi
+
+    if verifyContract "$NETWORK" "$CONTRACT" "$ADDRESS" "$CONSTRUCTOR_ARGS" "$SOLC" "$EVM" "$OPT"; then
+      VERIFIED_COUNT=$((VERIFIED_COUNT + 1))
+    else
+      FAILED_COUNT=$((FAILED_COUNT + 1))
+    fi
+  done <<<"$ROWS"
+
+  echo "[info] verifyUnverifiedContractsFromMongo ($ENVIRONMENT): verified=$VERIFIED_COUNT skipped=$SKIPPED_COUNT failed=$FAILED_COUNT"
+  [[ "$FAILED_COUNT" -eq 0 ]]
 }
 
 function getEtherscanApiKeyName() {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-656](https://linear.app/lifi-linear/issue/EXSC-656/move-eligible-networks-from-london-to-cancun)

# Why did I implement it this way?

Block-explorer verification recompiles from `foundry.toml` `[profile.default]`'s
`solc`/`evm_version`, not from the per-contract `solcVersion`/`evmVersion` stored
in the Mongo `contract-deployments` DB. So when a network's config group changes
(e.g. london -> cancun, as in #2094), re-verifying an *older* contract recompiles
it with the wrong toolchain and the bytecode no longer matches. This PR lets
verification use the recorded toolchain, which makes the config bump in #2094 safe
for existing deployments.

**Layer 1 — `verifyContract()` overrides (`script/helperFunctions.sh`).**
`verifyContract()` gains three optional positional args (`SOLC_VERSION`,
`EVM_VERSION`, `OPTIMIZER_RUNS`). This is backward compatible: all existing call
sites pass 4 args and get the previous behavior. When set, the non-zkEVM path
appends `--compiler-version`, `--evm-version`, and `--num-of-optimizations` to the
`forge verify-contract` command (flags confirmed via `forge verify-contract --help`).
The zkEVM (`--zksync`) path is intentionally left unchanged — it keeps its own
`zksolc` pinning — so the overrides are guarded behind `! isZkEvmNetwork`.

**Layer 2 — Mongo-driven sweep.**
- A new `list-unverified` command in `script/deploy/update-deployment-logs.ts`
  queries the environment's collection (default `production`) and prints TSV rows
  for records where `verified !== true`:
  `network`, `contractName`, `address`, `constructorArgs`, `solcVersion`,
  `evmVersion`, `optimizerRuns`. It mirrors the existing `citty` command style in
  that file and reuses the existing `queryDeployments`. TSV rows go to `stdout`;
  diagnostics use `consola`.
- A new `verifyUnverifiedContractsFromMongo()` bash helper runs that command,
  loops the rows, and calls `verifyContract` with the recorded toolchain. Rows with
  **both** `solc` and `evm` empty cannot pin a compile, so they are skipped with a
  `[skip] <contract>@<network>: no recorded solc/evm` log. It prints verified /
  skipped / failed totals.

**Follow-ups (out of scope here):**
- Layer 3: backfill `solcVersion` from on-chain CBOR metadata for the ~528 older
  records with empty fields — only ~13/541 currently carry full solc+evm+commit.
- zkEVM verification path (`--zksync`) toolchain matching.
- `via_ir` matching.
- Full historical reproduction also needs `git checkout <gitCommitHash>` when the
  source has drifted since deployment.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

