### PR TITLE
ci(clear-signing): normalize registry sync with erc7730 format

### DIFF
--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -1,7 +1,7 @@
 # Sync Clear Signing (ERC-7730) Registry
 # - Purpose: Keep `registry/lifi/calldata-LIFIDiamond.json` in the Ethereum Foundation-hosted ERC-7730 registry up to date with this repo's Diamond ABI + deployments AND with the `display.formats` proposal at `config/clearSigningProposal.json`.
 # - Triggers: push-to-main on ABI/deployment/proposal-relevant paths (fast path), a monthly cron safety net, and manual workflow_dispatch (with optional dry_run).
-# - Key behaviors: clones our fork (`lifinance/clear-signing-erc7730-registry`, originally forked from LedgerHQ, now tracking the EF-hosted registry), regenerates the JSON with merged `display.formats`, pushes a branch to the fork, creates/updates a PR upstream, and posts the PR link to Slack.
+# - Key behaviors: clones our fork (`lifinance/clear-signing-erc7730-registry`, originally forked from LedgerHQ, now tracking the EF-hosted registry), regenerates the JSON with merged `display.formats`, normalizes it with the registry's own `erc7730 format` so the diff carries only real changes (not formatting churn), pushes a branch to the fork, creates/updates a PR upstream, and posts the PR link to Slack.
 # - Trust model: this workflow assumes `config/clearSigningProposal.json` is current against the on-chain diamond, which is enforced at PR-merge time by `verifyClearSigning.yml`. If that gate is bypassed, the proposal may be stale.
 # - Note: The ERC-7730 registry moved from `LedgerHQ/clear-signing-erc7730-registry` to `ethereum/clear-signing-erc7730-registry` (Ethereum Foundation now hosts it). The fork retains its original name; only the upstream remote target changed.
 # - Upstream-only: guarded to lifinance/contracts because forks that sync this file (contracts-tron) lack `LEDGER_SYNC_TOKEN`/Slack secrets and must not push to the EF registry.
@@ -73,6 +73,22 @@ jobs:
       - name: Build contracts (generate Foundry artifacts)
         run: forge build --skip script --skip test --skip Base --skip Test --skip '*.t.sol'
 
+      - name: Set up Python for ERC-7730 formatter
+        # erc7730 pins `Requires-Python >=3.12,<3.13`, so the formatter only
+        # installs on 3.12 — pin it explicitly rather than trust the runner's
+        # default Python (which drifts and would break the install without notice).
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install ERC-7730 formatter
+        # `erc7730 format` is the exact formatter the registry runs in its own
+        # `format.yml` bot. We apply it to our generated descriptor (see the sync
+        # step) so our output already matches the registry's canonical shape.
+        # Left unpinned so we track whatever formatter version the registry uses;
+        # pinning would reintroduce drift the moment they upgrade theirs.
+        run: pip install erc7730
+
       - name: Checkout fork (clear-signing-erc7730-registry) with sync token
         # Use `actions/checkout` rather than a manual `git clone` token-in-URL.
         # The manual pattern failed in this job with `fatal: could not read
@@ -142,6 +158,17 @@ jobs:
 
           echo -e "\033[32mRegenerating ${LEDGER_FILE_PATH} (abi + deployments + display.formats merge; metadata preserved)...\033[0m"
           bunx tsx tasks/generateLedgerClearSigning.ts --ledgerFilePath "ledger-registry/${LEDGER_FILE_PATH}" --printDiff
+
+          # Normalize to the registry's canonical format before diffing/committing.
+          # Our generator writes fully-expanded `JSON.stringify(..., 2)`, but the
+          # registry stores the compact `erc7730 format` shape. Without this step
+          # every sync re-expands their file and their format bot re-compacts it,
+          # so the PR carries a permanent ~20k-line formatting diff that buries
+          # the real ABI/deployment changes. Running the registry's own formatter
+          # here makes the diff show only genuine changes (EXSC-781). Placed
+          # before the porcelain check so it applies to the dry-run preview too.
+          echo -e "\033[32mFormatting ${LEDGER_FILE_PATH} with erc7730 (registry canonical formatter)...\033[0m"
+          erc7730 format "ledger-registry/${LEDGER_FILE_PATH}"
 
           cd ledger-registry
           if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-781](https://linear.app/lifi-linear/issue/EXSC-781/wire-erc7730-format-into-clear-signing-registry-sync-to-eliminate)

# Why did I implement it this way?

The clear-signing registry stores `calldata-LIFIDiamond.json` in the compact shape produced by the ERC-7730 registry's own formatter (`erc7730 format`, run by its `format.yml` bot), but our sync generator writes fully-expanded `JSON.stringify(data, null, 2)`. The two disagree on every line, so each sync re-expands the registry's file and their bot re-compacts it — the file oscillates between formats and every sync PR carries a ~20k-line formatting diff that buries the real ABI/deployment change (e.g. the CBridge removal in registry PR #2901 was ~250 real lines out of ~20,700). Rather than reimplement the registry's serializer in TypeScript (a moving target that would drift the moment they change it), the sync now runs the registry's exact formatter on the generated descriptor before diffing/committing, so our output already matches the canonical shape. `erc7730` pins `Requires-Python >=3.12,<3.13`, so Python 3.12 is pinned explicitly instead of trusting the runner default. Verified locally under 3.12: feeding our generator output through `erc7730 format` reproduces the registry's format exactly, dropping the raw diff against the committed file from ~20,700 to 250 lines, all of which are the genuine change. The first sync PR after this merges is still a one-time reformat (adopting their shape as our baseline); every sync after is clean.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>