### PR TITLE
feat(LayerSwapFacet): add Tron deploy script + tron depository config (EXSC-674)

### DIFF
--- a/config/layerswap.json
+++ b/config/layerswap.json
@@ -40,6 +40,7 @@
     "swellchain": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",
     "taiko": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",
     "tempo": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",
+    "tron": "TTKKq5h2BXNi18qDTTjmHgWGqmvUc9eETw",
     "unichain": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",
     "worldchain": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",
     "xlayer": "0xE226E4825CB215aBaFAd98fdd400583eAb6a594f",

--- a/script/deploy/tron/deploy-and-register-layerswap-facet.ts
+++ b/script/deploy/tron/deploy-and-register-layerswap-facet.ts
@@ -60,8 +60,14 @@ async function deployAndRegisterLayerSwapFacet(options: { dryRun?: boolean }) {
     // Use default value
   }
 
-  const networkName =
-    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+  if (environment !== EnvironmentEnum.production) {
+    consola.error(
+      'LayerSwapFacet Tron deploy targets tron mainnet (production) only — tronshasta is not configured'
+    )
+    process.exit(1)
+  }
+
+  const networkName = 'tron'
 
   const network = networkName as SupportedChain
 
@@ -74,11 +80,7 @@ async function deployAndRegisterLayerSwapFacet(options: { dryRun?: boolean }) {
   } catch (error: any) {
     consola.error(error.message)
     consola.error(
-      `Please ensure ${
-        environment === EnvironmentEnum.production
-          ? 'PRIVATE_KEY_PRODUCTION'
-          : 'PRIVATE_KEY'
-      } is set in your .env file`
+      'Please ensure PRIVATE_KEY_PRODUCTION is set in your .env file'
     )
     process.exit(1)
   }
@@ -118,13 +120,11 @@ async function deployAndRegisterLayerSwapFacet(options: { dryRun?: boolean }) {
       )
 
     const globalConfig = await Bun.file('config/global.json').json()
-    const envKey =
-      environment === EnvironmentEnum.production ? 'production' : 'staging'
-    const backendSignerRaw = globalConfig.backendSigner?.[envKey]
+    const backendSignerRaw = globalConfig.backendSigner?.production
 
     if (!backendSignerRaw)
       throw new Error(
-        `backendSigner not found for '${envKey}' in config/global.json`
+        "backendSigner not found for 'production' in config/global.json"
       )
 
     const depository = tronAddressToHex(tronWeb, depositoryRaw)

