### PR TITLE
fix(ci): make the fork-RPC cache per-shard, solely-owned and refreshable (EXSC-726)

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -1,24 +1,26 @@
 # Composite action: install pinned foundry + verify (with caching)
 # - Reads .foundry-version from the checked-out repo
 # - Installs foundry at that version via foundry-rs/foundry-toolchain
-# - Restores ~/.foundry / ~/.svm (solc downloads) and cache/ + out/ (forge build artifacts)
-#   between runs to skip redundant downloads and recompilation.
+# - Restores three disjoint caches between runs to skip redundant work: foundry/solc binaries
+#   (~/.foundry/bin + share + versions, ~/.svm), forge build artifacts (cache/ + out/), and
+#   forked-chain state (~/.foundry/cache/rpc). Disjoint is load-bearing — see the RPC step.
 # - Verifies the installed binary matches the pin (catches action regressions or input typos)
 # Used by every workflow that needs forge/cast/anvil so a single pin source
 # (.foundry-version) flows everywhere.
 name: Setup Foundry
-description: Install pinned foundry from .foundry-version, restore solc + forge build caches, and verify the installed binary matches.
+description: Install pinned foundry from .foundry-version, restore the solc, forge-build and fork-RPC caches, and verify the installed binary matches.
 
 inputs:
   cache-key-suffix:
     description: >-
-      Extra segment folded into the forge-build cache key. Required whenever a
-      single workflow runs more than one build SCOPE in parallel — e.g. matrix
-      shards that each `forge test --match-path <subset>` and therefore compile
-      a different partial out/. Pass the shard id (e.g. matrix.shard) so each
-      scope owns its own cache; otherwise the shards share one key and the first
-      to finish poisons the rest with its partial out/. Leave empty for
-      workflows that produce a single, consistent out/.
+      Extra segment folded into the forge-build AND foundry-rpc cache keys.
+      Required whenever a single workflow runs more than one SCOPE in parallel —
+      e.g. matrix shards that each `forge test --match-path <subset>` and
+      therefore compile a different partial out/ and touch a different set of
+      forked chains. Pass the shard id (e.g. matrix.shard) so each scope owns its
+      own caches; otherwise the shards share one key and the first to finish
+      poisons the rest with its partial out/ and its partial RPC state. Leave
+      empty for workflows that produce a single, consistent out/.
     required: false
     default: ""
 
@@ -50,13 +52,21 @@ runs:
         echo "hash=${hash}" >> "$GITHUB_OUTPUT"
 
     - name: Cache Foundry RPC state
-      # Fork tests pin deterministic blocks; RPC cache is stable across runs until pins change.
+      # Fork tests pin deterministic blocks, so the fetched state stays valid until a pin moves.
+      # This step is the SOLE owner of ~/.foundry/cache/rpc — the toolchain cache below does not
+      # cover it and foundry-toolchain's own caching is off. When two actions cache overlapping
+      # paths the one restoring last wins, so a staler superset silently discards fresher state.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.foundry/cache/rpc
-        key: foundry-rpc-${{ runner.os }}-${{ steps.fork_blocks.outputs.hash }}
+        # run_id/run_attempt make the primary key unhittable on purpose: actions/cache skips
+        # its post-run save on an exact hit, so a stable key can never be refreshed once a
+        # cold entry lands. Unhittable means every green run saves a warmer entry, and the
+        # restore-keys below pick up the newest matching one.
+        key: foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ steps.fork_blocks.outputs.hash }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
-          foundry-rpc-${{ runner.os }}-
+          foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ steps.fork_blocks.outputs.hash }}-
+          foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-
 
     - name: Cache Foundry toolchain state (svm + foundryup)
       # Restored before the install step so foundry-toolchain can detect an existing
@@ -65,8 +75,12 @@ runs:
       # never mix solc binaries across foundry versions.
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
+        # Enumerated rather than all of ~/.foundry, which also holds cache/rpc: a
+        # superset path would make this the last writer over the RPC state above.
         path: |
-          ~/.foundry
+          ~/.foundry/bin
+          ~/.foundry/share
+          ~/.foundry/versions
           ~/.svm
         key: foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-${{ hashFiles('foundry.toml') }}
         restore-keys: |
