### PR TITLE
ci(clear-signing): unfreeze sync workflow and pin Foundry via setup-foundry

### DIFF
--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -1,6 +1,6 @@
 # Sync Clear Signing (ERC-7730) Registry
 # - Purpose: Keep `registry/lifi/calldata-LIFIDiamond.json` in the Ethereum Foundation-hosted ERC-7730 registry up to date with this repo's Diamond ABI + deployments AND with the `display.formats` proposal at `config/clearSigningProposal.json`.
-# - Triggers: manual only while frozen for EXSC-738 (monthly cron + push-to-main auto-triggers are commented out below; see the note in the `on:` block).
+# - Triggers: push-to-main on ABI/deployment/proposal-relevant paths (fast path), a monthly cron safety net, and manual workflow_dispatch (with optional dry_run).
 # - Key behaviors: clones our fork (`lifinance/clear-signing-erc7730-registry`, originally forked from LedgerHQ, now tracking the EF-hosted registry), regenerates the JSON with merged `display.formats`, pushes a branch to the fork, creates/updates a PR upstream, and posts the PR link to Slack.
 # - Trust model: this workflow assumes `config/clearSigningProposal.json` is current against the on-chain diamond, which is enforced at PR-merge time by `verifyClearSigning.yml`. If that gate is bypassed, the proposal may be stale.
 # - Note: The ERC-7730 registry moved from `LedgerHQ/clear-signing-erc7730-registry` to `ethereum/clear-signing-erc7730-registry` (Ethereum Foundation now hosts it). The fork retains its original name; only the upstream remote target changed.
@@ -16,27 +16,22 @@ on:
         type: boolean
         required: false
         default: false
-  # TEMPORARY FREEZE (EXSC-738): the schedule + push auto-triggers are disabled
-  # while the upstream PR (ethereum/clear-signing-erc7730-registry#2597) is being
-  # migrated to the v2 test format on the `sync/lifi-erc7730` branch. Both triggers
-  # force-push that branch and would clobber the hand-authored test files. Re-enable
-  # (uncomment both blocks) once #2597 is merged. Manual workflow_dispatch stays live.
-  # schedule:
-  #   # Monthly safety net at 03:00 UTC on the 1st. Push-based triggers below
-  #   # handle the fast path (new facet/deployment lands -> sync within minutes).
-  #   - cron: '0 3 1 * *'
-  # push:
-  #   branches:
-  #     - main # only sync on what's actually been merged
-  #   paths:
-  #     - 'src/Facets/**' # new/changed facets -> new/changed selectors
-  #     - 'src/Libraries/**' # struct definitions used by facets
-  #     - 'deployments/**' # new deployment addresses
-  #     - 'config/networks.json' # chain metadata used by deployments resolver
-  #     - 'config/clearSigningProposal.json' # the display.formats source of truth
-  #     - 'tasks/generateLedgerClearSigning.ts'
-  #     - 'tasks/buildClearSigningProposal.ts'
-  #     - '.github/workflows/syncLedgerClearSigning.yml'
+  schedule:
+    # Monthly safety net at 03:00 UTC on the 1st. Push-based triggers below
+    # handle the fast path (new facet/deployment lands -> sync within minutes).
+    - cron: '0 3 1 * *'
+  push:
+    branches:
+      - main # only sync on what's actually been merged
+    paths:
+      - 'src/Facets/**' # new/changed facets -> new/changed selectors
+      - 'src/Libraries/**' # struct definitions used by facets
+      - 'deployments/**' # new deployment addresses
+      - 'config/networks.json' # chain metadata used by deployments resolver
+      - 'config/clearSigningProposal.json' # the display.formats source of truth
+      - 'tasks/generateLedgerClearSigning.ts'
+      - 'tasks/buildClearSigningProposal.ts'
+      - '.github/workflows/syncLedgerClearSigning.yml'
 
 permissions:
   contents: read # required to fetch repository contents
@@ -69,7 +64,7 @@ jobs:
         run: bun install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
