### PR TITLE
fix(ci): compare facets against every registered address

### DIFF
--- a/script/tasks/checkDeploymentAddressConsistency.test.ts
+++ b/script/tasks/checkDeploymentAddressConsistency.test.ts
@@ -39,7 +39,7 @@ describe('findMismatches', () => {
         whitelistPeriphery: { OutputValidator: '0xAAA' },
         deploymentFlat: { OutputValidator: '0xaaa', DiamondCutFacet: '0xF00' },
         diamondPeriphery: { OutputValidator: '0xAaA' },
-        diamondFacets: { DiamondCutFacet: '0xf00' },
+        diamondFacets: { DiamondCutFacet: ['0xf00'] },
       },
     ]
     expect(findMismatches(sources)).toEqual([])
@@ -70,7 +70,7 @@ describe('findMismatches', () => {
       {
         ...base,
         deploymentFlat: { DexManagerFacet: '0xnew' },
-        diamondFacets: { DexManagerFacet: '0xold' },
+        diamondFacets: { DexManagerFacet: ['0xold'] },
       },
     ]
     const result = findMismatches(sources)
@@ -81,6 +81,46 @@ describe('findMismatches', () => {
     })
   })
 
+  it('agrees when a facet is registered at several addresses and one matches', () => {
+    const sources: INetworkSources[] = [
+      {
+        ...base,
+        deploymentFlat: { SymbiosisFacet: '0xnew' },
+        diamondFacets: { SymbiosisFacet: ['0xnew', '0xold'] },
+      },
+    ]
+    expect(findMismatches(sources)).toEqual([])
+  })
+
+  it('agrees regardless of the order the addresses are registered in', () => {
+    const flipped: INetworkSources[] = [
+      {
+        ...base,
+        deploymentFlat: { SymbiosisFacet: '0xnew' },
+        diamondFacets: { SymbiosisFacet: ['0xold', '0xnew'] },
+      },
+    ]
+    expect(findMismatches(flipped)).toEqual([])
+  })
+
+  it('flags a multi-address facet when none of the addresses match', () => {
+    const sources: INetworkSources[] = [
+      {
+        ...base,
+        deploymentFlat: { SymbiosisFacet: '0xdeployed' },
+        diamondFacets: { SymbiosisFacet: ['0xold', '0xolder'] },
+      },
+    ]
+    const result = findMismatches(sources)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      kind: 'facet',
+      contract: 'SymbiosisFacet',
+    })
+    // the deployment log plus every registered address
+    expect(result[0]?.addresses).toHaveLength(3)
+  })
+
   it('ignores empty placeholders and contracts present in only one source', () => {
     const sources: INetworkSources[] = [
       {
@@ -88,7 +128,7 @@ describe('findMismatches', () => {
         whitelistPeriphery: { Patcher: '0xabc' },
         deploymentFlat: { Patcher: '0xabc' },
         diamondPeriphery: { Patcher: '' }, // not deployed -> ignored
-        diamondFacets: { LonelyFacet: '0x999' }, // only one source -> ignored
+        diamondFacets: { LonelyFacet: ['0x999'] }, // only one source -> ignored
       },
     ]
     expect(findMismatches(sources)).toEqual([])

--- a/script/tasks/checkDeploymentAddressConsistency.ts
+++ b/script/tasks/checkDeploymentAddressConsistency.ts
@@ -24,7 +24,12 @@ export interface INetworkSources {
   whitelistPeriphery: Record<string, string>
   deploymentFlat: Record<string, string>
   diamondPeriphery: Record<string, string>
-  diamondFacets: Record<string, string>
+  /**
+   * Facet name to every address registered under that name in the diamond. A
+   * name maps to more than one address whenever an older version still serves
+   * selectors the newer one did not take over.
+   */
+  diamondFacets: Record<string, string[]>
 }
 
 export interface IMismatch {
@@ -70,6 +75,8 @@ function checkContract(
  * present" semantics). For facets, the cross-check is driven by the set of facets
  * installed in the diamond (`diamondFacets`); a facet that appears only in the flat
  * deployment log but has not yet been cut into the diamond will not be cross-checked.
+ * A facet registered at several addresses at once agrees as long as the deployment
+ * log matches any one of them.
  */
 export function findMismatches(sources: INetworkSources[]): IMismatch[] {
   const mismatches: IMismatch[] = []
@@ -95,18 +102,33 @@ export function findMismatches(sources: INetworkSources[]): IMismatch[] {
       ])
       if (m) mismatches.push(m)
     }
-    for (const name of Object.keys(s.diamondFacets)) {
-      const m = checkContract(s.network, 'facet', name, [
-        {
-          source: `deployments/${s.network}.json`,
-          address: s.deploymentFlat[name],
-        },
-        {
-          source: `deployments/${s.network}.diamond.json`,
-          address: s.diamondFacets[name],
-        },
-      ])
-      if (m) mismatches.push(m)
+    for (const [name, registered] of Object.entries(s.diamondFacets)) {
+      const flat = s.deploymentFlat[name]
+      const present = registered.filter((a) => !isEmpty(a))
+      if (isEmpty(flat) || present.length === 0) continue
+
+      // The deploy log records a single address per facet name while the diamond
+      // may have several registered at once, so agreement means matching any one
+      // of them. Comparing against just one would make the verdict depend on
+      // object key order.
+      if (present.some((a) => normalize(a) === normalize(flat as string)))
+        continue
+
+      mismatches.push({
+        network: s.network,
+        kind: 'facet',
+        contract: name,
+        addresses: [
+          {
+            source: `deployments/${s.network}.json`,
+            address: flat as string,
+          },
+          ...present.map((address) => ({
+            source: `deployments/${s.network}.diamond.json`,
+            address,
+          })),
+        ],
+      })
     }
   }
   return mismatches
@@ -240,7 +262,7 @@ export function loadSources(
 
     const diamondPath = `${deploymentsDir}/${network}.diamond.json`
     let diamondPeriphery: Record<string, string> = {}
-    const diamondFacets: Record<string, string> = {}
+    const diamondFacets: Record<string, string[]> = {}
     if (existsSync(diamondPath)) {
       const diamond =
         readJson<{
@@ -251,7 +273,7 @@ export function loadSources(
         }>(diamondPath).LiFiDiamond ?? {}
       diamondPeriphery = diamond.Periphery ?? {}
       for (const [address, info] of Object.entries(diamond.Facets ?? {}))
-        if (info?.Name) diamondFacets[info.Name] = address
+        if (info?.Name) (diamondFacets[info.Name] ??= []).push(address)
     }
 
     sources.push({


### PR DESCRIPTION
# Which Linear task belongs to this PR?

No dedicated ticket yet — found while finishing the PolymerCCTPFacet v3.1.0 rollout ([EXSC-662](https://linear.app/lifi-linear/issue/EXSC-662/sc-polymercctpfacet-emit-owner-wallet-nonevmreceiver-in-solana-event), #2167). Happy to file one if preferred.

# Why did I implement it this way?

`findMismatches` compared each facet against a single diamond address, because `loadSources` flattened the registry with last-write-wins:

```ts
for (const [address, info] of Object.entries(diamond.Facets ?? {}))
  if (info?.Name) diamondFacets[info.Name] = address
```

A facet name can legitimately map to **several** addresses at once — an older version still serving selectors the newer one never took over. On arbitrum today, `SymbiosisFacet` is registered twice with disjoint selectors:

| address | version | selectors served |
| --- | --- | --- |
| `0xe12b2488…` | 1.0.0 | `0xb70fb9a5`, `0x6e067161` |
| `0xd04034AE…` | 2.0.0 | `0xe23b7a08`, `0xc46059b2` |

With last-write-wins the check compared the deployment log against whichever entry came last in the JSON, so **the verdict depended on object key order** rather than on content. Regenerating a diamond log with `updateDiamondLogs` is enough to reorder the keys and flip a passing check to failing with no semantic change. That is what happened on #2167: 11 networks reported `SymbiosisFacet` mismatches whose registry entries were byte-identical in content to `main`'s.

The fix collects every address registered under a facet name and treats the deployment log as agreeing when it matches any of them. A facet whose log address matches none of its registered addresses is still flagged, and the report now lists all of them instead of one arbitrary pick.

Verified against #2167's `deployments/` tree: the old checker reports 11 mismatches, the fixed checker reports none, on identical files.

Note this means the current green status of this check on `main` is partly luck of serialisation order — it is not evidence that multi-version facets agree.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