@@ -76,6 +90,10 @@ runs:
       uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       with:
         version: ${{ steps.pin.outputs.version }}
+        # Its built-in cache covers ~/.foundry/cache with a key of
+        # <job>-<sha> — shared by every matrix shard, and its save is
+        # post-if: success(), so a failing shard never contributes state.
+        cache: false
 
     - name: Cache forge build artifacts (cache/, out/)
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -23,6 +23,15 @@ inputs:
       empty for workflows that produce a single, consistent out/.
     required: false
     default: ""
+  rpc-cache-refresh:
+    description: >-
+      Set to "true" for workflows whose fork-RPC state is worth accumulating —
+      in practice the forge test suites. It makes the RPC cache key unhittable
+      so each green run saves a warmer entry (see the RPC cache step). Leave at
+      the default for workflows that barely fork: they would each add a cache
+      entry per run for no gain, and crowd out the entries that matter.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -39,17 +48,30 @@ runs:
         fi
         echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    - name: Compute fork block pin hash
+    - name: Compute RPC cache key segments
       id: fork_blocks
       shell: bash
+      env:
+        RPC_CACHE_REFRESH: ${{ inputs.rpc-cache-refresh }}
+        WORKFLOW_RUN_ID: ${{ github.run_id }}
+        WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
       run: |
         set -euo pipefail
         hash="$(bash script/utils/hashForkBlockPins.sh)"
-        if [ -z "$hash" ]; then
+        if [[ -z "$hash" ]]; then
           echo "::error::hashForkBlockPins.sh returned empty hash"
           exit 1
         fi
         echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+        # A per-run segment makes the primary key unhittable: actions/cache skips its
+        # post-run save on an exact hit, so a key that always matches can never be
+        # refreshed once a cold entry lands.
+        if [[ "$RPC_CACHE_REFRESH" == "true" ]]; then
+          echo "refresh=-${WORKFLOW_RUN_ID}-${WORKFLOW_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+        else
+          echo "refresh=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Cache Foundry RPC state
       # Fork tests pin deterministic blocks, so the fetched state stays valid until a pin moves.
@@ -59,11 +81,10 @@ runs:
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.foundry/cache/rpc
-        # run_id/run_attempt make the primary key unhittable on purpose: actions/cache skips
-        # its post-run save on an exact hit, so a stable key can never be refreshed once a
-        # cold entry lands. Unhittable means every green run saves a warmer entry, and the
-        # restore-keys below pick up the newest matching one.
-        key: foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ steps.fork_blocks.outputs.hash }}-${{ github.run_id }}-${{ github.run_attempt }}
+        # `refresh` is empty unless rpc-cache-refresh is on, in which case it makes this key
+        # unhittable so every green run saves a warmer entry and the restore-keys below pick
+        # up the newest match.
+        key: foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ steps.fork_blocks.outputs.hash }}${{ steps.fork_blocks.outputs.refresh }}
         restore-keys: |
           foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-${{ steps.fork_blocks.outputs.hash }}-
           foundry-rpc-${{ runner.os }}-${{ inputs.cache-key-suffix }}-

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -89,9 +89,9 @@ jobs:
       - name: Install Foundry
         uses: ./.github/actions/setup-foundry
         with:
-          # Each shard runs `forge test --match-path <subset>` and so compiles a
-          # different partial out/; key the build cache per shard so they do not
-          # poison one another's cache.
+          # Each shard runs `forge test --match-path <subset>`, so it compiles a
+          # different partial out/ and forks a different set of chains; key the
+          # build and RPC caches per shard so they do not poison one another's.
           cache-key-suffix: ${{ matrix.shard }}
 
       - name: Install forge Dependencies

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -93,6 +93,8 @@ jobs:
           # different partial out/ and forks a different set of chains; key the
           # build and RPC caches per shard so they do not poison one another's.
           cache-key-suffix: ${{ matrix.shard }}
+          # This is the fork-RPC-heavy workflow, so it is worth accumulating state here.
+          rpc-cache-refresh: 'true'
 
       - name: Install forge Dependencies
         run: forge install

