### PR TITLE
chore(ci): mention Data-team agent in deployment Slack alerts (EXSC-673)

### DIFF
--- a/.github/workflows/notifyDataTeamOnDeployment.yml
+++ b/.github/workflows/notifyDataTeamOnDeployment.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.get-changes.outputs.has_changes == 'true'
         run: |
           # Initialize variables to store contract changes
-          SLACK_MESSAGE="📋 Contract Deployment Update\n\n"
+          SLACK_MESSAGE="<@U0BHHK4F4TU> 📋 Contract Deployment Update\n\n"
           CONTRACTS_FOUND=false
 
           # Create associative array to group contracts across networks


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-673](https://linear.app/lifi-linear/issue/EXSC-673/mention-data-team-agent-in-deployment-slack-alerts-data-alerts)

# Why did I implement it this way?

The Data team asked (Ali Honari, Slack `@smartcontract_core`) to have their new agent pinged on the deployment alerts we post into `#data-alerts`. `notifyDataTeamOnDeployment.yml` is the only workflow in this repo that posts to the Data team (via `secrets.SLACK_WEBHOOK_DATA_TEAM`), so this single message covers "all alert messages".

The mention is prepended to the message header that's already built for the `text:` payload. In a Slack incoming-webhook `text` field, `<@U…>` renders as a real mention (and pings the user) as long as it's not inside a code block — so no payload/format changes were needed beyond adding the token.

- One-line change: `SLACK_MESSAGE="<@U0BHHK4F4TU> 📋 Contract Deployment Update\n\n"`
- `U0BHHK4F4TU` is the agent's Slack user ID as supplied by the Data team.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
