### PR TITLE
feat(tron): deliver diamondCut init calldata (EXSC-650)

### DIFF
--- a/script/deploy/shared/propose-diamond-cut.ts
+++ b/script/deploy/shared/propose-diamond-cut.ts
@@ -13,21 +13,70 @@ import { encodeFunctionData, type Address, type Hex } from 'viem'
 import { getFacetSelectors } from '../../utils/utils'
 import type { TronTvmNetworkName } from '../tron/types'
 
-import { DIAMOND_CUT_ABI } from './constants'
+import { DIAMOND_CUT_ABI, ZERO_ADDRESS } from './constants'
+
+/**
+ * Post-cut initializer, delegatecalled by the diamond in the same transaction
+ * as the cut. Mirrors the `_init`/`_calldata` pair that
+ * `UpdateScriptBase.update()` passes on EVM. Grouped in one object so an
+ * address can never be supplied without its calldata (or vice versa) — a
+ * mismatched pair either silently skips the init or reverts the whole cut.
+ */
+export interface IDiamondCutInit {
+  /** Contract to delegatecall — normally the facet being added. */
+  initAddress: Address
+  /** Encoded initializer call, e.g. `initAllBridge(ChainIdConfig[])`. */
+  initCalldata: Hex
+}
 
 /**
  * Encode a `diamondCut` calldata for adding a facet.
  * Resolves selectors from Forge artifacts automatically.
+ *
+ * @param facetName - Facet whose selectors are read from the Forge artifact
+ * @param facetAddressHex - Deployed facet address (EVM hex form)
+ * @param options.init - Optional post-cut initializer (see {@link IDiamondCutInit})
+ * @param options.excludeSelectors - Selectors to leave unregistered, mirroring
+ *   `getExcludes()` on the EVM update scripts (e.g. an owner-only `init*`
+ *   function that is delegatecalled by the cut and must not be reachable
+ *   through the diamond afterwards)
  */
 export async function encodeDiamondCutCalldata(
   facetName: string,
-  facetAddressHex: Address
+  facetAddressHex: Address,
+  options: {
+    init?: IDiamondCutInit
+    excludeSelectors?: string[]
+  } = {}
 ): Promise<Hex> {
-  const selectors = await getFacetSelectors(facetName)
+  const selectors = await getFacetSelectors(
+    facetName,
+    options.excludeSelectors ?? []
+  )
+
+  if (selectors.length === 0)
+    throw new Error(
+      `No selectors left to register for ${facetName} after applying ${
+        options.excludeSelectors?.length ?? 0
+      } exclusion(s)`
+    )
 
   consola.info(
     `Encoding diamondCut for ${facetName} (${selectors.length} selectors)`
   )
+
+  if (options.init) {
+    if (options.init.initCalldata === '0x')
+      throw new Error(
+        'init.initCalldata is empty (0x); omit `init` entirely instead — the diamond skips the delegatecall when calldata is empty, so the initializer would never run'
+      )
+
+    consola.info(
+      `  + post-cut init via ${options.init.initAddress} (${
+        options.init.initCalldata.length / 2 - 1
+      } bytes calldata)`
+    )
+  }
 
   return encodeFunctionData({
     abi: DIAMOND_CUT_ABI,
@@ -40,8 +89,8 @@ export async function encodeDiamondCutCalldata(
           functionSelectors: selectors as Hex[],
         },
       ],
-      '0x0000000000000000000000000000000000000000' as Address,
-      '0x' as Hex,
+      options.init?.initAddress ?? (ZERO_ADDRESS as Address),
+      options.init?.initCalldata ?? ('0x' as Hex),
     ],
   })
 }