--- a/foundry.toml
+++ b/foundry.toml
@@ -21,10 +21,15 @@ cache = true
 runs = 256
 
 [profile.ci]
-# Inherits [profile.default]; only fuzz runs differ for faster CI.
+# Inherits [profile.default]; only fuzz settings differ for faster CI.
 
 [profile.ci.fuzz]
 runs = 32
+# Pinned so a fuzz run over a forked chain reads the same state on every run and can be
+# served from ~/.foundry/cache/rpc. Unseeded, each `--rerun` draws fresh inputs that miss
+# the cache, which makes a fork-RPC timeout unretryable. The local default profile stays
+# unseeded, so a wider input space is still explored outside CI.
+seed = '0x1'
 
 # Floor-compiler check (used by .github/workflows/solc-floor-build.yml).
 # Compiles the deployed contracts (src/) with the minimum pragma compiler so a PR that


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-726](https://linear.app/lifi-linear/issue/EXSC-726/fixci-make-the-fork-rpc-cache-per-shard-solely-owned-and-refreshable) — filed off the back of a live CI failure on the Tron fork
([contracts-tron#27](https://github.com/lifinance/contracts-tron/pull/27), run
[30410119235](https://github.com/lifinance/contracts-tron/actions/runs/30410119235)).

# Why did I implement it this way?

## Symptom

`Run Unit Tests` → `run-unit-tests (facets)` fails with

```text
[FAIL: EVM error; database error: failed to get storage for 0x833589fCD… :
 error sending request for url (***); operation timed out]
 testBase_CanBridgeTokens_fuzzed(uint256) (runs: 25)
```

Not a test failure — Foundry's fork backend can't read state from the RPC in time. The shard burns
**~16 minutes over 11 attempts** (initial + all 10 retries) and every attempt dies on the same fuzz
test while the other 1380 tests pass. On the fork it is currently red-or-lucky: one run failed all
11 attempts, the re-run passed on retry 9.

## Root cause: `~/.foundry/cache/rpc` is permanently cold

Same cache key, same fork-block pin hash, wildly different content:

| repo | `foundry-rpc-Linux-4733a4db…` | created |
|---|---|---|
| `lifinance/contracts` | **3.66 MiB** | 2026-07-16 |
| `lifinance/contracts-tron` | **95.61 KiB** | 2026-07-24 |

Three independent mechanisms keep an entry cold once it lands, and this PR fixes each:

1. **Shared key across the five matrix shards.** `foundry-rpc-${{ runner.os }}-${{ pinhash }}`
   carried no shard segment, so `actions/cache`'s first-writer-wins made the fastest shard the
   author of the entry — `misc` finishes in 59 s and forks almost nothing, `facets` needs 15 min of
   fork state. Fixed by folding `cache-key-suffix` in, exactly as the `forge-build` cache below it
   already does (its comment describes this same hazard for `out/`).

2. **`actions/cache` skips its post-run save on an exact key hit**
   ([`saveImpl.ts:50`](https://github.com/actions/cache/blob/5a3ec84/src/saveImpl.ts#L50)) — and its
   `post-if` is `success()`, so a *failing* shard saves nothing either. Cold restore → cold save →
   cold forever; the fork's entry has been 95 KiB since 2026-07-24. Fixed by folding
   `run_id`/`run_attempt` into the primary key so it can never be hit: every green run now saves a
   warmer entry and `restore-keys` pick up the newest match. This is behind a new
   `rpc-cache-refresh` input, default off — ten workflows use this action and only the forge test
   suites fork enough for accumulation to pay for itself; the rest would each add an entry per run
   and crowd out the ones that matter.

3. **Three caches wrote the same directory, in the wrong order.** The RPC cache restores first;
   then the toolchain cache for `~/.foundry` — a *superset* of `~/.foundry/cache/rpc`, 178 MiB,
   snapshot from 2026-07-10 — extracts on top; then `foundry-rs/foundry-toolchain`'s own built-in
   cache (`linux-foundry-chain-fork-<job>-<sha>`, 122 KiB, verified from its
   [`src/cache.ts`](https://github.com/foundry-rs/foundry-toolchain/blob/c7450ba/src/cache.ts):
   `CACHE_PATHS = [~/.foundry/cache]`) lands on top of that. Fixed by narrowing the toolchain cache
   to `bin`/`share`/`versions` and passing `cache: false` to `foundry-toolchain`, leaving exactly
   one owner of the RPC directory.

## Root cause: an unseeded fuzz profile makes the retry loop useless

`forge test --rerun` re-runs the failed test, but that test is a fuzz test and `[profile.ci.fuzz]`
pinned no `seed`. Each retry draws new random amounts → touches new addresses/storage → issues
fresh uncached RPC reads. The retry doesn't reduce the failure probability, it re-rolls it — which
is why 11 attempts produce 11 identical failures instead of converging. `seed = '0x1'` makes the
inputs deterministic, so the state they read is cacheable and a re-run is a real re-run.

## Evidence

Measured locally against the same Base pin (block 35717845), `FOUNDRY_PROFILE=ci`:

| run | `~/.foundry/cache/rpc/base` | result |
|---|---|---|
| 1 | cold | **FAIL** — RPC timeout after 51.7 s |
| 2 | warmed by run 1 | PASS in 13.9 s |
| 3 | warm | PASS in 1.7 s |

Run 2 passed with `eth_rpc_timeout` forced down to **5 seconds** — once the state is cached the
network is barely in the path. Full shard, warm, seeded: **1385 passed, 0 failed, 13.5 s** for
`--match-path "test/solidity/Facets/**"` (CI currently needs 50 s+ per attempt).

## What I tried and dropped

Raising `eth_rpc_timeout` and setting `no_rpc_rate_limit` looked like obvious cheap wins. Both are
inert here, so they are **not** in this PR:

- cold-cache run with `eth_rpc_timeout=5` → 52.0 s; with `=120` → 52.7 s. The setting does not reach
  the fork backend in forge 1.7.1.
- cold-cache run with `no_rpc_rate_limit` false → fail; true → fail.

I also drafted a `ci_deep` profile (unseeded, 256 runs) to preserve fuzz breadth, wired to
post-merge/manual runs. Measured, it times out the same way — it would have moved the flake onto
`main`. Dropped; noted as follow-up below. The local `[profile.default]` stays unseeded at 256 runs,
so breadth is still explored outside CI.

## Trade-offs a reviewer should weigh

- **Cache-store growth.** An unhittable primary key means a new entry per shard per run (~4 MB
  each), now scoped to this one workflow — 5 entries per unit-test run rather than ~14 per PR.
  GitHub evicts LRU and drops caches unused for 7 days, so steady state is bounded by ~7 days of
  unit-test runs, well under the 10 GB repo limit. The cheaper alternative is a date segment
  (weekly refresh instead of per-run); happy to switch if the store pressure still reads as too
  high.
- **One-time cold start.** The RPC key gains a `cache-key-suffix` segment, so existing entries no
  longer match and the first run per shard refetches. For this repo that is a 3.66 MiB refetch; for
  the Tron fork it discards a 95 KiB entry that was the whole problem.
- **A fixed seed narrows CI fuzz breadth.** Accepted deliberately: an unseeded fork-fuzz test in CI
  is not exploring more of the input space, it is failing before it explores any of it.

## Follow-ups (not in this PR)

- The retry loop retries *everything* 10 times: a genuine assertion failure also costs ~16 min and
  11 compiles. It should match on fork-infra signatures (`database error`, `operation timed out`,
  `error sending request`) and fail fast otherwise, and re-run `bun fetch-rpcs` between attempts so
  a bad endpoint gets swapped rather than hammered.
- A scheduled deep-fuzz job to recover the breadth a pinned seed gives up — needs its own warm-cache
  strategy first, per the `ci_deep` measurement above.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
      — n/a: CI-config change. Verified by measurement instead (table above): cold vs warm cache,
      full facets shard green under the seeded profile, and the two dropped settings falsified.
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation
      — the composite action's header, its `description`, the `cache-key-suffix` input docs and the
      caller's inline comment all previously described build-cache-only behaviour.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
      — n/a, no Solidity changed.
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
      — n/a, no Solidity changed.
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
      — n/a, no new contracts.

