### PR TITLE
fix(deploy): detect facet removals that never executed (EXSC-774)

### DIFF
--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -586,12 +586,20 @@ origin-PR lines to the signer.
         │                    │
         │       linked proposal executed + loupe confirms facet absent
         │                    ▼
-        │                executed  (terminal, = done)
-        │
-        └── operator CLI (deprecation reverted / obsolete) ─► cancelled (terminal)
+        │       executed / superseded  (terminal, = done)
+        │                    │
+        └────────────────────┘ reconcile: facet NAME still routed → reopen (EXSC-774)
+
+             operator CLI (deprecation reverted / obsolete) ─► cancelled (terminal)
 ```
 
-All five transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
+`executed`/`superseded` are terminal but **not trusted**: every reconcile re-verifies
+them against the loupe, because a removal recorded as done that never actually landed
+was otherwise never re-checked and stayed invisible indefinitely (EXSC-774 — worldchain's
+`AcrossFacetV3` sat live for 18 days behind an `executed` record). `cancelled` is the only
+truly final state.
+
+All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
 
 - **queued → proposed**: the drain, via the atomic `claimForProposal(parkedTasks,
   taskKey)` (`:324`) filtered on `status:'queued'` (§6 step 3). This is the dedup gate
@@ -608,6 +616,11 @@ All five transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
 - **queued/proposed → superseded**: `markSuperseded` (`:360`, accepts both open states)
   — the facet is already absent on-chain (removed via another route); self-healing
   reconcile.
+- **executed/superseded → queued**: `reopenResolvedTask` — the reconcile finds the facet
+  still routed despite a terminal status, so the removal never landed. Clears
+  `resolvedAt`/`proposedAt`/`safeTxHash` and alerts the multisig-proposals channel.
+  `cancelled` is deliberately excluded (it records an operator's decision, not a claim
+  about on-chain state).
 - **→ cancelled**: `markCancelled` (`:383`) — an operator explicitly abandons the intent
   (deprecation reverted, facet re-added, or a protected facet queued in error). **Merged
   behaviour: restricted to `queued`** — cancelling a `proposed` task would orphan its
@@ -723,7 +736,8 @@ only the PR-link surfacing (§6) and drops the manual `--auto` invocation.
 | No double-enqueue / no double-propose | Partial unique index `unique_open_task_key` on `taskKey`; the atomic `claimForProposal` flip — independent of the salt-nondeterministic `intentHash` (Facts 8, 9, 15; §7). |
 | Never park/remove a protected facet | Enqueue and drain both call `getProtectedNames()` (`diamondRemovalDiff.ts:119`); a queued protected facet is `cancelled` + alerted (§6). Inherits every #2047 guardrail (drift gate is N/A — named path). |
 | Deferred ≠ orphaned | Cold-network backstops: `--auto --all-networks` sweep + TTL Slack alert + observability CLI (§8). No silent truncation — the TTL alert names what's still queued. |
-| Deploy-log longevity | Address snapshot + loupe-by-address check so pruning the log doesn't false-`superseded` a live facet; strengthened `/deprecate-contract` warning (§8). |
+| Deploy-log longevity | Address snapshot as a *fallback* so pruning the log doesn't false-`superseded` a live facet; strengthened `/deprecate-contract` warning (§8). Presence is resolved by facet **name** first — a snapshot address can be flat wrong, and an address-only check then reports "gone" about an address nobody asked about (EXSC-774). |
+| A resolution can be wrong | `executed`/`superseded` are re-verified against the loupe on every reconcile and reopened when the facet is still routed (§7). A stored terminal status is never taken as proof. |
 | Opt-in in v1 | `DRAIN_PARKED_TASKS` **default off; ON for rollouts, OFF for emergencies** (§6) — an urgent pause/break-glass proposal never drags unrelated removals into its signing set; reentrancy-guarded (§6). |
 | Direct-send safety | Drain no-ops on staging/testnet/`SEND_PROPOSALS_DIRECTLY_TO_DIAMOND` (Fact 13; §12). |
 | Rule compliance | TS/Bash, no Python (`000:15`); viem (`200:14`); reuse helpers (`:24`); new helpers 100%-covered colocated tests (`:120`); `citty`/`consola`/`getEnvVar` CLI (`:116`); `I`-prefixed interfaces; injectable I/O + dry-run-default per #2047 convention (Fact 14). |

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -4,14 +4,17 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
+import { type Hex } from 'viem'
 
 import globalConfig from '../../config/global.json'
 import networksConfig from '../../config/networks.json'
+import { EnvironmentEnum } from '../common/types'
 
 import {
   CORE_FACET_EXEMPTIONS,
   HEALTH_CHECK_EXCLUSIONS,
   HEALTH_CHECK_INVARIANTS,
+  findDeprecatedLiveFacets,
   findDuplicateSelectors,
   getExemptCoreFacets,
   getExpectedPairs,
@@ -147,6 +150,91 @@ describe('findDuplicateSelectors', () => {
       { address: '0xAAA', selectors: ['0x11111111', '0x11111111'] },
     ])
     expect(result).toEqual([])
+  })
+})
+
+describe('findDeprecatedLiveFacets', () => {
+  const LIVE = '0x00000000000000000000000000000000000000AA'
+  const KEEP = '0x00000000000000000000000000000000000000bb'
+  const SELECTORS: Hex[] = ['0xdeadbeef']
+
+  /** A deprecated facet: routed, in the deploy log, absent from target state, source gone. */
+  function base(): Parameters<typeof findDeprecatedLiveFacets>[0] {
+    return {
+      networkLower: 'worldchain',
+      environment: EnvironmentEnum.production,
+      onChainFacets: [{ address: LIVE, selectors: SELECTORS }],
+      deployedContracts: { AcrossFacetV3: LIVE },
+      expectedNames: new Set(['AcrossFacetV4']),
+      protectedNames: new Set(['DiamondCutFacet']),
+      sourceNames: new Set(['AcrossFacetV4']),
+    }
+  }
+
+  it('flags a facet that is routed, absent from target state and whose source is gone', () => {
+    const found = findDeprecatedLiveFacets(base())
+    expect(found).toHaveLength(1)
+    expect(found[0]?.name).toBe('AcrossFacetV3')
+    expect(found[0]?.selectors).toEqual(SELECTORS)
+  })
+
+  it('ignores a facet that target state still expects', () => {
+    expect(
+      findDeprecatedLiveFacets({
+        ...base(),
+        expectedNames: new Set(['AcrossFacetV3']),
+      })
+    ).toHaveLength(0)
+  })
+
+  it('ignores a facet whose source still exists (target-state drift, not a deprecation)', () => {
+    expect(
+      findDeprecatedLiveFacets({
+        ...base(),
+        sourceNames: new Set(['AcrossFacetV3']),
+      })
+    ).toHaveLength(0)
+  })
+
+  it('never flags a protected facet, even when target state omits it', () => {
+    expect(
+      findDeprecatedLiveFacets({
+        ...base(),
+        deployedContracts: { DiamondCutFacet: LIVE },
+      })
+    ).toHaveLength(0)
+  })
+
+  it('ignores a routed address the deploy log cannot name (no-unexpected-facets owns that)', () => {
+    expect(
+      findDeprecatedLiveFacets({ ...base(), deployedContracts: {} })
+    ).toHaveLength(0)
+  })
+
+  it('matches deploy-log addresses case-insensitively', () => {
+    const found = findDeprecatedLiveFacets({
+      ...base(),
+      deployedContracts: { AcrossFacetV3: LIVE.toLowerCase() },
+    })
+    expect(found).toHaveLength(1)
+  })
+
+  it('returns nothing when the network has no target-state entry (would flag everything)', () => {
+    expect(
+      findDeprecatedLiveFacets({ ...base(), expectedNames: undefined })
+    ).toHaveLength(0)
+  })
+
+  it('reports only the deprecated facet when an expected one is routed alongside it', () => {
+    const found = findDeprecatedLiveFacets({
+      ...base(),
+      onChainFacets: [
+        { address: LIVE, selectors: SELECTORS },
+        { address: KEEP, selectors: ['0xfeedface'] },
+      ],
+      deployedContracts: { AcrossFacetV3: LIVE, AcrossFacetV4: KEEP },
+    })
+    expect(found.map((f) => f.name)).toEqual(['AcrossFacetV3'])
   })
 })
 

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -28,9 +28,20 @@ import {
   type PublicClient,
 } from 'viem'
 
-import type { IWhitelistConfig, TargetState } from '../common/types'
+import {
+  EnvironmentEnum,
+  type IWhitelistConfig,
+  type TargetState,
+} from '../common/types'
 import { normalizeSelector } from '../utils/utils'
 
+import {
+  diffFacets,
+  getExpectedFacetNames,
+  getProtectedNames,
+  getSourceContractNames,
+  type IFacetRemoval,
+} from './safe/diamondRemovalDiff'
 import { SAFE_THRESHOLD } from './shared/constants'
 import {
   evaluateFacetPeripheryCouplings,
@@ -879,6 +890,71 @@ async function readPeripheryRegistry(
   const address = await registry.read.getPeripheryContract([name])
   return address === zeroAddress ? null : getAddress(address)
 }
+
+/**
+ * Facets that are routed by the diamond but should no longer exist: absent from
+ * target state, not on the never-remove allowlist, and with no `.sol` source left
+ * under `src/` — i.e. deprecated by `/deprecate-contract` whose removal never
+ * actually landed on this chain.
+ *
+ * Returns `[]` when the network/environment has no target-state `LiFiDiamond`
+ * block: an absent entry is not "expects zero facets", and diffing it would
+ * classify every routed facet as deprecated.
+ *
+ * A facet routed at an address the deploy log cannot name is NOT reported here —
+ * that is `no-unexpected-facets`' job. This check answers the complementary
+ * question that invariant cannot: *should* a known facet still be here?
+ *
+ * @param params.deployedContracts - Deploy-log `{name: address}` map, inverted here
+ *   to resolve loupe addresses to names (works for both hex and Tron base58).
+ * @param params.expectedNames - Target-state `LiFiDiamond` contract names, or
+ *   `undefined` when the network/environment has no entry at all.
+ * @returns The deprecated-but-routed facets, each with the selectors the loupe
+ *   currently routes to it.
+ */
+export function findDeprecatedLiveFacets(params: {
+  networkLower: string
+  environment: EnvironmentEnum
+  onChainFacets: IOnChainFacet[]
+  deployedContracts: Record<string, Address | string>
+  expectedNames: Set<string> | undefined
+  protectedNames: Set<string>
+  sourceNames: Set<string>
+}): IFacetRemoval[] {
+  const { expectedNames } = params
+  if (!expectedNames) return []
+
+  const addressToName: Record<string, string> = {}
+  for (const [name, address] of Object.entries(params.deployedContracts))
+    addressToName[String(address).toLowerCase()] = name
+
+  return diffFacets({
+    network: params.networkLower,
+    environment: params.environment,
+    onChainFacets: params.onChainFacets.map((f) => ({
+      address: f.address as Address,
+      selectors: f.selectors as Hex[],
+    })),
+    addressToName,
+    expectedNames,
+    protectedNames: params.protectedNames,
+    // Detection only, so nothing is held back: with an empty active-selector set
+    // `removals` is exactly the deprecated-but-routed facet set. Populating it
+    // would require compiled artifacts and throws when they are stale — never
+    // acceptable in a health check, and the actual removal path
+    // (`cleanUpProdDiamond`) computes the real held-back set anyway.
+    activeSelectors: new Set<string>(),
+    sourceNames: params.sourceNames,
+  }).removals
+}
+
+/**
+ * Memoized `src/` walk — the health check evaluates every network in one process,
+ * and the source set is identical for all of them.
+ */
+let sourceContractNamesCache: Set<string> | undefined
+const cachedSourceContractNames = (): Set<string> =>
+  (sourceContractNamesCache ??= getSourceContractNames())
 
 /**
  * Ordered registry of every health-check invariant. The order matches historical log
@@ -1767,6 +1843,59 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         }
       if (unexpected === 0)
         consola.success('All on-chain facets are known deployed contracts')
+    },
+  },
+  {
+    name: 'no-deprecated-facets',
+    description:
+      'No deprecated facet (source deleted, absent from target state) is still routed',
+    severity: 'warning',
+    scope: {},
+    readsOnChainFacets: true,
+    remediation:
+      'The removal never landed on this chain. Run `cleanUpProdDiamond --auto --network <network>` to park/propose it (docs/DeferredDiamondCleanupQueue.md).',
+    run: async (ctx) => {
+      if (ctx.onChainFacets.length === 0) {
+        consola.info(
+          'On-chain facet list unavailable; skipping deprecated-facet check'
+        )
+        return
+      }
+      const environment =
+        ctx.environment === EnvironmentEnum.staging
+          ? EnvironmentEnum.staging
+          : EnvironmentEnum.production
+      const expectedNames = getExpectedFacetNames(ctx.networkLower, environment)
+      if (!expectedNames) {
+        consola.info(
+          `No LiFiDiamond target-state entry for ${ctx.networkLower}/${environment}; skipping deprecated-facet check`
+        )
+        return
+      }
+
+      const deprecated = findDeprecatedLiveFacets({
+        networkLower: ctx.networkLower,
+        environment,
+        onChainFacets: ctx.onChainFacets,
+        deployedContracts: ctx.deployedContracts,
+        expectedNames,
+        protectedNames: getProtectedNames(),
+        sourceNames: cachedSourceContractNames(),
+      })
+
+      if (deprecated.length === 0) {
+        consola.success('No deprecated facets are still routed')
+        return
+      }
+      // One aggregated warning per network, not one per facet: the fleet-wide
+      // backlog is large enough that per-facet lines would drown the report.
+      ctx.logWarn(
+        `${
+          deprecated.length
+        } deprecated facet(s) still routed by the diamond: ${deprecated
+          .map((f) => `${f.name} (${f.address})`)
+          .join(', ')}`
+      )
     },
   },
   {

--- a/script/deploy/safe/parked-tasks.test.ts
+++ b/script/deploy/safe/parked-tasks.test.ts
@@ -38,6 +38,7 @@ import {
   markCancelled,
   markExecuted,
   markSuperseded,
+  reopenResolvedTask,
   revertToQueued,
   setSafeTxHash,
   type IParkedTask,
@@ -188,6 +189,21 @@ function createFakeCollection(
     ): Promise<WithId<IParkedTask> | null> {
       const row = rows.find((r) => matchesFilter(r, filter))
       if (!row) return null
+      // The partial unique index applies to updates too, not only inserts: moving a
+      // terminal row back into an open status collides with an existing open row
+      // for the same taskKey (reopenResolvedTask depends on this).
+      const nextStatus = (update.$set as Partial<IParkedTask> | undefined)
+        ?.status
+      if (
+        nextStatus &&
+        OPEN.includes(nextStatus) &&
+        !OPEN.includes(row.status) &&
+        rows.some(
+          (r) =>
+            r !== row && r.taskKey === row.taskKey && OPEN.includes(r.status)
+        )
+      )
+        throw new FakeDuplicateKeyError()
       // Snapshot BEFORE mutating so the driver-default 'before' is honored — this
       // is what forces production to pass returnDocument:'after' for the
       // post-update assertions to hold.
@@ -461,24 +477,26 @@ describe('claimForProposal', () => {
 
 describe('status transitions', () => {
   const KEY = 'facet-removal|arbitrum|production|A'
+  function taskRow(status: IParkedTask['status']): IParkedTask {
+    return {
+      taskKey: KEY,
+      kind: 'facet-removal',
+      network: 'arbitrum',
+      environment: EnvironmentEnum.production,
+      facetName: 'A',
+      diamondAddress: DIAMOND,
+      facetAddress: FACET,
+      prUrl: PR_URL,
+      status,
+      enqueuer: 'dev@li.finance',
+      createdAt: new Date(),
+      proposedAt: new Date(),
+      safeTxHash: '0xabc',
+      resolvedAt: new Date(),
+    }
+  }
   function seedOne(status: IParkedTask['status']): IFakeCollection {
-    return createFakeCollection([
-      {
-        taskKey: KEY,
-        kind: 'facet-removal',
-        network: 'arbitrum',
-        environment: EnvironmentEnum.production,
-        facetName: 'A',
-        diamondAddress: DIAMOND,
-        facetAddress: FACET,
-        prUrl: PR_URL,
-        status,
-        enqueuer: 'dev@li.finance',
-        createdAt: new Date(),
-        proposedAt: new Date(),
-        safeTxHash: '0xabc',
-      },
-    ])
+    return createFakeCollection([taskRow(status)])
   }
 
   it('markExecuted flips proposed→executed and sets resolvedAt', async () => {
@@ -540,6 +558,37 @@ describe('status transitions', () => {
   it('revertToQueued is a no-op (null) on a queued task', async () => {
     const coll = seedOne('queued')
     expect(await revertToQueued(coll, KEY)).toBeNull()
+  })
+
+  it('reopenResolvedTask flips executed→queued and clears the resolution + proposal linkage', async () => {
+    const coll = seedOne('executed')
+    const doc = await reopenResolvedTask(coll, KEY)
+    expect(doc?.status).toBe('queued')
+    expect(doc?.resolvedAt).toBeUndefined()
+    expect(doc?.proposedAt).toBeUndefined()
+    expect(doc?.safeTxHash).toBeUndefined()
+  })
+
+  it('reopenResolvedTask flips superseded→queued', async () => {
+    const coll = seedOne('superseded')
+    expect((await reopenResolvedTask(coll, KEY))?.status).toBe('queued')
+  })
+
+  it('reopenResolvedTask refuses a cancelled task (deliberate operator decision)', async () => {
+    const coll = seedOne('cancelled')
+    expect(await reopenResolvedTask(coll, KEY)).toBeNull()
+    expect(coll.rows[0]?.status).toBe('cancelled')
+  })
+
+  it('reopenResolvedTask is a no-op (null) on an already-open task', async () => {
+    const coll = seedOne('queued')
+    expect(await reopenResolvedTask(coll, KEY)).toBeNull()
+  })
+
+  it('reopenResolvedTask returns null instead of throwing when an open task already tracks the facet', async () => {
+    const coll = createFakeCollection([taskRow('executed'), taskRow('queued')])
+    expect(await reopenResolvedTask(coll, KEY)).toBeNull()
+    expect(coll.rows[0]?.status).toBe('executed')
   })
 })
 

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -496,6 +496,52 @@ export async function setSafeTxHash(
 }
 
 /**
+ * Reopens a task that was resolved as done (`executed`/`superseded`) but whose
+ * facet is demonstrably still routed — the removal never actually landed. Sends it
+ * back to `queued` and clears the stale proposal linkage and resolution stamp so
+ * the next drain re-proposes it from scratch.
+ *
+ * `cancelled` is deliberately NOT reopenable: that state records an operator
+ * explicitly abandoning the intent, and re-queueing it would fight that decision.
+ *
+ * Reopening re-enters the *open* statuses the partial unique index covers, so it
+ * collides (E11000) when a fresh open task already exists for the same `taskKey`.
+ * That is a benign race — the facet is already tracked — so it returns `null`
+ * rather than throwing, mirroring {@link enqueueParkedTask}.
+ *
+ * @param parkedTasks - The queue collection.
+ * @param taskKey - The terminal task to reopen.
+ * @returns The reopened task, `null` if it was not `executed`/`superseded`, or
+ *   `null` if an open task for the same `taskKey` already exists.
+ */
+export async function reopenResolvedTask(
+  parkedTasks: Collection<IParkedTask>,
+  taskKey: string
+): Promise<WithId<IParkedTask> | null> {
+  try {
+    return await transition(
+      parkedTasks,
+      taskKey,
+      ['executed', 'superseded'],
+      { status: 'queued' },
+      { proposedAt: '', safeTxHash: '', resolvedAt: '' }
+    )
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: number }).code === 11000
+    ) {
+      consola.warn(
+        `Cannot reopen resolved task - an open task already tracks it.\n  Task key: ${taskKey}`
+      )
+      return null
+    }
+    throw error
+  }
+}
+
+/**
  * Reverts a claimed (`proposed`) task back to `queued` when no stored proposal
  * carries its removal (preparation failure, primary-proposal failure, or duplicate
  * primary), clearing the stale `proposedAt`/`safeTxHash` so the next drain

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -21,8 +21,11 @@ import { EnvironmentEnum } from '../../common/types'
 import { type IParkedTask } from './parked-tasks'
 import {
   computeTtlAlerts,
+  formatReconcileFailureMessage,
+  formatReopenAlertMessage,
   formatTtlAlertMessage,
   reconcileDecision,
+  resolveFacetPresence,
 } from './reconcile-parked-tasks'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -99,6 +102,146 @@ describe('reconcileDecision', () => {
     expect(
       reconcileDecision({ status: 'queued' }, { facetPresentOnChain: true })
     ).toBe('keep')
+  })
+
+  it('reopens an executed task whose facet is still routed (removal never landed)', () => {
+    expect(
+      reconcileDecision(
+        { status: 'executed' },
+        { facetPresentOnChain: true, proposalStatus: 'executed' }
+      )
+    ).toBe('reopen')
+  })
+
+  it('reopens a superseded task whose facet is still routed', () => {
+    expect(
+      reconcileDecision({ status: 'superseded' }, { facetPresentOnChain: true })
+    ).toBe('reopen')
+  })
+
+  it('keeps an executed task whose facet really is gone', () => {
+    expect(
+      reconcileDecision(
+        { status: 'executed' },
+        { facetPresentOnChain: false, proposalStatus: 'executed' }
+      )
+    ).toBe('keep')
+  })
+
+  it('keeps a superseded task whose facet really is gone', () => {
+    expect(
+      reconcileDecision(
+        { status: 'superseded' },
+        { facetPresentOnChain: false }
+      )
+    ).toBe('keep')
+  })
+
+  it('never revisits a cancelled task, present or not', () => {
+    expect(
+      reconcileDecision({ status: 'cancelled' }, { facetPresentOnChain: true })
+    ).toBe('keep')
+    expect(
+      reconcileDecision({ status: 'cancelled' }, { facetPresentOnChain: false })
+    ).toBe('keep')
+  })
+})
+
+describe('resolveFacetPresence', () => {
+  const task = { facetName: 'AcrossFacetV3', facetAddress: addr(0xabc) }
+
+  it('reports present when the facet NAME is routed, even though the stored address is not', () => {
+    // The worldchain regression: the task carried lisk's AcrossFacetV3 address, so
+    // an address-only check said "gone" while the named facet was still live.
+    expect(
+      resolveFacetPresence(
+        task,
+        new Set(['AcrossFacetV3']),
+        new Set(['0xdead'])
+      )
+    ).toBe(true)
+  })
+
+  it('reports present when only the stored address is routed (deploy-log entry pruned)', () => {
+    expect(
+      resolveFacetPresence(
+        task,
+        new Set(),
+        new Set([task.facetAddress.toLowerCase()])
+      )
+    ).toBe(true)
+  })
+
+  it('matches the stored address case-insensitively', () => {
+    expect(
+      resolveFacetPresence(
+        { ...task, facetAddress: addr(0xabc).toUpperCase() as Address },
+        new Set(),
+        new Set([addr(0xabc).toLowerCase()])
+      )
+    ).toBe(true)
+  })
+
+  it('reports absent when neither the name nor the address is routed', () => {
+    expect(
+      resolveFacetPresence(task, new Set(['OtherFacet']), new Set(['0xdead']))
+    ).toBe(false)
+  })
+})
+
+describe('formatReopenAlertMessage', () => {
+  it('returns an empty string when nothing was reopened', () => {
+    expect(formatReopenAlertMessage([])).toBe('')
+  })
+
+  it('groups reopened tasks by network and names the facet, prior status and PR', () => {
+    const msg = formatReopenAlertMessage([
+      {
+        network: 'worldchain',
+        facet: 'AcrossFacetV3',
+        prUrl: 'https://gh/pull/1',
+        from: 'executed',
+      },
+      {
+        network: 'lens',
+        facet: 'GenericSwapFacet',
+        prUrl: 'https://gh/pull/2',
+        from: 'superseded',
+      },
+    ])
+    expect(msg).toContain('2 deferred diamond-cleanup task(s)')
+    expect(msg).toContain('STILL ROUTED')
+    expect(msg).toContain('[worldchain]')
+    expect(msg).toContain('AcrossFacetV3 (was executed) → https://gh/pull/1')
+    expect(msg).toContain('[lens]')
+    expect(msg).toContain(
+      'GenericSwapFacet (was superseded) → https://gh/pull/2'
+    )
+  })
+})
+
+describe('formatReconcileFailureMessage', () => {
+  it('returns an empty string when every network was reconciled', () => {
+    expect(formatReconcileFailureMessage([])).toBe('')
+  })
+
+  it('names each skipped network, its environment and the reason', () => {
+    const msg = formatReconcileFailureMessage([
+      {
+        network: 'harmony',
+        environment: EnvironmentEnum.production,
+        reason: 'Chain harmony does not exist',
+      },
+      {
+        network: 'velas',
+        environment: EnvironmentEnum.production,
+        reason: 'no LiFiDiamond in deploy log',
+      },
+    ])
+    expect(msg).toContain('2 network(s) could not be reconciled')
+    expect(msg).toContain('NOT verified')
+    expect(msg).toContain('harmony:production — Chain harmony does not exist')
+    expect(msg).toContain('velas:production — no LiFiDiamond in deploy log')
   })
 })
 

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -4,12 +4,16 @@
  * Standalone counterpart to the drain (design: docs/DeferredDiamondCleanupQueue.md
  * §7/§8). Two responsibilities, both idempotent and safe to run on a cron:
  *
- *  1. **Reconcile** open tasks against on-chain truth. The loupe is primary — if a
- *     parked facet's address is no longer routed, the removal is done: a claimed
- *     (`proposed`) task whose linked proposal executed becomes `executed`, anything
- *     else that is already gone becomes `superseded` (removed via another route).
+ *  1. **Reconcile** tasks against on-chain truth. The loupe is primary, and presence
+ *     is resolved by facet NAME (see {@link resolveFacetPresence}) — if a parked
+ *     facet is no longer routed, the removal is done: a claimed (`proposed`) task
+ *     whose linked proposal executed becomes `executed`, anything else that is
+ *     already gone becomes `superseded` (removed via another route).
  *     A `proposed` task whose linked proposal `reverted` while the facet is still
- *     present is reverted to `queued` so the next drain re-proposes. The
+ *     present is reverted to `queued` so the next drain re-proposes. A task already
+ *     resolved as done (`executed`/`superseded`) whose facet is STILL routed is a
+ *     false resolution: it is reopened to `queued` and alerted, because a removal
+ *     recorded as done was otherwise never re-checked and stayed invisible. The
  *     `pendingTransactions` proposal status is an OPTIONAL signal: with tunnel
  *     access (`SC_MONGODB_URI`) the job distinguishes executed vs superseded and
  *     detects reverts; without it (loupe-only) a gone facet is `superseded`.
@@ -18,28 +22,38 @@
  *     to the multisig-proposals Slack channel, so a cold network that never gets
  *     another cut is never silently orphaned (spec §8 backstop).
  *
- * The pure decisions ({@link reconcileDecision}, {@link computeTtlAlerts},
- * {@link formatTtlAlertMessage}) are fully unit-tested; only the live CLI wiring
- * (Mongo/loupe/Slack) is unit-test exempt, mirroring `getParkedTasksCollection()`.
+ * Each (network, environment) is reconciled in isolation: the queue outlives
+ * networks, so one retired chain can no longer abort the sweep and leave every
+ * later network unverified. Skipped networks are alerted, never dropped silently.
+ *
+ * The pure decisions ({@link reconcileDecision}, {@link resolveFacetPresence},
+ * {@link computeTtlAlerts}, {@link formatTtlAlertMessage}) are fully unit-tested;
+ * only the live CLI wiring (Mongo/loupe/Slack) is unit-test exempt, mirroring
+ * `getParkedTasksCollection()`.
  * Dry-run by default (#2047 convention); pass `--yes` to apply transitions and
- * send the alert.
+ * send the alerts.
  */
 
 import 'dotenv/config'
 
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
-import { getAddress } from 'viem'
 
+import { type EnvironmentEnum } from '../../common/types'
 import { SlackNotifier } from '../../utils/slack-notifier'
 import { getEnvVar } from '../../utils/utils'
 
-import { fetchOnChainFacets, resolveDiamondAddress } from './diamondRemovalDiff'
+import {
+  fetchOnChainFacets,
+  resolveAddressToName,
+  resolveDiamondAddress,
+} from './diamondRemovalDiff'
 import {
   getParkedTasksCollection,
   listParkedTasks,
   markExecuted,
   markSuperseded,
+  reopenResolvedTask,
   revertToQueued,
   type IParkedTask,
   type ParkedTaskStatus,
@@ -53,24 +67,43 @@ const DAY_MS = 24 * 60 * 60 * 1000
 const DEFAULT_TTL_DAYS = 60
 
 /** Lifecycle transition the reconcile should apply to a task. */
-export type ReconcileDecision = 'executed' | 'superseded' | 'revert' | 'keep'
+export type ReconcileDecision =
+  | 'executed'
+  | 'superseded'
+  | 'revert'
+  | 'reopen'
+  | 'keep'
+
+/** Statuses that claim the removal is done and are therefore re-verified against the loupe. */
+const RESOLVED_STATUSES: ParkedTaskStatus[] = ['executed', 'superseded']
 
 /** On-chain / proposal truth for one task, gathered by the live adapter. */
 export interface IReconcileContext {
-  /** Whether the task's facet address is still routed by the diamond loupe. */
+  /**
+   * Whether the task's facet is still routed by the diamond loupe — resolved by
+   * facet NAME first, with the stored `facetAddress` only as a fallback. See
+   * {@link resolveFacetPresence} for why the name must lead.
+   */
   facetPresentOnChain: boolean
   /** Linked proposal status, if `SC_MONGODB_URI` (tunnel) was reachable. */
   proposalStatus?: SafeTxStatus
 }
 
 /**
- * Decides the lifecycle transition for one open parked task from on-chain truth
- * (spec §7 state machine). Loupe-primary: a facet that is gone is terminal
- * (`executed` when its own proposal executed, else `superseded`); a still-present
- * facet whose linked proposal reverted goes back to `queued`; everything else is
- * left untouched.
+ * Decides the lifecycle transition for one parked task from on-chain truth
+ * (spec §7 state machine). Loupe-primary in both directions:
  *
- * @param task - The open task (only its `status` matters here).
+ * - A task claiming to be done (`executed`/`superseded`) whose facet is still
+ *   routed is a false resolution — reopened to `queued` so the next drain
+ *   re-proposes it. Without this, a removal that never executed is invisible
+ *   forever, since terminal states were previously never re-checked.
+ * - An open task whose facet is gone becomes terminal (`executed` when its own
+ *   proposal executed, else `superseded`).
+ * - An open, still-present task whose linked proposal reverted goes back to `queued`.
+ *
+ * `cancelled` is never revisited — it records a deliberate operator decision.
+ *
+ * @param task - The task (only its `status` matters here).
  * @param ctx - On-chain presence + optional linked-proposal status.
  * @returns The transition to apply (`keep` = no change).
  */
@@ -78,6 +111,11 @@ export function reconcileDecision(
   task: Pick<IParkedTask, 'status'>,
   ctx: IReconcileContext
 ): ReconcileDecision {
+  if (task.status === 'cancelled') return 'keep'
+
+  if (RESOLVED_STATUSES.includes(task.status))
+    return ctx.facetPresentOnChain ? 'reopen' : 'keep'
+
   if (!ctx.facetPresentOnChain) {
     if (task.status === 'proposed' && ctx.proposalStatus === 'executed')
       return 'executed'
@@ -86,6 +124,38 @@ export function reconcileDecision(
   if (task.status === 'proposed' && ctx.proposalStatus === 'reverted')
     return 'revert'
   return 'keep'
+}
+
+/**
+ * Resolves whether a parked task's facet is still routed by the diamond.
+ *
+ * Name-primary, address-fallback — and the order is load-bearing. The stored
+ * `facetAddress` is a snapshot taken at enqueue and can be flat wrong: a
+ * worldchain `AcrossFacetV3` task carried lisk's address, so an address-only check
+ * truthfully answered "that address is not routed" while the facet actually routed
+ * under that name on worldchain was never examined, and the task was resolved as
+ * `executed` while the facet stayed live for 18 days. The drain removes by name
+ * (`computeNamedFacetRemovals`), so presence must be judged by name too or the two
+ * disagree about what "done" means.
+ *
+ * The address remains a fallback so a pruned deploy-log entry — where no loupe
+ * address resolves to the name any more, but the snapshot address is still routed —
+ * still counts as present rather than being false-resolved (spec §8).
+ *
+ * @param task - The task's facet identity (name + stored address snapshot).
+ * @param routedNames - Facet names currently routed, resolved via the deploy log.
+ * @param routedAddresses - Lowercased addresses currently routed by the loupe.
+ * @returns `true` while the facet is still routed under either identity.
+ */
+export function resolveFacetPresence(
+  task: Pick<IParkedTask, 'facetName' | 'facetAddress'>,
+  routedNames: Set<string>,
+  routedAddresses: Set<string>
+): boolean {
+  return (
+    routedNames.has(task.facetName) ||
+    routedAddresses.has(task.facetAddress.toLowerCase())
+  )
 }
 
 /** An open task that has aged past the TTL, for the cold-network alert. */
@@ -160,6 +230,89 @@ export function formatTtlAlertMessage(
   return lines.join('\n')
 }
 
+/** A task that claimed to be done while its facet is still routed. */
+export interface IReopenedParkedTask {
+  network: string
+  facet: string
+  prUrl: string
+  /** The terminal status the task was reopened from. */
+  from: ParkedTaskStatus
+}
+
+/** A (network, environment) whose on-chain state could not be read, so its tasks went unverified. */
+export interface IReconcileFailure {
+  network: string
+  environment: EnvironmentEnum
+  reason: string
+}
+
+/** Outcome of one reconcile sweep. */
+export interface IReconcileRun {
+  reopened: IReopenedParkedTask[]
+  /** Networks skipped because their state was unreadable — never silently dropped. */
+  failures: IReconcileFailure[]
+}
+
+/**
+ * Formats the unreconciled-network alert. Returns `''` when every network was
+ * verified.
+ *
+ * A network whose state cannot be read has its parked tasks verified by nothing at
+ * all, which is the same invisibility this job exists to prevent — so a skip is
+ * always reported rather than quietly tolerated.
+ *
+ * @param failures - Networks skipped during the sweep.
+ * @returns A Slack-ready message, or `''` if `failures` is empty.
+ */
+export function formatReconcileFailureMessage(
+  failures: IReconcileFailure[]
+): string {
+  if (failures.length === 0) return ''
+  const lines = [
+    `⚠️ ${failures.length} network(s) could not be reconciled — their parked tasks were NOT verified this run:`,
+  ]
+  for (const f of failures)
+    lines.push(`   - ${f.network}:${f.environment} — ${f.reason}`)
+  // Without a remedy this alert repeats every run forever: a retired network can
+  // never be reconciled, so its tasks have to be cancelled to clear the backlog.
+  lines.push(
+    '   → transient RPC/config problem: no action needed. Retired network: cancel its parked tasks so the queue stops tracking a chain that no longer exists.'
+  )
+  return lines.join('\n')
+}
+
+/**
+ * Formats the false-resolution alert. Returns `''` when nothing was reopened so
+ * the caller can skip sending.
+ *
+ * This is the loud half of the fix: a reopened task is proof that a removal we
+ * recorded as done never landed, which is exactly the failure that previously left
+ * a deprecated facet live and unmonitored.
+ *
+ * @param reopened - Tasks reopened by this run.
+ * @returns A Slack-ready message, or `''` if `reopened` is empty.
+ */
+export function formatReopenAlertMessage(
+  reopened: IReopenedParkedTask[]
+): string {
+  if (reopened.length === 0) return ''
+  const byNetwork = new Map<string, IReopenedParkedTask[]>()
+  for (const r of reopened) {
+    const list = byNetwork.get(r.network) ?? []
+    list.push(r)
+    byNetwork.set(r.network, list)
+  }
+  const lines = [
+    `🚨 ${reopened.length} deferred diamond-cleanup task(s) were marked done but their facet is STILL ROUTED — re-queued for removal:`,
+  ]
+  for (const [network, list] of byNetwork) {
+    lines.push(`[${network}]`)
+    for (const r of list)
+      lines.push(`   - ${r.facet} (was ${r.from}) → ${r.prUrl}`)
+  }
+  return lines.join('\n')
+}
+
 // ───────────────────────── live adapter (unit-test exempt) ─────────────────────
 
 type PendingTransactions = Awaited<
@@ -178,29 +331,31 @@ async function resolveProposalStatus(
   return doc?.status
 }
 
-/** Reconciles every open task, grouped by (network, environment) so the loupe is fetched once each. */
+/**
+ * Reconciles every task that is not `cancelled`, grouped by (network, environment)
+ * so the loupe and deploy log are fetched once each.
+ *
+ * Resolved (`executed`/`superseded`) tasks are re-verified alongside open ones:
+ * trusting a stored terminal status is what made a removal that never executed
+ * invisible indefinitely. Reopened tasks are returned so the caller can alert.
+ */
 async function reconcileAll(
   parkedTasks: Parameters<typeof listParkedTasks>[0],
   networkFilter: string | undefined,
   apply: boolean
-): Promise<void> {
-  const open = [
-    ...(await listParkedTasks(parkedTasks, {
-      network: networkFilter,
-      status: 'queued',
-    })),
-    ...(await listParkedTasks(parkedTasks, {
-      network: networkFilter,
-      status: 'proposed',
-    })),
-  ]
-  if (open.length === 0) {
-    consola.info('No open parked tasks to reconcile')
-    return
+): Promise<IReconcileRun> {
+  const candidates = (
+    await listParkedTasks(parkedTasks, { network: networkFilter })
+  ).filter((t) => t.status !== 'cancelled')
+  if (candidates.length === 0) {
+    consola.info('No parked tasks to reconcile')
+    return { reopened: [], failures: [] }
   }
 
-  const byNetworkEnv = new Map<string, typeof open>()
-  for (const t of open) {
+  const reopened: IReopenedParkedTask[] = []
+  const failures: IReconcileFailure[] = []
+  const byNetworkEnv = new Map<string, typeof candidates>()
+  for (const t of candidates) {
     const key = `${t.network}:${t.environment}`
     const list = byNetworkEnv.get(key) ?? []
     list.push(t)
@@ -224,15 +379,46 @@ async function reconcileAll(
       const first = tasks[0]
       if (!first) continue
       const { network, environment } = first
-      const diamondAddress = await resolveDiamondAddress(network, environment)
-      if (!diamondAddress) {
+      // Per-network isolation: the queue outlives networks (a retired chain keeps
+      // its parked tasks but leaves `networks.json`, so the loupe read throws), and
+      // one such chain must not abort the sweep. Every network ordered after it
+      // would otherwise never be reconciled at all — silently.
+      let onChain: Awaited<ReturnType<typeof fetchOnChainFacets>>
+      let addressToName: Record<string, string>
+      try {
+        const diamondAddress = await resolveDiamondAddress(network, environment)
+        if (!diamondAddress) {
+          consola.warn(
+            `[${network}:${environment}] no LiFiDiamond in deploy log — skipping`
+          )
+          failures.push({
+            network,
+            environment,
+            reason: 'no LiFiDiamond in deploy log',
+          })
+          continue
+        }
+        ;[onChain, addressToName] = await Promise.all([
+          fetchOnChainFacets(diamondAddress, network),
+          resolveAddressToName(network, environment),
+        ])
+      } catch (error: unknown) {
+        const reason = error instanceof Error ? error.message : String(error)
         consola.warn(
-          `[${network}:${environment}] no LiFiDiamond in deploy log — skipping`
+          `[${network}:${environment}] cannot read on-chain state — skipping: ${reason}`
         )
+        failures.push({ network, environment, reason })
         continue
       }
-      const onChain = await fetchOnChainFacets(diamondAddress, network)
-      const routed = new Set(onChain.map((f) => f.address.toLowerCase()))
+
+      const routedAddresses = new Set(
+        onChain.map((f) => f.address.toLowerCase())
+      )
+      const routedNames = new Set(
+        onChain
+          .map((f) => addressToName[f.address.toLowerCase()])
+          .filter((name): name is string => name !== undefined)
+      )
 
       for (const task of tasks) {
         const proposalStatus = await resolveProposalStatus(
@@ -240,15 +426,30 @@ async function reconcileAll(
           task.safeTxHash
         )
         const decision = reconcileDecision(task, {
-          facetPresentOnChain: routed.has(
-            getAddress(task.facetAddress).toLowerCase()
+          facetPresentOnChain: resolveFacetPresence(
+            task,
+            routedNames,
+            routedAddresses
           ),
           proposalStatus,
         })
         consola.info(
           `[${network}:${environment}] ${task.facetName} (${task.status}) → ${decision}`
         )
-        if (!apply || decision === 'keep') continue
+        if (decision === 'keep') continue
+        if (decision === 'reopen') {
+          // Recorded in dry-run too, so the false-resolution alert is visible
+          // without --yes; only the Slack send is gated on applying.
+          if (!apply || (await reopenResolvedTask(parkedTasks, task.taskKey)))
+            reopened.push({
+              network,
+              facet: task.facetName,
+              prUrl: task.prUrl,
+              from: task.status,
+            })
+          continue
+        }
+        if (!apply) continue
         if (decision === 'executed')
           await markExecuted(parkedTasks, task.taskKey)
         else if (decision === 'superseded')
@@ -259,6 +460,33 @@ async function reconcileAll(
     }
   } finally {
     await safeMongoClient?.close()
+  }
+  return { reopened, failures }
+}
+
+/** Logs and (when applying) sends the reconcile sweep's alerts. */
+async function runReconcileAlerts(
+  run: IReconcileRun,
+  apply: boolean
+): Promise<void> {
+  const webhookUrl = process.env.WEBHOOK_DEV_SC_MULTISIG_PROPOSALS
+  const send = async (message: string): Promise<void> => {
+    if (apply && webhookUrl)
+      await new SlackNotifier(webhookUrl).sendNotificationWithRetry({
+        text: message,
+      })
+  }
+
+  const reopenMessage = formatReopenAlertMessage(run.reopened)
+  if (reopenMessage) {
+    consola.error(reopenMessage)
+    await send(reopenMessage)
+  }
+
+  const failureMessage = formatReconcileFailureMessage(run.failures)
+  if (failureMessage) {
+    consola.warn(failureMessage)
+    await send(failureMessage)
   }
 }
 
@@ -316,7 +544,8 @@ const main = defineCommand({
     getEnvVar('MONGODB_URI')
     const { client, parkedTasks } = await getParkedTasksCollection()
     try {
-      await reconcileAll(parkedTasks, args.network, apply)
+      const run = await reconcileAll(parkedTasks, args.network, apply)
+      await runReconcileAlerts(run, apply)
       await runTtlAlert(parkedTasks, args.network, ttlDays, apply)
     } finally {
       await client.close()

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -488,6 +488,13 @@ async function runReconcileAlerts(
     consola.warn(failureMessage)
     await send(failureMessage)
   }
+
+  // A cron log nobody reads is not an alarm. Say so when there was something to
+  // raise but no webhook to raise it on, rather than degrading to log-only in silence.
+  if (apply && !webhookUrl && (reopenMessage || failureMessage))
+    consola.warn(
+      'WEBHOOK_DEV_SC_MULTISIG_PROPOSALS is not set — the alert(s) above were logged only, not delivered to Slack.'
+    )
 }
 
 /** Computes and (when applying) sends the cold-network TTL alert. */


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-774](https://linear.app/lifi-linear/issue/EXSC-774/detect-facet-removals-that-never-executed-false-executed-parked-tasks)

# Why did I implement it this way?

A facet removal that never executed could be recorded as done and then stay invisible indefinitely. On **worldchain** the parked `AcrossFacetV3` task was marked `executed` on 2026-08-03 while `AcrossFacetV3` at `0x08F7800449ad6681bd607EF21d3cc9C9dDDaF1C8` is still routed by the diamond today — 18 days later. Neither existing safety net could see it:

- `no-unexpected-facets` compares on-chain facets against `deployments/<net>.json` and warns only on addresses *absent* from that log. Deprecated facets are never pruned from the deploy log, so a deprecated-but-logged facet reads as "known" and passes. That invariant answers *"is this facet known?"*, not *"should this facet still be here?"*.
- `reconcile-parked-tasks` only reconciled `queued`/`proposed` tasks. `executed` was terminal and never re-verified, so a false-`executed` was permanent by construction.

## The root cause is not what the ticket first assumed

The worldchain task's stored `facetAddress` is `0xB5dD83183fD7CCF859b227CA83663a034d5B2f92` — **lisk's** `AcrossFacetV3` v1.0.0, not a worldchain address at all. That address genuinely is not routed on worldchain, so the reconcile's address-based presence check correctly concluded "gone" **while checking the wrong address entirely**. The facet actually routed under the name `AcrossFacetV3` on worldchain was never examined.

So re-verifying the *stored address* — the fix as originally proposed — would **not** have caught this. Proven against live data:

```text
task: status=executed storedFacetAddress=0xB5dD83183fD7CCF859b227CA83663a034d5B2f92
address-only presence : false   → decision: keep      ← the proposed fix misses it
name-primary presence : true    → decision: reopen    ← this PR catches it
routed under the name AcrossFacetV3: 0x08F7800449ad6681bd607EF21d3cc9C9dDDaF1C8
```

Presence therefore resolves by facet **name** first, with the stored address kept only as a fallback (so a pruned deploy-log entry still can't false-resolve a live facet). This also aligns the reconcile with the drain, which already removes by name via `computeNamedFacetRemovals` — otherwise the two disagree about what "done" means.

## What changed

**1. New `no-deprecated-facets` health-check invariant.** Diffs the on-chain facet set against `_targetState.json` and warns on facets that are routed, name-resolvable in the deploy log, unprotected, and whose `.sol` source no longer exists (i.e. genuinely deprecated). Reuses `diffFacets` — the same diff `cleanUpProdDiamond --auto` computes, which was never wired to a scheduled alarm. Severity `warning`, so it surfaces without failing bring-up on partially-deployed networks.

Deliberate scope choices:

- Target-state **drift** (facet live, source still present) is excluded. It is a different failure class and far noisier — the probe found it on ~40 networks, mostly benign.
- Findings are aggregated into **one warning per network** rather than one per facet, because the fleet-wide backlog is large (see below) and per-facet lines would drown the report.
- `activeSelectors` is passed empty: this is detection only, so nothing needs holding back, and populating it requires compiled artifacts and *throws* when they are stale — unacceptable inside a health check. The real removal path still computes the true held-back set.

**2. Name-primary presence + terminal re-verification in `reconcile-parked-tasks`.** `executed`/`superseded` are re-verified against the loupe on every run; a task whose facet is still routed is reopened to `queued` (so the next drain re-proposes it) and alerted to `#dev-sc-multisig-proposals`. `superseded` is included because it makes the identical "we believe it's gone" claim. `cancelled` is deliberately excluded — it records an operator's decision, not a claim about on-chain state.

