### PR TITLE
chore: retire intent-escrow flow on injective (EXSC-723)

### DIFF
--- a/script/deploy/_targetState.json
+++ b/script/deploy/_targetState.json
@@ -2267,7 +2267,6 @@
         "EmergencyPauseFacet": "1.0.1",
         "GasZipFacet": "2.0.5",
         "GenericSwapFacetV3": "2.0.0",
-        "LiFiIntentEscrowFacet": "1.1.2",
         "LiFiTimelockController": "1.0.1",
         "OwnershipFacet": "1.0.0",
         "PeripheryRegistryFacet": "1.0.0",

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -283,6 +283,12 @@ export const CORE_FACET_EXEMPTIONS: ICoreFacetExemption[] = [
       'Intent escrow settlers are not deployed on Jovay and BE confirmed the chain is not supported for intents — do not require LiFiIntentEscrowFacetV2 until product enables it.',
     networks: ['jovay'],
   },
+  {
+    facet: 'LiFiIntentEscrowFacetV2',
+    reason:
+      'Injective is retiring the intent-escrow flow rather than migrating it: no LiFiIntentEscrowFacetV2 is deployed there, and the deprecated LiFiIntentEscrowFacet was removed. Do not require V2 on injective.',
+    networks: ['injective'],
+  },
 ]
 
 /**

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -240,6 +240,7 @@ export const CORE_FACET_EXEMPTIONS: ICoreFacetExemption[] = [
       'hemi',
       'hyperevm',
       'immutablezkevm',
+      'injective',
       'ink',
       'kaia',
       'lens',
@@ -282,12 +283,6 @@ export const CORE_FACET_EXEMPTIONS: ICoreFacetExemption[] = [
     reason:
       'Intent escrow settlers are not deployed on Jovay and BE confirmed the chain is not supported for intents — do not require LiFiIntentEscrowFacetV2 until product enables it.',
     networks: ['jovay'],
-  },
-  {
-    facet: 'LiFiIntentEscrowFacetV2',
-    reason:
-      'Injective is retiring the intent-escrow flow rather than migrating it: no LiFiIntentEscrowFacetV2 is deployed there, and the deprecated LiFiIntentEscrowFacet was removed. Do not require V2 on injective.',
-    networks: ['injective'],
   },
 ]
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi/issue/EXSC-723

# Why did I implement it this way?

Three legacy `cleanUpProdDiamond` facet removals — scheduled directly (before the parked-task drain existed), so no parked snapshot carried their `safeTxHash` — were executed manually via their matured timelock ops. One removed the deprecated `LiFiIntentEscrowFacet` (V1) from the injective diamond. Two config sources still expected an intent-escrow facet on injective and would now flag the mismatch:

- **`_targetState.json`** pinned injective to `LiFiIntentEscrowFacet` `1.1.2` — injective was the only chain still on V1. Removed that entry so the target-state diff matches the on-chain diamond.
- **`healthCheckInvariants.ts`** — `LiFiIntentEscrowFacetV2` is a core facet required on all active mainnets. Injective is retiring the intent-escrow flow rather than migrating to V2 (no V2 is deployed there), so injective is added to `CORE_FACET_EXEMPTIONS` for that facet.

The direction here is retirement, not migration: V1 is gone and no V2 is coming to injective, so the correct fix is to drop V1 from the target state and exempt V2 — not to require V2.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
