### PR TITLE
chore(agent): allow curl in Bash permissions (EXSC-759)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,6 @@
       "Bash(git push --force*)",
       "Bash(git reset --hard*)",
       "Bash(git clean -f*)",
-      "Bash(curl *)",
       "Bash(mongosh *)",
       "Bash(mongo *)",
       "Bash(mongodump *)",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-759](https://linear.app/lifi-linear/issue/EXSC-759/allow-curl-in-agent-bash-permissions-remove-ineffective-deny)

# Why did I implement it this way?

This removes the blanket `Bash(curl *)` entry from `permissions.deny` in `.claude/settings.json`. No security is lost, because that rule was never an effective boundary: it blocked one binary, not egress. The agent already has `wget` (only `wget | bash` is denied, not plain `wget`) plus `bun`, `bunx`, `cast`, and `forge`, all of which can make outbound requests, so blocking `curl` closed one of many unlocked doors and never prevented data from leaving. The real protection against secret exfiltration lives at the read layer and is unchanged: you cannot exfiltrate what you cannot read, and `Read(**/.env)`/`Read(/.env)` are denied here while `~/.ssh`, `~/.aws`, `~/.gnupg`, keychains, and git/npm/pypi credentials are denied in global settings. The `curl | sh` remote-code-execution vector is still blocked by the built-in auto-mode classifier, which is semantic and whitespace-agnostic rather than relying on brittle glob patterns. A per-command deny is the wrong tool for real egress control anyway — that is an OS-level sandbox network-allowlist concern (`sandbox.network.allowedDomains`), not a command-name filter — so keeping the rule only produced false confidence. What we gain is that agents can query external protocol/chain APIs directly (block explorers, RPC/HTTP endpoints, price and gas oracles, docs) during transaction analysis and investigations, instead of being blocked on a tool that provided no real protection. The deny list keeps the genuinely dangerous, hard-to-undo commands (`rm -rf`, `git push --force`, `git reset --hard`, `git clean -f`) and the `mongo*` data-store guards; `wget` is left as-is so the two equivalent fetch tools are treated consistently.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
