### PR TITLE
feat(healthcheck): gate live facets on their companion periphery (EXSC-684)

### DIFF
--- a/config/global.json
+++ b/config/global.json
@@ -139,23 +139,23 @@
   },
   "facetPeripheryCouplings": {
     "AcrossFacetV4": {
-      "requiresAnyOf": ["ReceiverAcrossV4"],
+      "requires": "ReceiverAcrossV4",
       "devNotes": "Across V4 destination calls are completed by ReceiverAcrossV4 (EXSC-682, Robinhood)."
     },
     "AcrossFacetPackedV4": {
-      "requiresAnyOf": ["ReceiverAcrossV4"]
+      "requires": "ReceiverAcrossV4"
     },
     "AcrossV4SwapFacet": {
-      "requiresAnyOf": ["ReceiverAcrossV4"]
+      "requires": "ReceiverAcrossV4"
     },
     "ChainflipFacet": {
-      "requiresAnyOf": ["ReceiverChainflip"]
+      "requires": "ReceiverChainflip"
     },
     "LiFiIntentEscrowFacetV2": {
-      "requiresAnyOf": ["ReceiverOIF"]
+      "requires": "ReceiverOIF"
     },
     "StargateFacetV2": {
-      "requiresAnyOf": ["ReceiverStargateV2"]
+      "requires": "ReceiverStargateV2"
     }
   }
 }

--- a/config/global.json
+++ b/config/global.json
@@ -136,5 +136,26 @@
         "signature": "validateNativeOutput(uint256,address)"
       }
     ]
+  },
+  "facetPeripheryCouplings": {
+    "AcrossFacetV4": {
+      "requiresAnyOf": ["ReceiverAcrossV4"],
+      "devNotes": "Across V4 destination calls are completed by ReceiverAcrossV4 (EXSC-682, Robinhood)."
+    },
+    "AcrossFacetPackedV4": {
+      "requiresAnyOf": ["ReceiverAcrossV4"]
+    },
+    "AcrossV4SwapFacet": {
+      "requiresAnyOf": ["ReceiverAcrossV4"]
+    },
+    "ChainflipFacet": {
+      "requiresAnyOf": ["ReceiverChainflip"]
+    },
+    "LiFiIntentEscrowFacetV2": {
+      "requiresAnyOf": ["ReceiverOIF"]
+    },
+    "StargateFacetV2": {
+      "requiresAnyOf": ["ReceiverStargateV2"]
+    }
   }
 }

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1338,7 +1338,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       // (or troncast output drift) must not raise a false "destination calls disabled" gate.
       const registered = new Map<string, boolean>()
       const unresolved = new Set<string>()
