### PR TITLE
docs(script): correct stale getDeployLogFile JSDoc

### DIFF
--- a/script/utils/viemScriptHelpers.ts
+++ b/script/utils/viemScriptHelpers.ts
@@ -395,6 +395,7 @@ export function getFunctionSelectors(
  * @param network Name of the network
  * @param environment the production environment (production/staging)
  * @returns Parsed deploy log mapping contract names to their deployed addresses
+ * @throws If the network name resolves outside the deployments directory or no deploy log exists for the network/environment.
  */
 export function getDeployLogFile(
   network: string,

--- a/script/utils/viemScriptHelpers.ts
+++ b/script/utils/viemScriptHelpers.ts
@@ -390,11 +390,11 @@ export function getFunctionSelectors(
 }
 
 /**
- * Retrieves a contract address from a (prod or staging) deploy log file
+ * Reads and parses a (prod or staging) deploy log file
  *
  * @param network Name of the network
  * @param environment the production environment (production/staging)
- * @returns Hex-encoded calldata array like cast abi-encode would produce
+ * @returns Parsed deploy log mapping contract names to their deployed addresses
  */
 export function getDeployLogFile(
   network: string,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

None — trivial docs fix noticed during review of #2143.

# Why did I implement it this way?

The JSDoc summary and `@returns` line on `getDeployLogFile` described "Hex-encoded calldata array like cast abi-encode would produce" (copied from a calldata-building helper), but the function returns the parsed deploy-log JSON (`Record<string, string>` of contract names to deployed addresses) from `deployments/<network><suffix>.json`. Comment-only change; no behavior touched.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug (n/a — comment-only)
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e (n/a)
- [ ] I have updated any required documentation (n/a)

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)