+        uses: ./.github/actions/setup-foundry
 
       - name: Build contracts (generate Foundry artifacts)
         run: forge build --skip script --skip test --skip Base --skip Test --skip '*.t.sol'

--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -39,12 +39,16 @@ permissions:
 jobs:
   sync-ledger:
     concurrency:
-      # Key by event so a manual workflow_dispatch (especially dry_run) can't
-      # cancel an in-progress scheduled or push-triggered production sync.
-      # cancel-in-progress is still per-group: multiple dry-runs cancel each
-      # other, multiple push-triggered runs cancel each other, but the two
-      # never cross-cancel.
-      group: sync-ledger-clear-signing-${{ github.event_name }}
+      # Collapse the two production triggers (schedule + push) into one group so
+      # they never force-push sync/lifi-erc7730 or update the upstream PR
+      # concurrently — a second concurrent run would break the
+      # `--force-with-lease` push or send a duplicate Slack ping.
+      # cancel-in-progress lets a newer production run supersede an in-flight
+      # one; force-push is atomic, so whichever wins leaves a consistent branch
+      # + PR. Manual workflow_dispatch keeps its own group so a dry_run can
+      # neither cancel nor be cancelled by a production sync (and repeated
+      # dispatches still cancel each other).
+      group: sync-ledger-clear-signing-${{ github.event_name == 'workflow_dispatch' && 'dispatch' || 'production' }}
       cancel-in-progress: true
     if: github.repository == 'lifinance/contracts' # upstream-only, see header
     runs-on: ubuntu-latest

--- a/.github/workflows/verifyClearSigning.yml
+++ b/.github/workflows/verifyClearSigning.yml
@@ -40,7 +40,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
+        uses: ./.github/actions/setup-foundry
 
       - name: Build contracts (generate Foundry artifacts)
         run: forge build --skip script --skip test --skip Base --skip Test --skip '*.t.sol'


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-769](https://linear.app/lifi-linear/issue/EXSC-769/make-erc-7730-sync-workflow-test-aware-then-unfreeze-it)

`Ref` (not `Fixes`) intentionally: this PR delivers the unfreeze plus a reproducibility fix, but defers the ticket's "test-aware guard" scope (see below), so the ticket should not auto-close on merge.

# Why did I implement it this way?

The sync bot was frozen in #2172 (schedule + push triggers commented out) to stop it force-pushing `sync/lifi-erc7730` off `upstream/master` and clobbering the hand-authored v2 tests while EF PR #2597 was in flight. #2597 is now merged, so both the regenerated descriptor and the `testsv2` file live on `master`; a fresh bot run branches off a master that already contains that work, and the bot only ever regenerates and commits the descriptor (never the tests file) — so the clobbering risk that motivated the freeze is gone. I verified unfreezing is safe today by diffing the merged master descriptor's clear-signing entries against what this repo generates: all 14 covered test-case selectors render identically (13 byte-identical to our proposal, and `swapTokensGeneric` is preserved unchanged by the merge since our generator no longer emits it), so EF's snapshot runners stay green on the next sync. While re-enabling the workflow I also fixed a reproducibility bug: both clear-signing workflows installed Foundry by calling `foundry-rs/foundry-toolchain` directly at an off-pin v1.3.1, bypassing `.foundry-version` (1.7.1) that every other workflow and the pre-commit hook use — a version skew that could make the `verifyClearSigning` gate and the sync generate different ABI than a developer regenerating locally; both now use the `./.github/actions/setup-foundry` composite action per `[CONV:FOUNDRY-SETUP]`. The ticket's "make the sync test-aware" scope is deferred because investigation showed EF's `notify-missing-tests` gate fires only when a descriptor has no `testsv2` file at all (ours has one) rather than per new selector — so a new bridge selector does not block the upstream PR, and the only real residual risk is snapshot drift on an already-covered selector, which is a candidate for a follow-up guard rather than a blocker for unfreezing.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