**3. Per-network isolation in the reconcile sweep** — this one is load-bearing, not incidental. The fleet sweep was **aborting** at `harmony`, a retired network that kept its parked tasks but left `networks.json`, so the loupe read threw and killed the run. Every network ordered after it was never reconciled — **worldchain included**. Without this fix both changes above would have been inert in the scheduled job for the very network that motivated the ticket. Skipped networks are now alerted with a remedy rather than silently dropped.

**4. Alert delivery is no longer silently optional.** All three reconcile alerts degrade to log-only when `WEBHOOK_DEV_SC_MULTISIG_PROPOSALS` is unset (pre-existing behaviour for the TTL alert, inherited by the new ones). The job now says so explicitly rather than degrading in silence — the same failure class this PR closes.

## Fleet-wide scope of the underlying problem

worldchain is one instance of a systemic backlog, not an isolated incident. A probe of the loupe ∖ target-state diff across all active production networks found **~50 networks with at least one deprecated-but-live facet** (~100 findings), dominated by `GenericSwapFacet` and `CBridgeFacet`/`CBridgeFacetPacked`. The new invariant will be loud on its first run; that volume is a real cleanup backlog, and draining it is tracked separately (see follow-ups).

## Verification: proven to fire on real data, not just in unit tests

Same-PR unit tests are not evidence a new check works, so each was falsified against the live queue and live chains (read-only; **no Safe proposals created**).