--- a/script/deploy/tron/deploy-and-register-layerswap-facet.ts
+++ b/script/deploy/tron/deploy-and-register-layerswap-facet.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+
+/**
+ * Deploys LayerSwapFacet to the Tron Diamond and proposes its diamondCut to the
+ * Tron Safe. Use this instead of the generic core-facet deploy because
+ * LayerSwapFacet takes constructor arguments (the LayerSwap Depository address
+ * and the backend signer), which the core-facet loop does not supply.
+ */
+
+import {
+  MIN_BALANCE_WARNING,
+  TronContractDeployer,
+  createTronWeb,
+  tronAddressToHex,
+  type ITronDeploymentConfig,
+  type TronTvmNetworkName,
+} from '@lifi/tron-devkit'
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+
+import type { IDeploymentResult, SupportedChain } from '../../common/types'
+import { EnvironmentEnum } from '../../common/types'
+import { getPrivateKeyForEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import {
+  getEnvVar,
+  getRPCEnvVarName,
+  getEnvironment,
+  getContractAddress,
+  checkExistingDeployment,
+  confirmDeployment,
+  printDeploymentSummary,
+  displayNetworkInfo,
+  displayRegistrationInfo,
+  getFacetSelectors,
+} from '../../utils/utils'
+import { getContractVersion } from '../shared/getContractVersion'
+import { proposeDiamondCut } from '../shared/propose-diamond-cut'
+
+import { deployContractWithLogging, validateBalance } from './tronUtils'
+
+/**
+ * Deploy and register LayerSwapFacet to Tron.
+ *
+ * @param options - `dryRun` estimates and prints the plan without deploying or
+ *        creating a Safe proposal.
+ * @throws If required config (depository, backend signer, diamond address) is
+ *         missing, or the deploy/propose step fails.
+ */
+async function deployAndRegisterLayerSwapFacet(options: { dryRun?: boolean }) {
+  consola.start('TRON LayerSwapFacet Deployment & Registration')
+
+  const environment = getEnvironment()
+
+  const dryRun = options.dryRun ?? false
+  let verbose = true
+
+  try {
+    verbose = getEnvVar('VERBOSE') !== 'false'
+  } catch {
+    // Use default value
+  }
+
+  const networkName =
+    environment === EnvironmentEnum.production ? 'tron' : 'tronshasta'
+
+  const network = networkName as SupportedChain
+
+  const envVarName = getRPCEnvVarName(network)
+  const rpcUrl = getEnvVar(envVarName)
+
+  let privateKey: string
+  try {
+    privateKey = getPrivateKeyForEnvironment(environment)
+  } catch (error: any) {
+    consola.error(error.message)
+    consola.error(
+      `Please ensure ${
+        environment === EnvironmentEnum.production
+          ? 'PRIVATE_KEY_PRODUCTION'
+          : 'PRIVATE_KEY'
+      } is set in your .env file`
+    )
+    process.exit(1)
+  }
+
+  const config: ITronDeploymentConfig = {
+    fullHost: rpcUrl,
+    tvmNetworkKey: networkName as TronTvmNetworkName,
+    privateKey,
+    verbose,
+    dryRun,
+    safetyMargin: 1.5,
+    maxRetries: 3,
+    confirmationTimeout: 120000,
+  }
+
+  const deployer = new TronContractDeployer(config)
+
+  try {
+    const networkInfo = await deployer.getNetworkInfo()
+
+    displayNetworkInfo(networkInfo, environment, rpcUrl)
+
+    const tronWeb = createTronWeb({
+      rpcUrl,
+      networkKey: networkName as TronTvmNetworkName,
+      privateKey,
+    })
+
+    await validateBalance(tronWeb, MIN_BALANCE_WARNING)
+
+    const layerSwapConfig = await Bun.file('config/layerswap.json').json()
+    const depositoryRaw = layerSwapConfig.layerSwapDepository?.[networkName]
+
+    if (!depositoryRaw)
+      throw new Error(
+        `LayerSwap depository not found for '${networkName}' in config/layerswap.json`
+      )
+
+    const globalConfig = await Bun.file('config/global.json').json()
+    const envKey =
+      environment === EnvironmentEnum.production ? 'production' : 'staging'
+    const backendSignerRaw = globalConfig.backendSigner?.[envKey]
+
+    if (!backendSignerRaw)
+      throw new Error(
+        `backendSigner not found for '${envKey}' in config/global.json`
+      )
+
+    const depository = tronAddressToHex(tronWeb, depositoryRaw)
+    const backendSigner = tronAddressToHex(tronWeb, backendSignerRaw)
+
+    consola.info('\nLayerSwap Configuration:')
+    consola.info(`Depository: ${depositoryRaw} (hex: ${depository})`)
+    consola.info(`Backend Signer: ${backendSignerRaw} (hex: ${backendSigner})`)
+
+    const contracts = ['LayerSwapFacet']
+
+    if (!(await confirmDeployment(environment, network, contracts)))
+      process.exit(0)
+
+    const deploymentResults: IDeploymentResult[] = []
+
+    consola.info('\nDeploying LayerSwapFacet...')
+
+    const { exists, address, shouldRedeploy } = await checkExistingDeployment(
+      network,
+      'LayerSwapFacet',
+      dryRun
+    )
+
+    let facetAddress: string
+    if (exists && !shouldRedeploy && address) {
+      facetAddress = address
+      deploymentResults.push({
+        contract: 'LayerSwapFacet',
+        address: address,
+        txId: 'existing',
+        cost: 0,
+        version: await getContractVersion('LayerSwapFacet'),
+        status: 'existing',
+      })
+    } else
+      try {
+        const constructorArgs = [depository, backendSigner]
+
+        const result = await deployContractWithLogging(
+          deployer,
+          'LayerSwapFacet',
+          constructorArgs,
+          dryRun,
+          network
+        )
+
+        facetAddress = result.address
+        deploymentResults.push(result)
+      } catch (error: any) {
+        consola.error('Failed to deploy LayerSwapFacet:', error.message)
+        deploymentResults.push({
+          contract: 'LayerSwapFacet',
+          address: 'FAILED',
+          txId: 'FAILED',
+          cost: 0,
+          version: '0.0.0',
+          status: 'failed',
+        })
+        printDeploymentSummary(deploymentResults, dryRun)
+        process.exit(1)
+      }
+
+    consola.info('\nProposing LayerSwapFacet diamondCut to Safe...')
+
+    const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
+    if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
+
+    const selectors = await getFacetSelectors('LayerSwapFacet')
+
+    displayRegistrationInfo(
+      'LayerSwapFacet',
+      facetAddress,
+      diamondAddress,
+      selectors
+    )
+
+    if (!dryRun)
+      await proposeDiamondCut({
+        facetName: 'LayerSwapFacet',
+        facetAddressHex: tronAddressToHex(
+          tronWeb,
+          facetAddress
+        ) as `0x${string}`,
+        diamondAddress,
+        network: network,
+      })
+    else
+      consola.info('Dry run - skipping diamondCut proposal for LayerSwapFacet')
+
+    printDeploymentSummary(deploymentResults, dryRun)
+
+    consola.success(
+      dryRun
+        ? '\nDry run completed successfully! (no Safe tx created)'
+        : '\nDeployment and proposal completed successfully!'
+    )
+  } catch (error: any) {
+    consola.error('Deployment failed:', error.message)
+    if (error.stack) consola.error(error.stack)
+    process.exit(1)
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'deploy-and-register-layerswap-facet',
+    description: 'Deploy and register LayerSwapFacet to Tron Diamond',
+  },
+  args: {
+    dryRun: {
+      type: 'boolean',
+      description: 'Perform a dry run without actual deployment',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    await deployAndRegisterLayerSwapFacet({
+      dryRun: args.dryRun,
+    })
+  },
+})
+
+runMain(main)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-674](https://linear.app/lifi-linear/issue/EXSC-674/add-tron-deploy-script-config-for-layerswapfacet)

# Why did I implement it this way?

Tron has no Foundry support, so LayerSwapFacet cannot deploy through the standard `forge` flow — it deploys via the TronWeb scripts under `script/deploy/tron/` (source of truth is this upstream repo; the scripts reach the `contracts-tron` fork through the upstream→fork sync). LayerSwapFacet takes constructor arguments, and `deploy-core-facets.ts` only supplies args for the no-arg core facets, so — exactly like Eco/Symbiosis/Allbridge/NEARIntents — it needs a bespoke deploy script. This one is modeled on `deploy-and-register-symbiosis-facet.ts` (two-arg constructor) with the backend-signer resolution following the `deploy-and-register-near-intents-facet.ts` pattern. Constructor args are sourced exactly as declared in `script/deploy/resources/deployRequirements.json`: `_layerSwapDepository` from `config/layerswap.json` (`.layerSwapDepository.tron`, added here) and `_backendSigner` from `config/global.json` (`.backendSigner.<environment>`). The script deploys the facet and proposes the `diamondCut` to the Tron Safe, mirroring the sibling scripts. It follows the zkSync-family deploy-script precedent (EXSC-645).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>