### PR TITLE
feat(agents): add /aikido-weekly-review command for recurring feed reviews

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -64,6 +64,7 @@ Custom commands live in `.agents/commands/` (source of truth) and are symlinked 
 | `add-rule-or-skill.md` | `/add-rule-or-skill`         | Standard workflow for adding/updating rules & commands (scoping, dedupe, naming, validation, **skill-authoring principles**) |
 | `aikido-address-findings.md` | `/aikido-address-findings [<issue-id> \| all \| pr] [repo-name]` | Aikido triage scoped to the PR (default), a single finding, or the whole repo — ignore false positives, fix real findings in code |
 | `aikido-update-false-positive-catalog.md` | `/aikido-update-false-positive-catalog <file-path> <rule-name>` | Add a new false positive pattern to the catalog so aikido-address-findings auto-ignores it on future runs |
+| `aikido-weekly-review.md` | `/aikido-weekly-review [repo-name]` | Recurring whole-feed Aikido review: severity/SLA dashboard, per-bucket routing, offers to schedule the next weekly run |
 | `analyze-tx.md`   | `/analyze-tx <network> <tx_hash>` | Transaction trace/runbook analysis for a specific tx                                         |
 | `analyze-unverified-contract.md` | `/analyze-unverified-contract <address> <network>` | Investigate an unverified contract — resolve RPC, detect proxies, disassemble, enumerate selectors, emit a report |
 | `check-open-prs.md` | `/check-open-prs`               | Personal PR dashboard — own PRs + incoming review queue via the deterministic `script/utils/check-open-prs.ts` collector, with Slack cross-reference only for ambiguous PRs |

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -64,7 +64,7 @@ Custom commands live in `.agents/commands/` (source of truth) and are symlinked 
 | `add-rule-or-skill.md` | `/add-rule-or-skill`         | Standard workflow for adding/updating rules & commands (scoping, dedupe, naming, validation, **skill-authoring principles**) |
 | `aikido-address-findings.md` | `/aikido-address-findings [<issue-id> \| all \| pr] [repo-name]` | Aikido triage scoped to the PR (default), a single finding, or the whole repo — ignore false positives, fix real findings in code |
 | `aikido-update-false-positive-catalog.md` | `/aikido-update-false-positive-catalog <file-path> <rule-name>` | Add a new false positive pattern to the catalog so aikido-address-findings auto-ignores it on future runs |
-| `aikido-weekly-review.md` | `/aikido-weekly-review [repo-name]` | Recurring whole-feed Aikido review: severity/SLA dashboard, per-bucket routing, offers to schedule the next weekly run |
+| `aikido-weekly-review.md` | `/aikido-weekly-review [repo-name]` | Recurring whole-feed Aikido review: severity/SLA dashboard, grouped suggestions the user decides on per group (suggest-first, no auto-fix/ignore), offers to schedule the next weekly run |
 | `analyze-tx.md`   | `/analyze-tx <network> <tx_hash>` | Transaction trace/runbook analysis for a specific tx                                         |
 | `analyze-unverified-contract.md` | `/analyze-unverified-contract <address> <network>` | Investigate an unverified contract — resolve RPC, detect proxies, disassemble, enumerate selectors, emit a report |
 | `check-open-prs.md` | `/check-open-prs`               | Personal PR dashboard — own PRs + incoming review queue via the deterministic `script/utils/check-open-prs.ts` collector, with Slack cross-reference only for ambiguous PRs |

