### PR TITLE
ci(clearsigning): temporarily freeze ERC-7730 sync auto-triggers

### DIFF
--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -1,6 +1,6 @@
 # Sync Clear Signing (ERC-7730) Registry
 # - Purpose: Keep `registry/lifi/calldata-LIFIDiamond.json` in the Ethereum Foundation-hosted ERC-7730 registry up to date with this repo's Diamond ABI + deployments AND with the `display.formats` proposal at `config/clearSigningProposal.json`.
-# - Triggers: monthly cron (safety net), push to facets/deployments/proposal (fast path), and manual.
+# - Triggers: manual only while frozen for EXSC-738 (monthly cron + push-to-main auto-triggers are commented out below; see the note in the `on:` block).
 # - Key behaviors: clones our fork (`lifinance/clear-signing-erc7730-registry`, originally forked from LedgerHQ, now tracking the EF-hosted registry), regenerates the JSON with merged `display.formats`, pushes a branch to the fork, creates/updates a PR upstream, and posts the PR link to Slack.
 # - Trust model: this workflow assumes `config/clearSigningProposal.json` is current against the on-chain diamond, which is enforced at PR-merge time by `verifyClearSigning.yml`. If that gate is bypassed, the proposal may be stale.
 # - Note: The ERC-7730 registry moved from `LedgerHQ/clear-signing-erc7730-registry` to `ethereum/clear-signing-erc7730-registry` (Ethereum Foundation now hosts it). The fork retains its original name; only the upstream remote target changed.
@@ -16,22 +16,27 @@ on:
         type: boolean
         required: false
         default: false
-  schedule:
-    # Monthly safety net at 03:00 UTC on the 1st. Push-based triggers below
-    # handle the fast path (new facet/deployment lands -> sync within minutes).
-    - cron: '0 3 1 * *'
-  push:
-    branches:
-      - main # only sync on what's actually been merged
-    paths:
-      - 'src/Facets/**' # new/changed facets -> new/changed selectors
-      - 'src/Libraries/**' # struct definitions used by facets
-      - 'deployments/**' # new deployment addresses
-      - 'config/networks.json' # chain metadata used by deployments resolver
-      - 'config/clearSigningProposal.json' # the display.formats source of truth
-      - 'tasks/generateLedgerClearSigning.ts'
-      - 'tasks/buildClearSigningProposal.ts'
-      - '.github/workflows/syncLedgerClearSigning.yml'
+  # TEMPORARY FREEZE (EXSC-738): the schedule + push auto-triggers are disabled
+  # while the upstream PR (ethereum/clear-signing-erc7730-registry#2597) is being
+  # migrated to the v2 test format on the `sync/lifi-erc7730` branch. Both triggers
+  # force-push that branch and would clobber the hand-authored test files. Re-enable
+  # (uncomment both blocks) once #2597 is merged. Manual workflow_dispatch stays live.
+  # schedule:
+  #   # Monthly safety net at 03:00 UTC on the 1st. Push-based triggers below
+  #   # handle the fast path (new facet/deployment lands -> sync within minutes).
+  #   - cron: '0 3 1 * *'
+  # push:
+  #   branches:
+  #     - main # only sync on what's actually been merged
+  #   paths:
+  #     - 'src/Facets/**' # new/changed facets -> new/changed selectors
+  #     - 'src/Libraries/**' # struct definitions used by facets
+  #     - 'deployments/**' # new deployment addresses
+  #     - 'config/networks.json' # chain metadata used by deployments resolver
+  #     - 'config/clearSigningProposal.json' # the display.formats source of truth
+  #     - 'tasks/generateLedgerClearSigning.ts'
+  #     - 'tasks/buildClearSigningProposal.ts'
+  #     - '.github/workflows/syncLedgerClearSigning.yml'
 
 permissions:
   contents: read # required to fetch repository contents


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-738](https://linear.app/lifi-linear/issue/EXSC-738/migrate-lifi-erc-7730-registry-pr-to-v2-test-format-unblock-2597-ship) — this is Task 1 (freeze) of that ticket, so `Ref` (not `Fixes`) to avoid auto-closing the ticket on merge.

# Why did I implement it this way?

Temporary freeze of the ERC-7730 sync bot while the upstream registry PR [`ethereum/clear-signing-erc7730-registry#2597`](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2597) is migrated to the v2 test format. `syncLedgerClearSigning.yml` regenerates the descriptor and does `git checkout -B sync/lifi-erc7730 upstream/master` followed by `git push --force-with-lease`. The migration work hand-authors the v2 test files directly on that same `sync/lifi-erc7730` branch, so any automatic run — the monthly cron or the push-to-`main` fast path, which fires on `config/clearSigningProposal.json` and `tasks/*` (exactly the paths the migration touches) — would force-push over and clobber those hand-authored test files. This PR comments out both auto-triggers and leaves `workflow_dispatch` live so manual/dry-run syncs still work. It is fully reversible: uncomment both blocks once #2597 is merged (the final step of EXSC-738). No sync logic is changed and nothing is deleted.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
