### PR TITLE
chore(LayerSwapFacet): add tron mainnet deployment log (v1.0.0)

### DIFF
--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -68,6 +68,10 @@
       "TQC7Upeh5DNcR2eZoYXpSok57FiJXCdNpp": {
         "Name": "NEARIntentsFacet",
         "Version": "1.0.0"
+      },
+      "TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ": {
+        "Name": "LayerSwapFacet",
+        "Version": "1.0.0"
       }
     },
     "Periphery": {

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -22,5 +22,6 @@
   "ERC20Proxy": "TDCo8wrqwRVC7HaRAAsuCdbnS4AdAdtcn9",
   "Executor": "TUJnqSDodwaDo2HFX2Ct2JsVEzWFpkAbht",
   "FeeForwarder": "TBiwoFZpHoSG1NkdpTvgSi7bDm1W8DdAF8",
-  "OutputValidator": "TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR"
+  "OutputValidator": "TGYGf6DrV2whLwqYXJp2H2gzJhSiqVrMbR",
+  "LayerSwapFacet": "TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ"
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-679](https://linear.app/lifi-linear/issue/EXSC-679/deploy-layerswapfacet-v100-to-tron-mainnet)

# Why did I implement it this way?

Deploy-log round-trip for the **LayerSwapFacet v1.0.0** production deployment to Tron mainnet. Tron has no Foundry support, so it deploys via the TronWeb scripts in the `lifinance/contracts-tron` fork; per `docs/TronFork.md` the generated deploy logs flow back to upstream through a PR like this one (not a direct commit to the fork). Both logs change here: `deployments/tron.json` records the deployed facet address, and `deployments/tron.diamond.json` registers it in the production diamond registry now that the timelock `diamondCut` has executed.

Deployed from fork commit `a2a261f7a46239c5899ba44a74ff8f0963789a52` (checkout that commit to re-verify the bytecode). Constructor args: `_layerSwapDepository = TTKKq5h2BXNi18qDTTjmHgWGqmvUc9eETw`, `_backendSigner = 0xAF4B7A83591a6c4c8B9d1341C3F08BBc3b800fc5`.

| Chain | Contract address | Safe nonce |
| --- | --- | --- |
| tron | `TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ` | 20 |

Deploy tx `e8fc699160c9f5e00316c588dc744f1e5d4769280b3f42ad1d1b39f524e68bd5` (block 84741759, SUCCESS).

The `diamondCut` proposal (scheduleBatch, nonce 20, 3 selectors) has since been executed: timelock `executeBatch` tx `673b1bc16fd5f8609bd02bd1b2ed5bd7f85edf7dac5b4351b029ef4f1be62f9e` (block 84746136, SUCCESS), which called `diamondCut` on `TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt` with action `Add` for `TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ`. `deployments/tron.diamond.json` is therefore updated in this PR.

## Verification against on-chain state

Checked with `bun troncast` against Tron mainnet:

- `facetAddresses()` on the diamond returns exactly the 18 facets now listed in `tron.diamond.json` — same set, same order, no extras on either side.
- `facetFunctionSelectors(TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ)` returns the 3 expected LayerSwapFacet selectors: `0xb48fae2f` (`LAYERSWAP_DEPOSITORY()`), `0xee9e98e0` (`startBridgeTokensViaLayerSwap`), `0x4c279d6b` (`swapAndStartBridgeTokensViaLayerSwap`).
- `LAYERSWAP_DEPOSITORY()` on the facet returns `TTKKq5h2BXNi18qDTTjmHgWGqmvUc9eETw`, matching the documented constructor arg.
- Logged version `1.0.0` matches `@custom:version` in `src/Facets/LayerSwapFacet.sol` and the `LayerSwapFacet` `1.0.0` entry in `audit/auditLog.json` (`audit20260715_1`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