--- a/.agents/commands/aikido-weekly-review.md
+++ b/.agents/commands/aikido-weekly-review.md
@@ -1,0 +1,86 @@
+---
+name: aikido-weekly-review
+description: Recurring (weekly) Aikido security-feed review for a repo — pulls all open findings via the Aikido MCP, builds a severity/type dashboard with SLA status, routes each bucket (SAST triage via /aikido-address-findings, dependency CVEs, leaked secrets, IaC/actions), and ends by offering to schedule the next run. For tech leads reviewing their repo's security posture on a cadence, not for triaging a single PR. Use when asked to "review aikido findings", "weekly aikido review", "aikido security review", "what's open in aikido", or when a scheduled task fires with /aikido-weekly-review.
+usage: /aikido-weekly-review [repo-name] — repo defaults to the current git repo
+---
+
+# Aikido Weekly Review
+
+Cadence review of the whole Aikido feed for one repo. Produces a dashboard + routed
+action list, then offers to schedule the next run. Deep SAST triage mechanics live in
+`/aikido-address-findings` — this command orchestrates, it does not duplicate them.
+
+---
+
+## Preflight
+
+- Needs the Aikido MCP (`aikido_issues_list`). Verify exactly as described in the
+  Preflight section of `.agents/commands/aikido-address-findings.md` (including the
+  `/aikido:setup` fallback message). `aikido_login` should report already-signed-in.
+- Derive the repo name from `gh repo view --json name -q .name` unless overridden by the
+  argument. Never hardcode: forks share code under different Aikido repo names
+  (`contracts` vs `contracts-tron`).
+
+## Step 1 — Pull the full feed
+
+Call `aikido_issues_list` with `repo_name` and NO `issue_types` filter, paginating
+(`page: 0, 1, …`) until a page returns fewer than 25 issues. Then two cheap extra calls
+with `out_of_sla: true` and `sla_due_soon: true` to mark SLA state per issue.
+
+`issue_id` values are numbers in the feed but must be passed back as **strings** to
+`aikido_ignore_issue`.
+
+## Step 2 — Dashboard
+
+Group by `issue_type` × `issue_severity_label` and render:
+
+```text
+| Type          | Crit | High | Med | Low | Out of SLA | Due soon |
+|---------------|------|------|-----|-----|------------|----------|
+| open_source   | .    | .    | .   | .   | .          | .        |
+| sast          | .    | .    | .   | .   | .          | .        |
+| leaked_secret | .    | .    | .   | .   | .          | .        |
+| iac / other   | .    | .    | .   | .   | .          | .        |
+```
+
+Follow with the top items: every critical/high by name (CVE/package or rule/file:line),
+and everything out-of-SLA regardless of severity.
+
+## Step 3 — Route each bucket
+
+- **leaked_secret** — never auto-handle. Escalate immediately to the user with the file
+  and secret type; a value that reached a commit is compromised and needs rotation, not
+  ignoring.
+- **sast** — hand off to `/aikido-address-findings all <repo>` for the full
+  fix-vs-ignore triage. In repos without a false-positive catalog
+  (`.agents/references/aikido-false-positive-catalog.md` is contracts-only), do not
+  auto-ignore anything — report with a recommendation instead.
+- **open_source (dependency CVEs)** — group by package; for each, report installed vs
+  recommended version and whether it is a direct or transitive dep (check
+  `package.json`). Offer a bump PR (`vulnerable_dependency` recipe in
+  `/aikido-address-findings`). Check open PRs first — a bump may already be in flight.
+- **iac / scm_security / actions findings** — unpinned actions and template injection
+  are always real (fix recipes in `/aikido-address-findings`); `persist-credentials`
+  and broad-permissions findings need the workflow's push/trigger context before
+  deciding fix vs ignore.
+- Anything the user decides to accept: ignore via `aikido_ignore_issue` with a reason
+  that names the call-site/context justification, not a generic dismissal.
+
+## Step 4 — Report
+
+End with three lists: **fixed/PR'd now** (with PR links), **needs a human decision**
+(each with a one-line recommendation), and **ignored with reason** (id + reason). If
+nothing is open: say so — that IS the weekly report.
+
+## Step 5 — Offer the next run (scheduling)
+
+Ask which the user wants (skip if this run was itself triggered by a schedule):
+
+1. **Scheduled task (preferred)** — create a weekly recurring task that runs
+   `/aikido-weekly-review` in this repo (Claude Code: the `/schedule` flow or the
+   scheduled-tasks tooling available in the session; pick a weekday morning in the
+   user's timezone). Confirm the created schedule back to the user.
+2. **Calendar reminder** — if a calendar connector is available, create a weekly
+   30-minute "Aikido review — <repo>" event with a description linking
+   https://app.aikido.dev and naming this command.
+3. **Neither** — fine; mention the command name so they can invoke it ad hoc.

--- a/.agents/commands/aikido-weekly-review.md
+++ b/.agents/commands/aikido-weekly-review.md
@@ -1,13 +1,15 @@
 ---
 name: aikido-weekly-review
-description: Recurring (weekly) Aikido security-feed review for a repo — pulls all open findings via the Aikido MCP, builds a severity/type dashboard with SLA status, routes each bucket (SAST triage via /aikido-address-findings, dependency CVEs, leaked secrets, IaC/actions), and ends by offering to schedule the next run. For tech leads reviewing their repo's security posture on a cadence, not for triaging a single PR. Use when asked to "review aikido findings", "weekly aikido review", "aikido security review", "what's open in aikido", or when a scheduled task fires with /aikido-weekly-review.
+description: Recurring (weekly) Aikido security-feed review for a repo — pulls all open findings via the Aikido MCP, builds a severity/type dashboard with SLA status, groups findings into action groups with a recommendation each, and lets the USER decide per group (nothing is fixed or ignored without their pick); ends by offering to schedule the next run. For tech leads reviewing their repo's security posture on a cadence, not for triaging a single PR. Use when asked to "review aikido findings", "weekly aikido review", "aikido security review", "what's open in aikido", or when a scheduled task fires with /aikido-weekly-review.
 usage: /aikido-weekly-review [repo-name] — repo defaults to the current git repo
 ---
 
 # Aikido Weekly Review
 
-Cadence review of the whole Aikido feed for one repo. Produces a dashboard + routed
-action list, then offers to schedule the next run. Deep SAST triage mechanics live in
+Cadence review of the whole Aikido feed for one repo. Produces a dashboard + grouped
+suggestions, waits for the user's per-group decisions, executes only those, then offers
+to schedule the next run. **Suggest-first is the contract: this command never fixes or
+ignores anything the user hasn't picked.** Deep SAST triage mechanics live in
 `/aikido-address-findings` — this command orchestrates, it does not duplicate them.
 
 ---
@@ -47,35 +49,54 @@ Group by `issue_type` × `issue_severity_label` and render:
 Follow with the top items: every critical/high by name (CVE/package or rule/file:line),
 and everything out-of-SLA regardless of severity.
 
-## Step 3 — Route each bucket
+## Step 3 — Group into action groups and suggest (do not act)
 
-- **leaked_secret** — never auto-handle. Escalate immediately to the user with the file
-  and secret type; a value that reached a commit is compromised and needs rotation, not
-  ignoring.
-- **sast** — hand off to `/aikido-address-findings all <repo>` for the full
-  fix-vs-ignore triage. In repos without a false-positive catalog
-  (`.agents/references/aikido-false-positive-catalog.md` is contracts-only), do not
-  auto-ignore anything — report with a recommendation instead.
-- **open_source (dependency CVEs)** — group by package; for each, report installed vs
-  recommended version and whether it is a direct or transitive dep (check
-  `package.json`). Offer a bump PR following the `vulnerable_dependency` recipe written
-  in `/aikido-address-findings` Phase 4 (apply the recipe directly — that command's
-  feed mode queries SAST only, so don't invoke it for these buckets). Check open PRs
-  first — a bump may already be in flight.
-- **iac / scm_security / actions findings** — unpinned actions and template injection
-  are always real (apply the Phase 4 fix recipes, same note as above); `persist-credentials`
-  and broad-permissions findings need the workflow's push/trigger context before
-  deciding fix vs ignore.
-- Anything the user decides to accept: ignore via `aikido_ignore_issue` with a reason
-  that names the call-site/context justification, not a generic dismissal.
+Exception first: **leaked_secret** findings are surfaced immediately and individually
+(file + secret type + rotation note) at the top of the output — a value that reached a
+commit is compromised and needs rotation; never fold these into a group or suggest
+ignoring them.
 
-## Step 4 — Report
+Group everything else into decision-sized units — one group = one coherent action a
+human can accept or reject as a whole:
 
-End with three lists: **fixed/PR'd now** (with PR links), **needs a human decision**
-(each with a one-line recommendation), and **ignored with reason** (id + reason). If
-nothing is open: say so — that IS the weekly report.
+- **open_source** → by package (one version bump resolves all its CVEs). Note installed
+  vs recommended version and direct-vs-transitive (check `package.json`).
+- **sast** → by rule × file-family (e.g. "path traversal × script/tasks propose*
+  scripts"). Where a false-positive catalog exists
+  (`.agents/references/aikido-false-positive-catalog.md`, contracts-only), name the
+  matching pattern; without a catalog match, the only suggestions allowed are Fix or
+  Discuss — never Ignore.
+- **iac / scm_security / actions** → by rule (all unpinned actions together, all
+  persist-credentials together, …).
 
-## Step 5 — Offer the next run (scheduling)
+For each group output: findings covered (ids + count), severity range, SLA state, a
+one-line **suggested action** (Fix via the relevant `/aikido-address-findings` Phase 4
+recipe or a full `/aikido-address-findings all <repo>` triage for SAST / Ignore with the
+catalog reason / Discuss), and a one-line why. Then STOP and ask the user to decide per
+group (accept the suggestion, pick a different action, or defer) — a numbered list they
+can answer compactly ("1,3 fix; 2 ignore; rest defer") or the harness's question UI.
+
+## Step 4 — Execute only the accepted groups
+
+- Per accepted group, offer two execution modes where the harness supports background
+  task chips: **do it in this session now**, or **spawn a task chip per group** (a
+  self-contained prompt naming the repo, finding ids, and chosen action) so each fix
+  becomes its own session/PR the user starts with one click. Default to in-session when
+  chips are unavailable.
+- Fixes follow the `/aikido-address-findings` Phase 4 recipes (that command's feed mode
+  queries SAST only, so apply dependency/actions recipes directly rather than invoking
+  it for those buckets). Check open PRs first — a bump may already be in flight.
+- Accepted ignores go through `aikido_ignore_issue` with a reason naming the
+  call-site/context justification, not a generic dismissal.
+- Deferred/rejected groups are left untouched and listed as such in the report.
+
+## Step 5 — Report
+
+End with four lists: **fixed/PR'd** (links), **ignored with reason** (id + reason),
+**deferred by user**, and **escalated** (secrets, no-catalog-match items). If nothing is
+open: say so — that IS the weekly report.
+
+## Step 6 — Offer the next run (scheduling)
 
 Ask which the user wants (skip if this run was itself triggered by a schedule):
 

--- a/.agents/commands/aikido-weekly-review.md
+++ b/.agents/commands/aikido-weekly-review.md
@@ -71,10 +71,10 @@ human can accept or reject as a whole:
 
 For each group output: findings covered (ids + count), severity range, SLA state, a
 one-line **suggested action** (Fix via the relevant `/aikido-address-findings` Phase 4
-recipe or a full `/aikido-address-findings all <repo>` triage for SAST / Ignore with the
-catalog reason / Discuss), and a one-line why. Then STOP and ask the user to decide per
-group (accept the suggestion, pick a different action, or defer) — a numbered list they
-can answer compactly ("1,3 fix; 2 ignore; rest defer") or the harness's question UI.
+recipe / Ignore with the catalog reason / Discuss), and a one-line why. Then STOP and
+ask the user to decide per group (accept the suggestion, pick a different action, or
+defer) — a numbered list they can answer compactly ("1,3 fix; 2 ignore; rest defer") or
+the harness's question UI.
 
 ## Step 4 — Execute only the accepted groups
 
@@ -86,6 +86,11 @@ can answer compactly ("1,3 fix; 2 ignore; rest defer") or the harness's question
 - Fixes follow the `/aikido-address-findings` Phase 4 recipes (that command's feed mode
   queries SAST only, so apply dependency/actions recipes directly rather than invoking
   it for those buckets). Check open PRs first — a bump may already be in flight.
+- Keep SAST execution scoped to the accepted group: run
+  `/aikido-address-findings <issue-id> <repo>` per finding in the group. The whole-repo
+  `/aikido-address-findings all <repo>` hand-off is allowed only when the user accepted
+  every SAST group — it re-triages the full SAST feed and would otherwise touch
+  deferred/rejected groups.
 - Accepted ignores go through `aikido_ignore_issue` with a reason naming the
   call-site/context justification, not a generic dismissal.
 - Deferred/rejected groups are left untouched and listed as such in the report.
@@ -93,8 +98,8 @@ can answer compactly ("1,3 fix; 2 ignore; rest defer") or the harness's question
 ## Step 5 — Report
 
 End with four lists: **fixed/PR'd** (links), **ignored with reason** (id + reason),
-**deferred by user**, and **escalated** (secrets, no-catalog-match items). If nothing is
-open: say so — that IS the weekly report.
+**deferred by user**, and **escalated** (secrets, plus any group the user routed to
+Discuss or left undecided). If nothing is open: say so — that IS the weekly report.
 
 ## Step 6 — Offer the next run (scheduling)
 

--- a/.agents/commands/aikido-weekly-review.md
+++ b/.agents/commands/aikido-weekly-review.md
@@ -14,9 +14,9 @@ action list, then offers to schedule the next run. Deep SAST triage mechanics li
 
 ## Preflight
 
-- Needs the Aikido MCP (`aikido_issues_list`). Verify exactly as described in the
-  Preflight section of `.agents/commands/aikido-address-findings.md` (including the
-  `/aikido:setup` fallback message). `aikido_login` should report already-signed-in.
+- Needs the Aikido MCP (`aikido_issues_list`). Verify availability exactly as described
+  in the Preflight section of `.agents/commands/aikido-address-findings.md` (the
+  `aikido_full_scan` test call, and its `/aikido:setup` fallback message on failure).
 - Derive the repo name from `gh repo view --json name -q .name` unless overridden by the
   argument. Never hardcode: forks share code under different Aikido repo names
   (`contracts` vs `contracts-tron`).
@@ -24,8 +24,9 @@ action list, then offers to schedule the next run. Deep SAST triage mechanics li
 ## Step 1 — Pull the full feed
 
 Call `aikido_issues_list` with `repo_name` and NO `issue_types` filter, paginating
-(`page: 0, 1, …`) until a page returns fewer than 25 issues. Then two cheap extra calls
-with `out_of_sla: true` and `sla_due_soon: true` to mark SLA state per issue.
+(`page: 0, 1, …`) until a page returns fewer than 25 issues. Then two extra calls with
+`out_of_sla: true` and `sla_due_soon: true` to mark SLA state per issue — paginated the
+same way (the 25/page limit applies to every variant of this call).
 
 `issue_id` values are numbers in the feed but must be passed back as **strings** to
 `aikido_ignore_issue`.
@@ -57,10 +58,12 @@ and everything out-of-SLA regardless of severity.
   auto-ignore anything — report with a recommendation instead.
 - **open_source (dependency CVEs)** — group by package; for each, report installed vs
   recommended version and whether it is a direct or transitive dep (check
-  `package.json`). Offer a bump PR (`vulnerable_dependency` recipe in
-  `/aikido-address-findings`). Check open PRs first — a bump may already be in flight.
+  `package.json`). Offer a bump PR following the `vulnerable_dependency` recipe written
+  in `/aikido-address-findings` Phase 4 (apply the recipe directly — that command's
+  feed mode queries SAST only, so don't invoke it for these buckets). Check open PRs
+  first — a bump may already be in flight.
 - **iac / scm_security / actions findings** — unpinned actions and template injection
-  are always real (fix recipes in `/aikido-address-findings`); `persist-credentials`
+  are always real (apply the Phase 4 fix recipes, same note as above); `persist-credentials`
   and broad-permissions findings need the workflow's push/trigger context before
   deciding fix vs ignore.
 - Anything the user decides to accept: ignore via `aikido_ignore_issue` with a reason

--- a/.claude/skills/aikido-weekly-review/SKILL.md
+++ b/.claude/skills/aikido-weekly-review/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agents/commands/aikido-weekly-review.md

--- a/.cursor/commands/aikido-weekly-review.md
+++ b/.cursor/commands/aikido-weekly-review.md
@@ -1,0 +1,1 @@
+../../.agents/commands/aikido-weekly-review.md


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-733](https://linear.app/lifi-linear/issue/EXSC-733/add-aikido-weekly-review-team-skill-suggest-first-weekly-aikido-triage)

# Why did I implement it this way?

Adds `/aikido-weekly-review` — a cadence-review command any tech lead can run (or schedule) to review a repo's whole Aikido feed: pulls all open findings via the Aikido MCP with pagination, renders a severity×type dashboard with SLA state (`out_of_sla` / `sla_due_soon`), groups findings into decision-sized action groups (dependencies by package, SAST by rule × file-family, actions findings by rule), presents a suggested action per group, and executes ONLY what the user accepts — optionally spawning one background task chip per accepted group so each fix becomes its own session/PR. Leaked secrets are escalated individually and never grouped or ignorable. Ends by offering to schedule the next weekly run (scheduled task or calendar event).

It deliberately orchestrates rather than duplicates: all triage mechanics, fix recipes, and the false-positive catalogue stay in `/aikido-address-findings` (per the no-duplication rule in `010-agents-authoring`). Authored per `/add-rule-or-skill`: canonical file in `.agents/commands/`, symlinks for Cursor and Claude Code, README table updated.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