*Invariant fires, and discriminates:*

```text
severity=warning
worldchain: 19 facets routed
worldchain warnings: ["1 deprecated facet(s) still routed by the diamond: AcrossFacetV3 (0x08F7800449ad6681bd607EF21d3cc9C9dDDaF1C8)"]
✔ POSITIVE (worldchain names AcrossFacetV3): PASS
✔ warning-severity only (no errors logged): PASS
✔ NEGATIVE (jovay quiet, 13 facets): PASS
✔ NEGATIVE (pharos quiet, 14 facets): PASS
```

*Reconcile fires on the real false-`executed`, and discriminates within the same network* — all three worldchain tasks had an executed proposal, only the one still routed reopened:

```text
[worldchain:production] GenericSwapFacet (proposed)     → executed
[worldchain:production] AcrossFacetV3 (executed)        → reopen
[worldchain:production] AcrossFacetPackedV3 (proposed)  → executed
🚨 1 deferred diamond-cleanup task(s) were marked done but their facet is STILL ROUTED — re-queued for removal
```

*Fleet sweep now completes instead of aborting, with no false-reopen storm* — 123 tasks decided (previously the run died after ~47), exactly 1 reopen across the whole fleet, and the 3 unreconcilable retired networks reported rather than fatal:

```text
exit=0
  53 → executed
  69 → keep
   1 → reopen        ← worldchain AcrossFacetV3, the only one
⚠️ 3 network(s) could not be reconciled — harmony, okx, velas (left networks.json)
```