-      const markUnresolved = (companion: string, reason: unknown) => {
+      const markUnresolved = (companion: string, reason: unknown): void => {
         ctx.logWarn(
           `Failed to read periphery registration for ${companion}: ${String(
             reason

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -835,6 +835,51 @@ const RECEIVER_EXECUTOR_GETTERS: Array<{ name: string; getter: string }> = [
   { name: 'ReceiverStargateV2', getter: 'executor' },
 ]
 
+/** getPeripheryContract on an unregistered name returns address(0); on Tron that encodes to this. */
+const TRON_ZERO_ADDRESS = 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb'
+
+/**
+ * Read one periphery contract's address from the diamond's on-chain PeripheryRegistry.
+ *
+ * @param name - the periphery contract name to look up
+ * @param ctx - the health-check context (supplies the diamond address and RPC client)
+ * @returns the registered address (checksummed hex on EVM, base58 on Tron), or null when the
+ *   registry holds the zero address — i.e. nothing is registered under that name
+ * @throws when the read fails, returns malformed output, or no client is configured, so callers
+ *   can tell "not registered" (null) apart from "could not determine" (throw)
+ */
+async function readPeripheryRegistry(
+  name: string,
+  ctx: IHealthCheckContext
+): Promise<string | null> {
+  if (ctx.isTron) {
+    if (!ctx.tronRpcUrl) throw new Error('no Tron RPC URL configured')
+    const parsed = parseTronAddressOutput(
+      await callTronContract(
+        ctx.diamondAddress,
+        'getPeripheryContract(string)',
+        [name],
+        'address',
+        ctx.tronRpcUrl
+      )
+    )
+    if (!parsed.startsWith('T') || parsed.length !== 34)
+      throw new Error(`malformed Tron address for ${name}: ${parsed}`)
+    return parsed === TRON_ZERO_ADDRESS ? null : parsed
+  }
+
+  if (!ctx.publicClient) throw new Error('no EVM client configured')
+  const registry = getContract({
+    address: ctx.diamondAddress as Address,
+    abi: parseAbi([
+      'function getPeripheryContract(string) external view returns (address)',
+    ]),
+    client: ctx.publicClient,
+  })
+  const address = await registry.read.getPeripheryContract([name])
+  return address === zeroAddress ? null : getAddress(address)
+}
+
 /**
  * Ordered registry of every health-check invariant. The order matches historical log
  * output; earlier invariants may populate mutable context fields (e.g. `onChainFacets`)
@@ -1288,71 +1333,42 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       if (required.length === 0) return
 
       const wanted = required.map((requirement) => requirement.companion)
-      // A companion is present iff getPeripheryContract returns a non-zero address. A read that
-      // fails is undetermined, never treated as absence - one flaky RPC must not raise a false gate.
+      // A companion is present iff the registry returns a non-null (non-zero) address. A read that
+      // fails or returns malformed output is undetermined, never treated as absence - one flaky RPC
+      // (or troncast output drift) must not raise a false "destination calls disabled" gate.
       const registered = new Map<string, boolean>()
       const unresolved = new Set<string>()
+      const markUnresolved = (companion: string, reason: unknown) => {
+        ctx.logWarn(
+          `Failed to read periphery registration for ${companion}: ${String(
+            reason
+          )}`
+        )
+        unresolved.add(companion)
+      }
 
-      if (ctx.isTron && ctx.tronRpcUrl) {
-        // Tron: getPeripheryContract returns base58; the zero address encodes to this fixed string.
-        const TRON_ZERO_ADDRESS = 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb'
-        for (const periphery of wanted)
+      // EVM reads fold into the batched multicall client (concurrent); Tron reads stay sequential
+      // to avoid spawning a troncast subprocess per companion at once.
+      if (ctx.isTron)
+        for (const companion of wanted)
           try {
-            const output = await callTronContract(
-              ctx.diamondAddress,
-              'getPeripheryContract(string)',
-              [periphery],
-              'address',
-              ctx.tronRpcUrl
-            )
-            const parsed = parseTronAddressOutput(output)
             registered.set(
-              periphery,
-              parsed.startsWith('T') &&
-                parsed.length === 34 &&
-                parsed !== TRON_ZERO_ADDRESS
+              companion,
+              (await readPeripheryRegistry(companion, ctx)) !== null
             )
           } catch (error: unknown) {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error)
-            ctx.logWarn(
-              `Failed to read periphery registration for ${periphery}: ${errorMessage}`
-            )
-            unresolved.add(periphery)
+            markUnresolved(companion, error)
           }
-      } else if (ctx.publicClient) {
-        const peripheryRegistry = getContract({
-          address: ctx.diamondAddress as Address,
-          abi: parseAbi([
-            'function getPeripheryContract(string) external view returns (address)',
-          ]),
-          client: ctx.publicClient,
-        })
+      else {
         const results = await Promise.allSettled(
-          wanted.map((periphery) =>
-            peripheryRegistry.read.getPeripheryContract([periphery])
-          )
+          wanted.map((companion) => readPeripheryRegistry(companion, ctx))
         )
-        wanted.forEach((periphery, index) => {
+        wanted.forEach((companion, index) => {
           const result = results[index]
-          if (result?.status !== 'fulfilled') {
-            const reason =
-              result?.status === 'rejected'
-                ? String(result.reason)
-                : 'no result'
-            ctx.logWarn(
-              `Failed to read periphery registration for ${periphery}: ${reason}`
-            )
-            unresolved.add(periphery)
-            return
-          }
-          registered.set(periphery, result.value !== zeroAddress)
+          if (result?.status === 'fulfilled')
+            registered.set(companion, result.value !== null)
+          else markUnresolved(companion, result?.reason ?? 'no result')
         })
-      } else {
-        ctx.logWarn(
-          'Neither a Tron RPC URL nor an EVM client is available - facet/periphery coupling check skipped'
-        )
-        return
       }
 
       for (const { companion, triggeredBy } of required) {

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1282,14 +1282,12 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
 
       for (const carveOut of skipped)
         consola.info(
-          `⏭  ${carveOut.facet}: ${carveOut.requiresAnyOf.join(
-            ' / '
-          )} not required here — ${carveOut.reason}`
+          `⏭  ${carveOut.facet}: ${carveOut.companion} not required here — ${carveOut.reason}`
         )
 
       if (required.length === 0) return
 
-      const wanted = [...new Set(required.flatMap((r) => r.requiresAnyOf))]
+      const wanted = required.map((requirement) => requirement.companion)
       // A companion is present iff getPeripheryContract returns a non-zero address. A read that
       // fails is undetermined, never treated as absence - one flaky RPC must not raise a false gate.
       const registered = new Map<string, boolean>()
@@ -1357,39 +1355,27 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         return
       }
 
-      for (const requirement of required) {
-        const satisfiedBy = requirement.requiresAnyOf.filter((periphery) =>
-          registered.get(periphery)
-        )
-        if (satisfiedBy.length > 0) {
-          consola.success(
-            `${satisfiedBy.join(
-              ' / '
-            )} registered for ${requirement.triggeredBy.join(', ')}`
+      for (const { companion, triggeredBy } of required) {
+        if (unresolved.has(companion)) {
+          ctx.logWarn(
+            `${triggeredBy.join(
+              ', '
+            )}: could not determine whether ${companion} is registered (lookup failed)`
           )
           continue
         }
 
-        const undetermined = requirement.requiresAnyOf.filter((periphery) =>
-          unresolved.has(periphery)
-        )
-        if (undetermined.length === requirement.requiresAnyOf.length) {
-          ctx.logWarn(
-            `${requirement.triggeredBy.join(
-              ', '
-            )}: could not determine whether a companion is registered (all lookups failed: ${undetermined.join(
-              ', '
-            )})`
+        if (registered.get(companion)) {
+          consola.success(
+            `${companion} registered for ${triggeredBy.join(', ')}`
           )
           continue
         }
 
         ctx.logError(
-          `${requirement.triggeredBy.join(
+          `${triggeredBy.join(
             ', '
-          )} live but no companion periphery registered in Diamond (need one of: ${requirement.requiresAnyOf.join(
-            ', '
-          )}) - destination calls for this integration are disabled on this network`
+          )} live but companion ${companion} not registered in Diamond - destination calls for this integration are disabled on this network`
         )
       }
     },

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -22,6 +22,7 @@ import {
   getAddress,
   getContract,
   parseAbi,
+  zeroAddress,
   type Address,
   type Hex,
   type PublicClient,
@@ -31,6 +32,11 @@ import type { IWhitelistConfig, TargetState } from '../common/types'
 import { normalizeSelector } from '../utils/utils'
 
 import { SAFE_THRESHOLD } from './shared/constants'
+import {
+  evaluateFacetPeripheryCouplings,
+  getFacetPeripheryCouplings,
+  resolveLiveFacetsFromLog,
+} from './shared/facetPeripheryCouplings'
 import { getCorePeriphery } from './shared/globalContractLists'
 import { isRateLimitError } from './shared/rateLimit'
 import { parseTroncastFacetsOutput } from './tron/helpers/parseTroncastFacetsOutput'
@@ -1234,6 +1240,157 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
               `Periphery contract ${periphery} registered in Diamond`
             )
         }
+      }
+    },
+  },
+  {
+    name: 'facet-required-periphery',
+    description:
+      'Every live facet with a declared companion periphery contract has one registered in the diamond',
+    severity: 'error',
+    scope: { environments: ['production'] },
+    readsOnChainFacets: true,
+    remediation:
+      'Deploy the missing companion contract on this network and register it via diamondUpdatePeriphery, or - if destination calls genuinely do not apply here - add a reasoned notRequiredOn entry to config/global.json -> facetPeripheryCouplings.',
+    run: async (ctx) => {
+      // Triggers on facets live in the diamond, not on target state: the failure this guards against
+      // is a facet being live while its companion is absent, and target state itself was missing the
+      // receiver in the incident that motivated the check (Robinhood, EXSC-682).
+      if (ctx.onChainFacets.length === 0) {
+        ctx.logWarn(
+          'On-chain facet list unavailable - facet/periphery coupling check skipped'
+        )
+        return
+      }
+
+      // A facet is live iff its deploy-log address is one the diamond returns from facets(). The
+      // periphery side below reads on-chain truth (getPeripheryContract); the facet side trusts the
+      // deploy log for the name->address mapping and confirms that address on chain. A facet live on
+      // chain but absent from the log is the no-unexpected-facets warning's job, not this gate.
+      const couplings = getFacetPeripheryCouplings()
+      const liveFacets = resolveLiveFacetsFromLog(
+        ctx.onChainFacets.map((facet) => facet.address),
+        ctx.deployedContracts as Record<string, string>,
+        Object.keys(couplings)
+      )
+
+      const { required, skipped } = evaluateFacetPeripheryCouplings(
+        liveFacets,
+        ctx.networkLower,
+        couplings
+      )
+
+      for (const carveOut of skipped)
+        consola.info(
+          `⏭  ${carveOut.facet}: ${carveOut.requiresAnyOf.join(
+            ' / '
+          )} not required here — ${carveOut.reason}`
+        )
+
+      if (required.length === 0) return
+
+      const wanted = [...new Set(required.flatMap((r) => r.requiresAnyOf))]
+      // A companion is present iff getPeripheryContract returns a non-zero address. A read that
+      // fails is undetermined, never treated as absence - one flaky RPC must not raise a false gate.
+      const registered = new Map<string, boolean>()
+      const unresolved = new Set<string>()
+
+      if (ctx.isTron && ctx.tronRpcUrl) {
+        // Tron: getPeripheryContract returns base58; the zero address encodes to this fixed string.
+        const TRON_ZERO_ADDRESS = 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb'
+        for (const periphery of wanted)
+          try {
+            const output = await callTronContract(
+              ctx.diamondAddress,
+              'getPeripheryContract(string)',
+              [periphery],
+              'address',
+              ctx.tronRpcUrl
+            )
+            const parsed = parseTronAddressOutput(output)
+            registered.set(
+              periphery,
+              parsed.startsWith('T') &&
+                parsed.length === 34 &&
+                parsed !== TRON_ZERO_ADDRESS
+            )
+          } catch (error: unknown) {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error)
+            ctx.logWarn(
+              `Failed to read periphery registration for ${periphery}: ${errorMessage}`
+            )
+            unresolved.add(periphery)
+          }
+      } else if (ctx.publicClient) {
+        const peripheryRegistry = getContract({
+          address: ctx.diamondAddress as Address,
+          abi: parseAbi([
+            'function getPeripheryContract(string) external view returns (address)',
+          ]),
+          client: ctx.publicClient,
+        })
+        const results = await Promise.allSettled(
+          wanted.map((periphery) =>
+            peripheryRegistry.read.getPeripheryContract([periphery])
+          )
+        )
+        wanted.forEach((periphery, index) => {
+          const result = results[index]
+          if (result?.status !== 'fulfilled') {
+            const reason =
+              result?.status === 'rejected'
+                ? String(result.reason)
+                : 'no result'
+            ctx.logWarn(
+              `Failed to read periphery registration for ${periphery}: ${reason}`
+            )
+            unresolved.add(periphery)
+            return
+          }
+          registered.set(periphery, result.value !== zeroAddress)
+        })
+      } else {
+        ctx.logWarn(
+          'Neither a Tron RPC URL nor an EVM client is available - facet/periphery coupling check skipped'
+        )
+        return
+      }
+
+      for (const requirement of required) {
+        const satisfiedBy = requirement.requiresAnyOf.filter((periphery) =>
+          registered.get(periphery)
+        )
+        if (satisfiedBy.length > 0) {
+          consola.success(
+            `${satisfiedBy.join(
+              ' / '
+            )} registered for ${requirement.triggeredBy.join(', ')}`
+          )
+          continue
+        }
+
+        const undetermined = requirement.requiresAnyOf.filter((periphery) =>
+          unresolved.has(periphery)
+        )
+        if (undetermined.length === requirement.requiresAnyOf.length) {
+          ctx.logWarn(
+            `${requirement.triggeredBy.join(
+              ', '
+            )}: could not determine whether a companion is registered (all lookups failed: ${undetermined.join(
+              ', '
+            )})`
+          )
+          continue
+        }
+
+        ctx.logError(
+          `${requirement.triggeredBy.join(
+            ', '
+          )} live but no companion periphery registered in Diamond (need one of: ${requirement.requiresAnyOf.join(
+            ', '
+          )}) - destination calls for this integration are disabled on this network`
+        )
       }
     },
   },

--- a/script/deploy/shared/facetPeripheryCouplings.test.ts
+++ b/script/deploy/shared/facetPeripheryCouplings.test.ts
@@ -13,35 +13,34 @@ import {
 } from './facetPeripheryCouplings'
 
 const COUPLINGS: TFacetPeripheryCouplings = {
-  AcrossFacetV4: { requiresAnyOf: ['ReceiverAcrossV4'] },
-  AcrossFacetPackedV4: { requiresAnyOf: ['ReceiverAcrossV4'] },
+  AcrossFacetV4: { requires: 'ReceiverAcrossV4' },
+  AcrossFacetPackedV4: { requires: 'ReceiverAcrossV4' },
   ChainflipFacet: {
-    requiresAnyOf: ['ReceiverChainflip'],
+    requires: 'ReceiverChainflip',
     notRequiredOn: { somechain: 'destination calls not supported (EXSC-000)' },
   },
-  EmptyFacet: { requiresAnyOf: [] },
 }
 
 describe('getFacetPeripheryCouplings', () => {
   it('reads the coupling block declared in config/global.json', () => {
     const couplings = getFacetPeripheryCouplings()
-    expect(couplings.AcrossFacetV4?.requiresAnyOf).toContain('ReceiverAcrossV4')
+    expect(couplings.AcrossFacetV4?.requires).toBe('ReceiverAcrossV4')
   })
 })
 
 describe('evaluateFacetPeripheryCouplings', () => {
-  it('collapses facets sharing a companion set into one requirement', () => {
+  it('collapses facets sharing a companion into one requirement', () => {
     const { required } = evaluateFacetPeripheryCouplings(
       ['AcrossFacetV4', 'AcrossFacetPackedV4'],
       'mainnet',
       COUPLINGS
     )
     expect(required).toHaveLength(1)
+    expect(required[0]?.companion).toBe('ReceiverAcrossV4')
     expect(required[0]?.triggeredBy).toEqual([
       'AcrossFacetPackedV4',
       'AcrossFacetV4',
     ])
-    expect(required[0]?.requiresAnyOf).toEqual(['ReceiverAcrossV4'])
   })
 
   it('ignores facets that have no declared coupling', () => {
@@ -53,27 +52,17 @@ describe('evaluateFacetPeripheryCouplings', () => {
     expect(required).toHaveLength(0)
   })
 
-  it('drops a facet whose coupling declares an empty companion set', () => {
-    const { required, skipped } = evaluateFacetPeripheryCouplings(
-      ['EmptyFacet'],
-      'mainnet',
-      COUPLINGS
-    )
-    expect(required).toHaveLength(0)
-    expect(skipped).toHaveLength(0)
-  })
-
-  it('skips a facet carved out on the current network (case-insensitive)', () => {
+  it('skips a facet carved out on the current network', () => {
     const { required, skipped } = evaluateFacetPeripheryCouplings(
       ['ChainflipFacet'],
-      'SomeChain',
+      'somechain',
       COUPLINGS
     )
     expect(required).toHaveLength(0)
     expect(skipped).toEqual([
       {
         facet: 'ChainflipFacet',
-        requiresAnyOf: ['ReceiverChainflip'],
+        companion: 'ReceiverChainflip',
         reason: 'destination calls not supported (EXSC-000)',
       },
     ])
@@ -86,7 +75,7 @@ describe('evaluateFacetPeripheryCouplings', () => {
       COUPLINGS
     )
     expect(skipped).toHaveLength(0)
-    expect(required[0]?.requiresAnyOf).toEqual(['ReceiverChainflip'])
+    expect(required[0]?.companion).toBe('ReceiverChainflip')
   })
 
   it('deduplicates repeated facet names', () => {
@@ -103,7 +92,7 @@ describe('evaluateFacetPeripheryCouplings', () => {
       ['AcrossFacetV4'],
       'mainnet'
     )
-    expect(required[0]?.requiresAnyOf).toContain('ReceiverAcrossV4')
+    expect(required[0]?.companion).toBe('ReceiverAcrossV4')
   })
 })
 

--- a/script/deploy/shared/facetPeripheryCouplings.test.ts
+++ b/script/deploy/shared/facetPeripheryCouplings.test.ts
@@ -1,0 +1,155 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  evaluateFacetPeripheryCouplings,
+  getFacetPeripheryCouplings,
+  resolveLiveFacetsFromLog,
+  type TFacetPeripheryCouplings,
+} from './facetPeripheryCouplings'
+
+const COUPLINGS: TFacetPeripheryCouplings = {
+  AcrossFacetV4: { requiresAnyOf: ['ReceiverAcrossV4'] },
+  AcrossFacetPackedV4: { requiresAnyOf: ['ReceiverAcrossV4'] },
+  ChainflipFacet: {
+    requiresAnyOf: ['ReceiverChainflip'],
+    notRequiredOn: { somechain: 'destination calls not supported (EXSC-000)' },
+  },
+  EmptyFacet: { requiresAnyOf: [] },
+}
+
+describe('getFacetPeripheryCouplings', () => {
+  it('reads the coupling block declared in config/global.json', () => {
+    const couplings = getFacetPeripheryCouplings()
+    expect(couplings.AcrossFacetV4?.requiresAnyOf).toContain('ReceiverAcrossV4')
+  })
+})
+
+describe('evaluateFacetPeripheryCouplings', () => {
+  it('collapses facets sharing a companion set into one requirement', () => {
+    const { required } = evaluateFacetPeripheryCouplings(
+      ['AcrossFacetV4', 'AcrossFacetPackedV4'],
+      'mainnet',
+      COUPLINGS
+    )
+    expect(required).toHaveLength(1)
+    expect(required[0]?.triggeredBy).toEqual([
+      'AcrossFacetPackedV4',
+      'AcrossFacetV4',
+    ])
+    expect(required[0]?.requiresAnyOf).toEqual(['ReceiverAcrossV4'])
+  })
+
+  it('ignores facets that have no declared coupling', () => {
+    const { required } = evaluateFacetPeripheryCouplings(
+      ['SomeUnrelatedFacet'],
+      'mainnet',
+      COUPLINGS
+    )
+    expect(required).toHaveLength(0)
+  })
+
+  it('drops a facet whose coupling declares an empty companion set', () => {
+    const { required, skipped } = evaluateFacetPeripheryCouplings(
+      ['EmptyFacet'],
+      'mainnet',
+      COUPLINGS
+    )
+    expect(required).toHaveLength(0)
+    expect(skipped).toHaveLength(0)
+  })
+
+  it('skips a facet carved out on the current network (case-insensitive)', () => {
+    const { required, skipped } = evaluateFacetPeripheryCouplings(
+      ['ChainflipFacet'],
+      'SomeChain',
+      COUPLINGS
+    )
+    expect(required).toHaveLength(0)
+    expect(skipped).toEqual([
+      {
+        facet: 'ChainflipFacet',
+        requiresAnyOf: ['ReceiverChainflip'],
+        reason: 'destination calls not supported (EXSC-000)',
+      },
+    ])
+  })
+
+  it('enforces a carved-out facet on other networks', () => {
+    const { required, skipped } = evaluateFacetPeripheryCouplings(
+      ['ChainflipFacet'],
+      'mainnet',
+      COUPLINGS
+    )
+    expect(skipped).toHaveLength(0)
+    expect(required[0]?.requiresAnyOf).toEqual(['ReceiverChainflip'])
+  })
+
+  it('deduplicates repeated facet names', () => {
+    const { required } = evaluateFacetPeripheryCouplings(
+      ['AcrossFacetV4', 'AcrossFacetV4'],
+      'mainnet',
+      COUPLINGS
+    )
+    expect(required[0]?.triggeredBy).toEqual(['AcrossFacetV4'])
+  })
+
+  it('defaults to the config registry when none is passed', () => {
+    const { required } = evaluateFacetPeripheryCouplings(
+      ['AcrossFacetV4'],
+      'mainnet'
+    )
+    expect(required[0]?.requiresAnyOf).toContain('ReceiverAcrossV4')
+  })
+})
+
+describe('resolveLiveFacetsFromLog', () => {
+  const deployLog = {
+    AcrossFacetV4: '0xAAaa000000000000000000000000000000000001',
+    AcrossFacetPackedV4: '0xBBbb000000000000000000000000000000000002',
+    ChainflipFacet: '0xCCcc000000000000000000000000000000000003',
+  }
+
+  it('returns candidates whose deploy-log address is registered on chain', () => {
+    const live = resolveLiveFacetsFromLog(
+      [
+        '0xaaaa000000000000000000000000000000000001',
+        '0xdddd000000000000000000000000000000000009',
+      ],
+      deployLog,
+      ['AcrossFacetV4', 'AcrossFacetPackedV4', 'ChainflipFacet']
+    )
+    expect(live).toEqual(['AcrossFacetV4'])
+  })
+
+  it('matches addresses case-insensitively on both sides', () => {
+    const live = resolveLiveFacetsFromLog(
+      ['0xBBBB000000000000000000000000000000000002'],
+      deployLog,
+      ['AcrossFacetPackedV4']
+    )
+    expect(live).toEqual(['AcrossFacetPackedV4'])
+  })
+
+  it('skips a candidate absent from the deploy log', () => {
+    const live = resolveLiveFacetsFromLog(
+      ['0xaaaa000000000000000000000000000000000001'],
+      deployLog,
+      ['UnknownFacet']
+    )
+    expect(live).toEqual([])
+  })
+
+  it('returns empty when no candidate is registered on chain', () => {
+    const live = resolveLiveFacetsFromLog(
+      ['0xeeee00000000000000000000000000000000000a'],
+      deployLog,
+      ['AcrossFacetV4', 'ChainflipFacet']
+    )
+    expect(live).toEqual([])
+  })
+})

--- a/script/deploy/shared/facetPeripheryCouplings.ts
+++ b/script/deploy/shared/facetPeripheryCouplings.ts
@@ -14,9 +14,12 @@ import globalConfig from '../../../config/global.json'
 
 /** What one facet requires on the same chain to be functionally complete. */
 export interface IFacetPeripheryCoupling {
-  /** Periphery contracts, ANY ONE of which satisfies the coupling. */
-  requiresAnyOf: string[]
-  /** Per-network carve-outs: network key → why the companion is genuinely not needed there. */
+  /** The companion periphery contract this facet needs. */
+  requires: string
+  /**
+   * Per-network carve-outs: network key → why the companion is genuinely not needed there. Keys
+   * must be the canonical lowercase network key (as in `config/networks.json`).
+   */
   notRequiredOn?: Record<string, string>
   /** Free-form context for humans reading the config. Never consumed by code. */
   devNotes?: string
@@ -25,18 +28,18 @@ export interface IFacetPeripheryCoupling {
 /** Map of facet name → what it requires. Lookup is a direct key hit on the facet name. */
 export type TFacetPeripheryCouplings = Record<string, IFacetPeripheryCoupling>
 
-/** An active requirement for one chain: these facets are live and need one of these contracts. */
+/** An active requirement for one chain: these facets are live and all need this companion. */
 export interface IActiveCouplingRequirement {
-  /** The facets present on this chain that require this companion set. */
+  /** The companion periphery contract that must be registered. */
+  companion: string
+  /** The facets present on this chain that require it. */
   triggeredBy: string[]
-  /** Periphery contracts, any one of which satisfies it. */
-  requiresAnyOf: string[]
 }
 
 /** A facet whose companion requirement is deliberately not enforced on this chain. */
 export interface ISkippedCouplingRequirement {
   facet: string
-  requiresAnyOf: string[]
+  companion: string
   /** Why it is not enforced — always printed so a carve-out is never invisible. */
   reason: string
 }
@@ -62,13 +65,13 @@ export function getFacetPeripheryCouplings(): TFacetPeripheryCouplings {
 /**
  * Work out which companion periphery contracts one chain must have, given the facets live there.
  *
- * Each present facet is looked up directly by name. Facets that require the same companion set are
- * merged into one requirement, so three Across V4 facets needing `ReceiverAcrossV4` produce a single
- * entry listing all three as `triggeredBy`. A facet is reported as `skipped` (with a reason) instead
- * when `notRequiredOn` names this network. Pure — callers do the on-chain lookup.
+ * Each present facet is looked up directly by name. Facets requiring the same companion are merged
+ * into one requirement, so three Across V4 facets needing `ReceiverAcrossV4` produce a single entry
+ * listing all three as `triggeredBy`. A facet is reported as `skipped` (with a reason) instead when
+ * `notRequiredOn` names this network. Pure — callers do the on-chain lookup.
  *
  * @param presentFacets - facet names live on the chain (registered in the diamond)
- * @param network - network key as in `config/networks.json`; matched case-insensitively
+ * @param network - network key as in `config/networks.json`
  * @param couplings - registry override, for tests
  * @returns active requirements plus the deliberately-skipped ones
  */
@@ -79,31 +82,31 @@ export function evaluateFacetPeripheryCouplings(
 ): ICouplingEvaluation {
   const networkLower = network.toLowerCase()
   const skipped: ISkippedCouplingRequirement[] = []
-  // Keyed by the companion set so facets of the same family collapse into one requirement.
-  const byCompanionSet = new Map<string, IActiveCouplingRequirement>()
+  // Keyed by companion so facets of the same family collapse into one requirement.
+  const byCompanion = new Map<string, string[]>()
 
   for (const facet of [...new Set(presentFacets)].sort()) {
     const declaration = couplings[facet]
-    if (!declaration) continue
+    if (!declaration?.requires) continue
 
-    const requiresAnyOf = declaration.requiresAnyOf ?? []
-    if (requiresAnyOf.length === 0) continue
-
-    const perNetworkReason = Object.entries(
-      declaration.notRequiredOn ?? {}
-    ).find(([key]) => key.toLowerCase() === networkLower)?.[1]
-    if (perNetworkReason) {
-      skipped.push({ facet, requiresAnyOf, reason: perNetworkReason })
+    const reason = declaration.notRequiredOn?.[networkLower]
+    if (reason) {
+      skipped.push({ facet, companion: declaration.requires, reason })
       continue
     }
 
-    const key = requiresAnyOf.join('|')
-    const existing = byCompanionSet.get(key)
-    if (existing) existing.triggeredBy.push(facet)
-    else byCompanionSet.set(key, { triggeredBy: [facet], requiresAnyOf })
+    const triggeredBy = byCompanion.get(declaration.requires) ?? []
+    triggeredBy.push(facet)
+    byCompanion.set(declaration.requires, triggeredBy)
   }
 
-  return { required: [...byCompanionSet.values()], skipped }
+  return {
+    required: [...byCompanion].map(([companion, triggeredBy]) => ({
+      companion,
+      triggeredBy,
+    })),
+    skipped,
+  }
 }
 
 /**

--- a/script/deploy/shared/facetPeripheryCouplings.ts
+++ b/script/deploy/shared/facetPeripheryCouplings.ts
@@ -1,0 +1,136 @@
+/**
+ * Facet ↔ periphery coupling registry reader (EXSC-684).
+ *
+ * Some facets are only half a feature on their own: a bridge facet handles the source side, while
+ * the matching Receiver handles destination calls. Nothing used to tie the two together, so a facet
+ * could be rolled out to a new chain while its companion Receiver was silently forgotten — which is
+ * what disabled Across destination calls on Robinhood (EXSC-682).
+ *
+ * `config/global.json` → `facetPeripheryCouplings` declares those couplings, keyed by facet name.
+ * This module reads them and evaluates, for one chain, which companion periphery contracts are
+ * actually required. Import it from the `facet-required-periphery` health-check invariant.
+ */
+import globalConfig from '../../../config/global.json'
+
+/** What one facet requires on the same chain to be functionally complete. */
+export interface IFacetPeripheryCoupling {
+  /** Periphery contracts, ANY ONE of which satisfies the coupling. */
+  requiresAnyOf: string[]
+  /** Per-network carve-outs: network key → why the companion is genuinely not needed there. */
+  notRequiredOn?: Record<string, string>
+  /** Free-form context for humans reading the config. Never consumed by code. */
+  devNotes?: string
+}
+
+/** Map of facet name → what it requires. Lookup is a direct key hit on the facet name. */
+export type TFacetPeripheryCouplings = Record<string, IFacetPeripheryCoupling>
+
+/** An active requirement for one chain: these facets are live and need one of these contracts. */
+export interface IActiveCouplingRequirement {
+  /** The facets present on this chain that require this companion set. */
+  triggeredBy: string[]
+  /** Periphery contracts, any one of which satisfies it. */
+  requiresAnyOf: string[]
+}
+
+/** A facet whose companion requirement is deliberately not enforced on this chain. */
+export interface ISkippedCouplingRequirement {
+  facet: string
+  requiresAnyOf: string[]
+  /** Why it is not enforced — always printed so a carve-out is never invisible. */
+  reason: string
+}
+
+/** Outcome of evaluating the registry against one chain's facet set. */
+export interface ICouplingEvaluation {
+  required: IActiveCouplingRequirement[]
+  skipped: ISkippedCouplingRequirement[]
+}
+
+/**
+ * Read the coupling registry from `config/global.json`.
+ *
+ * @returns the declared couplings, or an empty map when the key is absent.
+ */
+export function getFacetPeripheryCouplings(): TFacetPeripheryCouplings {
+  return (
+    (globalConfig as { facetPeripheryCouplings?: TFacetPeripheryCouplings })
+      .facetPeripheryCouplings ?? {}
+  )
+}
+
+/**
+ * Work out which companion periphery contracts one chain must have, given the facets live there.
+ *
+ * Each present facet is looked up directly by name. Facets that require the same companion set are
+ * merged into one requirement, so three Across V4 facets needing `ReceiverAcrossV4` produce a single
+ * entry listing all three as `triggeredBy`. A facet is reported as `skipped` (with a reason) instead
+ * when `notRequiredOn` names this network. Pure — callers do the on-chain lookup.
+ *
+ * @param presentFacets - facet names live on the chain (registered in the diamond)
+ * @param network - network key as in `config/networks.json`; matched case-insensitively
+ * @param couplings - registry override, for tests
+ * @returns active requirements plus the deliberately-skipped ones
+ */
+export function evaluateFacetPeripheryCouplings(
+  presentFacets: string[],
+  network: string,
+  couplings: TFacetPeripheryCouplings = getFacetPeripheryCouplings()
+): ICouplingEvaluation {
+  const networkLower = network.toLowerCase()
+  const skipped: ISkippedCouplingRequirement[] = []
+  // Keyed by the companion set so facets of the same family collapse into one requirement.
+  const byCompanionSet = new Map<string, IActiveCouplingRequirement>()
+
+  for (const facet of [...new Set(presentFacets)].sort()) {
+    const declaration = couplings[facet]
+    if (!declaration) continue
+
+    const requiresAnyOf = declaration.requiresAnyOf ?? []
+    if (requiresAnyOf.length === 0) continue
+
+    const perNetworkReason = Object.entries(
+      declaration.notRequiredOn ?? {}
+    ).find(([key]) => key.toLowerCase() === networkLower)?.[1]
+    if (perNetworkReason) {
+      skipped.push({ facet, requiresAnyOf, reason: perNetworkReason })
+      continue
+    }
+
+    const key = requiresAnyOf.join('|')
+    const existing = byCompanionSet.get(key)
+    if (existing) existing.triggeredBy.push(facet)
+    else byCompanionSet.set(key, { triggeredBy: [facet], requiresAnyOf })
+  }
+
+  return { required: [...byCompanionSet.values()], skipped }
+}
+
+/**
+ * Resolve which coupled facets are live on a chain from the deploy log, confirmed against the
+ * diamond's registered facet addresses.
+ *
+ * A facet counts as live iff its `deployments/<network>.json` address is one of the addresses the
+ * diamond returns from `facets()`. The reverse gap — a facet registered on chain but absent from the
+ * deploy log — is the domain of the `no-unexpected-facets` warning, not this gate: a diamond whose
+ * live facets are not even recorded in the deploy log has a bookkeeping failure that a coupling check
+ * should not try to reconstruct from compiled selectors.
+ *
+ * @param onChainFacetAddresses - facet addresses from the diamond's `facets()` call
+ * @param deployedContracts - the deploy log for this chain (`deployments/<network>.json`)
+ * @param candidateFacetNames - facet names to test (the coupling registry keys)
+ * @returns the subset of `candidateFacetNames` whose deploy-log address is registered on chain
+ */
+export function resolveLiveFacetsFromLog(
+  onChainFacetAddresses: string[],
+  deployedContracts: Record<string, string>,
+  candidateFacetNames: string[]
+): string[] {
+  const onChain = new Set(
+    onChainFacetAddresses.map((address) => address.toLowerCase())
+  )
+  return candidateFacetNames.filter((name) => {
+    const address = deployedContracts[name]
+    return typeof address === 'string' && onChain.has(address.toLowerCase())
+  })
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-684 (and the incident it traces to, EXSC-682 — Robinhood: `AcrossFacetV4` live without `ReceiverAcrossV4`).

# Why did I implement it this way?

This is a deliberately minimal alternative to #2125, scoped to only the gap that caused the incident: a facet can go live in a diamond while its destination-side companion periphery contract is silently absent, so bridges out work but bridges in have nothing to complete them. The health check verified facets and periphery independently and never tied the two together.

The gate answers exactly two questions per chain, and nothing more:

- **Is the facet live?** Its `deployments/<network>.json` address is one the diamond returns from `facets()`. This is an address-membership test against `ctx.onChainFacets` (already read by `facets-registered`) — no new RPC, no compiled-selector reconstruction.
- **Is the companion registered?** One `getPeripheryContract()` read per companion. A read that fails is *undetermined* (warning), never treated as absence — one flaky RPC must not raise a false error gate. There is no deploy-log fallback: a check born from bookkeeping diverging from on-chain reality must not fall back to bookkeeping.

Coupling data lives in `config/global.json` → `facetPeripheryCouplings` (facet → `requiresAnyOf`, with optional per-network `notRequiredOn` carve-outs that are always printed so they are never invisible).

**Scope, on purpose.** The reverse gap — a facet live on chain but absent from the deploy log — is left to the existing `no-unexpected-facets` warning, not reconstructed here from artifact selectors. This PR excludes everything from #2125 that is not the Robinhood fix: `immutable-bindings-match-config`, the `periphery-registry-log-sync` warning, the registry-first refactor of the receiver invariants, the deploy-time reminder scripts, the `skipHealthcheck` → config-exclusions change, and the deploy-log backfills. Those are separable and can be judged on their own merits.

**Size:** 4 files, +469 (of which 155 are tests and 136 the config-reader module), versus ~8k lines across 54 files in #2125.

**Tests / checks:** `tsc-files`, `eslint`, and `bun test` on the new module (12/12) all pass; the existing `healthCheckInvariants.test.ts` suite still passes (43/43). The pure helpers have full coverage; the invariant's `run()` is exercised by live health-check runs (a fake-ctx unit test can be added if we want parity with #2125).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
