### PR TITLE
docs(agents): note Bun process-level assertion gotchas in TS test rule (EXSC-687)

### DIFF
--- a/.agents/rules/402-typescript-tests.md
+++ b/.agents/rules/402-typescript-tests.md
@@ -18,6 +18,13 @@ paths:
 - **Restore after each test**: when stubbing globals (e.g. `globalThis.fetch`), save the original in `beforeEach`/`beforeAll` and restore it in `afterEach`/`afterAll` to avoid cross-test pollution.
 - Prefer true unit tests that isolate the code under test; use mocks for any outbound calls (fetch, contract calls, file system if needed) so failures reflect logic bugs, not environment or network issues.
 
+## Asserting on process-level behavior ([CONV:TEST-PROCESS-SURFACE])
+
+Don't reach for a spy or a Bun matcher when asserting that code wrote to stdout, exited, or rejected — both routes fail for reasons unrelated to the code under test.
+
+- **Never assert via `spyOn(process.stdout, 'write')`** (same for `process.exit`). The spy does not capture writes made by the code under test — the assertion reports "was not called" even though the write happens (observed on Bun 1.3.8). Instead **inject the output/exit surface as a parameter defaulting to `process`** and pass a recorder in the test. `reportApprovalResult(failures, target: IReportTarget = process)` in `script/deploy/github/verify-approvals.ts` is the reference shape: production callers pass nothing, the test passes a fake and asserts on what it captured.
+- **Never assert rejections via `expect(...).rejects`** — awaiting Bun's matcher trips `@typescript-eslint/await-thenable` because it isn't a real Promise. Use a local `async function expectRejects(promise, match)` that catches and matches the error message, as in `script/deploy/safe/parked-tasks.test.ts`.
+
 ## Post-Change Actions
 
 - After TS test changes, run Bun tests (or state which suites remain).

--- a/.agents/rules/402-typescript-tests.md
+++ b/.agents/rules/402-typescript-tests.md
@@ -18,11 +18,8 @@ paths:
 - **Restore after each test**: when stubbing globals (e.g. `globalThis.fetch`), save the original in `beforeEach`/`beforeAll` and restore it in `afterEach`/`afterAll` to avoid cross-test pollution.
 - Prefer true unit tests that isolate the code under test; use mocks for any outbound calls (fetch, contract calls, file system if needed) so failures reflect logic bugs, not environment or network issues.
 
-## Asserting on process-level behavior ([CONV:TEST-PROCESS-SURFACE])
+## Asserting rejections ([CONV:TEST-ASSERT-REJECTS])
 
-Don't reach for a spy or a Bun matcher when asserting that code wrote to stdout, exited, or rejected — both routes fail for reasons unrelated to the code under test.
-
-- **Never assert via `spyOn(process.stdout, 'write')`** (same for `process.exit`). The spy does not capture writes made by the code under test — the assertion reports "was not called" even though the write happens (observed on Bun 1.3.8). Instead **inject the output/exit surface as a parameter defaulting to `process`** and pass a recorder in the test. `reportApprovalResult(failures, target: IReportTarget = process)` in `script/deploy/github/verify-approvals.ts` is the reference shape: production callers pass nothing, the test passes a fake and asserts on what it captured.
 - **Never assert rejections via `expect(...).rejects`** — awaiting Bun's matcher trips `@typescript-eslint/await-thenable` because it isn't a real Promise. Use a local `async function expectRejects(promise, match)` that catches and matches the error message, as in `script/deploy/safe/parked-tasks.test.ts`.
 
 ## Post-Change Actions


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-687](https://linear.app/lifi-linear/issue/EXSC-687) — this note is a byproduct of writing
`script/deploy/github/verify-approvals.test.ts` in #2128. No separate ticket was cut; the finding
belongs to the same work.

# Why did I implement it this way?

Two Bun-specific traps cost real debugging time while writing tests for the approval-check exit-code
gate, and both are invisible until you hit them:

1. `spyOn(process.stdout, 'write')` does **not** capture writes made by the code under test — the
   assertion reports "was not called" even though the write demonstrably happens. The working
   pattern is to inject the output/exit surface as a parameter defaulting to `process`
   (`reportApprovalResult(failures, target: IReportTarget = process)` in #2128) and pass a recorder
   in the test.
2. `expect(...).rejects` trips `@typescript-eslint/await-thenable`, because Bun's matcher isn't a
   real Promise. `script/deploy/safe/parked-tasks.test.ts` already documents this inline and works
   around it with a local `expectRejects` helper.

Both are "asserting on process-level behaviour" problems, so they're captured as one
`[CONV:TEST-PROCESS-SURFACE]` section rather than two scattered bullets. Landed in
`.agents/rules/402-typescript-tests.md` (globs `**/*.test.ts`) because that's the narrowest owning
rule — a test author hits both traps, and the rule auto-loads exactly when they do. The inline
comment in `parked-tasks.test.ts` stays where it is; the rule generalises it so the next author
doesn't have to have read that file.

Edited in `.agents/` per the repo's symlink convention; `.cursor/rules/402-typescript-tests.mdc`
and `.claude/rules/402-typescript-tests.md` already point at it, so no symlink work was needed.
`.agents/README.md` is unchanged — `name`, `description` and `globs` are all untouched, which is the
only trigger for a README update.

**One thing for the reviewer:** the `verify-approvals.ts` reference points at code that only exists
on #2128's branch — it resolves once that PR merges. Everything else cited (`expectRejects` in
`parked-tasks.test.ts`) is on `main` today. The Bun version is called out as *observed on 1.3.8*
(the local toolchain); the repo pins `bun@1.3.13` in `packageManager` and I did not re-verify the
spy behaviour there, so the guidance is stated unconditionally rather than as version-gated.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
