### PR TITLE
feat(VaultWrapper): cost-aware exits charge source exit fee to the exiter

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -21,6 +21,30 @@ asked. It does **not** catch share-side dilution (a vault that consumes the full
 asset but credits fewer shares via an internal deposit fee); such non-standard
 sources are unsupported and require a dedicated adapter.
 
+## Exit cost views
+
+Three methods give the wrapper cost-aware and loss-tolerant exits without
+assuming anything about the source beyond its own standard EIP-4626 previews:
+
+- `previewWithdrawCost` — the exact-out cost: the position value the source
+  consumes to deliver exactly `assets` out (`>= assets` when the source charges
+  an exit fee). Backs the wrapper's cost-aware `previewWithdraw`, so an exiting
+  holder's share burn is priced off the source's true exit cost instead of
+  diluting remaining holders.
+- `previewWithdrawUpTo` — the exact-in realizable amount: what the source would
+  deliver if the holder realizes up to `assets` of position value now, net of
+  any source exit fee. `type(uint256).max` means "the whole position" (the
+  drain affordance). It is the static mirror of `withdrawUpTo` and backs the
+  wrapper's realizable `previewRedeem`.
+- `withdrawUpTo` — the exact-in execution. DELEGATECALL only; realizes up to
+  `assets` of position value into the wrapper and returns the measured asset
+  delta. Backs `redeem`.
+
+These views read cost/realizable amounts straight from the source's own
+EIP-4626 `previewWithdraw`/`previewRedeem`, so they carry the same
+standard-source assumption as the rest of the adapter: a non-compliant or
+fee-on-transfer source is unsupported and needs a dedicated adapter.
+
 ## Functions
 
 ```solidity
@@ -35,6 +59,15 @@ function deposit(address _asset, address _underlying, uint256 _assets) external 
 
 /// Redeem `_assets` from the yield source; returns the asset amount received.
 function withdraw(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
+
+/// Position value the source consumes to deliver exactly `_assets` out (exact-out cost).
+function previewWithdrawCost(address _underlying, uint256 _assets) external view returns (uint256 cost)
+
+/// Assets delivered if `_holder` realizes up to `_assets` of position value now (exact-in preview).
+function previewWithdrawUpTo(address _underlying, address _holder, uint256 _assets) external view returns (uint256 delivered)
+
+/// Realizes up to `_assets` of position value from the source; returns the measured asset delta.
+function withdrawUpTo(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
 ```
 
 ## Related contracts

--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -38,6 +38,12 @@ assuming anything about the source beyond its own standard EIP-4626 previews:
 - `withdrawUpTo` — the exact-in execution. DELEGATECALL only; realizes up to
   `assets` of position value into the wrapper and returns the measured asset
   delta. Backs `redeem`.
+- `maxWithdrawableValue` — the source-liquidity signal: the floor valuation
+  (`convertToAssets`) of the GROSS worth of `min(holder position, source.maxRedeem)`.
+  Gross by design (not `previewRedeem`) — it does NOT net the source's exit fee, because
+  the wrapper feeds it into its own gross share math to clamp its `max*` views to what the
+  source can currently honor. Equals the full position value on a fully-liquid source (one
+  with no active liquidity limit).
 
 These views read cost/realizable amounts straight from the source's own
 EIP-4626 `previewWithdraw`/`previewRedeem`, so they carry the same
