### PR TITLE
fix(parked-tasks): reject enqueue for networks not active in networks.json

### DIFF
--- a/.agents/commands/deprecate-contract.md
+++ b/.agents/commands/deprecate-contract.md
@@ -106,10 +106,14 @@ The command performs these steps in order:
    and [docs/FacetRemovalReconciliation.md](../../docs/FacetRemovalReconciliation.md).
 
    - **What to park**: for each deprecated facet, one parked task per PRODUCTION
-     network whose **deploy log** (`deployments/<network>.json`) lists it — that
-     log is the authoritative facet → address map. Read the diamond address and
-     the facet address from that log; do **not** delete those entries yet
-     (see step 7).
+     network that (a) is **active** in `config/networks.json` **and** (b) whose
+     **deploy log** (`deployments/<network>.json`) lists the facet — that log is
+     the authoritative facet → address map. Read the diamond address and the facet
+     address from that log; do **not** delete those entries yet (see step 7).
+     Skip any network absent from `networks.json`: deprecated networks keep their
+     deploy logs but are gone from `networks.json`, so a task parked for one can
+     never be resolved by the reconcile/drain (which route via `networks.json`).
+     The enqueue CLI enforces this too and rejects a non-active network.
    - **Park last, after the deprecation PR exists.** Each parked task **requires**
      the originating PR URL (`--prUrl`) so the reviewer sees it at signing, and
      that URL only exists once `gh pr create` has returned it. So the enqueue is

--- a/script/deploy/safe/enqueue-parked-task.ts
+++ b/script/deploy/safe/enqueue-parked-task.ts
@@ -20,6 +20,7 @@ import * as dotenv from 'dotenv'
 import { getAddress, type Address } from 'viem'
 
 import { EnvironmentEnum } from '../../common/types'
