### PR TITLE
chore(claude): remove unusable Slack MCP server from .mcp.json (EXSC-770)

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -95,7 +95,7 @@ Several of the bundled skills (`sc-design-review`, `start-linear-ticket`, etc.) 
 
 ### Slack is not in `.mcp.json`
 
-`post-pr-for-review` and `finish-rollout` need Slack, but Slack cannot be declared here: its OAuth server does not support dynamic client registration, so Claude Code cannot register itself as a client and every auth attempt fails with `Incompatible auth server`. Slack requires a pre-registered OAuth app.
+`post-pr-for-review`, `finish-rollout`, `multisig-rollout`, `offboard-sc-dev`, `check-open-prs`, `request-audit` and `resolve-audit-issues` all call Slack, but Slack cannot be declared here: its OAuth server does not support dynamic client registration, so Claude Code cannot register itself as a client and every auth attempt fails with `Incompatible auth server`. Slack requires a pre-registered OAuth app.
 
 Add it as a **claude.ai connector** instead (claude.ai → Settings → Connectors → Slack), which uses Anthropic's registered Slack app. It then appears in Claude Code alongside the servers above, and the Slack-dependent skills work as documented.
 
@@ -118,3 +118,5 @@ Add it as a **claude.ai connector** instead (claude.ai → Settings → Connecto
 ### Adding a new MCP server
 
 If you're adding a skill that depends on a new MCP server, also add the server to `.mcp.json` and document it in the table above. Keep the criterion strict: only servers that something *in this repo* actively calls. Personal productivity MCPs (Gmail, Calendar, etc.) belong in your user-level Claude Code config, not here.
+
+One exception: a server whose OAuth provider doesn't support dynamic client registration cannot be declared in `.mcp.json` at all — Claude Code has no client ID to register with and the entry fails permanently. Route those through a claude.ai connector and document them like Slack above, rather than adding a block that can never authenticate.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -77,7 +77,7 @@ If you don't use Claude Code, you can ignore this directory entirely — none of
 
 ### Why bundle them
 
-Several of the bundled skills (`post-pr-for-review`, `sc-design-review`, `start-linear-ticket`, etc.) call out to external services via MCP. Without the right servers configured, the skills fail with cryptic errors. Bundling them via project-level `.mcp.json` means anyone who clones this repo gets a one-click setup instead of hunting through docs.
+Several of the bundled skills (`sc-design-review`, `start-linear-ticket`, etc.) call out to external services via MCP. Without the right servers configured, the skills fail with cryptic errors. Bundling them via project-level `.mcp.json` means anyone who clones this repo gets a one-click setup instead of hunting through docs.
 
 ### Security model
 
@@ -90,15 +90,20 @@ Several of the bundled skills (`post-pr-for-review`, `sc-design-review`, `start-
 | Server | Endpoint | Used by | Auth |
 |---|---|---|---|
 | `linear` | `https://mcp.linear.app/mcp` | `start-linear-ticket` | OAuth (linear.app) — browser flow on first call |
-| `slack` | `https://mcp.slack.com/mcp` | `post-pr-for-review` | OAuth (LI.FI Slack workspace) — sign in once, your messages post as you |
 | `notion` | `https://mcp.notion.com/mcp` | `sc-design-review` (PRD ingestion) | OAuth (notion.so) — grant access to the LI.FI Notion workspace |
 | `blockscout` | `https://mcp.blockscout.com/mcp` | Ad-hoc onchain inspection of deployed contracts (no specific skill yet) | No login — public read-only endpoint |
+
+### Slack is not in `.mcp.json`
+
+`post-pr-for-review` and `finish-rollout` need Slack, but Slack cannot be declared here: its OAuth server does not support dynamic client registration, so Claude Code cannot register itself as a client and every auth attempt fails with `Incompatible auth server`. Slack requires a pre-registered OAuth app.
+
+Add it as a **claude.ai connector** instead (claude.ai → Settings → Connectors → Slack), which uses Anthropic's registered Slack app. It then appears in Claude Code alongside the servers above, and the Slack-dependent skills work as documented.
 
 ### First-time setup
 
 1. `cd` into this repo and run `claude` (or open Claude Code in this directory).
 2. Claude Code detects `.mcp.json` and prompts: **"This workspace declares N MCP servers. Approve?"** Accept (or decline individual servers you don't need).
-3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX` → Linear), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** (Linear, Notion) or **LI.FI Slack identity** (Slack). Blockscout requires no auth.
+3. The first time you invoke a skill that uses one of these servers (e.g. `start ticket EXSC-XXX` → Linear), Claude Code triggers an OAuth flow in your browser. Sign in with your **LI.FI Google account** (Linear, Notion). Blockscout requires no auth.
 4. The token is stored locally by Claude Code (per-user); subsequent calls reuse it without prompting.
 
 > **Tip:** you don't have to authenticate everything upfront. Each server only triggers its OAuth flow the first time a skill actually calls it. If you only use `start-linear-ticket`, you'll only see the Linear prompt.

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,10 +4,6 @@
       "type": "http",
       "url": "https://mcp.linear.app/mcp"
     },
-    "slack": {
-      "type": "http",
-      "url": "https://mcp.slack.com/mcp"
-    },
     "notion": {
       "type": "http",
       "url": "https://mcp.notion.com/mcp"


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-770/remove-unusable-slack-mcp-server-from-contracts-mcpjson

# Why did I implement it this way?

The `slack` entry in the root `.mcp.json` can never authenticate, for anyone.

Slack's OAuth authorization server metadata advertises no `registration_endpoint`:

```bash
curl -s https://mcp.slack.com/.well-known/oauth-authorization-server
```

```text
issuer, authorization_endpoint, token_endpoint, response_types_supported,
grant_types_supported, token_endpoint_auth_methods_supported: ["client_secret_post"],
code_challenge_methods_supported, scopes_supported
```

No `registration_endpoint` means Claude Code cannot dynamically register itself as an OAuth client (RFC 7591), so every auth attempt on that server ends in:

```text
SDK auth failed: Incompatible auth server: does not support dynamic client registration
```

Slack requires a **pre-registered** OAuth app (client ID + secret, `client_secret_post`), which a project-level `.mcp.json` entry has no way to supply. Linear and Notion *do* support dynamic registration — that is why those two authenticate fine from the same file while Slack does not. The result today is that everyone who clones this repo gets a permanently failing server plus an "Authenticate" prompt that leads nowhere.

Removing the entry does not remove Slack capability. `post-pr-for-review` and `finish-rollout` still need Slack, and they get it through the **claude.ai connector** (Settings → Connectors → Slack), which is backed by Anthropic's pre-registered Slack app. Once connected it shows up in Claude Code next to the other servers and the skills work as documented. `.claude/README.md` gains a short section explaining exactly this, so the next person doesn't re-derive it.

Docs touched alongside the config, to keep the README from drifting:

- removed the `slack` row from the "Current servers" table
- dropped `post-pr-for-review` from the list of skills served by bundled MCP servers (its server is no longer bundled)
- dropped the "or **LI.FI Slack identity** (Slack)" clause from the first-time-setup sign-in step

Scope note: this only touches the Claude Code tooling config and its README — no Solidity, scripts, or deployment artifacts.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