@@ -49,6 +98,11 @@ export async function encodeDiamondCutCalldata(
 /**
  * Encode a diamondCut and propose it to Safe via Timelock.
  * Routes to the correct propose script based on network (Tron vs EVM).
+ *
+ * The optional `init`/`excludeSelectors` pass straight through to
+ * {@link encodeDiamondCutCalldata}, so the initializer rides inside the cut
+ * itself — one timelock operation, no window in which the facet is live but
+ * uninitialised.
  */
 export async function proposeDiamondCut(options: {
   facetName: string
@@ -56,10 +110,13 @@ export async function proposeDiamondCut(options: {
   diamondAddress: string
   network: string
   privateKey?: string
+  init?: IDiamondCutInit
+  excludeSelectors?: string[]
 }): Promise<void> {
   const calldata = await encodeDiamondCutCalldata(
     options.facetName,
-    options.facetAddressHex
+    options.facetAddressHex,
+    { init: options.init, excludeSelectors: options.excludeSelectors }
   )
 
   if (isTronNetworkKey(options.network)) {

--- a/script/deploy/shared/propose-diamond-cut.ts
+++ b/script/deploy/shared/propose-diamond-cut.ts
@@ -24,9 +24,9 @@ import { DIAMOND_CUT_ABI, ZERO_ADDRESS } from './constants'
  */
 export interface IDiamondCutInit {
   /** Contract to delegatecall — normally the facet being added. */
-  initAddress: Address
+  readonly initAddress: Address
   /** Encoded initializer call, e.g. `initAllBridge(ChainIdConfig[])`. */
-  initCalldata: Hex
+  readonly initCalldata: Hex
 }
 
 /**

--- a/script/deploy/tron/deploy-and-register-allbridge-facet.ts
+++ b/script/deploy/tron/deploy-and-register-allbridge-facet.ts
@@ -28,6 +28,11 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { proposeDiamondCut } from '../shared/propose-diamond-cut'
 
+import {
+  ALLBRIDGE_INIT_SELECTOR,
+  encodeAllBridgeInitCalldata,
+  parseAllBridgeMappings,
+} from './helpers/allBridgeInit'
 import { deployContractWithLogging, validateBalance } from './tronUtils'
 
 /**
@@ -107,8 +112,10 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
     // Use new utility for balance validation
     // Pre-flight balance check: warn on low balances but do not abort here
     await validateBalance(tronWeb, 0)
-    // Load AllBridge configuration
-    const allbridgeConfig = await Bun.file('config/allbridge.json').json()
+    // Load AllBridge configuration. Kept as raw text as well, because the
+    // chain-id mappings must be revived from the JSON source (see allBridgeInit)
+    const allbridgeConfigJson = await Bun.file('config/allbridge.json').text()
+    const allbridgeConfig = JSON.parse(allbridgeConfigJson)
     const allBridgeAddress = allbridgeConfig[network]?.allBridge
 
     if (!allBridgeAddress)
@@ -119,8 +126,16 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
     // Convert Base58 address to hex format with 0x prefix for constructor arguments
     const allBridgeAddressHex = tronAddressToHex(tronWeb, allBridgeAddress)
 
+    // Encode the post-cut initializer up front: a malformed `mappings` array
+    // should abort before anything is deployed, not after
+    const chainIdMappings = parseAllBridgeMappings(allbridgeConfigJson)
+    const initCalldata = encodeAllBridgeInitCalldata(chainIdMappings)
+
     consola.info('\nAllBridge Configuration:')
     consola.info(`AllBridge: ${allBridgeAddress} (${allBridgeAddressHex})`)
+    consola.info(`Chain-id mappings to seed: ${chainIdMappings.length}`)
+    for (const { chainId, allBridgeChainId } of chainIdMappings)
+      consola.info(`   ${chainId} -> ${allBridgeChainId}`)
 
     // Prepare deployment plan
     const contracts = ['AllBridgeFacet']
@@ -186,7 +201,14 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
     const diamondAddress = await getContractAddress(network, 'LiFiDiamond')
     if (!diamondAddress) throw new Error('LiFiDiamond not found in deployments')
 
-    const selectors = await getFacetSelectors('AllBridgeFacet')
+    // `initAllBridge` is delegatecalled by the cut and must not be registered
+    // on the diamond — mirrors UpdateAllBridgeFacet.getExcludes() on EVM
+    const excludeSelectors = [ALLBRIDGE_INIT_SELECTOR]
+
+    const selectors = await getFacetSelectors(
+      'AllBridgeFacet',
+      excludeSelectors
+    )
 
     displayRegistrationInfo(
       'AllBridgeFacet',
@@ -195,15 +217,22 @@ async function deployAndRegisterAllBridgeFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
+    const facetAddressHex = tronAddressToHex(
+      tronWeb,
+      facetAddress
+    ) as `0x${string}`
+
     if (!dryRun)
       await proposeDiamondCut({
         facetName: 'AllBridgeFacet',
-        facetAddressHex: tronAddressToHex(
-          tronWeb,
-          facetAddress
-        ) as `0x${string}`,
+        facetAddressHex,
         diamondAddress,
         network: network,
+        excludeSelectors,
+        // The initializer rides inside the cut (delegatecalled by the diamond),
+        // so the facet is never live-but-uninitialised — same shape as the
+        // `_init`/`_calldata` pair UpdateScriptBase passes on EVM
+        init: { initAddress: facetAddressHex, initCalldata },
       })
     else
       consola.info('Dry run - skipping diamondCut proposal for AllBridgeFacet')

--- a/script/deploy/tron/helpers/allBridgeInit.test.ts
+++ b/script/deploy/tron/helpers/allBridgeInit.test.ts
@@ -1,0 +1,107 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import { decodeFunctionData } from 'viem'
+
+import {
+  ALLBRIDGE_INIT_ABI,
+  ALLBRIDGE_INIT_SELECTOR,
+  encodeAllBridgeInitCalldata,
+  parseAllBridgeMappings,
+} from './allBridgeInit'
+
+// Tron (1885080386571452 -> 3) and Stellar (1201081091099710 -> 7) are the
+// headline mappings of the v2.2.0 rollout. 9270000000000000 exceeds
+// Number.MAX_SAFE_INTEGER and is the reason ids are revived from source text.
+const TRON = '{ "chainId": 1885080386571452, "allBridgeChainId": 3 }'
+const STELLAR = '{ "chainId": 1201081091099710, "allBridgeChainId": 7 }'
+const OVERFLOWING = '{ "chainId": 9270000000000000, "allBridgeChainId": 13 }'
+
+const config = (...entries: string[]): string =>
+  `{ "mappings": [${entries.join(
+    ','
+  )}], "tron": { "allBridge": "TAuErcuAtU6BPt6YwL51JZ4RpDCPQASCU2" } }`
+
+describe('parseAllBridgeMappings', () => {
+  it('normalizes entries to bigints in file order', () => {
+    expect(parseAllBridgeMappings(config(TRON, STELLAR))).toEqual([
+      { chainId: 1885080386571452n, allBridgeChainId: 3n },
+      { chainId: 1201081091099710n, allBridgeChainId: 7n },
+    ])
+  })
+
+  it('preserves ids beyond Number.MAX_SAFE_INTEGER exactly', () => {
+    const mappings = parseAllBridgeMappings(config(OVERFLOWING))
+    expect(mappings).toHaveLength(1)
+    // guards against a regression to JSON.parse's double, which cannot
+    // represent every integer in this range
+    expect(mappings[0]?.chainId).toBe(9270000000000000n)
+    expect(mappings[0]?.chainId.toString()).toBe('9270000000000000')
+  })
+
+  it('rejects a missing or empty mappings array', () => {
+    for (const input of ['{}', '{ "mappings": [] }', '{ "mappings": 5 }'])
+      expect(() => parseAllBridgeMappings(input)).toThrow(/"mappings" array/)
+  })
+
+  it('rejects a zero id (the reserved unmapped sentinel)', () => {
+    expect(() =>
+      parseAllBridgeMappings(config('{ "chainId": 1, "allBridgeChainId": 0 }'))
+    ).toThrow(/allBridgeChainId must be > 0/)
+    expect(() =>
+      parseAllBridgeMappings(config('{ "chainId": 0, "allBridgeChainId": 1 }'))
+    ).toThrow(/chainId must be > 0/)
+  })
+
+  it('rejects a fractional id', () => {
+    expect(() =>
+      parseAllBridgeMappings(
+        config('{ "chainId": 1.5, "allBridgeChainId": 1 }')
+      )
+    ).toThrow(/must be an integer/)
+  })
+
+  it('rejects a missing or non-numeric id', () => {
+    expect(() =>
+      parseAllBridgeMappings(config('{ "allBridgeChainId": 1 }'))
+    ).toThrow(/chainId must be a JSON number/)
+    expect(() =>
+      parseAllBridgeMappings(
+        config('{ "chainId": "1", "allBridgeChainId": 1 }')
+      )
+    ).toThrow(/chainId must be a JSON number/)
+  })
+
+  it('rejects a duplicated chainId', () => {
+    expect(() => parseAllBridgeMappings(config(TRON, TRON))).toThrow(
+      /is duplicated/
+    )
+  })
+})
+
+describe('encodeAllBridgeInitCalldata', () => {
+  it('encodes initAllBridge and round-trips the configs', () => {
+    const calldata = encodeAllBridgeInitCalldata(
+      parseAllBridgeMappings(config(TRON, STELLAR))
+    )
+
+    expect(calldata.startsWith(ALLBRIDGE_INIT_SELECTOR)).toBe(true)
+
+    const { functionName, args } = decodeFunctionData({
+      abi: ALLBRIDGE_INIT_ABI,
+      data: calldata,
+    })
+    expect(functionName).toBe('initAllBridge')
+    expect(args[0]).toEqual([
+      { chainId: 1885080386571452n, allBridgeChainId: 3n },
+      { chainId: 1201081091099710n, allBridgeChainId: 7n },
+    ])
+  })
+
+  it('refuses to encode an empty mapping set (initAllBridge reverts InvalidConfig)', () => {
+    expect(() => encodeAllBridgeInitCalldata([])).toThrow(/zero mappings/)
+  })
+})

--- a/script/deploy/tron/helpers/allBridgeInit.ts
+++ b/script/deploy/tron/helpers/allBridgeInit.ts
@@ -48,8 +48,8 @@ export const ALLBRIDGE_INIT_SELECTOR = toFunctionSelector(
 )
 
 export interface IAllBridgeChainIdConfig {
-  chainId: bigint
-  allBridgeChainId: bigint
+  readonly chainId: bigint
+  readonly allBridgeChainId: bigint
 }
 
 /** Id fields read from the JSON source text rather than the parsed double. */

--- a/script/deploy/tron/helpers/allBridgeInit.ts
+++ b/script/deploy/tron/helpers/allBridgeInit.ts
@@ -1,0 +1,175 @@
+/**
+ * AllBridgeFacet post-cut initializer encoder (Tron).
+ *
+ * The TS/Tron deploy path has no equivalent of the Foundry update scripts, so
+ * this mirrors `script/deploy/facets/UpdateAllBridgeFacet.s.sol` — both
+ * `getCallData()` (encode `initAllBridge` from `config/allbridge.json`'s
+ * `mappings`) and `getExcludes()` (keep `initAllBridge` off the diamond).
+ *
+ * Without this the facet would land on the Tron diamond with
+ * `chainMappingsInitialized == false`, and every
+ * `startBridgeTokensViaAllBridge` from Tron would revert
+ * `UnsupportedAllBridgeChainId`. It is not repairable afterwards:
+ * `setChainIdToAllBridgeChainId` itself reverts `NotInitialized`, so only the
+ * owner-only `initAllBridge` can bootstrap the storage.
+ *
+ * Pure and dependency-free (no TronWeb, no filesystem) so it is unit-testable.
+ */
+import { encodeFunctionData, toFunctionSelector, type Hex } from 'viem'
+
+/** Minimal ABI for `AllBridgeFacet.initAllBridge(ChainIdConfig[])`. */
+export const ALLBRIDGE_INIT_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { name: 'chainId', type: 'uint256' },
+          { name: 'allBridgeChainId', type: 'uint256' },
+        ],
+        name: 'chainIdConfigs',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'initAllBridge',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+/**
+ * Selector of `initAllBridge(ChainIdConfig[])`, excluded from the registered
+ * selectors exactly as `UpdateAllBridgeFacet.getExcludes()` does on EVM: the
+ * diamond delegatecalls it once during the cut, and leaving it reachable
+ * through the diamond afterwards would diverge from every EVM deployment.
+ */
+export const ALLBRIDGE_INIT_SELECTOR = toFunctionSelector(
+  'initAllBridge((uint256,uint256)[])'
+)
+
+export interface IAllBridgeChainIdConfig {
+  chainId: bigint
+  allBridgeChainId: bigint
+}
+
+/** Id fields read from the JSON source text rather than the parsed double. */
+const ID_FIELDS = new Set(['chainId', 'allBridgeChainId'])
+
+/**
+ * Parses the config file, reviving the chain-id fields straight from their JSON
+ * source text.
+ *
+ * LI.FI's synthetic non-EVM chain ids reach past IEEE-754 exact-integer range —
+ * `config/allbridge.json` already carries 9270000000000000, above
+ * `Number.MAX_SAFE_INTEGER` — so `JSON.parse` alone would hand back a double
+ * that is not guaranteed to equal what the file says. The Foundry path
+ * has no such hazard — `stdJson.parseRaw` decodes straight to `uint256`. The
+ * third reviver argument (`context.source`) carries the untouched number
+ * literal, so `BigInt` conversion is exact; it also rejects fractional ids for
+ * free, since `BigInt('1.5')` throws.
+ */
+function parseConfigWithBigIntIds(configJson: string): unknown {
+  return JSON.parse(
+    configJson,
+    // The 3-argument reviver (ES2025 JSON.parse source access) is not in the
+    // TS lib types yet, hence the casts
+    ((key: string, value: unknown, context?: { source?: string }): unknown => {
+      if (typeof value !== 'number' || !ID_FIELDS.has(key)) return value
+
+      if (context?.source === undefined)
+        throw new Error(
+          `Cannot read "${key}" without precision loss: this runtime's JSON.parse does not expose the number source text`
+        )
+
+      try {
+        return BigInt(context.source)
+      } catch {
+        throw new Error(`"${key}" must be an integer, got ${context.source}`)
+      }
+    }) as unknown as (key: string, value: unknown) => unknown
+  )
+}
+
+/**
+ * Validates and normalizes the `mappings` array of `config/allbridge.json`.
+ *
+ * Mirrors the on-chain guards in `initAllBridge`: it rejects an empty array and
+ * any zero id (0 is the reserved "unmapped" sentinel in the facet's storage).
+ * Failing here costs nothing; the same input reaching the chain would revert
+ * `InvalidConfig` only after signing and the full timelock delay.
+ *
+ * @param configJson - Raw text of `config/allbridge.json`
+ * @returns Chain-id configs in file order, as bigints
+ * @throws If `mappings` is missing/empty, an entry is malformed, an id is
+ *   absent, non-integral or zero, or a `chainId` appears twice
+ */
+export function parseAllBridgeMappings(
+  configJson: string
+): IAllBridgeChainIdConfig[] {
+  const config = parseConfigWithBigIntIds(configJson)
+
+  const mappings =
+    typeof config === 'object' && config !== null
+      ? (config as Record<string, unknown>).mappings
+      : undefined
+
+  if (!Array.isArray(mappings) || mappings.length === 0)
+    throw new Error(
+      'config/allbridge.json has no non-empty "mappings" array — AllBridgeFacet v2.2.0+ seeds its chain-id mappings from it (added in lifinance/contracts#2075). Is this checkout on a main that includes it?'
+    )
+
+  const seen = new Set<bigint>()
+
+  return mappings.map((entry, i) => {
+    if (typeof entry !== 'object' || entry === null)
+      throw new Error(`mappings[${i}] is not an object`)
+
+    const { chainId, allBridgeChainId } = entry as Record<string, unknown>
+
+    const toId = (value: unknown, field: string): bigint => {
+      if (typeof value !== 'bigint')
+        throw new Error(
+          `mappings[${i}].${field} must be a JSON number, got ${JSON.stringify(
+            value
+          )}`
+        )
+      if (value <= 0n)
+        throw new Error(
+          `mappings[${i}].${field} must be > 0 (0 is the reserved "unmapped" sentinel), got ${value}`
+        )
+      return value
+    }
+
+    const mapping = {
+      chainId: toId(chainId, 'chainId'),
+      allBridgeChainId: toId(allBridgeChainId, 'allBridgeChainId'),
+    }
+
+    // A duplicate chainId means the later entry silently wins on-chain, so the
+    // deployed mapping would not match what a reviewer reads in the config
+    if (seen.has(mapping.chainId))
+      throw new Error(`mappings[${i}].chainId ${mapping.chainId} is duplicated`)
+    seen.add(mapping.chainId)
+
+    return mapping
+  })
+}
+
+/**
+ * Encodes the `initAllBridge` call passed as the diamondCut's init calldata.
+ *
+ * @param mappings - Chain-id configs from {@link parseAllBridgeMappings}
+ * @returns Encoded `initAllBridge(ChainIdConfig[])` calldata
+ */
+export function encodeAllBridgeInitCalldata(
+  mappings: IAllBridgeChainIdConfig[]
+): Hex {
+  if (mappings.length === 0)
+    throw new Error('Cannot encode initAllBridge with zero mappings')
+
+  return encodeFunctionData({
+    abi: ALLBRIDGE_INIT_ABI,
+    functionName: 'initAllBridge',
+    args: [mappings],
+  })
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-650 (Tron leg — the EVM side is in #2075)

# Why did I implement it this way?

**Problem.** The Tron cut path cannot deliver an init call.
`script/deploy/shared/propose-diamond-cut.ts` hardcoded `address(0)` as the
diamondCut init address and `0x` as its calldata, and `proposeDiamondCut()`
exposed no way to override either. On EVM the init call comes from
`UpdateScriptBase.update()`, which passes the new facet address plus
`getCallData()` as the cut's `_init`/`_calldata` pair.

For AllBridgeFacet v2.2.0 that gap is a liveness bug, not a cosmetic one:
deploying it to Tron unchanged leaves `chainMappingsInitialized == false` with
every mapping zero, so **every `startBridgeTokensViaAllBridge` from Tron would
revert `UnsupportedAllBridgeChainId`**. It is not repairable after the fact —
`setChainIdToAllBridgeChainId` itself reverts `NotInitialized`, so only the
owner-only `initAllBridge` can bootstrap the storage.

**Approach.** Thread the init through the cut rather than batching a second
timelock call. Both were viable (`propose-calls-tron.ts` already supports
multi-call `scheduleBatch`), but riding inside the cut is atomic by
construction, needs no batch plumbing, and produces the same on-chain shape as
every EVM deployment — the diamond delegatecalls the initializer within
`diamondCut`, so there is no window where the facet is live but uninitialised.

- `IDiamondCutInit` groups `initAddress` + `initCalldata` in one object so an
  address can never be passed without its calldata; a mismatched pair either
  silently skips the init or reverts the whole cut.
- `excludeSelectors` also threads through, and the AllBridge script excludes
  `initAllBridge` — mirroring `UpdateAllBridgeFacet.getExcludes()`. Without it
  `getFacetSelectors()` would register the initializer on the diamond, a
  divergence from every EVM chain.
- The initializer is encoded **before** anything is deployed, so a malformed
  `mappings` array aborts up front rather than after a facet is on-chain.

**Chain ids are revived from the JSON source text.** `config/allbridge.json`
carries `9270000000000000`, above `Number.MAX_SAFE_INTEGER`, so `JSON.parse`
alone cannot be trusted to reproduce these ids exactly. The reviver's
`context.source` argument gives the untouched number literal for exact `BigInt`
conversion (and rejects fractional ids for free). The Foundry path has no such
hazard — `stdJson.parseRaw` decodes straight to `uint256`.

**Verification.** The encoded `initAllBridge` calldata for all 15 real mappings
is byte-identical to an independent Foundry encoding
(`cast calldata "initAllBridge((uint256,uint256)[])" ...`), which is how the
`MAX_SAFE_INTEGER` issue was caught in the first place. 9 new unit tests cover
precision, the zero sentinel, fractional/missing/non-numeric ids, duplicates,
and the encode round-trip. Error paths were exercised end-to-end; notably
today's `config/allbridge.json` (no `mappings` array yet) fails loud with
`no non-empty "mappings" array` rather than encoding an empty init.

**Sequencing.** This lands the deploy-tooling plumbing only; it does not touch
`config/allbridge.json` or any contract. The `mappings` array it consumes
arrives with #2075 (AllBridgeFacet v2.2.0), so the two PRs are independent to
merge in either order, but the Tron deployment itself needs both. Everything
here reaches `lifinance/contracts-tron` via the weekly upstream sync — this PR
supersedes lifinance/contracts-tron#25, which is closed in favour of landing
the change at its canonical home so the fork copies never diverge.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