## Operational impact a reviewer should weigh

**This changes the daily healthcheck's Slack behaviour.** `healthCheckAllNetworks.yml` posts when `warned_count != 0`, and its own comment states that a green run "stays silent to keep the channel signal-only." Because the invariant is `warning` severity, the ~50 affected networks all land in `warned` — so the daily job will post every day, listing them, until the backlog is drained (weeks of Safe proposals across ~50 chains).

Two readings, both defensible:

- **Land as-is.** The alert is true, it self-clears per network as each is drained, and it gives the cleanup visible progress. Risk: sustained ~50-network daily posts invite the team to mute the channel, which would be worse than not having the check.
- **Drain first, then land.** Keeps the channel signal-only, at the cost of leaving the detection gap open while the backlog is worked.

Worth noting the channel likely already posts on many days: `facets-registered` warns on any RPC failure, and the fleet probe for this PR hit 404/429/403/revert on arbitrum, bsc, moonbeam and gravity. So this may be incremental rather than a regime change — but I did not measure the current baseline, and that is the number that decides it.

**Coverage of the new invariant is 69/72 active networks.** The 3 skips — `arbitrumsepolia`, `basesepolia`, `tronshasta` — have no production target-state `LiFiDiamond` block, which is correct for testnets. This is deliberately the inverse of the failure that got `no-unexpected-erc20proxy-callers` deleted in #2156 (silently no-oped on 38 of ~62 networks while the sweep still reported green): here the skip set is small, is testnet-only, and is logged per network.

## Follow-ups (deliberately out of scope)

1. The enqueue-time bug that wrote a **lisk** address onto a **worldchain** parked task.
2. `deployments/worldchain.json` and `_deployments_log_file.json` disagree on `AcrossFacetV3`'s address (flat log `0x08F7…`; master log `0xAd99…` v1.0.0 / `0x5052fc…` v1.1.0).
3. Draining the ~100-item deprecated-but-live backlog.
4. Cancelling the parked tasks for retired networks (harmony, okx, velas) so that alert clears.
5. Target-state drift, e.g. `AcrossFacetV4`/`AcrossFacetPackedV4` live on linea but absent from its target state.
6. Measure the current `warned_count != 0` rate of the daily sweep, to settle whether this PR's Slack impact is incremental or a regime change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