+import { networks } from '../../utils/viemScriptHelpers'
 
 import {
   enqueueParkedTask,
@@ -119,9 +120,20 @@ const main = defineCommand({
       process.exit(1)
     }
 
+    const network = args.network.trim().toLowerCase()
+    if (networks[network]?.status !== 'active') {
+      consola.error(
+        `Network "${network}" is not an active network in config/networks.json — refusing to ` +
+          `park a removal the reconcile/drain can never resolve. A deprecated network's deploy ` +
+          `logs may still list the facet, but the network is gone; run /deprecate-network to ` +
+          `delete its deploy logs instead of parking a task.`
+      )
+      process.exit(1)
+    }
+
     const input: IParkedTaskInput = {
       kind: 'facet-removal',
-      network: args.network.toLowerCase(),
+      network,
       environment: EnvironmentEnum.production,
       facetName: args.facetName,
       diamondAddress: requireAddress('diamondAddress', args.diamondAddress),

--- a/script/deploy/safe/enqueue-parked-task.ts
+++ b/script/deploy/safe/enqueue-parked-task.ts
@@ -20,9 +20,9 @@ import * as dotenv from 'dotenv'
 import { getAddress, type Address } from 'viem'
 
 import { EnvironmentEnum } from '../../common/types'
-import { networks } from '../../utils/viemScriptHelpers'
 
 import {
+  assertActiveNetwork,
   enqueueParkedTask,
   getParkedTasksCollection,
   type IParkedTaskInput,
@@ -120,14 +120,11 @@ const main = defineCommand({
       process.exit(1)
     }
 
-    const network = args.network.trim().toLowerCase()
-    if (networks[network]?.status !== 'active') {
-      consola.error(
-        `Network "${network}" is not an active network in config/networks.json — refusing to ` +
-          `park a removal the reconcile/drain can never resolve. A deprecated network's deploy ` +
-          `logs may still list the facet, but the network is gone; run /deprecate-network to ` +
-          `delete its deploy logs instead of parking a task.`
-      )
+    let network: string
+    try {
+      network = assertActiveNetwork(args.network)
+    } catch (error: unknown) {
+      consola.error(error instanceof Error ? error.message : String(error))
       process.exit(1)
     }
 

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -29,6 +29,7 @@ import { type Address } from 'viem'
 import { EnvironmentEnum } from '../../common/types'
 
 import {
+  assertActiveNetwork,
   claimForProposal,
   computeTaskKey,
   enqueueParkedTask,
@@ -240,6 +241,22 @@ describe('computeTaskKey', () => {
   })
 })
 
+describe('assertActiveNetwork', () => {
+  it('returns the trimmed, lowercased key for an active network', () => {
+    expect(assertActiveNetwork('  Arbitrum ')).toBe('arbitrum')
+  })
+
+  it('throws "not in config" for a network absent from networks.json', () => {
+    expect(() => assertActiveNetwork('evmos')).toThrow(
+      /not in config\/networks\.json/
+    )
+  })
+
+  it('throws "not active" for a present-but-inactive network', () => {
+    expect(() => assertActiveNetwork('localanvil')).toThrow(/not active/)
+  })
+})
+
 describe('enqueueParkedTask', () => {
   it('inserts a queued task and stamps taskKey/status/createdAt', async () => {
     const coll = createFakeCollection()
@@ -314,11 +331,11 @@ describe('enqueueParkedTask', () => {
     expect(coll.rows).toHaveLength(0)
   })
 
-  it('throws when the network is not in config/networks.json', async () => {
+  it('throws when the network is absent from config/networks.json', async () => {
     const coll = createFakeCollection()
     await expectRejects(
       enqueueParkedTask(coll, buildInput({ network: 'evmos' })),
-      /not an active network/
+      /not in config\/networks\.json/
     )
     expect(coll.rows).toHaveLength(0)
   })
@@ -327,7 +344,7 @@ describe('enqueueParkedTask', () => {
     const coll = createFakeCollection()
     await expectRejects(
       enqueueParkedTask(coll, buildInput({ network: 'localanvil' })),
-      /not an active network/
+      /not active/
     )
     expect(coll.rows).toHaveLength(0)
   })

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -314,6 +314,24 @@ describe('enqueueParkedTask', () => {
     expect(coll.rows).toHaveLength(0)
   })
 
+  it('throws when the network is not in config/networks.json', async () => {
+    const coll = createFakeCollection()
+    await expectRejects(
+      enqueueParkedTask(coll, buildInput({ network: 'evmos' })),
+      /not an active network/
+    )
+    expect(coll.rows).toHaveLength(0)
+  })
+
+  it('throws when the network exists but is not active', async () => {
+    const coll = createFakeCollection()
+    await expectRejects(
+      enqueueParkedTask(coll, buildInput({ network: 'localanvil' })),
+      /not an active network/
+    )
+    expect(coll.rows).toHaveLength(0)
+  })
+
   it('trims network, facetName and prUrl before storing/keying', async () => {
     const coll = createFakeCollection()
     await enqueueParkedTask(

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -44,6 +44,7 @@ import { type Address } from 'viem'
 
 import { type EnvironmentEnum } from '../../common/types'
 import { getEnvVar } from '../../utils/utils'
+import { networks } from '../../utils/viemScriptHelpers'
 
 /** Database for the deferred diamond-cleanup queue inside the non-sensitive `MONGODB_URI` cluster. */
 const PARKED_TASKS_DB_NAME = 'deferred-cleanup'
@@ -291,11 +292,19 @@ export async function getParkedTasksCollection(): Promise<{
  * because `taskKey` is built from `network`+`facetName` and a stray space would
  * silently mint a distinct, undeduplicated task for the same facet.
  *
+ * The network must be `active` in `config/networks.json`. Deploy logs outlive a
+ * network's removal from `networks.json` (deprecated networks keep their
+ * `deployments/<network>.json` snapshot), so a deploy-log-driven caller could
+ * otherwise park a task for a network the reconcile/drain resolves against
+ * `networks.json` and can never route — the failure mode that took down the
+ * scheduled reconcile.
+ *
  * @param parkedTasks - The queue collection.
  * @param input - Task identity + snapshots + required `prUrl` + enqueuer.
  * @returns The insert result, or `null` if a duplicate open task already exists.
  * @throws Error if `prUrl` or `facetName` is missing or blank (prUrl is the
- *   PR-link requirement, spec §6; facetName is the task identity).
+ *   PR-link requirement, spec §6; facetName is the task identity), or if
+ *   `network` is not an active network in `config/networks.json`.
  */
 export async function enqueueParkedTask(
   parkedTasks: Collection<IParkedTask>,
@@ -309,6 +318,13 @@ export async function enqueueParkedTask(
     throw new Error('facetName is required to park a facet-removal task')
 
   const network = input.network.trim().toLowerCase()
+  if (networks[network]?.status !== 'active')
+    throw new Error(
+      `Network "${network}" is not an active network in config/networks.json — refusing to ` +
+        `park a facet-removal task the reconcile/drain can never resolve. A deprecated network's ` +
+        `deploy logs may still list the facet, but the network is gone; run /deprecate-network to ` +
+        `delete its deploy logs instead of parking a removal.`
+    )
   const facetName = input.facetName.trim()
   const doc: IParkedTask = {
     ...input,

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -281,6 +281,39 @@ export async function getParkedTasksCollection(): Promise<{
 }
 
 /**
+ * Normalises `network` (trim + lowercase) and asserts it is an `active` network in
+ * `config/networks.json`, returning the normalised key. Both the enqueue chokepoint
+ * and the CLI validate through here so the rule and its message have one source.
+ *
+ * Deploy logs outlive a network's removal from `networks.json` (deprecated networks
+ * keep their `deployments/<network>.json` snapshot), so a deploy-log-driven caller
+ * could otherwise park a task the reconcile/drain — which routes via `networks.json`
+ * — can never resolve. The two rejections are distinct: an **absent** network is
+ * deprecated/gone (clean it up via `/deprecate-network`); a **present-but-inactive**
+ * one exists in config but is not parkable.
+ *
+ * @param network - Raw network slug (any case, untrimmed).
+ * @returns The normalised (trimmed, lowercased) network key.
+ * @throws Error if the network is absent from, or not `active` in, `config/networks.json`.
+ */
+export function assertActiveNetwork(network: string): string {
+  const normalized = network.trim().toLowerCase()
+  const status = networks[normalized]?.status
+  if (status === 'active') return normalized
+  if (status === undefined)
+    throw new Error(
+      `Network "${normalized}" is not in config/networks.json — refusing to park a ` +
+        `facet-removal task the reconcile/drain can never resolve. A deprecated network's ` +
+        `deploy logs may still list the facet, but the network is gone; run /deprecate-network ` +
+        `to delete its deploy logs instead of parking a removal.`
+    )
+  throw new Error(
+    `Network "${normalized}" is "${status}" (not active) in config/networks.json — refusing ` +
+      `to park a facet-removal task; only active networks are parkable.`
+  )
+}
+
+/**
  * Enqueues a parked task. Fills `taskKey`, `status: 'queued'` and `createdAt`,
  * then inserts. A duplicate open task (same `taskKey` while queued/proposed) hits
  * the partial unique index → E11000 → returns `null` (a repeat deprecation of the
@@ -292,12 +325,9 @@ export async function getParkedTasksCollection(): Promise<{
  * because `taskKey` is built from `network`+`facetName` and a stray space would
  * silently mint a distinct, undeduplicated task for the same facet.
  *
- * The network must be `active` in `config/networks.json`. Deploy logs outlive a
- * network's removal from `networks.json` (deprecated networks keep their
- * `deployments/<network>.json` snapshot), so a deploy-log-driven caller could
- * otherwise park a task for a network the reconcile/drain resolves against
- * `networks.json` and can never route — the failure mode that took down the
- * scheduled reconcile.
+ * The network is validated and normalised via {@link assertActiveNetwork} — it
+ * must be `active` in `config/networks.json`, else the reconcile/drain could never
+ * resolve the task (the failure mode that took down the scheduled reconcile).
  *
  * @param parkedTasks - The queue collection.
  * @param input - Task identity + snapshots + required `prUrl` + enqueuer.
@@ -317,14 +347,7 @@ export async function enqueueParkedTask(
   if (!input.facetName || input.facetName.trim() === '')
     throw new Error('facetName is required to park a facet-removal task')
 
-  const network = input.network.trim().toLowerCase()
-  if (networks[network]?.status !== 'active')
-    throw new Error(
-      `Network "${network}" is not an active network in config/networks.json — refusing to ` +
-        `park a facet-removal task the reconcile/drain can never resolve. A deprecated network's ` +
-        `deploy logs may still list the facet, but the network is gone; run /deprecate-network to ` +
-        `delete its deploy logs instead of parking a removal.`
-    )
+  const network = assertActiveNetwork(input.network)
   const facetName = input.facetName.trim()
   const doc: IParkedTask = {
     ...input,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-764](https://linear.app/lifi-linear/issue/EXSC-764/parked-task-enqueue-reject-networks-not-active-in-networksjson)

# Why did I implement it this way?

The scheduled `reconcile-parked-tasks` workflow crashed with `Chain evmos does not exist in config/networks.json` and aborted the entire run. The cause is a source-of-truth mismatch: the parked-task **enqueue** path (driven by `/deprecate-contract`) enumerates target networks from the **deploy logs** (`deployments/<network>.json`), which outlive a network's removal from `config/networks.json`. A deprecated network like `evmos` (a 2022 deployment) keeps its deploy log, so a facet-removal task was parked for it — but the **reconcile/drain** path resolves chains via `networks.json`, where `evmos` no longer exists, so it threw and blocked reconciliation for every other network. `evmos` is one of 9 orphaned networks that have deploy logs but no `networks.json` entry.

The fix makes `networks.json` authoritative at write time. The guard lives in `enqueueParkedTask` — the single enqueue chokepoint that already validates `prUrl`/`facetName` — so every caller (CLI, `/deprecate-contract`, the future drain) is covered; it throws unless the network is `status: 'active'` in `config/networks.json`. A matching fail-fast pre-check in the `enqueue-parked-task.ts` CLI gives a clean exit before the Mongo connect, mirroring the existing `prUrl`/`facetName` belt-and-suspenders pattern. The predicate reuses the canonical `networks` map from `viemScriptHelpers` (the same `status === 'active'` definition `getAllActiveNetworks` uses), so no new config reader is introduced. The already-parked `evmos` task was separately cancelled to unblock the current run; two follow-ups (reconcile skip-and-warn resilience, and cleaning up the 9 orphaned deploy logs) are noted on the ticket and left out of this PR to keep it single-concern.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
