### PR TITLE
fix(deploy): allow intent facets to deploy against codeless settler refs

### DIFF
--- a/script/deploy/facets/DeployLiFiIntentEscrowFacetV2.s.sol
+++ b/script/deploy/facets/DeployLiFiIntentEscrowFacetV2.s.sol
@@ -2,12 +2,9 @@
 pragma solidity ^0.8.17;
 
 import { DeployScriptBase } from "./utils/DeployScriptBase.sol";
-import { stdJson } from "forge-std/Script.sol";
 import { LiFiIntentEscrowFacetV2 } from "lifi/Facets/LiFiIntentEscrowFacetV2.sol";
 
 contract DeployScript is DeployScriptBase {
-    using stdJson for string;
-
     constructor() DeployScriptBase("LiFiIntentEscrowFacetV2") {}
 
     function run()
@@ -29,10 +26,16 @@ contract DeployScript is DeployScriptBase {
             root,
             "/config/lifiintentescrow.json"
         );
-        string memory json = vm.readFile(path);
 
-        address lifiIntentEscrowSettler = json.readAddress(
-            ".lifiEscrowInputSettler"
+        // allowNonContractAddress: true — lifiEscrowInputSettler is a reserved, deterministically
+        // deployed vanity address (identical on every chain). The facet is deployed on a chain
+        // before the settler exists there, so the ref legitimately has no code yet (see EXSC-748).
+        // It is a real non-zero address, so allowZeroAddress stays false.
+        address lifiIntentEscrowSettler = _getConfigContractAddress(
+            path,
+            ".lifiEscrowInputSettler",
+            false, // allowZeroAddress
+            true // allowNonContractAddress (settler may not be deployed on this chain yet)
         );
 
         return abi.encode(lifiIntentEscrowSettler);

--- a/script/deploy/facets/DeployReceiverOIF.s.sol
+++ b/script/deploy/facets/DeployReceiverOIF.s.sol
@@ -38,9 +38,15 @@ contract DeployScript is DeployScriptBase {
             root,
             "/config/lifiintentescrow.json"
         );
+        // allowNonContractAddress: true — OIFOutputSettlerSimple is a reserved, deterministically
+        // deployed vanity address (identical on every chain). ReceiverOIF is deployed on a chain
+        // before the settler exists there, so the ref legitimately has no code yet (see EXSC-748).
+        // It is a real non-zero address, so allowZeroAddress stays false.
         address outputSettler = _getConfigContractAddress(
             path,
-            string.concat(".OIFOutputSettlerSimple")
+            ".OIFOutputSettlerSimple",
+            false, // allowZeroAddress
+            true // allowNonContractAddress (settler may not be deployed on this chain yet)
         );
 
         // get Executor address from deploy log


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-748](https://linear.app/lifi-linear/issue/EXSC-748/allow-redeploying-intent-facets-against-codeless-reserved-settler-refs)

# Why did I implement it this way?

The intent settlers (InputSettlerEscrowLIFI / OutputSettlerSimple) are reserved, deterministically-deployed vanity addresses — identical on every chain. We deploy `LiFiIntentEscrowFacetV2` and `ReceiverOIF` on a chain before the settler is deployed there, so the immutable ref legitimately points at an address that has no code yet (e.g. jovay/megaeth after the 2026-08-06 switchover). `DeployReceiverOIF` read the output settler through the default `_getConfigContractAddress`, which runs `LibAsset.isContract` and reverted on a codeless ref, blocking (re)deployment on those chains.

This reuses the existing 4-arg `_getConfigContractAddress` overload with `allowNonContractAddress=true` — the same pattern already used for tempo's dummy wrappedNative in `DeployAcrossFacetV4` — scoped only to the settler fields. `allowZeroAddress` stays `false` and the `Executor` read stays checked, so a zero address or a missing real dependency is still caught; only the intentional codeless-settler case is allowed through. The facet script previously read the input settler with a raw `stdJson.readAddress` (no zero/code checks at all); it now uses the same checked reader, keeping the codeless allowance while adding the zero-address guard it was missing.

No automated test is added: this repo does not unit-test Foundry deploy scripts (the tempo precedent has none either), and `getConstructorArgs` is internal and env/config-dependent. Functional validation is the actual (re)deploy against a chain whose settler ref is codeless.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
