### PR TITLE
fix(deploy): report FAILED when a periphery deploy fails

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3978,7 +3978,12 @@ function deployAndAddContractToDiamond() {
     diamondUpdatePeriphery "$NETWORK" "$ENVIRONMENT" "$DIAMOND_CONTRACT_NAME" false false "$CONTRACT"
     RETURN_CODE2=$?
 
-    if [[ "$RETURN_CODE1" -eq 0 || "$RETURN_CODE2" -eq 0 ]]; then
+    # Both must succeed: a failed deploy (RETURN_CODE1) whose old contract is still
+    # registered makes diamondUpdatePeriphery report "no action needed" (RETURN_CODE2=0),
+    # and a successful deploy that fails to register leaves the diamond pointed at the
+    # old address - neither is a success, so an OR here would report a stale/broken state
+    # as OK (EXSC-741).
+    if [[ "$RETURN_CODE1" -eq 0 && "$RETURN_CODE2" -eq 0 ]]; then
       return 0
     else
       return 1

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3978,11 +3978,9 @@ function deployAndAddContractToDiamond() {
     diamondUpdatePeriphery "$NETWORK" "$ENVIRONMENT" "$DIAMOND_CONTRACT_NAME" false false "$CONTRACT"
     RETURN_CODE2=$?
 
-    # Both must succeed: a failed deploy (RETURN_CODE1) whose old contract is still
-    # registered makes diamondUpdatePeriphery report "no action needed" (RETURN_CODE2=0),
-    # and a successful deploy that fails to register leaves the diamond pointed at the
-    # old address - neither is a success, so an OR here would report a stale/broken state
-    # as OK (EXSC-741).
+    # Both must succeed: a failed deploy whose old contract is still registered makes
+    # diamondUpdatePeriphery report "no action needed" (RETURN_CODE2=0), and a deploy that
+    # fails to register leaves the diamond pointed at the old address - neither is a success.
     if [[ "$RETURN_CODE1" -eq 0 && "$RETURN_CODE2" -eq 0 ]]; then
       return 0
     else

--- a/script/tasks/diamondUpdatePeriphery.sh
+++ b/script/tasks/diamondUpdatePeriphery.sh
@@ -130,10 +130,7 @@ function diamondUpdatePeriphery() {
 
       if [ "$KNOWN_ADDRESS" != "$CONTRACT_ADDRESS" ]; then
         # register contract
-        register "$NETWORK" "$DIAMOND_ADDRESS" "$CONTRACT" "$CONTRACT_ADDRESS" "$ENVIRONMENT"
-        local REGISTER_RC=$?
-
-        if [ $REGISTER_RC -eq 0 ]; then
+        if register "$NETWORK" "$DIAMOND_ADDRESS" "$CONTRACT" "$CONTRACT_ADDRESS" "$ENVIRONMENT"; then
           echo "[info] contract $CONTRACT successfully registered on diamond $DIAMOND_ADDRESS"
         else
           # latch: a failure must not be reset to 0 by a later successful iteration

--- a/script/tasks/diamondUpdatePeriphery.sh
+++ b/script/tasks/diamondUpdatePeriphery.sh
@@ -131,10 +131,13 @@ function diamondUpdatePeriphery() {
       if [ "$KNOWN_ADDRESS" != "$CONTRACT_ADDRESS" ]; then
         # register contract
         register "$NETWORK" "$DIAMOND_ADDRESS" "$CONTRACT" "$CONTRACT_ADDRESS" "$ENVIRONMENT"
-        LAST_CALL=$?
+        local REGISTER_RC=$?
 
-        if [ $LAST_CALL -eq 0 ]; then
+        if [ $REGISTER_RC -eq 0 ]; then
           echo "[info] contract $CONTRACT successfully registered on diamond $DIAMOND_ADDRESS"
+        else
+          # latch: a failure must not be reset to 0 by a later successful iteration
+          LAST_CALL=1
         fi
       else
         echo "[info] contract $CONTRACT is already registered on diamond $DIAMOND_ADDRESS - no action needed"

--- a/script/tasks/diamondUpdatePeriphery.sh
+++ b/script/tasks/diamondUpdatePeriphery.sh
@@ -165,6 +165,11 @@ function diamondUpdatePeriphery() {
   fi
 
   echo "[info] <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< diamondUpdatePeriphery completed"
+
+  # Propagate the registration outcome. With EXIT_ON_ERROR=false the failure path
+  # above does not exit, so without this the final echo's 0 would mask a failed
+  # registration and callers checking $? would treat it as success.
+  return "$LAST_CALL"
 }
 
 register() {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-741](https://linear.app/lifi-linear/issue/EXSC-741/deploycontracttonetworkssh-reports-ok-when-every-deploy-attempt-failed)

# Why did I implement it this way?

`deployContractToNetworks.sh` reported a network as `OK` (printing the previously-deployed address) even when every deploy attempt for that network failed. The cause was two compounding defects in the shared deploy framework, not the script itself. First, `diamondUpdatePeriphery` tracked its registration outcome in `LAST_CALL` but, when called with `EXIT_ON_ERROR=false`, never returned it — it fell through to a final `echo`, so the function returned `0` in almost every case, even after a failed registration. Second, `deployAndAddContractToDiamond` combined the deploy outcome (`RETURN_CODE1`) and the registration outcome (`RETURN_CODE2`) with `||`. Together, a failed deploy whose old contract was still registered ("no action needed") returned `0`, and that success propagated to the summary line and the exit code. The fix returns `LAST_CALL` from `diamondUpdatePeriphery` so registration failures propagate, and requires both the deploy and the registration to succeed (`&&`) before a periphery deploy is treated as successful. A failed deploy now writes no result file, so the network surfaces as `FAILED` with a non-zero exit code, and the address printed for successful networks is the one actually deployed in this run. I fixed it at the root rather than only in the calling script because the same masking affects the propose flow (`proposeContractToNetworks.sh`) and the interactive `scriptMaster.sh` path, which both go through these helpers; that flow's idempotent cases are already carved out by a grep check before the return-code check, so no false failures are introduced. Per the ticket decision, the fix is scoped to eliminating the false `OK` (FAILED-only semantics); a distinct `SKIPPED — already current` state and a regression test were deferred.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