@@ -67,6 +73,9 @@ function previewWithdrawUpTo(address _underlying, address _holder, uint256 _asse
 
 /// Realizes up to `_assets` of position value from the source; returns the measured asset delta.
 function withdrawUpTo(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
+
+/// Gross floor valuation of `min(holder position, source.maxRedeem)` — the source-liquidity signal (not exit-fee-netted).
+function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 
 ## Related contracts

--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -32,10 +32,9 @@ assuming anything about the source beyond its own standard EIP-4626 previews:
   holder's share burn is priced off the source's true exit cost instead of
   diluting remaining holders.
 - `previewWithdrawUpTo` — the exact-in realizable amount: what the source would
-  deliver if the holder realizes up to `assets` of position value now, net of
-  any source exit fee. `type(uint256).max` means "the whole position" (the
-  drain affordance). It is the static mirror of `withdrawUpTo` and backs the
-  wrapper's realizable `previewRedeem`.
+  deliver if the holder realizes up to `assets` of position value now, capped
+  at the holder's position, net of any source exit fee. It is the static
+  mirror of `withdrawUpTo` and backs the wrapper's realizable `previewRedeem`.
 - `withdrawUpTo` — the exact-in execution. DELEGATECALL only; realizes up to
   `assets` of position value into the wrapper and returns the measured asset
   delta. Backs `redeem`.

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -29,6 +29,32 @@ withdrawal.
 - A single pluggable `IAccessGate` (zero = permissionless) enforced fail-closed on
   entry, share transfers, and exits.
 - Pause is enforced on the deposit/mint path only; withdrawals stay open.
+- Exits are cost-aware: the exiting caller bears the yield source's exit cost
+  (fee or realized loss), never remaining holders — see
+  [Exit semantics](#exit-semantics).
+
+## Exit semantics
+
+- `withdraw` is **exact-out and cost-aware**: the exiter's share burn is priced
+  off the source's true exit cost (`previewWithdrawCost`), so a source exit fee
+  falls on the exiter rather than diluting remaining holders. On a fee source,
+  `maxWithdraw` reports the fee-adjusted net amount, so requesting the full
+  nominal deposit exceeds it and reverts `ERC4626ExceededMaxWithdraw` —
+  `redeem` is the guaranteed full exit.
+- `redeem` is **exact-in and loss-tolerant**: it realizes the burned shares'
+  proportional slice via the adapter's `withdrawUpTo` and pays out what the
+  source actually delivered, net of the wrapper's withdrawal fee (charged on
+  the actual proceeds). A source exit fee or a loss reduces the exiting
+  caller's payout — it never dilutes remaining holders and never bricks the
+  last exit. It always floor-values (`_convertToAssets(shares, Floor)`) and
+  never drains the raw source position, so a full exit leaves the tiny
+  virtual-offset residue behind — that residue is the inflation-attack buffer,
+  matching standard OZ behavior.
+- The `max*`/preview views: `maxWithdraw` and `maxRedeem` route through the
+  realizable, net-of-source-fee `previewRedeem`, so on a fee source
+  `maxWithdraw` reports the net amount. Neither reflects the source's own
+  liquidity/withdrawal limits (tracked separately as finding #4); deposits do
+  not reflect a source entry fee.
 
 ## Admin role
 

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -65,8 +65,16 @@ withdrawal.
 - Dust tradeoff on OZ-style sources (e.g. MetaMorpho, whose own `maxRedeem` floors ~1
   share below `balanceOf` even at full liquidity): a one-call full exit via
   `redeem(balanceOf)` may hit `ERC4626ExceededMaxRedeem`. Callers should exit via
-  `redeem(maxRedeem(owner))`; `redeem` is the guaranteed exit and leaves at most
-  sub-1e-12-token dust that a follow-up call clears.
+  `redeem(maxRedeem(owner))`; `redeem` is the guaranteed exit and leaves residual dust
+  that a follow-up call clears. The dust bound is **one source share's value** — not a
+  fixed 1e-12: sub-1e-12 token on fine-grained sources (18-decimal shares, modest price
+  per share), but potentially 1e-6 token or more on a coarse-share source (fewer share
+  decimals than the asset, or a heavily grown price per share). A redeem whose slice
+  values below one source share burns the shares for a **zero payout** (standard
+  ERC-4626 dust semantics with the threshold at one source share instead of one wei);
+  `previewRedeem` quotes 0 for the same input, and the EIP-5143
+  `redeem(shares, receiver, owner, minAssets)` overload reverts `SlippageExceeded` —
+  integrators of coarse-share sources should use one of the two.
 - The exact-out `withdraw` rounding boundary near `maxWithdraw` remains the one tolerated
   artifact, unchanged by the liquidity-awareness above.
 

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -50,11 +50,25 @@ withdrawal.
   never drains the raw source position, so a full exit leaves the tiny
   virtual-offset residue behind — that residue is the inflation-attack buffer,
   matching standard OZ behavior.
-- The `max*`/preview views: `maxWithdraw` and `maxRedeem` route through the
-  realizable, net-of-source-fee `previewRedeem`, so on a fee source
-  `maxWithdraw` reports the net amount. Neither reflects the source's own
-  liquidity/withdrawal limits (tracked separately as finding #4); deposits do
-  not reflect a source entry fee.
+- The `max*`/preview views are **source-liquidity-aware**: `maxRedeem` clamps the
+  owner's balance to what the source can currently honor (via the adapter's
+  `maxWithdrawableValue`), with a full-position short-circuit so it equals `balanceOf`
+  on a fully-liquid source and only clamps when the source is genuinely
+  liquidity-limited (an Aave-style utilization cap, a paused source). `maxWithdraw`
+  inherits the clamp because OZ derives it as `previewRedeem(maxRedeem(owner))`, so the
+  `withdraw` entrypoint's `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too. On a
+  fee source `maxWithdraw` still reports the net (fee-adjusted) amount. Deposits do not
+  reflect a source entry fee.
+- `previewRedeem`/`previewWithdraw` remain **liquidity-agnostic**: EIP-4626 requires
+  previews to ignore withdrawal limits, so they value against the full position and never
+  consult `maxWithdrawableValue`.
+- Dust tradeoff on OZ-style sources (e.g. MetaMorpho, whose own `maxRedeem` floors ~1
+  share below `balanceOf` even at full liquidity): a one-call full exit via
+  `redeem(balanceOf)` may hit `ERC4626ExceededMaxRedeem`. Callers should exit via
+  `redeem(maxRedeem(owner))`; `redeem` is the guaranteed exit and leaves at most
+  sub-1e-12-token dust that a follow-up call clears.
+- The exact-out `withdraw` rounding boundary near `maxWithdraw` remains the one tolerated
+  artifact, unchanged by the liquidity-awareness above.
 
 ## Admin role
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -683,13 +683,41 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Reports 0 while the access gate flags the owner as sanctioned, mirroring
-    ///      `redeem`'s exit freeze (the asset receiver is unknowable in this view and
-    ///      is checked in the entrypoint only).
+    /// @dev Reports 0 while the access gate flags the owner as sanctioned (mirroring `redeem`'s
+    ///      exit freeze). Otherwise clamps the owner's balance to what the source can currently
+    ///      honor: if the source can release the wrapper's whole position (the common case — a
+    ///      source with no active liquidity limit, where `maxWithdrawableValue == totalAssets()`),
+    ///      returns the plain balance unchanged; only when the source is liquidity-limited (an
+    ///      Aave-style utilization cap, a paused source) does it clamp to
+    ///      `_convertToShares(maxWithdrawableValue, Floor)`. The full-position short-circuit
+    ///      avoids the ~1-share under-report the virtual-offset share round-trip would otherwise
+    ///      introduce on a fully-liquid source, so `redeem` still empties a holder's balance in
+    ///      one call there. `maxWithdraw` inherits the clamp because OZ derives it as
+    ///      `previewRedeem(maxRedeem(owner))`, so the `withdraw` entrypoint's
+    ///      `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too. This keeps the EIP-4626
+    ///      guarantee that a `redeem` within `maxRedeem` never reverts even under a source
+    ///      liquidity limit; when limited, the floor round-trip is conservative (may under-report
+    ///      by up to one source-share of value, never over-report). On a source whose own
+    ///      `maxRedeem` floors below `balanceOf` (OZ-derived vaults such as MetaMorpho), a
+    ///      one-call full exit via `redeem(balanceOf)` is therefore not guaranteed; callers
+    ///      should use `redeem(maxRedeem(owner))`, which may leave sub-1e-12-token dust that a
+    ///      follow-up call clears.
     function maxRedeem(address owner) public view override returns (uint256) {
         if (_sanctioned(owner)) return 0;
 
-        return super.maxRedeem(owner);
+        uint256 balance = super.maxRedeem(owner);
+        uint256 realizable = IYieldAdapter(adapter).maxWithdrawableValue(
+            underlying,
+            address(this)
+        );
+        if (realizable >= totalAssets()) return balance;
+
+        uint256 liquidityCap = _convertToShares(
+            realizable,
+            Math.Rounding.Floor
+        );
+
+        return balance < liquidityCap ? balance : liquidityCap;
     }
 
     /// Internal ///

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -448,8 +448,13 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Deliberately NOT floor-checked (see `_enforceSupplyFloor` for why exits
-    ///      are exempt): an exit must always be able to empty the caller's position.
+    /// @dev Exact-in and loss-tolerant: realizes the burned shares' proportional slice of
+    ///      the source position via the adapter's `withdrawUpTo` and pays out what the
+    ///      source actually delivered (net of the withdrawal fee, charged on ACTUAL
+    ///      proceeds). A source that pays under valuation — an exit fee, a post-deployment
+    ///      change — reduces THIS caller's payout instead of diluting the remaining
+    ///      holders or bricking the last exit. The exact-out counterpart `withdraw` stays
+    ///      strict. Deliberately NOT floor-checked (exits are exempt — `_enforceSupplyFloor`).
     function redeem(
         uint256 shares,
         address receiver,
@@ -458,7 +463,11 @@ contract LiFiVaultWrapper is
         _checkExitAccess(owner, receiver);
         _accrueFees();
 
-        return super.redeem(shares, receiver, owner);
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares)
+            revert ERC4626ExceededMaxRedeem(owner, shares, maxShares);
+
+        return _redeemExactIn(_msgSender(), receiver, owner, shares);
     }
 
     /// EIP-5143 slippage-guarded entrypoints ///
@@ -602,15 +611,37 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
+    /// @dev Realizable-value preview: mirrors `redeem` — the shares' floor valuation is
+    ///      pushed through the adapter's `previewWithdrawUpTo` (the same source math
+    ///      `withdrawUpTo` executes), then the withdrawal fee is carved out of the
+    ///      realizable amount. Equals the plain valuation on a no-fee source. Always uses
+    ///      the floor valuation (never the adapter's full-position drain sentinel, even on
+    ///      a full-supply redeem): the wrapper cannot distinguish an honest last holder
+    ///      from a donation-inflation attacker at redeem time, and draining the raw
+    ///      position would hand the attacker the virtual-offset residue the inflation
+    ///      protection is supposed to keep unredeemable. Standard OZ ERC-4626 behavior. A
+    ///      zero-valuation gross (e.g. a total-loss source, `totalAssets() == 0` with
+    ///      `totalSupply() > 0`) short-circuits before the adapter call — mirroring
+    ///      `_redeemExactIn` exactly — instead of forwarding a 0 into the adapter's
+    ///      `previewWithdrawUpTo`, which round-trips through the source's own
+    ///      `convertToShares` and can divide by a zero `totalAssets` there.
     function previewRedeem(
         uint256 shares
     ) public view override returns (uint256) {
-        uint256 assets = super.previewRedeem(shares);
+        uint256 gross = _convertToAssets(shares, Math.Rounding.Floor);
+        uint256 realizable = gross == 0
+            ? 0
+            : IYieldAdapter(adapter).previewWithdrawUpTo(
+                underlying,
+                address(this),
+                gross
+            );
+        if (realizable == 0) return 0;
 
         return
-            assets -
+            realizable -
             LibVaultWrapperMath.feeOnTotal({
-                _assets: assets,
+                _assets: realizable,
                 _feeBps: _rate(FeeType.Withdrawal)
             });
     }
@@ -769,6 +800,71 @@ contract LiFiVaultWrapper is
         // untracked dust that silently left AUM.
         _routeFee(FeeType.Withdrawal, withdrawalFee + (withdrawn - owed));
         SafeERC20.safeTransfer(IERC20(assetToken), _to, _assets);
+    }
+
+    /// @dev Exact-in redeem: OZ's allowance-spend + burn + `Withdraw` event, with a
+    ///      loss-tolerant realization instead of the strict `_transferOut`. The slice
+    ///      valuation is computed BEFORE the burn (the burn changes the supply the
+    ///      valuation divides by), post-accrual so pending fee-shares are already minted.
+    ///      Always floor-values the burned shares (never the adapter's full-position drain
+    ///      sentinel, even on a full-supply redeem): the wrapper cannot tell an honest last
+    ///      holder from a donation-inflation attacker at redeem time, and draining the raw
+    ///      source position would hand either of them the virtual-offset residue the
+    ///      inflation protection is supposed to keep unredeemable. A full exit therefore
+    ///      leaves that tiny residue in the source by design (standard OZ ERC-4626
+    ///      behavior) rather than stranding it as a bug. The withdrawal fee is charged on
+    ///      ACTUAL proceeds via `feeOnTotal`, so fee and payout sum to what the source
+    ///      paid. A dust redeem — either `gross` itself is 0, or the adapter's own
+    ///      `previewWithdrawUpTo` reports 0 (the source's floor-rounded conversion of a
+    ///      tiny `gross` back to assets can floor to 0 even when the corresponding source
+    ///      share count is nonzero) — skips the adapter's mutating round-trip entirely
+    ///      (mirrors `_transferOut`'s zero short-circuit and matches what `previewRedeem`
+    ///      already predicts). This is required, not just an optimization: some ERC-4626
+    ///      sources (e.g. solmate's) hard-revert their own `redeem` when their own preview
+    ///      is 0, which would otherwise make `redeem` revert for a `_shares` amount within
+    ///      `maxRedeem` — an exit must always succeed.
+    /// @param _caller The account spending the allowance (msg.sender in `redeem`).
+    /// @param _receiver The asset receiver.
+    /// @param _owner The share owner being exited.
+    /// @param _shares The exact share amount to burn.
+    /// @return assets The assets actually paid out (net of the withdrawal fee).
+    function _redeemExactIn(
+        address _caller,
+        address _receiver,
+        address _owner,
+        uint256 _shares
+    ) private returns (uint256 assets) {
+        uint256 gross = _convertToAssets(_shares, Math.Rounding.Floor);
+        uint256 realizable = gross == 0
+            ? 0
+            : IYieldAdapter(adapter).previewWithdrawUpTo(
+                underlying,
+                address(this),
+                gross
+            );
+
+        if (_caller != _owner) _spendAllowance(_owner, _caller, _shares);
+        _burn(_owner, _shares);
+
+        uint256 withdrawn;
+        if (realizable != 0) {
+            withdrawn = _routeThroughAdapter(
+                abi.encodeCall(
+                    IYieldAdapter.withdrawUpTo,
+                    (asset(), underlying, gross)
+                )
+            );
+        }
+
+        uint256 fee = LibVaultWrapperMath.feeOnTotal({
+            _assets: withdrawn,
+            _feeBps: _rate(FeeType.Withdrawal)
+        });
+        _routeFee(FeeType.Withdrawal, fee);
+        assets = withdrawn - fee;
+
+        SafeERC20.safeTransfer(IERC20(asset()), _receiver, assets);
+        emit Withdraw(_caller, _receiver, _owner, assets, _shares);
     }
 
     /// @dev Delegatecalls the adapter so its deposit/withdraw logic runs in this wrapper's

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -700,8 +700,14 @@ contract LiFiVaultWrapper is
     ///      by up to one source-share of value, never over-report). On a source whose own
     ///      `maxRedeem` floors below `balanceOf` (OZ-derived vaults such as MetaMorpho), a
     ///      one-call full exit via `redeem(balanceOf)` is therefore not guaranteed; callers
-    ///      should use `redeem(maxRedeem(owner))`, which may leave sub-1e-12-token dust that a
-    ///      follow-up call clears. Because this now consults the source's views via
+    ///      should use `redeem(maxRedeem(owner))`, which may leave residual dust that a
+    ///      follow-up call clears. That dust is bounded by ONE SOURCE SHARE's value, not a
+    ///      fixed magnitude: on fine-grained sources (18-decimal shares, modest price per
+    ///      share) it is sub-1e-12 token, but a coarse-share source (fewer share decimals
+    ///      than the asset, or a heavily grown price per share) can put one source share at
+    ///      1e-6 token or more — integrators of such sources should quote `previewRedeem`
+    ///      or use the EIP-5143 `redeem(shares, receiver, owner, minAssets)` overload.
+    ///      Because this now consults the source's views via
     ///      `adapter.maxWithdrawableValue`, it reverts if those source views revert (a
     ///      fully-paused/bricked source) — consistent with the fail-closed posture of
     ///      `maxWithdraw`/`previewRedeem`, a deliberate deviation from EIP-4626's view-safety
@@ -854,7 +860,12 @@ contract LiFiVaultWrapper is
     ///      already predicts). This is required, not just an optimization: some ERC-4626
     ///      sources (e.g. solmate's) hard-revert their own `redeem` when their own preview
     ///      is 0, which would otherwise make `redeem` revert for a `_shares` amount within
-    ///      `maxRedeem` — an exit must always succeed.
+    ///      `maxRedeem` — an exit must always succeed. The shares are still burned and the
+    ///      payout is 0 (standard ERC-4626 dust semantics, with the threshold at one
+    ///      SOURCE share's value rather than one wei); the unrealized slice accrues to the
+    ///      remaining holders. `previewRedeem` quotes 0 for the same input and the
+    ///      EIP-5143 `redeem(..., minAssets)` overload reverts `SlippageExceeded`, so the
+    ///      silent-zero path only reaches callers who skip both.
     /// @param _caller The account spending the allowance (msg.sender in `redeem`).
     /// @param _receiver The asset receiver.
     /// @param _owner The share owner being exited.

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -567,15 +567,25 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
+    /// @dev Cost-aware exact-out preview: shares to burn are priced off the position value
+    ///      the source actually consumes to deliver `owed` (adapter `previewWithdrawCost`,
+    ///      >= `owed` when the source charges an exit fee), not off `owed` alone — so the
+    ///      exiting caller pays their own source-side exit cost instead of diluting the
+    ///      remaining holders. Equal to the plain valuation on a no-fee source.
     function previewWithdraw(
         uint256 assets
     ) public view override returns (uint256) {
-        uint256 withdrawalFee = LibVaultWrapperMath.feeOnRaw({
-            _assets: assets,
-            _feeBps: _rate(FeeType.Withdrawal)
-        });
+        uint256 owed = assets +
+            LibVaultWrapperMath.feeOnRaw({
+                _assets: assets,
+                _feeBps: _rate(FeeType.Withdrawal)
+            });
+        uint256 cost = IYieldAdapter(adapter).previewWithdrawCost(
+            underlying,
+            owed
+        );
 
-        return super.previewWithdraw(assets + withdrawalFee);
+        return _convertToShares(cost, Math.Rounding.Ceil);
     }
 
     /// @inheritdoc ERC4626Upgradeable

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -701,7 +701,11 @@ contract LiFiVaultWrapper is
     ///      `maxRedeem` floors below `balanceOf` (OZ-derived vaults such as MetaMorpho), a
     ///      one-call full exit via `redeem(balanceOf)` is therefore not guaranteed; callers
     ///      should use `redeem(maxRedeem(owner))`, which may leave sub-1e-12-token dust that a
-    ///      follow-up call clears.
+    ///      follow-up call clears. Because this now consults the source's views via
+    ///      `adapter.maxWithdrawableValue`, it reverts if those source views revert (a
+    ///      fully-paused/bricked source) — consistent with the fail-closed posture of
+    ///      `maxWithdraw`/`previewRedeem`, a deliberate deviation from EIP-4626's view-safety
+    ///      expectation.
     function maxRedeem(address owner) public view override returns (uint256) {
         if (_sanctioned(owner)) return 0;
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -584,6 +584,19 @@ contract LiFiVaultWrapper is
             underlying,
             owed
         );
+        // The adapter's cost round-trips through the source's OWN preview/convert
+        // functions, which lack this contract's ceiling safety margin (the "+1"
+        // virtual-share protection `_convertToShares`/`_convertToAssets` rely on). Near a
+        // full exit that round-trip can round `cost` up to (or past) `totalAssets()`,
+        // which would then overshoot `totalSupply()` once converted to shares. Cap `cost`
+        // at the largest value this contract can always safely convert back to at most
+        // `totalSupply()` shares — the same value a direct full redemption already relies
+        // on being safe.
+        uint256 maxSafeCost = _convertToAssets(
+            totalSupply(),
+            Math.Rounding.Floor
+        );
+        if (cost > maxSafeCost) cost = maxSafeCost;
 
         return _convertToShares(cost, Math.Rounding.Ceil);
     }

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -94,9 +94,9 @@ contract ERC4626Adapter is IYieldAdapter {
     }
 
     /// @inheritdoc IYieldAdapter
-    /// @dev Exact-in realizable: the source-share slice worth `_assets` (capped at the
-    ///      holder's position; `type(uint256).max` = the whole position), priced through
-    ///      the source's own `previewRedeem` so previews match `withdrawUpTo`'s execution.
+    /// @dev Exact-in realizable: the source-share slice worth `_assets`, capped at the
+    ///      holder's position, priced through the source's own `previewRedeem` so
+    ///      previews match `withdrawUpTo`'s execution.
     function previewWithdrawUpTo(
         address _underlying,
         address _holder,
@@ -108,7 +108,8 @@ contract ERC4626Adapter is IYieldAdapter {
 
     /// @inheritdoc IYieldAdapter
     /// @dev DELEGATECALL: `address(this)` is the wrapper. Redeems the source-share slice
-    ///      worth `_assets` and returns the measured asset balance delta.
+    ///      worth `_assets`, capped at the holder's position, and returns the measured
+    ///      asset balance delta.
     function withdrawUpTo(
         address _asset,
         address _underlying,
@@ -122,17 +123,14 @@ contract ERC4626Adapter is IYieldAdapter {
     }
 
     /// @dev Source-share slice worth `_assets` of `_holder`'s position, capped at the
-    ///      whole position. `type(uint256).max` selects the entire balance (drain), which
-    ///      also makes a full exit exact (no asset round-trip stranding).
+    ///      holder's whole position.
     function _sliceShares(
         address _underlying,
         address _holder,
         uint256 _assets
     ) private view returns (uint256 shares) {
         uint256 position = IERC4626(_underlying).balanceOf(_holder);
-        shares = _assets == type(uint256).max
-            ? position
-            : IERC4626(_underlying).convertToShares(_assets);
+        shares = IERC4626(_underlying).convertToShares(_assets);
         if (shares > position) shares = position;
     }
 }

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -83,28 +83,56 @@ contract ERC4626Adapter is IYieldAdapter {
     }
 
     /// @inheritdoc IYieldAdapter
-    /// @dev Placeholder pending the exit-fee-aware implementation (returns the no-fee
-    ///      default, `_assets` unchanged); a follow-up task implements the real logic.
+    /// @dev Exact-out cost: source shares needed to deliver `_assets` (rounds up in the
+    ///      source's favor), valued back to assets. >= `_assets` on a fee-charging source.
     function previewWithdrawCost(
-        address,
+        address _underlying,
         uint256 _assets
-    ) external pure returns (uint256 cost) {
-        cost = _assets;
+    ) external view returns (uint256 cost) {
+        uint256 shares = IERC4626(_underlying).previewWithdraw(_assets);
+        cost = IERC4626(_underlying).convertToAssets(shares);
     }
 
     /// @inheritdoc IYieldAdapter
-    /// @dev Placeholder; a follow-up task implements the real logic.
+    /// @dev Exact-in realizable: the source-share slice worth `_assets` (capped at the
+    ///      holder's position; `type(uint256).max` = the whole position), priced through
+    ///      the source's own `previewRedeem` so previews match `withdrawUpTo`'s execution.
     function previewWithdrawUpTo(
-        address,
-        address,
-        uint256
-    ) external pure returns (uint256 delivered) {}
+        address _underlying,
+        address _holder,
+        uint256 _assets
+    ) external view returns (uint256 delivered) {
+        uint256 shares = _sliceShares(_underlying, _holder, _assets);
+        delivered = IERC4626(_underlying).previewRedeem(shares);
+    }
 
     /// @inheritdoc IYieldAdapter
-    /// @dev Placeholder; a follow-up task implements the real logic.
+    /// @dev DELEGATECALL: `address(this)` is the wrapper. Redeems the source-share slice
+    ///      worth `_assets` and returns the measured asset balance delta.
     function withdrawUpTo(
-        address,
-        address,
-        uint256
-    ) external pure returns (uint256 withdrawn) {}
+        address _asset,
+        address _underlying,
+        uint256 _assets
+    ) external returns (uint256 withdrawn) {
+        uint256 shares = _sliceShares(_underlying, address(this), _assets);
+        if (shares == 0) return 0;
+        uint256 balanceBefore = IERC20(_asset).balanceOf(address(this));
+        IERC4626(_underlying).redeem(shares, address(this), address(this));
+        withdrawn = IERC20(_asset).balanceOf(address(this)) - balanceBefore;
+    }
+
+    /// @dev Source-share slice worth `_assets` of `_holder`'s position, capped at the
+    ///      whole position. `type(uint256).max` selects the entire balance (drain), which
+    ///      also makes a full exit exact (no asset round-trip stranding).
+    function _sliceShares(
+        address _underlying,
+        address _holder,
+        uint256 _assets
+    ) private view returns (uint256 shares) {
+        uint256 position = IERC4626(_underlying).balanceOf(_holder);
+        shares = _assets == type(uint256).max
+            ? position
+            : IERC4626(_underlying).convertToShares(_assets);
+        if (shares > position) shares = position;
+    }
 }

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -122,6 +122,21 @@ contract ERC4626Adapter is IYieldAdapter {
         withdrawn = IERC20(_asset).balanceOf(address(this)) - balanceBefore;
     }
 
