### PR TITLE
chore(scripts): cap cast RPC calls and add castRead fallback helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ PRIVATE_KEY="<your private key>"
 # To populate all RPCs, please run "bun fetch-rpcs"
 # To add a new RPC for a specific network, run: "bun add-network-rpc --network {networkName} --rpcUrl {rpcUrl}"
 
+# Hard cap (seconds) on every `cast` RPC request. Without it, a dead or blocked endpoint
+# hangs until the caller's own timeout, blocking deploy/verify/proposal scripts for minutes.
+ETH_RPC_TIMEOUT=12
+
 # Mainnet Explorer API Keys
 MAINNET_ETHERSCAN_API_KEY=
 ABSTRACT_ETHERSCAN_API_KEY=

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3912,6 +3912,73 @@ function getRpcUrlFromNetworksJson() {
   echo "$RPC_URL"
 }
 
+# castRead: Run a read-only `cast` call with a hard timeout and RPC fallback, so a dead or
+# blocked endpoint fails fast instead of hanging the caller. Tries the env RPC (getRPCUrl)
+# first, then the public rpcUrl from networks.json, returning the first that answers.
+# ETH_RPC_TIMEOUT caps each request inside cast; a coreutils timeout/gtimeout wrapper (when
+# present) is an additional hard kill. Read-only only — never use for `cast send`.
+#
+# Usage: castRead NETWORK CAST_ARG [CAST_ARG...]
+#   NETWORK  - network name as keyed in networks.json
+#   CAST_ARG - the cast subcommand and its args, WITHOUT --rpc-url (appended per candidate)
+#
+# Returns: prints cast stdout and returns 0 on the first endpoint that succeeds; returns 1
+#          if every candidate endpoint fails or none is configured.
+# Example: castRead bsc call "$DIAMOND" "owner()(address)"
+# Example: CODE=$(castRead katana code "$ADDRESS")
+function castRead() {
+  local NETWORK="$1"
+  shift || true
+
+  if [[ -z "$NETWORK" || $# -eq 0 ]]; then
+    echo "Error: castRead usage: castRead NETWORK CAST_ARG [CAST_ARG...] (no --rpc-url)." >&2
+    return 1
+  fi
+
+  local HARD_TIMEOUT="${CAST_READ_TIMEOUT:-15}"
+  local REQ_TIMEOUT="${ETH_RPC_TIMEOUT:-12}"
+
+  # resolve an optional hard-kill wrapper (coreutils, may be absent on stock macOS)
+  local TIMEOUT_BIN=""
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+  fi
+
+  # build ordered, de-duplicated candidate list: env RPC, then networks.json public RPC
+  local RPC_URLS=()
+  local CANDIDATE
+  CANDIDATE=$(getRPCUrl "$NETWORK" 2>/dev/null) && [[ -n "$CANDIDATE" ]] && RPC_URLS+=("$CANDIDATE")
+  CANDIDATE=$(getRpcUrlFromNetworksJson "$NETWORK" 2>/dev/null) || CANDIDATE=""
+  if [[ -n "$CANDIDATE" && ( ${#RPC_URLS[@]} -eq 0 || "$CANDIDATE" != "${RPC_URLS[0]}" ) ]]; then
+    RPC_URLS+=("$CANDIDATE")
+  fi
+
+  if [[ ${#RPC_URLS[@]} -eq 0 ]]; then
+    echo "Error: castRead found no RPC URL for network '$NETWORK'." >&2
+    return 1
+  fi
+
+  local OUT RC URL
+  for URL in "${RPC_URLS[@]}"; do
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+      OUT=$(ETH_RPC_TIMEOUT="$REQ_TIMEOUT" "$TIMEOUT_BIN" "$HARD_TIMEOUT" cast "$@" --rpc-url "$URL" 2>/dev/null)
+      RC=$?
+    else
+      OUT=$(ETH_RPC_TIMEOUT="$REQ_TIMEOUT" cast "$@" --rpc-url "$URL" 2>/dev/null)
+      RC=$?
+    fi
+    if [[ $RC -eq 0 ]]; then
+      echo "$OUT"
+      return 0
+    fi
+  done
+
+  echo "Error: castRead failed on all ${#RPC_URLS[@]} RPC endpoint(s) for network '$NETWORK'." >&2
+  return 1
+}
+
 # getCastSendAsync: Return "true" if cast send should use --async for this network (avoids receipt
 # deserialization errors when RPC returns receipts missing fields like feePayer). Used by universalSendRaw.
 # Usage: getCastSendAsync NETWORK


### PR DESCRIPTION
# Which Linear task belongs to this PR?

<!-- EXSC ticket to be created + linked once Linear re-auths (token expired mid-session). -->

# Why did I implement it this way?

During the LiFi Intents settler switchover rollout, on-chain read calls via `cast` repeatedly hung for the full 2-minute shell timeout whenever an RPC endpoint was unreachable or slow, because `cast` had no client-side request cap and `getRPCUrl` returns a single endpoint with no fallback. Over a multi-network rollout that added up to a lot of dead waiting.

Two layered fixes, both low-risk and opt-in for existing callers:

- **`ETH_RPC_TIMEOUT`** — documented in `.env.example`. `cast` (Foundry ≥ 1.7) reads this env var as a per-request timeout, so a dead or blocked endpoint fails in seconds instead of hanging. It flows into every `cast` invocation automatically, including the existing `universalCall`/`universalCode` paths, with zero code changes to them.
- **`castRead()`** in `helperFunctions.sh` — a read-only `cast` wrapper that applies a hard timeout (a coreutils `timeout`/`gtimeout` kill when present, otherwise `ETH_RPC_TIMEOUT` alone) and falls back across the env RPC (`getRPCUrl`) then the public `rpcUrl` from `networks.json`, returning the first endpoint that answers. It reuses the two RPC sources that already exist rather than introducing a new curated endpoint list.

`castRead` is deliberately standalone and has no callers in this diff — I did not rewire the deploy-critical `universalCall`/`universalCode` path, since adding fallback there changes behavior for every existing caller (silent failover could mask a primary-RPC problem and shift timing). **Design question for the reviewer:** keep `castRead` as an opt-in helper adopted incrementally, or fold the timeout+fallback into `universalCall`/`universalCode` so it applies everywhere? I lean standalone first, but it's a call for whoever owns that path.

Verified locally: `ETH_RPC_TIMEOUT=12` aborts a non-routable endpoint in 12s (vs hanging); `castRead katana chain-id` with a deliberately dead primary falls back to the `networks.json` RPC and returns `747474`; `bash -n`, strict-mode source, and `shellcheck` are clean on the new function (the one SC2155 in `helperFunctions.sh` is pre-existing on `main`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>