### PR TITLE
fix(VaultWrapper): review follow-ups (deposits, fees, OZ v5, docs)

### DIFF
--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -44,6 +44,27 @@ the initial fee configuration, receivers, and access gate; resolves the ERC-20
 asset via the adapter; derives the virtual-share offset from the asset decimals;
 and anchors the performance watermark at the empty-vault share price.
 
+## Upgradeability and the FACTORY binding
+
+Instances are `BeaconProxy` contracts; the `UpgradeableBeacon` is owned by the
+subsystem's 48h timelock, so a `upgradeTo` repoints every live instance to a new
+implementation at once. `FACTORY` is an **implementation immutable** (bytecode, not
+proxy storage), and it is the source every instance reads for the factory-level
+global circuit breaker (`globalPaused`), fee bounds, and `lifiFeeRecipient`, as well
+as the `initialize` caller check.
+
+Because that reference lives in implementation bytecode rather than per-instance
+storage, a beacon upgrade to an implementation constructed with a **different**
+factory address silently repoints all live instances' config authority — for
+example flipping `globalPaused` to `false` across every wrapper — with no
+per-instance migration or event beyond the beacon's generic `Upgraded`.
+
+Operational invariant: every implementation the beacon points to must be
+constructed with the same factory address. Upgrade tooling must assert
+`newImpl.FACTORY() == oldImpl.FACTORY()` before repointing the beacon (mirroring the
+deploy script's `_verifyWiring` check), and the change is only reachable through the
+48h timelock, which can already replace the implementation with arbitrary logic.
+
 ## Fee config getters
 
 ```solidity

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -780,7 +780,11 @@ contract LiFiVaultWrapper is
     ///      from disabled re-anchors the watermark UP to the current share price when
     ///      that is higher, so gains made while it was disabled are never charged
     ///      retroactively; it never moves the watermark down, so toggling the fee off
-    ///      and on after a drawdown cannot re-charge the recovery to the old peak.
+    ///      and on after a drawdown cannot re-charge the recovery to the old peak. The
+    ///      re-anchor is skipped while supply is zero: with no holders there is no
+    ///      disabled-period growth to exclude, and the price per share at zero supply is
+    ///      measured against the virtual offset alone, so a dust donation would otherwise
+    ///      park the watermark permanently out of reach.
     /// @param _feeType The fee type to update.
     /// @param _newRateBps The new rate in basis points (0 disables the fee).
     function setFeeRate(
@@ -796,7 +800,9 @@ contract LiFiVaultWrapper is
             if (_newRateBps < minBps || _newRateBps > maxBps)
                 revert FeeRateOutOfBounds(_newRateBps, minBps, maxBps);
             if (
-                _feeType == FeeType.Performance && _feeConfig.rateBps[idx] == 0
+                _feeType == FeeType.Performance &&
+                _feeConfig.rateBps[idx] == 0 &&
+                totalSupply() != 0
             ) {
                 uint192 currentPps = SafeCast.toUint192(
                     LibVaultWrapperMath.pricePerShare(

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -643,12 +643,14 @@ contract LiFiVaultWrapper is
     /// @dev Deposit-side supply floor: after a non-zero deposit/mint the total supply must
     ///      be at least `MIN_SHARE_SUPPLY`, so no depositor ever transacts against a
     ///      dust-sized share denominator (the first-depositor inflation attack's
-    ///      precondition) — the existing supply plus the deposit's own mint always sum
-    ///      to the floor, capping a donation-griefer's damage at ~`1/MIN_SHARE_SUPPLY`
-    ///      of the donation. A post-operation supply of exactly zero is rejected too:
-    ///      that is only reachable when a non-zero deposit mints zero shares (its assets
-    ///      rounded away against a donation-inflated, zero-supply vault), which would
-    ///      forward the caller's assets into the yield source for no shares — a 100% loss.
+    ///      precondition), capping a donation-griefer's damage at ~`1/MIN_SHARE_SUPPLY`
+    ///      of the donation. A post-operation supply of exactly zero is rejected here too:
+    ///      it is reached when a non-zero deposit mints zero shares against a
+    ///      donation-inflated *empty* vault. The complementary case — a non-zero deposit
+    ///      minting zero shares while supply already sits at or above the floor (parked
+    ///      there by prior floor-exempt exits, then donation-inflated) — passes this check
+    ///      and is caught instead by the `shares == 0` guard in `_deposit`: a passing
+    ///      supply check alone does not imply the deposit minted anything.
     ///      A zero-amount `deposit(0)`/`mint(0)` moves nothing and mints nothing, so the
     ///      caller skips this check entirely: the no-op stays a no-op even in a sub-floor
     ///      state. Exits are also deliberately exempt (they never call this): `_accrueFees`
@@ -659,8 +661,9 @@ contract LiFiVaultWrapper is
     ///      limit views (a documented EIP-4626 deviation): with the offset floored at
     ///      `MIN_DECIMALS_OFFSET`, an ordinary deposit into a clean vault always clears the
     ///      floor, so the only amounts `<= maxDeposit` that still revert are non-zero
-    ///      deposits into a donation-inflated empty vault or an exit-stranded sub-floor
-    ///      vault — edge states not worth modeling in the limit views.
+    ///      deposits that mint zero shares against a donation-inflated vault and deposits
+    ///      into an exit-stranded sub-floor vault — edge states not worth modeling in the
+    ///      limit views.
     function _enforceSupplyFloor() private view {
         uint256 supply = totalSupply();
         if (supply < MIN_SHARE_SUPPLY)
@@ -675,11 +678,15 @@ contract LiFiVaultWrapper is
     ///      whole — sub-fee-denominator dust — input, or a bare zero deposit) skips the adapter
     ///      call entirely: there is nothing to invest, the fee is already routed, and a standard
     ///      ERC-4626 source reverts on a zero-asset forward, so short-circuiting keeps `deposit`
-    ///      non-reverting in exactly the cases where `previewDeposit` returns 0. Pause is
-    ///      enforced upstream in `deposit`/`mint`. Both `deposit` and `mint` route through
-    ///      this seam, so the post-operation supply floor is enforced here once for every
-    ///      inflow entrypoint (a zero-amount call mints nothing and skips it); exits go
-    ///      through `_withdraw` and are structurally exempt (see `_enforceSupplyFloor`).
+    ///      non-reverting in exactly the cases where `previewDeposit` returns 0. A deposit
+    ///      that would forward a non-zero net amount yet minted zero shares (assets rounded
+    ///      away against a donation-inflated price while supply sits at/above the floor)
+    ///      reverts `ZeroSharesMinted` before the forward, so the caller never loses assets
+    ///      to the pool for no shares. Pause is enforced upstream in `deposit`/`mint`. Both
+    ///      `deposit` and `mint` route through this seam, so the post-operation supply floor
+    ///      is enforced here once for every inflow entrypoint (a zero-amount call mints
+    ///      nothing and skips it); exits go through `_withdraw` and are structurally exempt
+    ///      (see `_enforceSupplyFloor`).
     function _deposit(
         address caller,
         address receiver,
@@ -696,6 +703,7 @@ contract LiFiVaultWrapper is
         _routeFee(FeeType.Deposit, depositFee);
         uint256 invested = assets - depositFee;
         if (invested == 0) return;
+        if (shares == 0) revert ZeroSharesMinted(assets);
 
         uint256 deposited = _routeThroughAdapter(
             abi.encodeCall(

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -785,12 +785,16 @@ contract LiFiVaultWrapper is
     ///      disabled-period growth to exclude, and the price per share at zero supply is
     ///      measured against the virtual offset alone, so a dust donation would otherwise
     ///      park the watermark permanently out of reach.
+    ///      `nonReentrant` because this is the only `_accrueFees` caller outside the entry/
+    ///      exit/`distributeFees` guard: without it, a payout hook fired during
+    ///      `distributeFees` could reenter here (owner-controlled receiver), book fresh fees,
+    ///      and have them erased by that call's post-transfer counter rewrite.
     /// @param _feeType The fee type to update.
     /// @param _newRateBps The new rate in basis points (0 disables the fee).
     function setFeeRate(
         FeeType _feeType,
         uint16 _newRateBps
-    ) external onlyOwner {
+    ) external onlyOwner nonReentrant {
         _accrueFees();
 
         uint8 idx = uint8(_feeType);

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -804,22 +804,23 @@ contract LiFiVaultWrapper is
             if (_newRateBps < minBps || _newRateBps > maxBps)
                 revert FeeRateOutOfBounds(_newRateBps, minBps, maxBps);
             if (
-                _feeType == FeeType.Performance &&
-                _feeConfig.rateBps[idx] == 0 &&
-                totalSupply() != 0
+                _feeType == FeeType.Performance && _feeConfig.rateBps[idx] == 0
             ) {
-                uint192 currentPps = SafeCast.toUint192(
-                    LibVaultWrapperMath.pricePerShare(
-                        totalSupply(),
-                        totalAssets(),
-                        _decimalsOffset()
-                    )
-                );
-                // Up-only: anchoring below the stored watermark would let the owner
-                // toggle the fee off/on at a trough and charge the recovery back to
-                // the old peak — the double-charge the watermark exists to prevent.
-                if (currentPps > perfHighWaterMarkPps) {
-                    perfHighWaterMarkPps = currentPps;
+                uint256 supply = totalSupply();
+                if (supply != 0) {
+                    uint192 currentPps = SafeCast.toUint192(
+                        LibVaultWrapperMath.pricePerShare(
+                            supply,
+                            totalAssets(),
+                            _decimalsOffset()
+                        )
+                    );
+                    // Up-only: anchoring below the stored watermark would let the owner
+                    // toggle the fee off/on at a trough and charge the recovery back to
+                    // the old peak — the double-charge the watermark exists to prevent.
+                    if (currentPps > perfHighWaterMarkPps) {
+                        perfHighWaterMarkPps = currentPps;
+                    }
                 }
             }
         }

--- a/src/VaultWrapper/access/ReferenceAccessGate.sol
+++ b/src/VaultWrapper/access/ReferenceAccessGate.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
-import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import { IAccessGate } from "lifi/VaultWrapper/interfaces/IAccessGate.sol";
-import { InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 
 /// @title ReferenceAccessGate
 /// @author LI.FI (https://li.fi)
@@ -23,7 +23,12 @@ import { InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 ///      live feed can instead back `isSanctioned` with a call to an external Chainalysis
 ///      `SanctionsList`, whose `isSanctioned(address)` signature is identical.
 /// @custom:version 1.0.0
-contract ReferenceAccessGate is TransferrableOwnership, IAccessGate {
+contract ReferenceAccessGate is Ownable2Step, IAccessGate {
+    /// Errors ///
+
+    /// @notice Thrown when `renounceOwnership` is called: the gate must never be ownerless.
+    error RenounceDisabled();
+
     /// Storage ///
 
     /// @notice Whether allowlisting is enforced; when false, every non-blocked account may enter.
@@ -49,13 +54,18 @@ contract ReferenceAccessGate is TransferrableOwnership, IAccessGate {
     /// @notice Initializes the gate with an owner and starting allowlist mode.
     /// @param _owner The address that manages the lists and configuration.
     /// @param _allowlistEnabled Whether allowlist enforcement starts on.
-    constructor(
-        address _owner,
-        bool _allowlistEnabled
-    ) TransferrableOwnership(_owner) {
-        if (_owner == address(0)) revert InvalidConfig();
-
+    constructor(address _owner, bool _allowlistEnabled) Ownable(_owner) {
         allowlistEnabled = _allowlistEnabled;
+    }
+
+    /// Ownership ///
+
+    /// @notice Disabled: the gate must never be left ownerless.
+    /// @dev Ownership rotates via OZ's two-step `transferOwnership`/`acceptOwnership`;
+    ///      `renounceOwnership` is the only OZ path to `owner == address(0)` and is
+    ///      overridden to always revert, mirroring the vault wrapper's admin role.
+    function renounceOwnership() public pure override {
+        revert RenounceDisabled();
     }
 
     /// Views ///

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -5,7 +5,6 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
-import { LibAsset } from "../../Libraries/LibAsset.sol";
 
 /// @title ERC4626Adapter
 /// @author LI.FI (https://li.fi)
@@ -32,7 +31,7 @@ contract ERC4626Adapter is IYieldAdapter {
     function resolveAsset(
         address _underlying
     ) external view returns (address asset) {
-        if (!LibAsset.isContract(_underlying)) revert AssetResolutionFailed();
+        if (_underlying.code.length == 0) revert AssetResolutionFailed();
         asset = IERC4626(_underlying).asset();
         if (asset == address(0)) revert AssetResolutionFailed();
     }

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -144,6 +144,11 @@ interface ILiFiVaultWrapper {
     /// @notice Thrown when a deposit or mint would leave the total share supply below the
     ///         minimum supply floor (a post-operation supply of exactly zero included).
     error SupplyBelowMinimum(uint256 supply, uint256 minSupply);
+    /// @notice Thrown when a deposit would forward a non-zero net amount into the yield
+    ///         source yet mint zero shares (its assets rounded away against a
+    ///         donation-inflated price per share while supply sits at or above the
+    ///         floor) — otherwise the caller's assets are lost to the pool for no shares.
+    error ZeroSharesMinted(uint256 assets);
     /// @notice Thrown at initialization when the asset's ERC-20 decimals() cannot be read
     ///         as a well-formed uint8, so the virtual-share offset cannot be sized safely.
     error AssetDecimalsUnavailable();

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -270,6 +270,31 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertGt(_accruedFeeShares(), 0);
     }
 
+    function test_SetFeeRateEnableAtZeroSupplyIgnoresDonatedPrice() public {
+        _stackWithFactory(0); // performance disabled, no deposits — supply stays 0
+
+        uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
+
+        // Donate underlying shares straight to the wrapper: totalAssets() reports them
+        // as AUM while the real share supply is still zero, so the price per share is
+        // measured against the virtual offset alone and reads far above par.
+        uint256 donation = 1_000e18;
+        asset.mint(address(this), donation);
+        asset.approve(address(underlying), donation);
+        underlying.deposit(donation, address(wrapper));
+
+        assertEq(wrapper.totalSupply(), 0);
+        assertGt(_pps(), hwmBefore);
+
+        vm.prank(vaultAdmin);
+        wrapper.setFeeRate(FeeType.Performance, PERF_RATE);
+
+        // The watermark must ignore the donation-inflated price and stay at par;
+        // otherwise it parks permanently above any reachable price and the
+        // performance fee accrues zero for the vault's entire life.
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
+    }
+
     function test_SetFeeRateToggleAtTroughCannotLowerWatermark() public {
         _stackWithFactory(PERF_RATE);
         _deposit(alice, DEPOSIT);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -353,7 +353,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         // The victim's deposit rounds to zero shares against the inflated price. Without
         // the zero-supply guard this would forward the assets for no shares (100% loss);
-        // the floor must reject it.
+        // the floor must reject it (post-operation supply stays 0).
         uint256 victimDeposit = 1e18;
         asset.mint(victim, victimDeposit);
         vm.startPrank(victim);
@@ -365,6 +365,45 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
                 ILiFiVaultWrapper.SupplyBelowMinimum.selector,
                 0,
                 MIN_SHARE_SUPPLY
+            )
+        );
+
+        wrapper.deposit(victimDeposit, victim);
+        vm.stopPrank();
+    }
+
+    function testRevert_ZeroShareDepositAtParkedSupplyFloor() public {
+        // The supply floor alone does not catch a zero-share deposit: an attacker parks
+        // the supply at exactly MIN_SHARE_SUPPLY with a dust deposit (exits are
+        // floor-exempt, so any supply >= the floor is reachable and holdable), then
+        // donates source shares to inflate the price. A later non-zero deposit rounds to
+        // zero shares while supply stays at the floor, so `_enforceSupplyFloor` passes —
+        // the `shares == 0` guard must reject it, else the assets are forwarded for free.
+        _deposit(attacker, 1);
+        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+
+        MockERC4626 source = MockERC4626(address(underlying));
+        uint256 donated = 3_000_000e18;
+        asset.mint(attacker, donated);
+        vm.startPrank(attacker);
+        asset.approve(address(source), donated);
+        uint256 donatedShares = source.deposit(donated, attacker);
+        source.transfer(address(wrapper), donatedShares);
+        vm.stopPrank();
+
+        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertGt(wrapper.totalAssets(), 0);
+
+        uint256 victimDeposit = 1e18;
+        asset.mint(victim, victimDeposit);
+        vm.startPrank(victim);
+        asset.approve(address(wrapper), victimDeposit);
+        assertEq(wrapper.previewDeposit(victimDeposit), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILiFiVaultWrapper.ZeroSharesMinted.selector,
+                victimDeposit
             )
         );
 

--- a/test/solidity/VaultWrapper/VaultWrapperFeeReentrancy.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeReentrancy.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { Test } from "forge-std/Test.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { FeeType, FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+
+interface IReenterHook {
+    function onTokensReceived() external;
+}
+
+/// @notice ERC20 whose `transfer` hands control to a registered recipient mid-transfer,
+///         modelling an ERC-777-style asset. Used to drive a reentrant `setFeeRate` from
+///         inside a `distributeFees` payout.
+contract ReenteringHookERC20 is MockERC20 {
+    address public hookTarget;
+
+    constructor() MockERC20("Hook", "HK", 18) {}
+
+    function setHookTarget(address _target) external {
+        hookTarget = _target;
+    }
+
+    function transfer(
+        address _to,
+        uint256 _amount
+    ) public override returns (bool ok) {
+        ok = super.transfer(_to, _amount);
+        if (hookTarget != address(0) && _to == hookTarget) {
+            IReenterHook(_to).onTokensReceived();
+        }
+    }
+}
+
+/// @notice The wrapper `owner` AND an integrator fee receiver. When paid its fee share it
+///         reenters `setFeeRate` (permitted by `onlyOwner`, since it is the owner) to change
+///         a rate mid-distribution — the reentrancy the guard must block.
+contract ReenteringFeeOwner is IReenterHook {
+    LiFiVaultWrapper private wrapper;
+    FeeType private feeType;
+    uint16 private sentinelRate;
+
+    function configure(
+        LiFiVaultWrapper _wrapper,
+        FeeType _feeType,
+        uint16 _sentinelRate
+    ) external {
+        wrapper = _wrapper;
+        feeType = _feeType;
+        sentinelRate = _sentinelRate;
+    }
+
+    function onTokensReceived() external override {
+        wrapper.setFeeRate(feeType, sentinelRate);
+    }
+}
+
+/// @notice Regression for the #2092 review finding 6: `distributeFees` rewrites the fee
+///         counters after the payout transfers, so a fee booked reentrantly during a
+///         transfer hook would be erased. `setFeeRate` is the only `_accrueFees` caller
+///         outside the entry/exit/`distributeFees` reentrancy guard; guarding it makes the
+///         post-transfer rewrite safe. This suite proves a payout hook cannot reenter it.
+contract VaultWrapperFeeReentrancyTest is Test {
+    ReenteringHookERC20 internal asset;
+    MockERC4626 internal underlying;
+    ERC4626Adapter internal adapter;
+    UpgradeableBeacon internal beacon;
+    LiFiVaultWrapperFactory internal factory;
+    LiFiVaultWrapper internal wrapper;
+    ReenteringFeeOwner internal ownerHook;
+
+    address internal owner = makeAddr("owner");
+    address internal onboarder = makeAddr("onboarder");
+    address internal lifiRecipient = makeAddr("lifiRecipient");
+    address internal alice = makeAddr("alice");
+
+    uint256 internal constant DEPOSIT = 1_000e18;
+    uint16 internal constant SPLIT = 8000; // 80% integrator / 20% LI.FI
+    uint16 internal constant DEP_RATE = 100; // 1%
+    uint16 internal constant WD_RATE = 100; // 1%
+    uint16 internal constant SENTINEL_RATE = 200; // distinct in-bounds rate the hook tries to set
+
+    function setUp() public {
+        asset = new ReenteringHookERC20();
+        underlying = new MockERC4626(asset, "Yield Token", "yTKN");
+        adapter = new ERC4626Adapter();
+        ownerHook = new ReenteringFeeOwner();
+
+        // The implementation binds the factory allowed to call initialize; the factory is
+        // the second CREATE after the implementation (beacon in between).
+        address predictedFactory = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
+        beacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper(predictedFactory)),
+            address(this)
+        );
+        factory = new LiFiVaultWrapperFactory(
+            address(beacon),
+            owner,
+            makeAddr("pauser"),
+            onboarder,
+            lifiRecipient
+        );
+
+        vm.startPrank(owner);
+        factory.setAdapterApproved(address(adapter), true);
+        factory.setUnderlyingAllowed(address(underlying), true);
+        factory.setFeeBounds(FeeType.Deposit, 0, 2000);
+        factory.setFeeBounds(FeeType.Withdrawal, 0, 2000);
+        vm.stopPrank();
+
+        // The reentering hook contract is both the vault owner and the sole integrator fee
+        // receiver, so paying it its asset-side share fires the hook mid-distribution.
+        uint16[4] memory rates = [uint16(0), 0, DEP_RATE, WD_RATE];
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({
+            wallet: address(ownerHook),
+            bps: 10_000
+        });
+
+        vm.prank(onboarder);
+        wrapper = LiFiVaultWrapper(
+            factory.deploy(
+                DeployParams({
+                    namespace: bytes32("Coinbase"),
+                    vaultWrapperAdmin: address(ownerHook),
+                    adapter: address(adapter),
+                    underlying: address(underlying),
+                    nonce: 0,
+                    fees: FeeConfig({ rateBps: rates }),
+                    integratorShareBps: [SPLIT, SPLIT, SPLIT, SPLIT],
+                    accessGate: address(0),
+                    receivers: receivers
+                })
+            )
+        );
+    }
+
+    function test_SetFeeRateCannotBeReenteredFromDistributionHook() public {
+        _deposit(alice, DEPOSIT);
+        asset.setHookTarget(address(ownerHook));
+        ownerHook.configure(wrapper, FeeType.Withdrawal, SENTINEL_RATE);
+
+        uint256 integratorPart = wrapper.integratorFeeAssets();
+        uint256 lifiPart = wrapper.lifiFeeAssets();
+        assertGt(integratorPart, 0);
+        assertGt(lifiPart, 0);
+
+        wrapper.distributeFees(); // must not revert
+
+        // The reentrant setFeeRate reverted under the guard, so its whole transfer reverted:
+        // the integrator payout failed and is retained, and the rate is unchanged. Without the
+        // guard the hook would succeed — paying the wallet and flipping the rate to SENTINEL.
+        assertEq(asset.balanceOf(address(ownerHook)), 0);
+        assertEq(wrapper.integratorFeeAssets(), integratorPart);
+        assertEq(wrapper.feeRate(uint8(FeeType.Withdrawal)), WD_RATE);
+
+        // LI.FI's recipient has no hook, so its side pays out normally and is not held hostage.
+        assertEq(asset.balanceOf(lifiRecipient), lifiPart);
+        assertEq(wrapper.lifiFeeAssets(), 0);
+    }
+
+    function _deposit(address _from, uint256 _amount) internal {
+        asset.mint(_from, _amount);
+        vm.startPrank(_from);
+        asset.approve(address(wrapper), _amount);
+        wrapper.deposit(_amount, _from);
+        vm.stopPrank();
+    }
+}

--- a/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
+++ b/test/solidity/VaultWrapper/access/ReferenceAccessGate.t.sol
@@ -2,9 +2,8 @@
 pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ReferenceAccessGate } from "lifi/VaultWrapper/access/ReferenceAccessGate.sol";
-import { TransferrableOwnership } from "lifi/Helpers/TransferrableOwnership.sol";
-import { InvalidConfig } from "lifi/Errors/GenericErrors.sol";
 
 contract ReferenceAccessGateTest is Test {
     ReferenceAccessGate internal gate;
@@ -25,7 +24,12 @@ contract ReferenceAccessGateTest is Test {
     /// Construction ///
 
     function testRevert_ConstructedWithZeroOwner() public {
-        vm.expectRevert(InvalidConfig.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableInvalidOwner.selector,
+                address(0)
+            )
+        );
         new ReferenceAccessGate(address(0), false);
     }
 
@@ -146,10 +150,21 @@ contract ReferenceAccessGateTest is Test {
 
     /// Ownership ///
 
-    function test_RevertWhen_NonOwnerConfigures() public {
+    function testRevert_NonOwnerConfigures() public {
         vm.prank(alice);
-        vm.expectRevert(TransferrableOwnership.UnAuthorized.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                alice
+            )
+        );
         gate.setAllowlisted(bob, true);
+    }
+
+    function testRevert_RenounceOwnershipDisabled() public {
+        vm.prank(owner);
+        vm.expectRevert(ReferenceAccessGate.RenounceDisabled.selector);
+        gate.renounceOwnership();
     }
 
     /// Events ///


### PR DESCRIPTION
# Which Linear task belongs to this PR?

<!-- No Linear task -->
Follow-up to the #2092 review, continuing after #2097 (findings 2, 3, 8, 9, 10) landed on `dev-vault-wrapper`. Targets `dev-vault-wrapper`, not `main`.

# Why did I implement it this way?

Five independent VaultWrapper review follow-ups, one commit each, all closing gaps left after #2097 pinned the subsystem to OZ v5.6.1 (`^0.8.29`) and re-anchored the performance watermark. Three are behavioral fixes, one is a convention fix, one is documentation.

**Reject zero-share deposits reaching the yield source (finding 1).** The post-operation supply floor rejects a non-zero deposit that mints zero shares only when it drives supply to exactly zero (a donation-inflated *empty* vault). The complementary case — supply already parked at or above the floor by prior floor-exempt exits, then donation-inflated so a non-zero deposit rounds its assets away to zero shares — passed the supply check and forwarded the caller's net assets into the yield source for no shares (a 100% loss). `_deposit` now reverts `ZeroSharesMinted(assets)` after routing the fee and before the adapter forward, so a passing supply-floor check no longer implies the deposit minted anything. The NatSpec on `_enforceSupplyFloor` and `_deposit` is updated to describe the split responsibility.

**Don't re-anchor the performance HWM at zero supply (finding 4).** Re-enabling the performance fee re-anchors the high-water mark up to the current price per share so gains earned while the fee was disabled aren't charged retroactively. At zero supply there are no holders and no disabled-period growth to exclude, and price per share is measured against the virtual offset alone — so a dust donation could park the watermark permanently out of reach. `setFeeRate` now skips the re-anchor while `totalSupply() == 0`.

**Guard `setFeeRate` against reentrant fee accrual (finding 6).** `distributeFees` zeroes the four fee counters (CEI), pays out via the non-reverting `trySafeTransfer`, then rewrites the counters with the retained amounts. `setFeeRate` was the only `_accrueFees` caller *outside* the entry/exit/`distributeFees` reentrancy guard, so with a hook-capable asset (ERC-777-style) an owner-controlled fee receiver could reenter `setFeeRate` from its payout hook, book fresh fees into the just-zeroed counters, and have them erased by the post-transfer rewrite — stranding the freshly minted fee shares. Adding `nonReentrant` to `setFeeRate` makes the rewrite provably safe: a reentrant call now reverts inside the payout's `trySafeTransfer`, so that payout is simply retained (fail-closed, like a blacklisted wallet) and no shares are stranded. Low real-world reach (needs a hook-capable underlying plus a self-interested owner), but the fix is one modifier with no downside.

**Document the beacon-repointable FACTORY invariant (finding 7).** `FACTORY` is an implementation *immutable* (bytecode, not per-instance proxy storage), and it is the source every live instance reads for `globalPaused`, fee bounds, and `lifiFeeRecipient`. A beacon upgrade to an implementation built with a different factory address silently repoints all instances' config authority with no per-instance migration. Rather than add a runtime guard (the change is already gated by the 48h timelock, which can replace the implementation with arbitrary logic anyway), this documents the operational invariant in `docs/VaultWrapper/LiFiVaultWrapper.md`: every implementation the beacon points to must be constructed with the same factory address, and upgrade tooling must assert `newImpl.FACTORY() == oldImpl.FACTORY()` before repointing.

**Drop OZ v4 coupling from the adapter and gate (finding 13).** `[CONV:VW-OZ-VERSION]` mandates OZ v5 only across the subsystem, but two files reached into `src/Libraries/` (which resolves to the Diamond's vendored OZ v4.9.2): `ERC4626Adapter` imported `LibAsset` for `isContract`, and `ReferenceAccessGate` extended the Diamond's `TransferrableOwnership` (itself a v4 dragger). No runtime bug — both compiled — but it violated the version-isolation convention and pulled v4 code into a v5 subsystem. `ERC4626Adapter` now uses inline `_underlying.code.length == 0`; `ReferenceAccessGate` extends OZ v5 `Ownable2Step` with `renounceOwnership` overridden to revert `RenounceDisabled` (the gate must never be left ownerless, mirroring the wrapper). The gate's ownership errors change selectors to OZ's standard `OwnableInvalidOwner` / `OwnableUnauthorizedAccount`; since the gate is a template integrators fork, the standard OZ surface is an improvement. A sweep confirms the subsystem now imports nothing outside its own v5-scoped paths.

Two other review findings were assessed and deliberately not actioned: **finding 5** (a reverting access gate propagates through the `max*` views) — low value, the views are fail-closed by design and a reverting gate is the integrator's own misconfiguration; **finding 14** (entry/exit guards and the `max*` overrides each hit the gate/factory once, so the staticcall runs twice per op) — the duplication is structural (`super.*` re-derives `max*`), the duplicate calls are warm (a few hundred gas on a path that already forwards into a yield source), and both candidate fixes cost more than they save (inlining OZ bodies couples to internals and regresses the exit revert surface; a transient-storage memo is overkill).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
