### PR TITLE
fix(deploy): apply customDeployFlags on the zkEVM deploy path (EXSC-684)

### DIFF
--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -311,11 +311,14 @@ deploySingleContract() {
     # The zkEVM command pins --skip-simulation and --gas-limit; appending customDeployFlags
     # verbatim would pass either flag twice, so drop the redundant --skip-simulation and let a
     # custom --gas-limit replace the pinned default.
-    local ZK_ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS//--skip-simulation/}"
+    local ZK_ADDITIONAL_FLAGS=""
     local ZK_GAS_LIMIT_FLAG="--gas-limit 50000000"
-    if [[ "$ZK_ADDITIONAL_FLAGS" == *"--gas-limit"* ]]; then
-      ZK_GAS_LIMIT_FLAG=""
-      echoDebug "customDeployFlags specify --gas-limit; not applying the zkEVM default of 50000000"
+    if isZkEvmNetwork "$NETWORK"; then
+      ZK_ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS//--skip-simulation/}"
+      if [[ "$ZK_ADDITIONAL_FLAGS" == *"--gas-limit"* ]]; then
+        ZK_GAS_LIMIT_FLAG=""
+        echoDebug "customDeployFlags specify --gas-limit; not applying the zkEVM default of 50000000"
+      fi
     fi
 
     # Use a local effective multiplier so per-network overrides don't leak into subsequent calls.

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -308,6 +308,16 @@ deploySingleContract() {
       SKIP_SIMULATION_FLAG=""
     fi
 
+    # The zkEVM command pins --skip-simulation and --gas-limit; appending customDeployFlags
+    # verbatim would pass either flag twice, so drop the redundant --skip-simulation and let a
+    # custom --gas-limit replace the pinned default.
+    local ZK_ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS//--skip-simulation/}"
+    local ZK_GAS_LIMIT_FLAG="--gas-limit 50000000"
+    if [[ "$ZK_ADDITIONAL_FLAGS" == *"--gas-limit"* ]]; then
+      ZK_GAS_LIMIT_FLAG=""
+      echoDebug "customDeployFlags specify --gas-limit; not applying the zkEVM default of 50000000"
+    fi
+
     # Use a local effective multiplier so per-network overrides don't leak into subsequent calls.
     local NETWORK_GAS_MULTIPLIER
     NETWORK_GAS_MULTIPLIER=$(jq -r --arg NETWORK "$NETWORK" '.[$NETWORK].gasEstimateMultiplier // empty' "$NETWORKS_JSON" 2>/dev/null || true)
@@ -334,7 +344,7 @@ deploySingleContract() {
     if isZkEvmNetwork "$NETWORK"; then
       # Deploy zksync scripts using the zksync specific fork of forge
       executeAndParse \
-        "FOUNDRY_PROFILE=zksync DEPLOYSALT=$DEPLOYSALT NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" ./foundry-zksync/forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --skip-simulation --slow --zksync --gas-estimate-multiplier \"$EFFECTIVE_GAS_ESTIMATE_MULTIPLIER\" --gas-limit 50000000" \
+        "FOUNDRY_PROFILE=zksync DEPLOYSALT=$DEPLOYSALT NETWORK=$NETWORK FILE_SUFFIX=$FILE_SUFFIX PRIVATE_KEY=\"$(getPrivateKey \"$NETWORK\" \"$ENVIRONMENT\")\" ./foundry-zksync/forge script \"$FULL_SCRIPT_PATH\" --fork-url \"$NETWORK\" --sender \"$DEPLOYER_ADDRESS\" --json --broadcast --skip-simulation --slow --zksync --gas-estimate-multiplier \"$EFFECTIVE_GAS_ESTIMATE_MULTIPLIER\" $ZK_GAS_LIMIT_FLAG $ZK_ADDITIONAL_FLAGS" \
         "true"
     else
       # try to execute call


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-684 — found by `/gate-review` while working on #2145 (SquidFacet on tempo). No dedicated
ticket could be created from this session (Linear connector unavailable here); happy to move it
under its own ticket if preferred.

# Why did I implement it this way?

`deploySingleContract.sh` has two branches for the `forge script` deploy command. The standard
branch interpolates `$ADDITIONAL_FLAGS` (a network's `customDeployFlags` from
`config/networks.json`); the zkEVM branch built its own command string and never did, so
`customDeployFlags` was **silently dropped** on zkEVM chains. No zkEVM network sets the field
today (`abstract`, `lens`, `zksync` all leave it unset), so nothing is broken in production —
this is a latent trap for the next zkEVM network that needs a custom deploy flag.

I chose to **make the field work on zkEVM** rather than warn that it is ignored: a silent-drop
bug and a warn-on-drop bug both still leave the field unusable on those chains, and a warning
only helps someone who happens to read the log.

**Why the flags are composed instead of appended verbatim.** The zkEVM command pins two flags
that `customDeployFlags` values realistically also carry — `--skip-simulation` and
`--gas-limit 50000000`. Appending verbatim would pass one of them twice (all three networks that
use `customDeployFlags` today set `--gas-limit`, and `megaeth` also sets `--skip-simulation`).
Rather than rely on `forge`'s duplicate-flag semantics — which I could not verify here, since the
`foundry-zksync` binary is not vendored into a fresh checkout — the change guarantees each flag is
emitted exactly once:

- a `--gas-limit` in `customDeployFlags` **replaces** the pinned default (with an `echoDebug` note)
- the redundant `--skip-simulation` token is stripped, since the zkEVM path always skips simulation
- every other flag is appended verbatim, matching the standard path

This also resolves the related dead branch noted in review: the `--skip-simulation` override at
L306-309 (which blanks `SKIP_SIMULATION_FLAG`) is structurally a no-op on the zkEVM path because
that branch hardcodes the flag. Net behaviour is now correct there — a network asking for
`--skip-simulation` gets it — so I left those lines alone rather than widen the diff.

**Verification.** No unit-test harness exists for this script, so I dry-ran the flag composition
by extracting the actual command line from the file and expanding it with stub values, over every
`customDeployFlags` value present in `config/networks.json` plus the empty case:

| `customDeployFlags` | `--gas-limit` count | `--skip-simulation` count | effective tail |
| --- | --- | --- | --- |
| _(unset — all zkEVM networks today)_ | 1 | 1 | `--gas-limit 50000000` |
| `--gas-limit 40000000` (tempo) | 1 | 1 | `--gas-limit 40000000` |
| `--gas-limit 50000000 --gas-price 2000000 --skip-simulation` (megaeth) | 1 | 1 | `--gas-limit 50000000 --gas-price 2000000` |
| `--with-gas-price 110000000` (robinhood) | 1 | 1 | `--gas-limit 50000000 --with-gas-price 110000000` |

The unset case — which is every zkEVM network as of today — reproduces the pre-change command
exactly, so this is a no-op for current deploys. `bash -n` and a `set -euo pipefail` source both
pass.

## Two follow-ups deliberately left out of scope

1. **The `INetwork` JSDoc for `customDeployFlags` is not on `main`.** The review note asked me to
   update it, but that field and its docstring are added by **#2145**, which is still open — so
   there is nothing to edit on this base. The sentence it lands with ("Only applied on the standard
   deploy path; the zkEVM path builds its own command and ignores this field") becomes wrong once
   this PR merges. Rather than stack on an unmerged PR or pre-declare the field and guarantee a
   conflict, I've flagged it on #2145; if that merges first I'll rebase and correct the wording
   here.
2. **`megaeth`'s `devNotes` in `config/networks.json` is inaccurate** — it claims
   `customDeployFlags` "are applied by deploySingleContract.sh, updateFacetConfig.sh, and
   diamondUpdateFacet.sh". Neither `updateFacetConfig.sh` nor `diamondUpdateFacet.sh` reads the
   field at all (`grep customDeployFlags` matches only `deploySingleContract.sh`). Left alone to
   keep this diff to one file and avoid `networks.json` CI churn.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
