### PR TITLE
chore(AllBridgeFacet): deploy v2.2.0 to tron (EXSC-650)

### DIFF
--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -49,9 +49,9 @@
         "Name": "SymbiosisFacet",
         "Version": "1.0.0"
       },
-      "TCyAJzpLJjGyUqPoQ9Kvm1Zjw9zDmXLUfU": {
+      "TR15epdwXG9kBXtEBnF5bv6kSYRY5w6mXY": {
         "Name": "AllBridgeFacet",
-        "Version": "2.1.1"
+        "Version": "2.2.0"
       },
       "TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8": {
         "Name": "EcoFacet",
@@ -72,6 +72,10 @@
       "TBFPs7mxPN3nCrnmbjrJh6BS48VpGbu6oQ": {
         "Name": "LayerSwapFacet",
         "Version": "1.0.0"
+      },
+      "TMY1N6rC61Fu1C8qvZEhwb3WLR7iY1ERuW": {
+        "Name": "SymbiosisFacet",
+        "Version": "2.0.0"
       }
     },
     "Periphery": {

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -11,7 +11,7 @@
   "LiFiDiamond": "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt",
   "TokenWrapper": "TBfUqkmaBBMFA87ZCCu9aibjo2EZLTSJv2",
   "SymbiosisFacet": "TAXonvq4chZufsFS1NdTLaK4zq8ruPct8f",
-  "AllBridgeFacet": "TCyAJzpLJjGyUqPoQ9Kvm1Zjw9zDmXLUfU",
+  "AllBridgeFacet": "TR15epdwXG9kBXtEBnF5bv6kSYRY5w6mXY",
   "EcoFacet": "TG6586TTEv664XWSD875tMk6yDuwedphpW",
   "WhitelistManagerFacet": "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn",
   "FeeCollector": "TA7qd9KpEBH7qASAxxUpjWVfE3GiTwpd7q",

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -10,7 +10,7 @@
   "PeripheryRegistryFacet": "TA9z2Lmg6g4tAwn31CK57ekjpmVXCr8kum",
   "LiFiDiamond": "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt",
   "TokenWrapper": "TBfUqkmaBBMFA87ZCCu9aibjo2EZLTSJv2",
-  "SymbiosisFacet": "TAXonvq4chZufsFS1NdTLaK4zq8ruPct8f",
+  "SymbiosisFacet": "TMY1N6rC61Fu1C8qvZEhwb3WLR7iY1ERuW",
   "AllBridgeFacet": "TR15epdwXG9kBXtEBnF5bv6kSYRY5w6mXY",
   "EcoFacet": "TG6586TTEv664XWSD875tMk6yDuwedphpW",
   "WhitelistManagerFacet": "TViNVAJsVwfsL96yS8RqYMzg6uB9JmAYWn",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-650](https://linear.app/lifi-linear/issue/EXSC-650/add-stellar-as-destination-to-allbridgefacet-dynamic-chainid-mapping)

# Why did I implement it this way?

Production deploy of `AllBridgeFacet` v2.2.0 to Tron from `contracts-tron` @ `00b0546f374b0fc5303e2d77559be04f504e9416` (sync #27 baseline). The facet was redeployed via TronWeb (`deploy-and-register-allbridge-facet.ts`); the diamondCut + `initAllBridge` (15 chainId mappings incl. Stellar) is proposed to the Tron Safe (timelock `scheduleBatch`, nonce **22**). Only `deployments/tron.json` is updated here — `tron.diamond.json` updates when the cut executes (`/finish-rollout`).

| Chain | Contract address | Safe nonce |
| --- | --- | --- |
| tron | `TR15epdwXG9kBXtEBnF5bv6kSYRY5w6mXY` | 22 |

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