+    /// @inheritdoc IYieldAdapter
+    /// @dev Source floor valuation (`convertToAssets`) of the smaller of the holder's position
+    ///      and the source's current `maxRedeem`. Gross by design (not `previewRedeem`): the
+    ///      wrapper converts it back through its own gross share math to clamp exits to source
+    ///      liquidity. Equals the full position value when the source imposes no active limit.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets) {
+        uint256 position = IERC4626(_underlying).balanceOf(_holder);
+        uint256 redeemable = IERC4626(_underlying).maxRedeem(_holder);
+        uint256 shares = redeemable < position ? redeemable : position;
+        assets = IERC4626(_underlying).convertToAssets(shares);
+    }
+
     /// @dev Source-share slice worth `_assets` of `_holder`'s position, capped at the
     ///      holder's whole position.
     function _sliceShares(

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -81,4 +81,30 @@ contract ERC4626Adapter is IYieldAdapter {
         });
         withdrawn = IERC20(_asset).balanceOf(address(this)) - balanceBefore;
     }
+
+    /// @inheritdoc IYieldAdapter
+    /// @dev Placeholder pending the exit-fee-aware implementation (returns the no-fee
+    ///      default, `_assets` unchanged); a follow-up task implements the real logic.
+    function previewWithdrawCost(
+        address,
+        uint256 _assets
+    ) external pure returns (uint256 cost) {
+        cost = _assets;
+    }
+
+    /// @inheritdoc IYieldAdapter
+    /// @dev Placeholder; a follow-up task implements the real logic.
+    function previewWithdrawUpTo(
+        address,
+        address,
+        uint256
+    ) external pure returns (uint256 delivered) {}
+
+    /// @inheritdoc IYieldAdapter
+    /// @dev Placeholder; a follow-up task implements the real logic.
+    function withdrawUpTo(
+        address,
+        address,
+        uint256
+    ) external pure returns (uint256 withdrawn) {}
 }

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -10,15 +10,15 @@ pragma solidity ^0.8.29;
 ///         than changing the factory or the wrapper implementation.
 /// @dev Methods split by how the wrapper invokes them, and this split is a security
 ///      invariant adapters MUST honour:
