### PR TITLE
chore(config): allow Timelock Auto Execution workflow dispatch (EXSC-760)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,7 @@
       "Bash(jq *)",
       "Bash(wc *)",
       "Bash(ls *)",
+      "Bash(gh workflow run runPendingTimelockTXs.yml --repo lifinance/contracts)",
       "Read",
       "Write",
       "Edit",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-760](https://linear.app/lifi-linear/issue/EXSC-760/allow-timelock-auto-execution-workflow-dispatch-in-claude-code)

# Why did I implement it this way?

The `finish-rollout` skill's Phase 2b nudge dispatches the Timelock Auto Execution workflow (`gh workflow run runPendingTimelockTXs.yml`) to execute ready-but-unexecuted timelock ops — the same pipeline the cron uses. That exact command was being blocked by the permission layer on every rollout finish. Adding it to the team-wide `.claude/settings.json` allow-list as an exact-match rule (not a wildcard) unblocks just this one dispatch while keeping the scope tight.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
