### PR TITLE
fix(script): route helper error/warning output to stderr

### DIFF
--- a/.agents/rules/300-bash.md
+++ b/.agents/rules/300-bash.md
@@ -12,7 +12,7 @@ paths:
 - Start with `#!/bin/bash`; organize into functions (logging, error handling, deployment); keep DRY via helpers.
 - **Use existing helpers**: Source `script/helperFunctions.sh` and `script/playgroundHelpers.sh` for reusable functions (deployment, verification, network queries, logging, etc.). Prefer existing helpers over reimplementing logic.
 - Load env from `.env`; validate required vars early; update `.env.example` when adding envs; add system deps to `preinstall.sh` when needed.
-- Use logging helpers (`echoDebug`, `error`, `warning`, `success`) and `checkFailure`; implement retries for RPC-sensitive steps; avoid inline secrets.
+- Use logging helpers (`echoDebug`, `error`, `warning`, `info`, `success`) and `checkFailure`; implement retries for RPC-sensitive steps; avoid inline secrets. `error`/`warning`/`info` write to stderr so they survive a `$(...)` capture of a value-returning helper; use plain `echo` for progress output that belongs on stdout.
 - Variable names: all uppercase (e.g., `NETWORK`, `CONTRACT_ADDRESS`).
 - Provide usage/help text; clear exit codes; document TODOs/limits succinctly; keep indentation and naming consistent.
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -363,7 +363,8 @@ function findContractInMasterLogByAddress() {
     done
   done
 
-  echo "[info] address not found in MongoDB"
+  # stderr, not stdout: callers capture this function's stdout via $(...)
+  echo "[info] address not found in MongoDB" >&2
   return 1
 }
 function getContractVersionFromMasterLog() {
@@ -4370,7 +4371,7 @@ function getCreate3FactoryAddress() {
   CREATE3_FACTORY=$(jq --arg NETWORK "$NETWORK" -r '.[$NETWORK].create3Factory // empty' "$NETWORKS_JSON_FILE_PATH")
 
   if [ -z "$CREATE3_FACTORY" ]; then
-    echo "Error: create3Factory address not found for network '$NETWORK'"
+    error "create3Factory address not found for network '$NETWORK'"
     return 1
   fi
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -363,8 +363,7 @@ function findContractInMasterLogByAddress() {
     done
   done
 
-  # stderr, not stdout: callers capture this function's stdout via $(...)
-  echo "[info] address not found in MongoDB" >&2
+  info "address not found in MongoDB"
   return 1
 }
 function getContractVersionFromMasterLog() {
@@ -3267,14 +3266,18 @@ function echoDebug() {
     printf "$BLUE[debug] %s$NC\n" "$MESSAGE" >&2
   fi
 }
-# error/warning must write to stderr: many value-returning helpers are captured via
-# $(...), and a stdout message would be swallowed into the captured value instead of
-# reaching the console (making `-z` guards on the result unreachable)
+# error/warning/info must write to stderr: many value-returning helpers are captured
+# via $(...), and a stdout message would be swallowed into the captured value instead
+# of reaching the console (making `-z` guards on the result unreachable). Progress
+# output that is not a diagnostic still uses plain echo so it stays on stdout.
 function error() {
   printf '\033[31m[error] %s\033[0m\n' "$1" >&2
 }
 function warning() {
   printf '\033[33m[warning] %s\033[0m\n' "$1" >&2
+}
+function info() {
+  printf '[info] %s\n' "$1" >&2
 }
 function success() {
   printf '\033[0;32m[success] %s\033[0m\n' "$1"
@@ -3457,8 +3460,7 @@ function findContractVersionInTargetState() {
     return 0
   else
     # entry not found - issue error message and return error code
-    # stderr, not stdout: callers capture this function's stdout via $(...)
-    echo "[info] No matching entry found in target state file for NETWORK=$NETWORK, ENVIRONMENT=$ENVIRONMENT, CONTRACT=$CONTRACT" >&2
+    info "No matching entry found in target state file for NETWORK=$NETWORK, ENVIRONMENT=$ENVIRONMENT, CONTRACT=$CONTRACT"
     return 1
   fi
 }

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3250,7 +3250,8 @@ function checkFailure() {
 
   # check RESULT code and display error message if code != 0
   if [[ $RESULT -ne 0 ]]; then
-    echo "Failed to $ERROR_MESSAGE"
+    # stderr, not stdout: this can fire inside a $(...) capture, which swallows stdout
+    echo "Failed to $ERROR_MESSAGE" >&2
     exit 1
   fi
 }
@@ -3265,11 +3266,14 @@ function echoDebug() {
     printf "$BLUE[debug] %s$NC\n" "$MESSAGE" >&2
   fi
 }
+# error/warning must write to stderr: many value-returning helpers are captured via
+# $(...), and a stdout message would be swallowed into the captured value instead of
+# reaching the console (making `-z` guards on the result unreachable)
 function error() {
-  printf '\033[31m[error] %s\033[0m\n' "$1"
+  printf '\033[31m[error] %s\033[0m\n' "$1" >&2
 }
 function warning() {
-  printf '\033[33m[warning] %s\033[0m\n' "$1"
+  printf '\033[33m[warning] %s\033[0m\n' "$1" >&2
 }
 function success() {
   printf '\033[0;32m[success] %s\033[0m\n' "$1"
@@ -3452,7 +3456,8 @@ function findContractVersionInTargetState() {
     return 0
   else
     # entry not found - issue error message and return error code
-    echo "[info] No matching entry found in target state file for NETWORK=$NETWORK, ENVIRONMENT=$ENVIRONMENT, CONTRACT=$CONTRACT"
+    # stderr, not stdout: callers capture this function's stdout via $(...)
+    echo "[info] No matching entry found in target state file for NETWORK=$NETWORK, ENVIRONMENT=$ENVIRONMENT, CONTRACT=$CONTRACT" >&2
     return 1
   fi
 }
@@ -3694,7 +3699,7 @@ function doesAddressContainBytecode() {
 
   # check address value
   if [[ "$ADDRESS" == "null" || "$ADDRESS" == "" ]]; then
-    echo "[warning]: trying to verify deployment at invalid address: ($ADDRESS)"
+    warning "trying to verify deployment at invalid address: ($ADDRESS)"
     return 1
   fi
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-734](https://linear.app/lifi-linear/issue/EXSC-734/route-bash-helper-diagnostics-to-stderr-so-dollar-captures-dont)

# Why did I implement it this way?

`error()` and `warning()` in `script/helperFunctions.sh` printed to stdout. Many of the helpers that call them also *return* their value on stdout and are consumed via command substitution, so on the failure path the caller captured the rendered ANSI error text as the value instead of an empty string — silently defeating `-z`/emptiness guards while the message never reached the console. #2148 fixed one such site (`getCurrentContractVersion` → `CURRENT_VERSION`, which ended up 127 characters long instead of empty) by rc-checking and blanking at the call site.

I swept the helper and the deploy scripts for the rest of the class and fixed it at the source instead of per call site. The sweep enumerated every function in `script/helperFunctions.sh` (plus `script/deploy/**/*.sh`, `script/multiNetworkExecution.sh`, `script/universalCast.sh`, `script/scriptMaster.sh`) whose body calls `error`/`warning`, then grepped for `$(...)` captures of each: within that scope, 79 capture sites across 20 distinct helpers. Because `error`/`warning` are pure output helpers with no callers depending on their stdout, redirecting them to stderr once fixes every current and future capture site, whereas rc-check-and-blank would need repeating at every site and would still leave the next new capture broken. That also means #2148's call-site guard stays correct — it is now belt-and-braces rather than load-bearing.

Five related stragglers in the same class — hand-rolled stdout diagnostics inside value-returning helpers — found by the same sweep:

- `checkFailure` printed `Failed to <msg>` to stdout — same swallowing problem when it fires inside a capture.
- `findContractVersionInTargetState` printed its `[info] No matching entry found…` miss message to stdout, i.e. into the very variable callers read as the target version. Its call sites all rc-check, so none were broken today, but the message was invisible whenever the capture succeeded in the shell's eyes.
- `findContractInMasterLogByAddress` printed `[info] address not found in MongoDB` into the captured `RESULT`/`JSON_ENTRY` (`script/helperFunctions.sh:824`, `:1097`). Both rc-check (`:1097` already uses the #2148-style `|| JSON_ENTRY=""` workaround), so again invisible rather than broken.

The two `[info]`-level ones go through a new `info()` helper rather than a hand-rolled `echo … >&2`, so all four diagnostic levels now sit together and share one explanation of why they are stderr-bound (per CodeRabbit review). Its contract is deliberately narrow — *diagnostics emitted from inside a value-returning helper* — because the 43 other `[info]` echoes in this file are progress output that belongs on stdout and must keep using plain `echo`. `.agents/rules/300-bash.md` is updated to list it, since that rule enumerated the logging helpers exhaustively.
- `doesAddressContainBytecode` hand-rolled `echo "[warning]: …"` on the invalid-address path, which landed in `NEW_DEPLOYMENT` at `script/deploy/deploySingleContract.sh:192`. Switched to the `warning` helper so it follows the same routing and matches `[CONV:BASH-HELPERS]`.
- `getCreate3FactoryAddress` hand-rolled `echo "Error: create3Factory address not found…"` into `CREATE3_FACTORY_ADDRESS` at `script/deploy/deploySingleContract.sh:154` (rc-checked by the following `checkFailure`). Switched to the `error` helper, same rationale.

Six helpers (`getZkSolcVersion`, `processNetworkLine`, `getCoreFacetsArray`, `normalizePrivateKey`, `install_foundry_zksync`, `estimatePauseCost`) already appended `>&2` to individual `error`/`warning` calls — 18 call sites in total. Those are now redundant but harmless — a second `>&2` on an already-stderr-bound `printf` is a no-op — so I left them rather than widen the diff.

**Deliberately not changed.** `success()` stays on stdout: no captured helper calls it, so there is no live bug, and changing it would widen the diff for no behavioural gain. `findContractInMasterLog` (`script/helperFunctions.sh:280`) is the one straggler I left in place — see the escalation comment below; fixing it correctly means also deleting two now-dead string-match blocks, one of which lives in `script/playgroundHelpers.sh`, outside this PR's scope.

I checked every consumer that reads these scripts' output as text before making the switch, to be sure nothing depends on the messages arriving on stdout: `.github/workflows/deploy-smoke-test.yml` (`2>&1 | tee`), `.github/workflows/runPendingTimelockTXs.yml` (`2>&1 | tee execution.log`, then greps for `Failed to execute`), and the per-network capture in `script/multiNetworkExecution.sh:1699` (`2>&1 | tee`). All three already merge stderr into the captured stream, so error text still reaches the logs and the greps they run. There is no `| tee` without `2>&1` anywhere in the repo, and no TypeScript consumer parses helper output.

**Known trade-off, disclosed.** Two call sites suppress stderr with `2>/dev/null`, and those redirects were written when our diagnostics went to stdout — so they previously suppressed only `forge`/`cast` noise and now also swallow our own error detail: `script/helperFunctions.sh:2744` (`deploySingleContract … 2>/dev/null` on the diamond-bootstrap path) and `script/deploy/deploySingleContract.sh:525` (`verifyContract … 2>/dev/null`). Neither becomes a silent *success* — both are rc-checked, and `:2744`'s `checkFailure` runs outside the redirect so `Failed to deploy contract …` still prints — but the *reason* is now hidden where it used to be visible. Fixing that means removing the redirects, which re-exposes the tool noise they exist to suppress; that is a separate judgment call, so I left them and flagged it in the review comment rather than deciding it here.

**Verification.** The strongest evidence is end-to-end on a real call path, not on the helper in isolation. Running the real `processNetworkLine` (`script/helperFunctions.sh:1908`) against a nonexistent contract with cell value `latest`, before vs after (Google-Sheets download stubbed with the CSV line it would have produced; helper, guard and JSON writer are unmodified repo code):

- **Before**: `CURRENT_VERSION` captured a ~130-char ANSI blob, the `-z "$CURRENT_VERSION"` guard did not fire, and the ANSI error text was written *into the network target-state JSON* (`"NonexistentFacetXYZ": "[31m[error] …"`), which `mergeNetworkResults` would then fold into `_targetState.json`.
- **After**: capture empty, guard fires, JSON gets `""`, and both error lines reach stderr.

Per-helper, sourcing the modified file and exercising both paths directly:

| Case | Before | After |
|---|---|---|
| `getCurrentContractVersion` on a bad path | rc=1, captured 127 chars (16-char contract name; length is `111 + len(name)`) | rc=1, captured 0 chars, `[error]` on stderr |
| `getCurrentContractVersion "SquidFacet"` (happy path) | `1.0.0` | `1.0.0` — unchanged |
| `findContractVersionInTargetState` miss | rc=1, captured the 125-char `[info]` line | rc=1, captured 0 chars, `[info]` on stderr |
| `findContractVersionInTargetState` hit (real `_targetState.json`, `DiamondCutFacet`) | `1.0.0` | `1.0.0` — unchanged |
| `doesAddressContainBytecode` with empty address | rc=1, captured the 61-char warning | rc=1, captured 0 chars, `[warning]` on stderr |
| `getCreate3FactoryAddress` on an unknown network | rc=1, captured the error text | rc=1, captured 0 chars, `[error]` on stderr |
| `getCreate3FactoryAddress "mainnet"` (real `networks.json`) | `0x93FEC2C0…4AE1` | `0x93FEC2C0…4AE1` — unchanged |

Also ran `bash -n script/helperFunctions.sh` and `bash -c 'set -euo pipefail; source script/helperFunctions.sh'` — both clean.

No tests are added: these are shell helpers with no existing bash test harness in the repo, and the behaviour is verified by the executed before/after cases above rather than by a committed test.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