-///      - `resolveAsset` and `totalAssets` are invoked as ordinary (static) calls and
-///        run in the adapter's own context; they take an explicit `_holder`/`_underlying`
-///        and MUST be free of side effects.
-///      - `deposit` and `withdraw` are invoked via `delegatecall` and therefore run in
-///        the wrapper's context: `address(this)`, token balances, and yield-source
-///        positions are the wrapper's. They MUST be stateless with respect to adapter
-///        storage (no reads or writes of adapter state) so a shared adapter cannot
-///        corrupt or be corrupted by the wrapper's storage layout; they may only act on
-///        their arguments and external calls.
+///      - `resolveAsset`, `totalAssets`, `previewWithdrawCost`, and `previewWithdrawUpTo`
+///        are invoked as ordinary (static) calls and run in the adapter's own context;
+///        they take an explicit `_holder`/`_underlying` and MUST be free of side effects.
+///      - `deposit`, `withdraw`, and `withdrawUpTo` are invoked via `delegatecall` and
+///        therefore run in the wrapper's context: `address(this)`, token balances, and
+///        yield-source positions are the wrapper's. They MUST be stateless with respect
+///        to adapter storage (no reads or writes of adapter state) so a shared adapter
+///        cannot corrupt or be corrupted by the wrapper's storage layout; they may only
+///        act on their arguments and external calls.
 /// @custom:version 1.0.0
 interface IYieldAdapter {
     /// @notice Thrown when the adapter cannot resolve the underlying's asset.
@@ -68,6 +68,52 @@ interface IYieldAdapter {
     /// @param _assets The amount of `_asset` to withdraw.
     /// @return withdrawn The amount of `_asset` returned to the wrapper.
     function withdraw(
+        address _asset,
+        address _underlying,
+        uint256 _assets
+    ) external returns (uint256 withdrawn);
+
+    /// @notice Position value the source consumes to deliver exactly `_assets` out.
+    /// @dev Ordinary static call; used by the wrapper's exact-out `previewWithdraw` so
+    ///      the exiting user's shares — not the remaining holders — pay the source's
+    ///      exit cost. Returns >= `_assets` when the source charges an exit fee. Rounds
+    ///      up (conservative for the vault). MAY revert if the source's preview reverts.
+    /// @param _underlying The yield source identifier.
+    /// @param _assets The net assets to be delivered out of the source.
+    /// @return cost The position value consumed to deliver `_assets`.
+    function previewWithdrawCost(
+        address _underlying,
+        uint256 _assets
+    ) external view returns (uint256 cost);
+
+    /// @notice Assets actually delivered if `_holder` realizes up to `_assets` of position
+    ///         value right now (net of any source exit fee), capped at `_holder`'s position.
+    /// @dev Ordinary static call; the static mirror of `withdrawUpTo` and MUST use the same
+    ///      share math so `previewRedeem` matches `redeem`. `_assets == type(uint256).max`
+    ///      means "the whole position" (the drain sentinel). Does NOT cap at source
+    ///      liquidity limits (only at the position). MAY revert if the source preview reverts.
+    /// @param _underlying The yield source identifier.
+    /// @param _holder The account whose position is valued (the wrapper).
+    /// @param _assets The position value to realize, or `type(uint256).max` to drain.
+    /// @return delivered The assets the source would deliver.
+    function previewWithdrawUpTo(
+        address _underlying,
+        address _holder,
+        uint256 _assets
+    ) external view returns (uint256 delivered);
+
+    /// @notice Realizes up to `_assets` of position value from `_underlying` into the wrapper
+    ///         (exact-in), paying out whatever the source delivers rather than targeting an
+    ///         exact asset amount.
+    /// @dev DELEGATECALL ONLY — runs in the wrapper's context (see `withdraw`). Redeems the
+    ///      source-share slice worth `_assets`, capped at the wrapper's whole position;
+    ///      `_assets == type(uint256).max` drains the entire position. Reports the measured
+    ///      asset balance delta. MUST NOT touch adapter storage.
+    /// @param _asset The ERC20 asset withdrawn (lands on the wrapper).
+    /// @param _underlying The yield source to realize from.
+    /// @param _assets The position value to realize, or `type(uint256).max` to drain.
+    /// @return withdrawn The assets returned to the wrapper.
+    function withdrawUpTo(
         address _asset,
         address _underlying,
         uint256 _assets

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -89,12 +89,11 @@ interface IYieldAdapter {
     /// @notice Assets actually delivered if `_holder` realizes up to `_assets` of position
     ///         value right now (net of any source exit fee), capped at `_holder`'s position.
     /// @dev Ordinary static call; the static mirror of `withdrawUpTo` and MUST use the same
-    ///      share math so `previewRedeem` matches `redeem`. `_assets == type(uint256).max`
-    ///      means "the whole position" (the drain sentinel). Does NOT cap at source
+    ///      share math so `previewRedeem` matches `redeem`. Does NOT cap at source
     ///      liquidity limits (only at the position). MAY revert if the source preview reverts.
     /// @param _underlying The yield source identifier.
     /// @param _holder The account whose position is valued (the wrapper).
-    /// @param _assets The position value to realize, or `type(uint256).max` to drain.
+    /// @param _assets The position value to realize, capped at `_holder`'s position.
     /// @return delivered The assets the source would deliver.
     function previewWithdrawUpTo(
         address _underlying,
@@ -106,12 +105,11 @@ interface IYieldAdapter {
     ///         (exact-in), paying out whatever the source delivers rather than targeting an
     ///         exact asset amount.
     /// @dev DELEGATECALL ONLY — runs in the wrapper's context (see `withdraw`). Redeems the
-    ///      source-share slice worth `_assets`, capped at the wrapper's whole position;
-    ///      `_assets == type(uint256).max` drains the entire position. Reports the measured
-    ///      asset balance delta. MUST NOT touch adapter storage.
+    ///      source-share slice worth `_assets`, capped at the wrapper's whole position.
+    ///      Reports the measured asset balance delta. MUST NOT touch adapter storage.
     /// @param _asset The ERC20 asset withdrawn (lands on the wrapper).
     /// @param _underlying The yield source to realize from.
-    /// @param _assets The position value to realize, or `type(uint256).max` to drain.
+    /// @param _assets The position value to realize, capped at the wrapper's position.
     /// @return withdrawn The assets returned to the wrapper.
     function withdrawUpTo(
         address _asset,

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -116,4 +116,26 @@ interface IYieldAdapter {
         address _underlying,
         uint256 _assets
     ) external returns (uint256 withdrawn);
+
+    /// @notice Gross position value `_holder` may withdraw from `_underlying` right now, capped
+    ///         by the source's current withdrawal/redemption liquidity limits.
+    /// @dev Ordinary static call; runs in the adapter's context, so the holder is passed
+    ///      explicitly. Returns the source's floor valuation (`convertToAssets`) of
+    ///      `min(_holder's position, source maxRedeem)` — deliberately the GROSS valuation, not
+    ///      the fee-netted `previewRedeem` the sibling `previewWithdrawUpTo` uses, because the
+    ///      wrapper feeds this straight into its own gross-denominated share math
+    ///      (`_convertToShares`) to clamp `maxRedeem`/`maxWithdraw` to the shares the source can
+    ///      honor; any source exit fee is applied separately by the wrapper's realizable redeem
+    ///      path. This keeps the EIP-4626 guarantee that an exit within `maxRedeem` never
+    ///      reverts. Equals the full position value on a source with no active liquidity limit.
+    ///      Does NOT net the source's exit fee or the wrapper's own fees. MAY revert if the
+    ///      source's views revert (the wrapper treats a reverting source view as fail-closed,
+    ///      matching its existing preview posture).
+    /// @param _underlying The yield source identifier.
+    /// @param _holder The account whose position is valued (the wrapper).
+    /// @return assets The gross, source-liquidity-capped position value.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets);
 }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -125,6 +125,14 @@ contract LossyVault {
     function convertToShares(uint256 _assets) external pure returns (uint256) {
         return _assets;
     }
+
+    /// @dev Unlimited withdrawal liquidity: the whole balance is always redeemable, so the
+    ///      wrapper's liquidity clamp in `maxRedeem` is a no-op and the shortfall path under
+    ///      test is still reached. Needed since the wrapper's `maxRedeem` now reads the source
+    ///      liquidity via `ERC4626Adapter.maxWithdrawableValue`, which calls this.
+    function maxRedeem(address _owner) external view returns (uint256) {
+        return balanceOf[_owner];
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -101,6 +101,13 @@ contract LossyVault {
     function convertToAssets(uint256 _shares) external pure returns (uint256) {
         return _shares;
     }
+
+    /// @dev 1:1 share/asset ratio (see `convertToAssets`), so previewing an exact-out
+    ///      withdrawal is the identity — needed since `ERC4626Adapter.previewWithdrawCost`
+    ///      now calls this as an ordinary IERC4626 preview.
+    function previewWithdraw(uint256 _assets) external pure returns (uint256) {
+        return _assets;
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -108,6 +108,23 @@ contract LossyVault {
     function previewWithdraw(uint256 _assets) external pure returns (uint256) {
         return _assets;
     }
+
+    /// @dev 1:1 share/asset ratio (see `convertToAssets`), so previewing an exact-in
+    ///      redemption is the identity — needed since `ERC4626Adapter.previewWithdrawUpTo`
+    ///      now calls this as an ordinary IERC4626 preview (reached via the wrapper's
+    ///      `maxWithdraw`, which previews a full redeem of the owner's balance).
+    function previewRedeem(uint256 _shares) external pure returns (uint256) {
+        return _shares;
+    }
+
+    /// @dev 1:1 share/asset ratio (see `convertToAssets`), so converting a finite asset
+    ///      amount to shares is the identity — needed since `ERC4626Adapter._sliceShares`
+    ///      (reached via `previewWithdrawUpTo`) now calls this whenever the wrapper passes
+    ///      a floor-valued (non-sentinel) amount, which the wrapper's `redeem`/
+    ///      `previewRedeem` always do since the drain sentinel was removed.
+    function convertToShares(uint256 _assets) external pure returns (uint256) {
+        return _assets;
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {
@@ -437,7 +454,12 @@ contract LiFiVaultWrapperTest is Test {
         vm.prank(alice);
         uint256 assetsOut = wrapper.redeem(shares, alice, alice);
 
-        assertApproxEqAbs(assetsOut, DEPOSIT + yield, 1);
+        // Exact-in redeem always floor-values the burned shares (never the adapter's
+        // full-position drain sentinel — see LiFiVaultWrapper.previewRedeem/_redeemExactIn),
+        // so on top of the wrapper's own floor rounding the underlying vault's OWN
+        // convertToShares/redeem rounding adds up to one more wei; tolerance widened from 1
+        // to 2 to account for that extra adapter round-trip.
+        assertApproxEqAbs(assetsOut, DEPOSIT + yield, 2);
     }
 
     function test_TwoDepositorsShareProportionally() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { Test } from "forge-std/Test.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { defaultReceivers } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
+import { MockFeeERC4626 } from "test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol";
+
+/// @notice Regression coverage for cost-aware exact-out `previewWithdraw`: when the
+///         underlying yield source charges an exit fee, the wrapper must price the
+///         exiting caller's share burn off the position value the source actually
+///         consumes, not off the requested assets alone — otherwise the source's exit
+///         fee is socialized onto remaining holders instead of being paid by the exiter.
+contract LiFiVaultWrapperExitCostTest is Test {
+    MockERC20 internal asset;
+    MockFeeERC4626 internal underlying;
+    ERC4626Adapter internal adapter;
+    UpgradeableBeacon internal beacon;
+    LiFiVaultWrapper internal wrapper;
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal sourceFeeSink = makeAddr("sourceFeeSink");
+
+    uint256 internal constant DEPOSIT = 1_000e18;
+    uint256 internal constant SOURCE_FEE_BPS = 100; // 1%
+
+    /// @dev This test contract is the `factory` (it deploys the beacon proxies), so the
+    ///      wrapper reads the global circuit breaker back from here.
+    function globalPaused() external pure returns (bool) {
+        return false;
+    }
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        underlying = new MockFeeERC4626(
+            asset,
+            "Yield Token",
+            "yTKN",
+            SOURCE_FEE_BPS,
+            sourceFeeSink
+        );
+        adapter = new ERC4626Adapter();
+        beacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper(address(this))),
+            address(this)
+        );
+        wrapper = _newWrapper(address(underlying));
+    }
+
+    function test_WithdrawDoesNotDiluteRemainingHolder() public {
+        _deposit(alice, DEPOSIT);
+        _deposit(bob, DEPOSIT);
+
+        uint256 bobClaimBefore = wrapper.convertToAssets(
+            wrapper.balanceOf(bob)
+        );
+
+        vm.prank(alice);
+        wrapper.withdraw(500e18, alice, alice);
+
+        uint256 bobClaimAfter = wrapper.convertToAssets(
+            wrapper.balanceOf(bob)
+        );
+
+        assertApproxEqAbs(bobClaimAfter, bobClaimBefore, 2);
+    }
+
+    /// Helpers ///
+
+    function _splits8000() internal pure returns (uint16[4] memory) {
+        return [uint16(8000), 8000, 8000, 8000];
+    }
+
+    function _newWrapper(
+        address _underlying
+    ) internal returns (LiFiVaultWrapper w) {
+        FeeConfig memory fees; // all wrapper fees 0 -> isolates the SOURCE fee
+        bytes memory initCall = abi.encodeCall(
+            LiFiVaultWrapper.initialize,
+            (
+                _underlying,
+                address(adapter),
+                vaultAdmin,
+                _splits8000(),
+                fees,
+                defaultReceivers(),
+                address(0)
+            )
+        );
+
+        w = LiFiVaultWrapper(
+            address(new BeaconProxy(address(beacon), initCall))
+        );
+    }
+
+    function _deposit(address _from, uint256 _amount) internal {
+        asset.mint(_from, _amount);
+        vm.startPrank(_from);
+        asset.approve(address(wrapper), _amount);
+        wrapper.deposit(_amount, _from);
+        vm.stopPrank();
+    }
+}

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
@@ -72,6 +72,97 @@ contract LiFiVaultWrapperExitCostTest is Test {
         assertApproxEqAbs(bobClaimAfter, bobClaimBefore, 2);
     }
 
+    function test_RedeemDoesNotDiluteRemainingHolder() public {
+        _deposit(alice, DEPOSIT);
+        _deposit(bob, DEPOSIT);
+
+        uint256 bobClaimBefore = wrapper.convertToAssets(
+            wrapper.balanceOf(bob)
+        );
+
+        uint256 aliceShares = wrapper.balanceOf(alice);
+        vm.prank(alice);
+        wrapper.redeem(aliceShares, alice, alice);
+
+        uint256 bobClaimAfter = wrapper.convertToAssets(
+            wrapper.balanceOf(bob)
+        );
+
+        assertApproxEqAbs(bobClaimAfter, bobClaimBefore, 2);
+    }
+
+    function test_RedeemExiterBearsSourceFee() public {
+        _deposit(alice, DEPOSIT);
+        _deposit(bob, DEPOSIT);
+
+        uint256 aliceShares = wrapper.balanceOf(alice);
+        vm.prank(alice);
+        uint256 out = wrapper.redeem(aliceShares, alice, alice);
+
+        assertApproxEqAbs(
+            out,
+            (DEPOSIT * (10_000 - SOURCE_FEE_BPS)) / 10_000,
+            2
+        );
+        assertEq(asset.balanceOf(alice), out);
+    }
+
+    function test_PreviewRedeemMatchesRedeem() public {
+        _deposit(alice, DEPOSIT);
+        _deposit(bob, DEPOSIT);
+
+        uint256 aliceShares = wrapper.balanceOf(alice);
+        uint256 previewed = wrapper.previewRedeem(aliceShares);
+        vm.prank(alice);
+        uint256 out = wrapper.redeem(aliceShares, alice, alice);
+
+        assertEq(out, previewed);
+    }
+
+    function test_RedeemLastHolderDrainsCleanly() public {
+        _deposit(alice, DEPOSIT);
+
+        uint256 aliceShares = wrapper.balanceOf(alice);
+        vm.prank(alice);
+        uint256 out = wrapper.redeem(aliceShares, alice, alice);
+
+        assertApproxEqAbs(
+            out,
+            (DEPOSIT * (10_000 - SOURCE_FEE_BPS)) / 10_000,
+            2
+        );
+        assertEq(wrapper.totalSupply(), 0);
+        // Virtual-offset residue stays in the source by design (inflation buffer), so the
+        // vault does not necessarily drain to exactly zero. Measured residue for this
+        // single-depositor, no-donation scenario is 0 (the wrapper's virtual-share math
+        // and the source's own conversion cancel exactly here); bound kept well above that
+        // at 1e6 wei so the assertion stays robust to sub-wei accounting drift without
+        // masking a real, large residue.
+        assertApproxEqAbs(wrapper.totalAssets(), 0, 1e6);
+    }
+
+    function test_PreviewRedeemMatchesRedeemInTotalLossState() public {
+        _deposit(alice, DEPOSIT);
+
+        // Force the source into total loss: totalAssets()==0 while the wrapper still
+        // holds shares. previewRedeem's floor-valued `gross` is then 0, and must
+        // short-circuit before the adapter call instead of forwarding a 0 into the
+        // source's own convertToShares (which divides by totalAssets and would revert).
+        // The balance is read BEFORE the prank: an inline argument call would itself
+        // consume vm.prank's next-call scope before transfer() runs.
+        uint256 underlyingBalance = asset.balanceOf(address(underlying));
+        vm.prank(address(underlying));
+        asset.transfer(address(0xdead), underlyingBalance);
+
+        uint256 shares = wrapper.maxRedeem(alice);
+        uint256 previewed = wrapper.previewRedeem(shares);
+        vm.prank(alice);
+        uint256 out = wrapper.redeem(shares, alice, alice);
+
+        assertEq(previewed, out);
+        assertEq(out, 0);
+    }
+
     /// Helpers ///
 
     function _splits8000() internal pure returns (uint16[4] memory) {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperExitCost.t.sol
@@ -198,4 +198,18 @@ contract LiFiVaultWrapperExitCostTest is Test {
         wrapper.deposit(_amount, _from);
         vm.stopPrank();
     }
+
+    function testRevert_WithdrawByLastHolderOnFeeSource() public {
+        _deposit(alice, DEPOSIT); // sole holder
+
+        // On a fee-charging source, maxWithdraw is fee-aware (previewRedeem(maxRedeem),
+        // with the realizable, net-of-source-fee previewRedeem), so it reports ~990e18 net
+        // for a 1000e18 deposit. A holder trying to withdraw their full NOMINAL deposit
+        // (1000e18) therefore exceeds maxWithdraw and reverts ERC4626ExceededMaxWithdraw.
+        // redeem is the guaranteed exit for the full position (see
+        // test_RedeemLastHolderDrainsCleanly).
+        vm.prank(alice);
+        vm.expectRevert();
+        wrapper.withdraw(DEPOSIT, alice, alice);
+    }
 }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.29;
 
 import { Vm } from "forge-std/Vm.sol";
+import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626 } from "solmate/mixins/ERC4626.sol";
@@ -373,30 +374,33 @@ contract LiFiVaultWrapperFeesTest is VaultWrapperFeeTestBase {
         );
     }
 
-    function test_FullExitViaMaxWithdrawWithWithdrawalFee() public {
-        // The classic ERC-4626 fee-wrapper failure: the exit fee pushes the share burn
-        // for withdraw(maxWithdraw(owner)) above the holder's balance. Guards the
-        // maxWithdraw == previewRedeem(maxRedeem(owner)) semantics the wrapper relies on.
+    function testRevert_FullExitViaMaxWithdrawWithWithdrawalFeeExceedsBalance()
+        public
+    {
+        // The classic ERC-4626 fee-wrapper failure, re-surfacing at the cost-aware exact-
+        // out boundary: previewWithdraw's cost now round-trips through the *source's own*
+        // preview/convert functions (adapter.previewWithdrawCost), which lack the wrapper's
+        // "+1" ceiling safety margin. At the precise full-position edge that round-trip can
+        // snap the requested cost up to exactly totalAssets, pushing the share burn for
+        // withdraw(maxWithdraw(owner)) a few wei past the holder's balance. `redeem`
+        // (exact-in) has no such boundary and remains the safe full-exit path.
         wrapper = _newWrapperAssetFees(0, WD_RATE);
         _deposit(alice, DEPOSIT);
         _simulateYield(50e18); // non-trivial PPS so rounding paths are exercised
 
         uint256 sharesBefore = wrapper.balanceOf(alice);
         uint256 maxAssets = wrapper.maxWithdraw(alice);
-        uint256 previewedShares = wrapper.previewWithdraw(maxAssets);
 
         vm.prank(alice);
-        uint256 burned = wrapper.withdraw(maxAssets, alice, alice);
+        vm.expectPartialRevert(IERC20Errors.ERC20InsufficientBalance.selector);
 
-        assertEq(burned, previewedShares);
-        assertLe(burned, sharesBefore);
-        assertEq(asset.balanceOf(alice), maxAssets);
-        // At most rounding dust may remain; a full exit must never revert. Dust is in
-        // shares, so its bound scales with 10 ** offset (one asset-wei of shares).
-        assertLe(
-            wrapper.balanceOf(alice),
-            2 * 10 ** wrapper.shareDecimalsOffset()
-        );
+        wrapper.withdraw(maxAssets, alice, alice);
+
+        vm.prank(alice);
+        uint256 assetsOut = wrapper.redeem(sharesBefore, alice, alice);
+
+        assertEq(asset.balanceOf(alice), assetsOut);
+        assertEq(wrapper.balanceOf(alice), 0);
     }
 
     function test_WithdrawRedeemInverseWithFee() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -543,7 +543,12 @@ contract LiFiVaultWrapperFeesTest is VaultWrapperFeeTestBase {
         uint256 out = wrapper.redeem(shares, alice, alice);
 
         assertEq(out, previewed);
-        assertApproxEqAbs(out, DEPOSIT + 50e18, 1);
+        // Exact-in redeem always floor-values the burned shares (never the adapter's
+        // full-position drain sentinel — see LiFiVaultWrapper.previewRedeem/_redeemExactIn),
+        // so on top of the wrapper's own floor rounding the underlying vault's OWN
+        // convertToShares/redeem rounding adds up to one more wei; tolerance widened from 1
+        // to 2 to account for that extra adapter round-trip.
+        assertApproxEqAbs(out, DEPOSIT + 50e18, 2);
         assertEq(_accruedFeeShares(), 0);
         assertEq(_accruedFeeAssets(), 0);
     }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.29;
 
 import { Vm } from "forge-std/Vm.sol";
-import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626 } from "solmate/mixins/ERC4626.sol";
@@ -374,33 +373,36 @@ contract LiFiVaultWrapperFeesTest is VaultWrapperFeeTestBase {
         );
     }
 
-    function testRevert_FullExitViaMaxWithdrawWithWithdrawalFeeExceedsBalance()
-        public
-    {
-        // The classic ERC-4626 fee-wrapper failure, re-surfacing at the cost-aware exact-
-        // out boundary: previewWithdraw's cost now round-trips through the *source's own*
-        // preview/convert functions (adapter.previewWithdrawCost), which lack the wrapper's
-        // "+1" ceiling safety margin. At the precise full-position edge that round-trip can
-        // snap the requested cost up to exactly totalAssets, pushing the share burn for
-        // withdraw(maxWithdraw(owner)) a few wei past the holder's balance. `redeem`
-        // (exact-in) has no such boundary and remains the safe full-exit path.
+    function test_FullExitViaMaxWithdrawWithWithdrawalFee() public {
+        // The classic ERC-4626 fee-wrapper failure: the exit fee pushes the share burn
+        // for withdraw(maxWithdraw(owner)) above the holder's balance. Guards the
+        // maxWithdraw == previewRedeem(maxRedeem(owner)) semantics the wrapper relies on.
+        // Cost-aware previewWithdraw (see LiFiVaultWrapper.previewWithdraw) additionally
+        // routes pricing through the adapter's previewWithdrawCost, which round-trips
+        // through the source's own preview/convert functions and can round the reported
+        // cost up to `totalAssets()` right at this boundary; previewWithdraw clamps `cost`
+        // at the largest value this contract can always safely convert back to at most
+        // `totalSupply()` shares, so the guard below still holds.
         wrapper = _newWrapperAssetFees(0, WD_RATE);
         _deposit(alice, DEPOSIT);
         _simulateYield(50e18); // non-trivial PPS so rounding paths are exercised
 
         uint256 sharesBefore = wrapper.balanceOf(alice);
         uint256 maxAssets = wrapper.maxWithdraw(alice);
+        uint256 previewedShares = wrapper.previewWithdraw(maxAssets);
 
         vm.prank(alice);
-        vm.expectPartialRevert(IERC20Errors.ERC20InsufficientBalance.selector);
+        uint256 burned = wrapper.withdraw(maxAssets, alice, alice);
 
-        wrapper.withdraw(maxAssets, alice, alice);
-
-        vm.prank(alice);
-        uint256 assetsOut = wrapper.redeem(sharesBefore, alice, alice);
-
-        assertEq(asset.balanceOf(alice), assetsOut);
-        assertEq(wrapper.balanceOf(alice), 0);
+        assertEq(burned, previewedShares);
+        assertLe(burned, sharesBefore);
+        assertEq(asset.balanceOf(alice), maxAssets);
+        // At most rounding dust may remain; a full exit must never revert. Dust is in
+        // shares, so its bound scales with 10 ** offset (one asset-wei of shares).
+        assertLe(
+            wrapper.balanceOf(alice),
+            2 * 10 ** wrapper.shareDecimalsOffset()
+        );
     }
 
     function test_WithdrawRedeemInverseWithFee() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
+import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
@@ -83,9 +84,17 @@ contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
 
     function testRevert_RedeemAboveClampedMax() public {
         source.setWithdrawable(300e18);
-        uint256 shares = wrapper.maxRedeem(alice) + 1;
+        uint256 maxShares = wrapper.maxRedeem(alice);
+        uint256 shares = maxShares + 1;
 
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxRedeem.selector,
+                alice,
+                shares,
+                maxShares
+            )
+        );
 
         vm.prank(alice);
         wrapper.redeem(shares, alice, alice);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
+
+contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
+    MockERC20 internal asset;
+    MockLiquidityCappedERC4626 internal source;
+
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal integrator = makeAddr("integrator");
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        source = new MockLiquidityCappedERC4626(asset, "Yield", "yTKN");
+
+        _bringUpFactory(address(source), [uint16(5000), 1000, 2000, 2000]);
+        _deployWrapper(_params());
+
+        asset.mint(alice, 1_000e18);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), 1_000e18);
+        wrapper.deposit(1_000e18, alice);
+
+        vm.stopPrank();
+    }
+
+    function _params() private view returns (DeployParams memory) {
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({ wallet: integrator, bps: 10000 });
+
+        return
+            DeployParams({
+                namespace: bytes32("LI.FI-Earn"),
+                vaultWrapperAdmin: vaultAdmin,
+                adapter: address(adapter),
+                underlying: address(source),
+                nonce: 0,
+                fees: FeeConfig({ rateBps: [uint16(0), 0, 0, 0] }),
+                integratorShareBps: [uint16(8000), 8000, 8000, 8000],
+                accessGate: address(0),
+                receivers: receivers
+            });
+    }
+
+    function test_MaxRedeemEqualsBalanceWhenSourceUnlimited() public {
+        source.setWithdrawable(1_000_000e18);
+
+        assertEq(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+    }
+
+    function test_MaxRedeemClampsToSourceLiquidity() public {
+        source.setWithdrawable(300e18);
+
+        assertLt(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+        assertApproxEqAbs(
+            wrapper.convertToAssets(wrapper.maxRedeem(alice)),
+            300e18,
+            2
+        );
+    }
+
+    function test_MaxWithdrawInheritsLiquidityClamp() public {
+        source.setWithdrawable(300e18);
+
+        assertApproxEqAbs(wrapper.maxWithdraw(alice), 300e18, 2);
+    }
+
+    function test_RedeemAtClampedMaxSucceeds() public {
+        source.setWithdrawable(300e18);
+        uint256 shares = wrapper.maxRedeem(alice);
+
+        vm.prank(alice);
+        uint256 assets = wrapper.redeem(shares, alice, alice);
+
+        assertGt(assets, 0);
+        assertApproxEqAbs(assets, 300e18, 2);
+    }
+
+    function testRevert_RedeemAboveClampedMax() public {
+        source.setWithdrawable(300e18);
+        uint256 shares = wrapper.maxRedeem(alice) + 1;
+
+        vm.expectRevert();
+
+        vm.prank(alice);
+        wrapper.redeem(shares, alice, alice);
+    }
+
+    function test_MaxRedeemIsZeroWhenSourceDry() public {
+        source.setWithdrawable(0);
+
+        assertEq(wrapper.maxRedeem(alice), 0);
+        assertEq(wrapper.maxWithdraw(alice), 0);
+    }
+}

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -7,6 +7,7 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
+import { MockLiquidityCappedERC4626 } from "../mocks/MockLiquidityCappedERC4626.sol";
 
 contract ERC4626AdapterTest is Test {
     ERC4626Adapter internal adapter;
@@ -90,6 +91,24 @@ contract ERC4626AdapterTest is Test {
         assertEq(
             adapter.maxWithdrawableValue(address(vault), makeAddr("nobody")),
             0
+        );
+    }
+
+    function test_MaxWithdrawableValueCapsAtSourceLiquidity() public {
+        MockLiquidityCappedERC4626 capped = new MockLiquidityCappedERC4626(
+            asset,
+            "Capped",
+            "cTKN"
+        );
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(capped), 1_000e18);
+        capped.deposit(1_000e18, address(this));
+        capped.setWithdrawable(300e18);
+
+        // Position is worth 1_000e18 but only 300e18 is currently withdrawable.
+        assertEq(
+            adapter.maxWithdrawableValue(address(capped), address(this)),
+            300e18
         );
     }
 }

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -59,18 +59,17 @@ contract ERC4626AdapterTest is Test {
         );
     }
 
-    function test_PreviewWithdrawUpToReturnsFullPositionOnDrainSentinel()
-        public
-    {
+    function test_PreviewWithdrawUpToCapsAtFullPosition() public {
         asset.mint(address(this), 1_000e18);
         asset.approve(address(vault), 1_000e18);
         vault.deposit(1_000e18, address(this));
 
+        // Asking for more position value than the holder owns caps at the full position.
         assertEq(
             adapter.previewWithdrawUpTo(
                 address(vault),
                 address(this),
-                type(uint256).max
+                5_000e18
             ),
             1_000e18
         );

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -74,4 +74,22 @@ contract ERC4626AdapterTest is Test {
             1_000e18
         );
     }
+
+    function test_MaxWithdrawableValueEqualsPositionWhenUnlimited() public {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), address(this)),
+            1_000e18
+        );
+    }
+
+    function test_MaxWithdrawableValueIsZeroForEmptyHolder() public {
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), makeAddr("nobody")),
+            0
+        );
+    }
 }

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
@@ -9,14 +11,20 @@ import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
 contract ERC4626AdapterTest is Test {
     ERC4626Adapter internal adapter;
     address internal assetToken = makeAddr("asset");
+    MockERC20 internal asset;
+    MockERC4626 internal vault;
 
     function setUp() public {
         adapter = new ERC4626Adapter();
+        asset = new MockERC20("Token", "TKN", 18);
+        vault = new MockERC4626(asset, "Yield Token", "yTKN");
     }
 
     function test_ResolveAssetReturnsAssetForValidVault() public {
-        MockERC4626Underlying vault = new MockERC4626Underlying(assetToken);
-        assertEq(adapter.resolveAsset(address(vault)), assetToken);
+        MockERC4626Underlying resolveVault = new MockERC4626Underlying(
+            assetToken
+        );
+        assertEq(adapter.resolveAsset(address(resolveVault)), assetToken);
     }
 
     function test_ResolveAssetRevertsOnNoCode() public {
@@ -25,8 +33,46 @@ contract ERC4626AdapterTest is Test {
     }
 
     function test_ResolveAssetRevertsOnZeroAsset() public {
-        MockERC4626Underlying vault = new MockERC4626Underlying(address(0));
+        MockERC4626Underlying zeroAssetVault = new MockERC4626Underlying(
+            address(0)
+        );
         vm.expectRevert(IYieldAdapter.AssetResolutionFailed.selector);
-        adapter.resolveAsset(address(vault));
+        adapter.resolveAsset(address(zeroAssetVault));
+    }
+
+    function test_PreviewWithdrawCostEqualsAssetsWhenNoFee() public {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(adapter.previewWithdrawCost(address(vault), 100e18), 100e18);
+    }
+
+    function test_PreviewWithdrawUpToEqualsAssetsWhenNoFee() public {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(
+            adapter.previewWithdrawUpTo(address(vault), address(this), 100e18),
+            100e18
+        );
+    }
+
+    function test_PreviewWithdrawUpToReturnsFullPositionOnDrainSentinel()
+        public
+    {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(
+            adapter.previewWithdrawUpTo(
+                address(vault),
+                address(this),
+                type(uint256).max
+            ),
+            1_000e18
+        );
     }
 }

--- a/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
+++ b/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
@@ -27,6 +27,11 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
     // (booked with the fee); the drained wrapper keeps sub-cent virtual-offset/flooring dust.
     uint256 internal constant WITHDRAW_TOL = 3;
     uint256 internal constant DRAIN_DUST = 1000; // 0.001 USDC
+    // Value of the shares left outstanding after every holder exits at `maxRedeem`: the source's
+    // own `balanceOf`-flooring `maxRedeem` (finding #4) strands ~1 source-share per exit, worth 1
+    // asset-wei in total at the pinned block. Bounded tight (0.00001 USDC) so any real share
+    // leakage — orders of magnitude larger on a ~45k-USDC flow — still trips it.
+    uint256 internal constant DRAIN_SHARE_DUST = 10;
 
     function _rpcEnvVar() internal pure override returns (string memory) {
         return "ETH_NODE_URI_ARBITRUM";
@@ -59,11 +64,14 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         _warpWithAccrual(WARP);
         _enter(carol, 15_000e6);
 
-        // Final accrual, everyone exits fully.
+        // Final accrual, everyone exits fully. Exit at `maxRedeem` (the EIP-4626-recommended
+        // pattern): the wrapper's `maxRedeem` is liquidity-aware and, over a MetaMorpho source
+        // whose own `maxRedeem` floors ~1 source-share below `balanceOf`, lands a dust amount
+        // below the raw balance — so `redeem(balanceOf)` would revert `ERC4626ExceededMaxRedeem`.
         _warpWithAccrual(WARP);
-        _exit(bob, wrapper.balanceOf(bob));
-        _exit(carol, wrapper.balanceOf(carol));
-        _exit(alice, wrapper.balanceOf(alice));
+        _exit(bob, wrapper.maxRedeem(bob));
+        _exit(carol, wrapper.maxRedeem(carol));
+        _exit(alice, wrapper.maxRedeem(alice));
 
         _distributeFeesAndAssertFanOut();
         _drainAndAssertConservation();
@@ -71,7 +79,7 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
 
     /// Deposits revert while paused; withdrawals stay open (withdrawals-always-open).
     function test_withdrawalsRemainOpenWhilePaused() public {
-        uint256 shares = _deposit(alice, 10_000e6);
+        _deposit(alice, 10_000e6);
 
         vm.prank(vaultAdmin);
         wrapper.pause();
@@ -85,7 +93,10 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         vm.stopPrank();
 
         uint256 balBefore = asset.balanceOf(alice);
-        _redeem(alice, shares);
+        // Exit at `maxRedeem` (see the lifecycle test): over MetaMorpho the wrapper's
+        // liquidity-aware `maxRedeem` sits a dust below `balanceOf`, so redeeming the raw
+        // balance would revert; the pause-does-not-block-withdrawals property is what matters.
+        _redeem(alice, wrapper.maxRedeem(alice));
 
         assertGt(
             asset.balanceOf(alice),
@@ -234,11 +245,20 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         wrapper.setFeeRate(FeeType.Withdrawal, 0);
         vm.stopPrank();
 
-        _redeem(lifiRecipient, wrapper.balanceOf(lifiRecipient));
-        _redeem(integrator1, wrapper.balanceOf(integrator1));
-        _redeem(integrator2, wrapper.balanceOf(integrator2));
+        _redeem(lifiRecipient, wrapper.maxRedeem(lifiRecipient));
+        _redeem(integrator1, wrapper.maxRedeem(integrator1));
+        _redeem(integrator2, wrapper.maxRedeem(integrator2));
 
-        assertEq(wrapper.totalSupply(), 0, "shares left outstanding");
+        // A clean-drain `totalSupply() == 0` is unreachable over a MetaMorpho source: each
+        // holder exits at `maxRedeem`, which the source's own `balanceOf`-flooring `maxRedeem`
+        // (finding #4) leaves ~1 source-share below the raw balance, so a dust of shares stays
+        // outstanding. Bound the residue by VALUE instead — it must be economically nothing yet
+        // still catch real share leakage.
+        assertLe(
+            wrapper.convertToAssets(wrapper.totalSupply()),
+            DRAIN_SHARE_DUST,
+            "residual share value exceeds source-flooring dust"
+        );
         assertLe(wrapper.totalAssets(), DRAIN_DUST, "position not drained");
         assertLe(
             asset.balanceOf(address(wrapper)),

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -7,6 +7,8 @@ import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaul
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
 import { VaultWrapperInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
 import { MockFeeERC4626 } from "test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
+import { VaultWrapperCappedSourceInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
 
 /// @notice Shared stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A
 ///         handler drives randomized multi-actor sequences — deposits, mints, withdrawals,
@@ -68,18 +70,28 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
         );
         _deployWrapper(_deployParams());
 
-        handler = new VaultWrapperInvariantHandler(
-            wrapper,
-            asset,
-            underlying,
-            factory,
-            vaultAdmin
-        );
+        handler = _deployHandler();
 
         targetContract(address(handler));
         targetSelector(
             FuzzSelector({ addr: address(handler), selectors: _actions() })
         );
+    }
+
+    /// @dev Subclass seam: the handler under test. Base = plain handler.
+    function _deployHandler()
+        internal
+        virtual
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
     }
 
     /// @dev The idle asset balance is exactly the deposit/withdrawal fees booked but not yet
@@ -146,6 +158,24 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
         );
     }
 
+    /// @dev The value of each actor's `maxRedeem` never exceeds what the source can currently
+    ///      pay the wrapper — the liquidity clamp is honored. On an unlimited source this is
+    ///      the full position; on a capped source it tracks the cap. Complements the
+    ///      fail-on-revert proof that a `redeem` bounded to `maxRedeem` never reverts.
+    function invariant_MaxRedeemWithinSourceLiquidity() public view {
+        uint256 realizable = adapter.maxWithdrawableValue(
+            address(underlying),
+            address(wrapper)
+        );
+        for (uint256 i; i < 3; ++i) {
+            assertLe(
+                wrapper.convertToAssets(wrapper.maxRedeem(handler.actors(i))),
+                realizable,
+                "maxRedeem value exceeds source liquidity"
+            );
+        }
+    }
+
     function _deployParams() private view returns (DeployParams memory) {
         uint16[4] memory rates = [
             PERF_RATE,
@@ -178,7 +208,12 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
     }
 
     /// @dev The handler entrypoints the fuzzer may call; the ghost/actor getters are excluded.
-    function _actions() private pure returns (bytes4[] memory selectors) {
+    function _actions()
+        internal
+        pure
+        virtual
+        returns (bytes4[] memory selectors)
+    {
         selectors = new bytes4[](10);
         selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
         selectors[1] = VaultWrapperInvariantHandler.mint.selector;
@@ -211,5 +246,58 @@ contract VaultWrapperFeeSourceInvariantTest is VaultWrapperInvariantBase {
                 SOURCE_FEE_BPS,
                 sourceFeeSink
             );
+    }
+}
+
+/// @notice Same invariant suite over a source whose withdrawal liquidity is fuzzed up and
+///         down — proving the wrapper's liquidity-aware `max*` never over-report and a redeem
+///         within `maxRedeem` never reverts even as source liquidity shifts.
+contract VaultWrapperCappedSourceInvariantTest is VaultWrapperInvariantBase {
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal override returns (MockERC4626) {
+        return new MockLiquidityCappedERC4626(_asset, "Yield Token", "yTKN");
+    }
+
+    function _deployHandler()
+        internal
+        override
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperCappedSourceInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
+    }
+
+    // `withdraw` is deliberately omitted: on a liquidity-capped source the exact-out withdraw
+    // path can revert at EITHER the share-rounding boundary OR a source-liquidity boundary, and
+    // it is not the guaranteed exit. Its boundary behavior is covered by the no-fee/fee-source
+    // suites (share-rounding) and the wrapper unit tests (liquidity clamp + ExceededMaxWithdraw).
+    // This suite exercises the guaranteed `redeem` path and the max-view clamp under shifting
+    // liquidity.
+    function _actions()
+        internal
+        pure
+        override
+        returns (bytes4[] memory selectors)
+    {
+        selectors = new bytes4[](10);
+        selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
+        selectors[1] = VaultWrapperInvariantHandler.mint.selector;
+        selectors[2] = VaultWrapperInvariantHandler.redeem.selector;
+        selectors[3] = VaultWrapperInvariantHandler.distributeFees.selector;
+        selectors[4] = VaultWrapperInvariantHandler.injectYield.selector;
+        selectors[5] = VaultWrapperInvariantHandler.injectLoss.selector;
+        selectors[6] = VaultWrapperInvariantHandler.warp.selector;
+        selectors[7] = VaultWrapperInvariantHandler.setFee.selector;
+        selectors[8] = VaultWrapperInvariantHandler.togglePause.selector;
+        selectors[9] = VaultWrapperCappedSourceInvariantHandler
+            .setLiquidity
+            .selector;
     }
 }

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -6,19 +6,22 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
 import { VaultWrapperInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
+import { MockFeeERC4626 } from "test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol";
 
-/// @notice Stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A handler
-///         drives randomized multi-actor sequences — deposits, mints, withdrawals, redeems,
-///         fee distributions, fee retunes, pause toggles, and injected yield/loss/time — against one
-///         wrapper charging all four fee types over an inflatable mock underlying. The math
-///         library is already property-fuzzed in isolation; this suite proves the stateful
-///         composition holds under arbitrary interleavings: idle assets and the wrapper's own
-///         share balance always exactly back the booked fee counters, the performance
-///         high-water mark never regresses (asserted in the handler), depositors can never
-///         extract more than was deposited plus injected yield, and no shares are minted or
-///         burned outside the tracked holder set. The suite runs `fail-on-revert = true`, so a
-///         pause that ever blocked an exit — or any other unexpected revert — fails a run.
-contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
+/// @notice Shared stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A
+///         handler drives randomized multi-actor sequences — deposits, mints, withdrawals,
+///         redeems, fee distributions, fee retunes, pause toggles, and injected yield/loss/time
+///         — against one wrapper charging all four fee types over an underlying source. The
+///         underlying source is a virtual seam (`_deployUnderlying`) so the exact same suite runs
+///         over both a plain no-fee source and a source charging its own exit fee (EXSC-421 /
+///         S12 exit-cost-awareness): idle assets and the wrapper's own share balance always
+///         exactly back the booked fee counters, the performance high-water mark never regresses
+///         (asserted in the handler), depositors can never extract more than was deposited plus
+///         injected yield, exits never pay out more than the burned shares were worth at exit,
+///         and no shares are minted or burned outside the tracked holder set. The suite runs
+///         `fail-on-revert = true`, so a pause that ever blocked an exit — or any other
+///         unexpected revert — fails a run.
+abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
     // Governance-set bounds equal to the immutable bytecode caps, so the handler can retune
     // each fee across its whole legal range.
     uint16 internal constant PERF_CAP = 5000;
@@ -36,6 +39,9 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
     uint16 internal constant RECEIVER_1_BPS = 6000;
     uint16 internal constant RECEIVER_2_BPS = 4000;
 
+    // 1% exit fee, used only by the fee-charging-source subclass.
+    uint16 internal constant SOURCE_FEE_BPS = 100;
+
     MockERC20 internal asset;
     MockERC4626 internal underlying;
     VaultWrapperInvariantHandler internal handler;
@@ -43,10 +49,18 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
     address internal vaultAdmin = makeAddr("vaultAdmin");
     address internal integrator1 = makeAddr("integrator1");
     address internal integrator2 = makeAddr("integrator2");
+    address internal sourceFeeSink = makeAddr("sourceFeeSink");
+
+    /// @dev Subclass seam: the underlying source under test. Base = plain no-fee mock.
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal virtual returns (MockERC4626) {
+        return new MockERC4626(_asset, "Yield Token", "yTKN");
+    }
 
     function setUp() public {
         asset = new MockERC20("Token", "TKN", 18);
-        underlying = new MockERC4626(asset, "Yield Token", "yTKN");
+        underlying = _deployUnderlying(asset);
 
         _bringUpFactory(
             address(underlying),
@@ -119,6 +133,19 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
         );
     }
 
+    /// @dev An exit can lose value to a source exit fee or a loss, but can NEVER pay the
+    ///      exiter more than their burned shares were worth at exit — otherwise the exit
+    ///      created value at the remaining holders' expense (dilution). Cost-aware
+    ///      previewWithdraw and realizable redeem both enforce this per-exit; the ghost
+    ///      totals prove it holds cumulatively under arbitrary interleavings.
+    function invariant_ExitsNeverCreateValueForExiter() public view {
+        assertLe(
+            handler.cumulativePaidOut(),
+            handler.cumulativeSliceValue(),
+            "an exit paid out more than the burned shares were worth"
+        );
+    }
+
     function _deployParams() private view returns (DeployParams memory) {
         uint16[4] memory rates = [
             PERF_RATE,
@@ -163,5 +190,26 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
         selectors[7] = VaultWrapperInvariantHandler.warp.selector;
         selectors[8] = VaultWrapperInvariantHandler.setFee.selector;
         selectors[9] = VaultWrapperInvariantHandler.togglePause.selector;
+    }
+}
+
+/// @notice Invariant suite over a plain, no-fee ERC-4626 source.
+contract VaultWrapperInvariantTest is VaultWrapperInvariantBase {}
+
+/// @notice Same invariant suite over a compliant source charging a 1% exit fee that
+///         leaves the source vault — proving cost-aware exits never dilute stayers even
+///         when the source imposes an exit cost.
+contract VaultWrapperFeeSourceInvariantTest is VaultWrapperInvariantBase {
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal override returns (MockERC4626) {
+        return
+            new MockFeeERC4626(
+                _asset,
+                "Yield Token",
+                "yTKN",
+                SOURCE_FEE_BPS,
+                sourceFeeSink
+            );
     }
 }

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -7,6 +7,7 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { FeeType } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
 
 /// @notice Handler that drives a single `LiFiVaultWrapper` through bounded, randomized
 ///         multi-actor sequences for the invariant suite: three depositors enter/exit while
@@ -155,10 +156,10 @@ contract VaultWrapperInvariantHandler is Test {
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {
         address actor = _actor(_actorSeed);
-        uint256 balance = WRAPPER.balanceOf(actor);
-        if (balance == 0) return;
+        uint256 ceiling = WRAPPER.maxRedeem(actor);
+        if (ceiling == 0) return;
 
-        uint256 shares = bound(_shares, 1, balance);
+        uint256 shares = bound(_shares, 1, ceiling);
         uint256 sliceValue = WRAPPER.convertToAssets(shares);
 
         vm.prank(actor);
@@ -228,5 +229,35 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 current = WRAPPER.perfHighWaterMarkPps();
         assertGe(current, hwmFloor, "high-water mark regressed");
         hwmFloor = current;
+    }
+}
+
+/// @notice Handler variant that additionally fuzzes the source's withdrawal-liquidity cap,
+///         driving `maxRedeem`/`maxWithdraw` through their full liquidity-clamped range.
+contract VaultWrapperCappedSourceInvariantHandler is
+    VaultWrapperInvariantHandler
+{
+    constructor(
+        LiFiVaultWrapper _wrapper,
+        MockERC20 _asset,
+        MockERC4626 _underlying,
+        LiFiVaultWrapperFactory _factory,
+        address _vaultAdmin
+    )
+        VaultWrapperInvariantHandler(
+            _wrapper,
+            _asset,
+            _underlying,
+            _factory,
+            _vaultAdmin
+        )
+    {}
+
+    /// @notice Moves the source's withdrawable-liquidity cap anywhere in [0, totalAssets].
+    function setLiquidity(uint256 _assets) external {
+        uint256 total = UNDERLYING.totalAssets();
+        MockLiquidityCappedERC4626(address(UNDERLYING)).setWithdrawable(
+            bound(_assets, 0, total)
+        );
     }
 }

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -51,6 +51,12 @@ contract VaultWrapperInvariantHandler is Test {
     uint256 public ghostYield;
     /// @notice Highest high-water mark observed; the ratchet asserts it never regresses.
     uint256 public hwmFloor;
+    /// @notice Assets ever paid out to exiters across all exits.
+    uint256 public cumulativePaidOut;
+    /// @notice Value the exiters' burned shares were worth at exit (pre-exit, accrual-aware
+    ///         convertToAssets). The new invariant asserts paid-out never exceeds this — an
+    ///         exit can lose value to a source fee/loss but never GAIN at the stayers' expense.
+    uint256 public cumulativeSliceValue;
 
     constructor(
         LiFiVaultWrapper _wrapper,
@@ -123,10 +129,16 @@ contract VaultWrapperInvariantHandler is Test {
         if (ceiling == 0) return;
 
         uint256 assets = bound(_assets, 1, ceiling);
+        // Value the shares the exit will burn, at the pre-exit (accrual-aware) price.
+        uint256 sliceValue = WRAPPER.convertToAssets(
+            WRAPPER.previewWithdraw(assets)
+        );
 
         vm.prank(actor);
         try WRAPPER.withdraw(assets, actor, actor) returns (uint256) {
             ghostAssetsOut += assets;
+            cumulativePaidOut += assets;
+            cumulativeSliceValue += sliceValue;
             _ratchetHwm();
         } catch {
             // The ONLY accepted revert is the exact-out boundary (finding #4, out of
@@ -147,11 +159,14 @@ contract VaultWrapperInvariantHandler is Test {
         if (balance == 0) return;
 
         uint256 shares = bound(_shares, 1, balance);
+        uint256 sliceValue = WRAPPER.convertToAssets(shares);
 
         vm.prank(actor);
         uint256 received = WRAPPER.redeem(shares, actor, actor);
 
         ghostAssetsOut += received;
+        cumulativePaidOut += received;
+        cumulativeSliceValue += sliceValue;
         _ratchetHwm();
     }
 

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -13,7 +13,14 @@ import { FeeType } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 ///         the underlying's price per share is moved by injected yield/loss and time warps,
 ///         the vaultAdmin retunes fee rates and toggles pause, and anyone distributes fees. Every input
 ///         is bounded so no operation reverts for a legitimate reason (the suite runs
-///         `fail-on-revert = true`, so any revert is a real defect); deposits are the only
+///         `fail-on-revert = true`, so any revert is a real defect), with one documented
+///         exception: `withdraw`'s exact-out cost-aware pricing round-trips through the
+///         source's own preview/convert functions, whose rounding noise scales with the
+///         source's price per share and can occasionally exceed an actor's tight headroom
+///         right at their own `maxWithdraw` (see `withdraw` below) — that single, understood
+///         revert path is caught and re-verified as exactly that boundary (asserting the
+///         burn would have exceeded the owner's balance) rather than failing the campaign;
+///         any other revert still fails it. Deposits are the only
 ///         path gated by pause, so they are skipped while paused while exits are left
 ///         unguarded — a pause that ever blocked an exit would surface as a revert. Ghost
 ///         totals (assets in vs out, yield injected) and a high-water-mark ratchet are
@@ -102,18 +109,36 @@ contract VaultWrapperInvariantHandler is Test {
     function withdraw(uint256 _actorSeed, uint256 _assets) external {
         address actor = _actor(_actorSeed);
         // maxWithdraw is fee-aware (previewRedeem(maxRedeem(owner)) with the wrapper's
-        // fee-deducting previewRedeem), so withdraw(maxWithdraw(actor)) is exactly
-        // exitable — drive the full allowed range so near-max/full exits are exercised.
+        // fee-deducting previewRedeem) — drive the full allowed range so near-max/full
+        // exits are exercised. Cost-aware previewWithdraw prices the burn through the
+        // adapter's previewWithdrawCost, which round-trips through the source's own
+        // preview/convert functions; that round-trip's rounding noise is bounded by
+        // roughly "one source-share's worth of assets", which scales with the source's
+        // price per share and can exceed the few wei of headroom left right at an
+        // actor's own maxWithdraw (exercised here via the fuzzed high-yield injections).
+        // The ONLY accepted revert is that exact-out burn-exceeds-balance boundary;
+        // `redeem` has no such boundary and is exercised separately below, so exiting is
+        // never blocked. Any other revert is a real defect and must fail the campaign.
         uint256 ceiling = WRAPPER.maxWithdraw(actor);
         if (ceiling == 0) return;
 
         uint256 assets = bound(_assets, 1, ceiling);
 
         vm.prank(actor);
-        WRAPPER.withdraw(assets, actor, actor);
-
-        ghostAssetsOut += assets;
-        _ratchetHwm();
+        try WRAPPER.withdraw(assets, actor, actor) returns (uint256) {
+            ghostAssetsOut += assets;
+            _ratchetHwm();
+        } catch {
+            // The ONLY accepted revert is the exact-out boundary (finding #4, out of
+            // scope): cost-aware previewWithdraw rounds the share burn above the owner's
+            // balance at/near their own maxWithdraw. Any revert while the burn is
+            // affordable is a real defect and must fail the campaign.
+            assertGt(
+                WRAPPER.previewWithdraw(assets),
+                WRAPPER.balanceOf(actor),
+                "withdraw reverted below the exact-out share-rounding boundary"
+            );
+        }
     }
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {

--- a/test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { FixedPointMathLib } from "solmate/utils/FixedPointMathLib.sol";
+import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
+
+/// @notice Compliant ERC-4626 charging a bps exit fee whose assets LEAVE the vault (to
+///         `feeSink`). Exact-out `withdraw` delivers exactly `assets` (burning grossed-up
+///         shares); exact-in `redeem` delivers the net; both send the fee to `feeSink` so
+///         a sole depositor's redeemable claim actually shrinks. Used to prove the wrapper
+///         charges a source exit fee to the exiting user, not remaining holders.
+contract MockFeeERC4626 is MockERC4626 {
+    using FixedPointMathLib for uint256;
+    using SafeTransferLib for ERC20;
+
+    uint256 public immutable EXIT_FEE_BPS; // 100 = 1%
+    address public immutable FEE_SINK;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol,
+        uint256 _exitFeeBps,
+        address _feeSink
+    ) MockERC4626(_asset, _name, _symbol) {
+        EXIT_FEE_BPS = _exitFeeBps;
+        FEE_SINK = _feeSink;
+    }
+
+    function _exitFee(uint256 gross) internal view returns (uint256) {
+        return gross.mulDivUp(EXIT_FEE_BPS, 10_000);
+    }
+
+    /// @dev Exact-in: net of the exit fee.
+    function previewRedeem(
+        uint256 shares
+    ) public view override returns (uint256) {
+        uint256 gross = super.previewRedeem(shares);
+        return gross - _exitFee(gross);
+    }
+
+    /// @dev Exact-out: grossed-up shares so the net delivered equals `assets`.
+    function previewWithdraw(
+        uint256 assets
+    ) public view override returns (uint256) {
+        uint256 gross = assets.mulDivUp(10_000, 10_000 - EXIT_FEE_BPS);
+        return super.previewWithdraw(gross);
+    }
+
+    function maxWithdraw(
+        address owner
+    ) public view override returns (uint256) {
+        return previewRedeem(balanceOf[owner]);
+    }
+
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override returns (uint256 assets) {
+        uint256 gross = super.previewRedeem(shares);
+        uint256 fee = _exitFee(gross);
+        assets = gross - fee;
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+            if (allowed != type(uint256).max)
+                allowance[owner][msg.sender] = allowed - shares;
+        }
+        _burn(owner, shares);
+        asset.safeTransfer(receiver, assets);
+        asset.safeTransfer(FEE_SINK, fee);
+    }
+
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256 shares) {
+        shares = previewWithdraw(assets);
+        // Fee basis mirrors previewWithdraw's grossing, so `fee` is exactly the bps
+        // fee; any share/asset rounding surplus stays in the vault, not the sink.
+        uint256 gross = assets.mulDivUp(10_000, 10_000 - EXIT_FEE_BPS);
+        uint256 fee = gross - assets;
+
+        if (msg.sender != owner) {
+            uint256 allowed = allowance[owner][msg.sender];
+            if (allowed != type(uint256).max)
+                allowance[owner][msg.sender] = allowed - shares;
+        }
+        _burn(owner, shares);
+        asset.safeTransfer(receiver, assets);
+        asset.safeTransfer(FEE_SINK, fee);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+
+/// @notice Compliant ERC-4626 modelling an Aave-style withdrawal-liquidity cap: all deposited
+///         assets stay on the vault (so `totalAssets` and price-per-share are unchanged), but
+///         only `withdrawableAssets` of value may leave via `withdraw`/`redeem` at any moment.
+///         `maxWithdraw`/`maxRedeem` report the cap and the mutating paths revert past it, so a
+///         caller that respects the reported max never reverts. `setWithdrawable` moves the cap
+///         up and down to fuzz shifting liquidity. Used to prove the wrapper's liquidity-aware
+///         `max*` views. The cap is a policy limit, not a balance: the assets are always
+///         physically present, so any within-cap exit succeeds.
+contract MockLiquidityCappedERC4626 is MockERC4626 {
+    error WithdrawExceedsLiquidity();
+
+    uint256 public withdrawableAssets;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol
+    ) MockERC4626(_asset, _name, _symbol) {}
+
+    function setWithdrawable(uint256 _assets) external {
+        withdrawableAssets = _assets;
+    }
+
+    function maxWithdraw(
+        address owner
+    ) public view override returns (uint256) {
+        uint256 own = convertToAssets(balanceOf[owner]);
+        return own < withdrawableAssets ? own : withdrawableAssets;
+    }
+
+    function maxRedeem(address owner) public view override returns (uint256) {
+        uint256 capShares = convertToShares(withdrawableAssets);
+        uint256 own = balanceOf[owner];
+        return own < capShares ? own : capShares;
+    }
+
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (assets > maxWithdraw(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (shares > maxRedeem(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.redeem(shares, receiver, owner);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -54,4 +54,11 @@ contract MockZeroAdapter is IYieldAdapter {
     ) external pure returns (uint256) {
         return 0;
     }
+
+    function maxWithdrawableValue(
+        address,
+        address
+    ) external pure returns (uint256) {
+        return 0;
+    }
 }

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -31,4 +31,27 @@ contract MockZeroAdapter is IYieldAdapter {
     ) external pure returns (uint256) {
         return 0;
     }
+
+    function previewWithdrawCost(
+        address,
+        uint256 _assets
+    ) external pure returns (uint256) {
+        return _assets;
+    }
+
+    function previewWithdrawUpTo(
+        address,
+        address,
+        uint256
+    ) external pure returns (uint256) {
+        return 0;
+    }
+
+    function withdrawUpTo(
+        address,
+        address,
+        uint256
+    ) external pure returns (uint256) {
+        return 0;
+    }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_TODO: link the Linear ticket (e.g. `EXSC-XXX`) before requesting review — required for the ticket-linkage metric._

# Why did I implement it this way?

This PR makes the wrapper's exit paths **and** exit views correct against a real yield source: the exiter bears the source's exit cost (no dilution of stayers, no bricked last exit), and the `max*` views never over-report what the source can actually honor right now. It folds in two findings that were originally split across two branches — the exit-cost fix and the source-liquidity-aware `max*` views (finding #4, previously PR #2206, now merged in here).

## Cost-aware exits (exit-cost)

The wrapper previously priced exits off the shares' face valuation. When the underlying yield source charges an exit fee, that fee was socialized onto the remaining holders (dilution), and a last holder's full redeem could revert on a fee-charging source. This PR prices exits off the source's own EIP-4626 previews (its true exit cost), so the exiting user bears the source's exit fee instead of the remaining holders.

- Added three views to `IYieldAdapter` (implemented in `ERC4626Adapter`): `previewWithdrawCost` (exact-out: position value the source consumes to deliver `N` assets, `>= N` on a fee source), `previewWithdrawUpTo` (exact-in realizable, net of the source fee), and `withdrawUpTo` (exact-in execution, delegatecall).
- `previewWithdraw` is now cost-aware exact-out: the exiter's share burn is priced off the source's true exit cost, clamped at the full-position floor value so source-preview rounding cannot overshoot near a full exit. The exiter bears the source exit fee; remaining holders are not diluted.
- `redeem` is now exact-in and loss-tolerant: it realizes the burned shares' proportional slice via `withdrawUpTo` and pays out what the source actually delivered, net of the wrapper withdrawal fee (charged on actual proceeds). A source paying under valuation (exit fee or loss) reduces this caller's payout rather than diluting stayers or bricking the last exit. `previewRedeem` is the realizable mirror.
- Exits always floor-value (no raw-position drain). Draining the raw position for the last holder would bypass the virtual-offset inflation protection (a donation-inflation attacker who is the last holder could recover their donation); floor-valuing keeps the small virtual-offset residue in the source as the inflation buffer, matching standard OpenZeppelin behaviour.

On a fee source, `maxWithdraw`/`maxRedeem` are fee-aware (they route through the realizable `previewRedeem`), so attempting to exact-out `withdraw` the full nominal deposit reverts `ERC4626ExceededMaxWithdraw`; `redeem` is the guaranteed full exit.

## Source-liquidity-aware max views (finding #4)

The exit-cost work above made the `max*` views fee/loss-aware but not **source-liquidity**-aware. When a yield source can only release part of the wrapper's position right now (an Aave-style utilization cap, a paused source, an illiquid Morpho market), the views over-reported and a `redeem`/`withdraw` within the reported max could revert — breaking the EIP-4626 guarantee that an exit within `maxRedeem` never reverts.

- Added one static adapter view `IYieldAdapter.maxWithdrawableValue(underlying, holder)` (implemented in `ERC4626Adapter`): the source's floor valuation (`convertToAssets`) of `min(holder position, source.maxRedeem)`. It is the **gross** valuation (deliberately not the fee-netted `previewRedeem` the sibling `previewWithdrawUpTo` uses), because the wrapper feeds it straight into its own gross-denominated share math to clamp the views; any source exit fee is applied separately by the realizable redeem path.
- `LiFiVaultWrapper.maxRedeem` now clamps the owner's balance to `_convertToShares(maxWithdrawableValue, Floor)` — but only when the source is genuinely liquidity-limited. A full-position short-circuit (`realizable >= totalAssets()`) returns the plain balance on fully-liquid sources, avoiding the ~1-share under-report the virtual-offset share round-trip would otherwise introduce. `maxWithdraw` inherits the clamp because OZ derives it as `previewRedeem(maxRedeem(owner))`, so the `withdraw` entrypoint's `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too.
- `previewRedeem`/`previewWithdraw` stay liquidity-agnostic (EIP-4626 requires previews to ignore withdrawal limits). Exit execution paths are unchanged — they already fail on a short source; finding #4 was about the views.

Accepted tradeoff (documented): on OZ-style sources whose own `maxRedeem` floors ~1 share below `balanceOf` even at full liquidity (e.g. MetaMorpho), the clamp lands a sub-`1e-12`-token dust below `balanceOf`, so a one-call `redeem(balanceOf)` can hit `ERC4626ExceededMaxRedeem`. Callers should exit via `redeem(maxRedeem(owner))` (the EIP-4626-recommended pattern); a follow-up call clears the dust. `redeem` remains the guaranteed exit.

## Scope, versioning, health-check

Scope is the exit paths and exit views only. Out of scope and documented as the only remaining gaps: deposit entry-fee awareness, and fee-on-transfer / non-compliant sources (unsupported — they need a dedicated adapter). `@custom:version` is held at `1.0.0` (subsystem is pre-release). `script/deploy/healthCheckInvariants.ts` was reviewed: no change needed (this adds interface methods and internal view logic only — no deployed-contract topology, constructor, selector, or storage change; the Vault Wrapper is outside the Diamond the health-check covers).

# Testing

- Exit-cost: added `MockFeeERC4626` (a compliant ERC-4626 whose exit fee leaves the source vault, so dilution is observable), exit-cost unit and regression tests, and extended the stateful invariant suite to run over both a no-fee and a fee-charging source with a new `invariant_ExitsNeverCreateValueForExiter`. Two pre-existing full-supply-redeem assertions were widened from 1 to 2 wei (the realizable path adds one bounded layer of source-preview rounding); the `LossyVault` test mock gained standard ERC-4626 views now reached through the exit-cost path.
- Source-liquidity (finding #4): added `MockLiquidityCappedERC4626` (models an Aave-style withdrawal cap — assets stay on the vault, only a policy-limited amount may leave), adapter and wrapper unit tests, and a third stateful invariant suite that fuzzes the source's liquidity cap up and down while a `redeem` bounded to `maxRedeem` runs under `fail-on-revert` (0 reverts, with the clamp actively binding on most executed redeems), plus `invariant_MaxRedeemWithinSourceLiquidity`. The Morpho Arbitrum fork scenario was updated to exit via `redeem(maxRedeem)` and to assert the drain residue is dust (`convertToAssets(totalSupply()) <= 10 wei`) instead of exactly 0.

Full subsystem suite: 349 tests passing (347 non-fork re-verified locally after merging latest `main` via `dev-vault-wrapper`; fork suite unchanged).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
