### PR TITLE
feat(VaultWrapper): source-liquidity-aware exit views (finding #4)

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -38,6 +38,12 @@ assuming anything about the source beyond its own standard EIP-4626 previews:
 - `withdrawUpTo` — the exact-in execution. DELEGATECALL only; realizes up to
   `assets` of position value into the wrapper and returns the measured asset
   delta. Backs `redeem`.
+- `maxWithdrawableValue` — the source-liquidity signal: the floor valuation
+  (`convertToAssets`) of the GROSS worth of `min(holder position, source.maxRedeem)`.
+  Gross by design (not `previewRedeem`) — it does NOT net the source's exit fee, because
+  the wrapper feeds it into its own gross share math to clamp its `max*` views to what the
+  source can currently honor. Equals the full position value on a fully-liquid source (one
+  with no active liquidity limit).
 
 These views read cost/realizable amounts straight from the source's own
 EIP-4626 `previewWithdraw`/`previewRedeem`, so they carry the same
@@ -67,6 +73,9 @@ function previewWithdrawUpTo(address _underlying, address _holder, uint256 _asse
 
 /// Realizes up to `_assets` of position value from the source; returns the measured asset delta.
 function withdrawUpTo(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
+
+/// Gross floor valuation of `min(holder position, source.maxRedeem)` — the source-liquidity signal (not exit-fee-netted).
+function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 
 ## Related contracts

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -50,11 +50,25 @@ withdrawal.
   never drains the raw source position, so a full exit leaves the tiny
   virtual-offset residue behind — that residue is the inflation-attack buffer,
   matching standard OZ behavior.
-- The `max*`/preview views: `maxWithdraw` and `maxRedeem` route through the
-  realizable, net-of-source-fee `previewRedeem`, so on a fee source
-  `maxWithdraw` reports the net amount. Neither reflects the source's own
-  liquidity/withdrawal limits (tracked separately as finding #4); deposits do
-  not reflect a source entry fee.
+- The `max*`/preview views are **source-liquidity-aware**: `maxRedeem` clamps the
+  owner's balance to what the source can currently honor (via the adapter's
+  `maxWithdrawableValue`), with a full-position short-circuit so it equals `balanceOf`
+  on a fully-liquid source and only clamps when the source is genuinely
+  liquidity-limited (an Aave-style utilization cap, a paused source). `maxWithdraw`
+  inherits the clamp because OZ derives it as `previewRedeem(maxRedeem(owner))`, so the
+  `withdraw` entrypoint's `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too. On a
+  fee source `maxWithdraw` still reports the net (fee-adjusted) amount. Deposits do not
+  reflect a source entry fee.
+- `previewRedeem`/`previewWithdraw` remain **liquidity-agnostic**: EIP-4626 requires
+  previews to ignore withdrawal limits, so they value against the full position and never
+  consult `maxWithdrawableValue`.
+- Dust tradeoff on OZ-style sources (e.g. MetaMorpho, whose own `maxRedeem` floors ~1
+  share below `balanceOf` even at full liquidity): a one-call full exit via
+  `redeem(balanceOf)` may hit `ERC4626ExceededMaxRedeem`. Callers should exit via
+  `redeem(maxRedeem(owner))`; `redeem` is the guaranteed exit and leaves at most
+  sub-1e-12-token dust that a follow-up call clears.
+- The exact-out `withdraw` rounding boundary near `maxWithdraw` remains the one tolerated
+  artifact, unchanged by the liquidity-awareness above.
 
 ## Admin role
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -683,13 +683,41 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Reports 0 while the access gate flags the owner as sanctioned, mirroring
-    ///      `redeem`'s exit freeze (the asset receiver is unknowable in this view and
-    ///      is checked in the entrypoint only).
+    /// @dev Reports 0 while the access gate flags the owner as sanctioned (mirroring `redeem`'s
+    ///      exit freeze). Otherwise clamps the owner's balance to what the source can currently
+    ///      honor: if the source can release the wrapper's whole position (the common case — a
+    ///      source with no active liquidity limit, where `maxWithdrawableValue == totalAssets()`),
+    ///      returns the plain balance unchanged; only when the source is liquidity-limited (an
+    ///      Aave-style utilization cap, a paused source) does it clamp to
+    ///      `_convertToShares(maxWithdrawableValue, Floor)`. The full-position short-circuit
+    ///      avoids the ~1-share under-report the virtual-offset share round-trip would otherwise
+    ///      introduce on a fully-liquid source, so `redeem` still empties a holder's balance in
+    ///      one call there. `maxWithdraw` inherits the clamp because OZ derives it as
+    ///      `previewRedeem(maxRedeem(owner))`, so the `withdraw` entrypoint's
+    ///      `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too. This keeps the EIP-4626
+    ///      guarantee that a `redeem` within `maxRedeem` never reverts even under a source
+    ///      liquidity limit; when limited, the floor round-trip is conservative (may under-report
+    ///      by up to one source-share of value, never over-report). On a source whose own
+    ///      `maxRedeem` floors below `balanceOf` (OZ-derived vaults such as MetaMorpho), a
+    ///      one-call full exit via `redeem(balanceOf)` is therefore not guaranteed; callers
+    ///      should use `redeem(maxRedeem(owner))`, which may leave sub-1e-12-token dust that a
+    ///      follow-up call clears.
     function maxRedeem(address owner) public view override returns (uint256) {
         if (_sanctioned(owner)) return 0;
 
-        return super.maxRedeem(owner);
+        uint256 balance = super.maxRedeem(owner);
+        uint256 realizable = IYieldAdapter(adapter).maxWithdrawableValue(
+            underlying,
+            address(this)
+        );
+        if (realizable >= totalAssets()) return balance;
+
+        uint256 liquidityCap = _convertToShares(
+            realizable,
+            Math.Rounding.Floor
+        );
+
+        return balance < liquidityCap ? balance : liquidityCap;
     }
 
     /// Internal ///

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -701,7 +701,11 @@ contract LiFiVaultWrapper is
     ///      `maxRedeem` floors below `balanceOf` (OZ-derived vaults such as MetaMorpho), a
     ///      one-call full exit via `redeem(balanceOf)` is therefore not guaranteed; callers
     ///      should use `redeem(maxRedeem(owner))`, which may leave sub-1e-12-token dust that a
-    ///      follow-up call clears.
+    ///      follow-up call clears. Because this now consults the source's views via
+    ///      `adapter.maxWithdrawableValue`, it reverts if those source views revert (a
+    ///      fully-paused/bricked source) — consistent with the fail-closed posture of
+    ///      `maxWithdraw`/`previewRedeem`, a deliberate deviation from EIP-4626's view-safety
+    ///      expectation.
     function maxRedeem(address owner) public view override returns (uint256) {
         if (_sanctioned(owner)) return 0;
 

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -122,6 +122,21 @@ contract ERC4626Adapter is IYieldAdapter {
         withdrawn = IERC20(_asset).balanceOf(address(this)) - balanceBefore;
     }
 
+    /// @inheritdoc IYieldAdapter
+    /// @dev Source floor valuation (`convertToAssets`) of the smaller of the holder's position
+    ///      and the source's current `maxRedeem`. Gross by design (not `previewRedeem`): the
+    ///      wrapper converts it back through its own gross share math to clamp exits to source
+    ///      liquidity. Equals the full position value when the source imposes no active limit.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets) {
+        uint256 position = IERC4626(_underlying).balanceOf(_holder);
+        uint256 redeemable = IERC4626(_underlying).maxRedeem(_holder);
+        uint256 shares = redeemable < position ? redeemable : position;
+        assets = IERC4626(_underlying).convertToAssets(shares);
+    }
+
     /// @dev Source-share slice worth `_assets` of `_holder`'s position, capped at the
     ///      holder's whole position.
     function _sliceShares(

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -116,4 +116,26 @@ interface IYieldAdapter {
         address _underlying,
         uint256 _assets
     ) external returns (uint256 withdrawn);
+
+    /// @notice Gross position value `_holder` may withdraw from `_underlying` right now, capped
+    ///         by the source's current withdrawal/redemption liquidity limits.
+    /// @dev Ordinary static call; runs in the adapter's context, so the holder is passed
+    ///      explicitly. Returns the source's floor valuation (`convertToAssets`) of
+    ///      `min(_holder's position, source maxRedeem)` — deliberately the GROSS valuation, not
+    ///      the fee-netted `previewRedeem` the sibling `previewWithdrawUpTo` uses, because the
+    ///      wrapper feeds this straight into its own gross-denominated share math
+    ///      (`_convertToShares`) to clamp `maxRedeem`/`maxWithdraw` to the shares the source can
+    ///      honor; any source exit fee is applied separately by the wrapper's realizable redeem
+    ///      path. This keeps the EIP-4626 guarantee that an exit within `maxRedeem` never
+    ///      reverts. Equals the full position value on a source with no active liquidity limit.
+    ///      Does NOT net the source's exit fee or the wrapper's own fees. MAY revert if the
+    ///      source's views revert (the wrapper treats a reverting source view as fail-closed,
+    ///      matching its existing preview posture).
+    /// @param _underlying The yield source identifier.
+    /// @param _holder The account whose position is valued (the wrapper).
+    /// @return assets The gross, source-liquidity-capped position value.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets);
 }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -125,6 +125,14 @@ contract LossyVault {
     function convertToShares(uint256 _assets) external pure returns (uint256) {
         return _assets;
     }
+
+    /// @dev Unlimited withdrawal liquidity: the whole balance is always redeemable, so the
+    ///      wrapper's liquidity clamp in `maxRedeem` is a no-op and the shortfall path under
+    ///      test is still reached. Needed since the wrapper's `maxRedeem` now reads the source
+    ///      liquidity via `ERC4626Adapter.maxWithdrawableValue`, which calls this.
+    function maxRedeem(address _owner) external view returns (uint256) {
+        return balanceOf[_owner];
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
+import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
@@ -83,9 +84,17 @@ contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
 
     function testRevert_RedeemAboveClampedMax() public {
         source.setWithdrawable(300e18);
-        uint256 shares = wrapper.maxRedeem(alice) + 1;
+        uint256 maxShares = wrapper.maxRedeem(alice);
+        uint256 shares = maxShares + 1;
 
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxRedeem.selector,
+                alice,
+                shares,
+                maxShares
+            )
+        );
 
         vm.prank(alice);
         wrapper.redeem(shares, alice, alice);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
+
+contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
+    MockERC20 internal asset;
+    MockLiquidityCappedERC4626 internal source;
+
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal integrator = makeAddr("integrator");
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        source = new MockLiquidityCappedERC4626(asset, "Yield", "yTKN");
+
+        _bringUpFactory(address(source), [uint16(5000), 1000, 2000, 2000]);
+        _deployWrapper(_params());
+
+        asset.mint(alice, 1_000e18);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), 1_000e18);
+        wrapper.deposit(1_000e18, alice);
+
+        vm.stopPrank();
+    }
+
+    function _params() private view returns (DeployParams memory) {
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({ wallet: integrator, bps: 10000 });
+
+        return
+            DeployParams({
+                namespace: bytes32("LI.FI-Earn"),
+                vaultWrapperAdmin: vaultAdmin,
+                adapter: address(adapter),
+                underlying: address(source),
+                nonce: 0,
+                fees: FeeConfig({ rateBps: [uint16(0), 0, 0, 0] }),
+                integratorShareBps: [uint16(8000), 8000, 8000, 8000],
+                accessGate: address(0),
+                receivers: receivers
+            });
+    }
+
+    function test_MaxRedeemEqualsBalanceWhenSourceUnlimited() public {
+        source.setWithdrawable(1_000_000e18);
+
+        assertEq(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+    }
+
+    function test_MaxRedeemClampsToSourceLiquidity() public {
+        source.setWithdrawable(300e18);
+
+        assertLt(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+        assertApproxEqAbs(
+            wrapper.convertToAssets(wrapper.maxRedeem(alice)),
+            300e18,
+            2
+        );
+    }
+
+    function test_MaxWithdrawInheritsLiquidityClamp() public {
+        source.setWithdrawable(300e18);
+
+        assertApproxEqAbs(wrapper.maxWithdraw(alice), 300e18, 2);
+    }
+
+    function test_RedeemAtClampedMaxSucceeds() public {
+        source.setWithdrawable(300e18);
+        uint256 shares = wrapper.maxRedeem(alice);
+
+        vm.prank(alice);
+        uint256 assets = wrapper.redeem(shares, alice, alice);
+
+        assertGt(assets, 0);
+        assertApproxEqAbs(assets, 300e18, 2);
+    }
+
+    function testRevert_RedeemAboveClampedMax() public {
+        source.setWithdrawable(300e18);
+        uint256 shares = wrapper.maxRedeem(alice) + 1;
+
+        vm.expectRevert();
+
+        vm.prank(alice);
+        wrapper.redeem(shares, alice, alice);
+    }
+
+    function test_MaxRedeemIsZeroWhenSourceDry() public {
+        source.setWithdrawable(0);
+
+        assertEq(wrapper.maxRedeem(alice), 0);
+        assertEq(wrapper.maxWithdraw(alice), 0);
+    }
+}

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -7,6 +7,7 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
+import { MockLiquidityCappedERC4626 } from "../mocks/MockLiquidityCappedERC4626.sol";
 
 contract ERC4626AdapterTest is Test {
     ERC4626Adapter internal adapter;
@@ -90,6 +91,24 @@ contract ERC4626AdapterTest is Test {
         assertEq(
             adapter.maxWithdrawableValue(address(vault), makeAddr("nobody")),
             0
+        );
+    }
+
+    function test_MaxWithdrawableValueCapsAtSourceLiquidity() public {
+        MockLiquidityCappedERC4626 capped = new MockLiquidityCappedERC4626(
+            asset,
+            "Capped",
+            "cTKN"
+        );
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(capped), 1_000e18);
+        capped.deposit(1_000e18, address(this));
+        capped.setWithdrawable(300e18);
+
+        // Position is worth 1_000e18 but only 300e18 is currently withdrawable.
+        assertEq(
+            adapter.maxWithdrawableValue(address(capped), address(this)),
+            300e18
         );
     }
 }

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -74,4 +74,22 @@ contract ERC4626AdapterTest is Test {
             1_000e18
         );
     }
+
+    function test_MaxWithdrawableValueEqualsPositionWhenUnlimited() public {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), address(this)),
+            1_000e18
+        );
+    }
+
+    function test_MaxWithdrawableValueIsZeroForEmptyHolder() public {
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), makeAddr("nobody")),
+            0
+        );
+    }
 }

--- a/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
+++ b/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
@@ -27,6 +27,11 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
     // (booked with the fee); the drained wrapper keeps sub-cent virtual-offset/flooring dust.
     uint256 internal constant WITHDRAW_TOL = 3;
     uint256 internal constant DRAIN_DUST = 1000; // 0.001 USDC
+    // Value of the shares left outstanding after every holder exits at `maxRedeem`: the source's
+    // own `balanceOf`-flooring `maxRedeem` (finding #4) strands ~1 source-share per exit, worth 1
+    // asset-wei in total at the pinned block. Bounded tight (0.00001 USDC) so any real share
+    // leakage — orders of magnitude larger on a ~45k-USDC flow — still trips it.
+    uint256 internal constant DRAIN_SHARE_DUST = 10;
 
     function _rpcEnvVar() internal pure override returns (string memory) {
         return "ETH_NODE_URI_ARBITRUM";
@@ -59,11 +64,14 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         _warpWithAccrual(WARP);
         _enter(carol, 15_000e6);
 
-        // Final accrual, everyone exits fully.
+        // Final accrual, everyone exits fully. Exit at `maxRedeem` (the EIP-4626-recommended
+        // pattern): the wrapper's `maxRedeem` is liquidity-aware and, over a MetaMorpho source
+        // whose own `maxRedeem` floors ~1 source-share below `balanceOf`, lands a dust amount
+        // below the raw balance — so `redeem(balanceOf)` would revert `ERC4626ExceededMaxRedeem`.
         _warpWithAccrual(WARP);
-        _exit(bob, wrapper.balanceOf(bob));
-        _exit(carol, wrapper.balanceOf(carol));
-        _exit(alice, wrapper.balanceOf(alice));
+        _exit(bob, wrapper.maxRedeem(bob));
+        _exit(carol, wrapper.maxRedeem(carol));
+        _exit(alice, wrapper.maxRedeem(alice));
 
         _distributeFeesAndAssertFanOut();
         _drainAndAssertConservation();
@@ -71,7 +79,7 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
 
     /// Deposits revert while paused; withdrawals stay open (withdrawals-always-open).
     function test_withdrawalsRemainOpenWhilePaused() public {
-        uint256 shares = _deposit(alice, 10_000e6);
+        _deposit(alice, 10_000e6);
 
         vm.prank(vaultAdmin);
         wrapper.pause();
@@ -85,7 +93,10 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         vm.stopPrank();
 
         uint256 balBefore = asset.balanceOf(alice);
-        _redeem(alice, shares);
+        // Exit at `maxRedeem` (see the lifecycle test): over MetaMorpho the wrapper's
+        // liquidity-aware `maxRedeem` sits a dust below `balanceOf`, so redeeming the raw
+        // balance would revert; the pause-does-not-block-withdrawals property is what matters.
+        _redeem(alice, wrapper.maxRedeem(alice));
 
         assertGt(
             asset.balanceOf(alice),
@@ -234,11 +245,20 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         wrapper.setFeeRate(FeeType.Withdrawal, 0);
         vm.stopPrank();
 
-        _redeem(lifiRecipient, wrapper.balanceOf(lifiRecipient));
-        _redeem(integrator1, wrapper.balanceOf(integrator1));
-        _redeem(integrator2, wrapper.balanceOf(integrator2));
+        _redeem(lifiRecipient, wrapper.maxRedeem(lifiRecipient));
+        _redeem(integrator1, wrapper.maxRedeem(integrator1));
+        _redeem(integrator2, wrapper.maxRedeem(integrator2));
 
-        assertEq(wrapper.totalSupply(), 0, "shares left outstanding");
+        // A clean-drain `totalSupply() == 0` is unreachable over a MetaMorpho source: each
+        // holder exits at `maxRedeem`, which the source's own `balanceOf`-flooring `maxRedeem`
+        // (finding #4) leaves ~1 source-share below the raw balance, so a dust of shares stays
+        // outstanding. Bound the residue by VALUE instead — it must be economically nothing yet
+        // still catch real share leakage.
+        assertLe(
+            wrapper.convertToAssets(wrapper.totalSupply()),
+            DRAIN_SHARE_DUST,
+            "residual share value exceeds source-flooring dust"
+        );
         assertLe(wrapper.totalAssets(), DRAIN_DUST, "position not drained");
         assertLe(
             asset.balanceOf(address(wrapper)),

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -7,6 +7,8 @@ import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaul
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
 import { VaultWrapperInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
 import { MockFeeERC4626 } from "test/solidity/VaultWrapper/mocks/MockFeeERC4626.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
+import { VaultWrapperCappedSourceInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
 
 /// @notice Shared stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A
 ///         handler drives randomized multi-actor sequences — deposits, mints, withdrawals,
@@ -68,18 +70,28 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
         );
         _deployWrapper(_deployParams());
 
-        handler = new VaultWrapperInvariantHandler(
-            wrapper,
-            asset,
-            underlying,
-            factory,
-            vaultAdmin
-        );
+        handler = _deployHandler();
 
         targetContract(address(handler));
         targetSelector(
             FuzzSelector({ addr: address(handler), selectors: _actions() })
         );
+    }
+
+    /// @dev Subclass seam: the handler under test. Base = plain handler.
+    function _deployHandler()
+        internal
+        virtual
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
     }
 
     /// @dev The idle asset balance is exactly the deposit/withdrawal fees booked but not yet
@@ -146,6 +158,24 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
         );
     }
 
+    /// @dev The value of each actor's `maxRedeem` never exceeds what the source can currently
+    ///      pay the wrapper — the liquidity clamp is honored. On an unlimited source this is
+    ///      the full position; on a capped source it tracks the cap. Complements the
+    ///      fail-on-revert proof that a `redeem` bounded to `maxRedeem` never reverts.
+    function invariant_MaxRedeemWithinSourceLiquidity() public view {
+        uint256 realizable = adapter.maxWithdrawableValue(
+            address(underlying),
+            address(wrapper)
+        );
+        for (uint256 i; i < 3; ++i) {
+            assertLe(
+                wrapper.convertToAssets(wrapper.maxRedeem(handler.actors(i))),
+                realizable,
+                "maxRedeem value exceeds source liquidity"
+            );
+        }
+    }
+
     function _deployParams() private view returns (DeployParams memory) {
         uint16[4] memory rates = [
             PERF_RATE,
@@ -178,7 +208,12 @@ abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
     }
 
     /// @dev The handler entrypoints the fuzzer may call; the ghost/actor getters are excluded.
-    function _actions() private pure returns (bytes4[] memory selectors) {
+    function _actions()
+        internal
+        pure
+        virtual
+        returns (bytes4[] memory selectors)
+    {
         selectors = new bytes4[](10);
         selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
         selectors[1] = VaultWrapperInvariantHandler.mint.selector;
@@ -211,5 +246,58 @@ contract VaultWrapperFeeSourceInvariantTest is VaultWrapperInvariantBase {
                 SOURCE_FEE_BPS,
                 sourceFeeSink
             );
+    }
+}
+
+/// @notice Same invariant suite over a source whose withdrawal liquidity is fuzzed up and
+///         down — proving the wrapper's liquidity-aware `max*` never over-report and a redeem
+///         within `maxRedeem` never reverts even as source liquidity shifts.
+contract VaultWrapperCappedSourceInvariantTest is VaultWrapperInvariantBase {
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal override returns (MockERC4626) {
+        return new MockLiquidityCappedERC4626(_asset, "Yield Token", "yTKN");
+    }
+
+    function _deployHandler()
+        internal
+        override
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperCappedSourceInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
+    }
+
+    // `withdraw` is deliberately omitted: on a liquidity-capped source the exact-out withdraw
+    // path can revert at EITHER the share-rounding boundary OR a source-liquidity boundary, and
+    // it is not the guaranteed exit. Its boundary behavior is covered by the no-fee/fee-source
+    // suites (share-rounding) and the wrapper unit tests (liquidity clamp + ExceededMaxWithdraw).
+    // This suite exercises the guaranteed `redeem` path and the max-view clamp under shifting
+    // liquidity.
+    function _actions()
+        internal
+        pure
+        override
+        returns (bytes4[] memory selectors)
+    {
+        selectors = new bytes4[](10);
+        selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
+        selectors[1] = VaultWrapperInvariantHandler.mint.selector;
+        selectors[2] = VaultWrapperInvariantHandler.redeem.selector;
+        selectors[3] = VaultWrapperInvariantHandler.distributeFees.selector;
+        selectors[4] = VaultWrapperInvariantHandler.injectYield.selector;
+        selectors[5] = VaultWrapperInvariantHandler.injectLoss.selector;
+        selectors[6] = VaultWrapperInvariantHandler.warp.selector;
+        selectors[7] = VaultWrapperInvariantHandler.setFee.selector;
+        selectors[8] = VaultWrapperInvariantHandler.togglePause.selector;
+        selectors[9] = VaultWrapperCappedSourceInvariantHandler
+            .setLiquidity
+            .selector;
     }
 }

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -7,6 +7,7 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { FeeType } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
 
 /// @notice Handler that drives a single `LiFiVaultWrapper` through bounded, randomized
 ///         multi-actor sequences for the invariant suite: three depositors enter/exit while
@@ -155,10 +156,10 @@ contract VaultWrapperInvariantHandler is Test {
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {
         address actor = _actor(_actorSeed);
-        uint256 balance = WRAPPER.balanceOf(actor);
-        if (balance == 0) return;
+        uint256 ceiling = WRAPPER.maxRedeem(actor);
+        if (ceiling == 0) return;
 
-        uint256 shares = bound(_shares, 1, balance);
+        uint256 shares = bound(_shares, 1, ceiling);
         uint256 sliceValue = WRAPPER.convertToAssets(shares);
 
         vm.prank(actor);
@@ -228,5 +229,35 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 current = WRAPPER.perfHighWaterMarkPps();
         assertGe(current, hwmFloor, "high-water mark regressed");
         hwmFloor = current;
+    }
+}
+
+/// @notice Handler variant that additionally fuzzes the source's withdrawal-liquidity cap,
+///         driving `maxRedeem`/`maxWithdraw` through their full liquidity-clamped range.
+contract VaultWrapperCappedSourceInvariantHandler is
+    VaultWrapperInvariantHandler
+{
+    constructor(
+        LiFiVaultWrapper _wrapper,
+        MockERC20 _asset,
+        MockERC4626 _underlying,
+        LiFiVaultWrapperFactory _factory,
+        address _vaultAdmin
+    )
+        VaultWrapperInvariantHandler(
+            _wrapper,
+            _asset,
+            _underlying,
+            _factory,
+            _vaultAdmin
+        )
+    {}
+
+    /// @notice Moves the source's withdrawable-liquidity cap anywhere in [0, totalAssets].
+    function setLiquidity(uint256 _assets) external {
+        uint256 total = UNDERLYING.totalAssets();
+        MockLiquidityCappedERC4626(address(UNDERLYING)).setWithdrawable(
+            bound(_assets, 0, total)
+        );
     }
 }

--- a/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+
+/// @notice Compliant ERC-4626 modelling an Aave-style withdrawal-liquidity cap: all deposited
+///         assets stay on the vault (so `totalAssets` and price-per-share are unchanged), but
+///         only `withdrawableAssets` of value may leave via `withdraw`/`redeem` at any moment.
+///         `maxWithdraw`/`maxRedeem` report the cap and the mutating paths revert past it, so a
+///         caller that respects the reported max never reverts. `setWithdrawable` moves the cap
+///         up and down to fuzz shifting liquidity. Used to prove the wrapper's liquidity-aware
+///         `max*` views. The cap is a policy limit, not a balance: the assets are always
+///         physically present, so any within-cap exit succeeds.
+contract MockLiquidityCappedERC4626 is MockERC4626 {
+    error WithdrawExceedsLiquidity();
+
+    uint256 public withdrawableAssets;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol
+    ) MockERC4626(_asset, _name, _symbol) {}
+
+    function setWithdrawable(uint256 _assets) external {
+        withdrawableAssets = _assets;
+    }
+
+    function maxWithdraw(
+        address owner
+    ) public view override returns (uint256) {
+        uint256 own = convertToAssets(balanceOf[owner]);
+        return own < withdrawableAssets ? own : withdrawableAssets;
+    }
+
+    function maxRedeem(address owner) public view override returns (uint256) {
+        uint256 capShares = convertToShares(withdrawableAssets);
+        uint256 own = balanceOf[owner];
+        return own < capShares ? own : capShares;
+    }
+
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (assets > maxWithdraw(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (shares > maxRedeem(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.redeem(shares, receiver, owner);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -54,4 +54,11 @@ contract MockZeroAdapter is IYieldAdapter {
     ) external pure returns (uint256) {
         return 0;
     }
+
+    function maxWithdrawableValue(
+        address,
+        address
+    ) external pure returns (uint256) {
+        return 0;
+    }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_TODO: link the Linear ticket (e.g. `EXSC-XXX`) before requesting review — required for the ticket-linkage metric._

**Stacked on #2197** (`fix/vault-wrapper-exit-cost-awareness`) — this PR targets that branch and should be reviewed/merged after it. Once #2197 merges to `dev-vault-wrapper`, rebase this onto `dev-vault-wrapper`.

# Why did I implement it this way?

This is finding #4 from the exit-cost PR (#2197): the wrapper's `maxWithdraw`/`maxRedeem` were fee/loss-aware but not **source-liquidity**-aware. When a yield source can only release part of the wrapper's position right now (an Aave-style utilization cap, a paused source, an illiquid Morpho market), the views over-reported and a `redeem`/`withdraw` within the reported max could revert — breaking the EIP-4626 guarantee that an exit within `maxRedeem` never reverts.

- Added one static adapter view `IYieldAdapter.maxWithdrawableValue(underlying, holder)` (implemented in `ERC4626Adapter`): the source's floor valuation (`convertToAssets`) of `min(holder position, source.maxRedeem)`. It is the **gross** valuation (deliberately not the fee-netted `previewRedeem` the sibling `previewWithdrawUpTo` uses), because the wrapper feeds it straight into its own gross-denominated share math to clamp the views; any source exit fee is applied separately by the realizable redeem path.
- `LiFiVaultWrapper.maxRedeem` now clamps the owner's balance to `_convertToShares(maxWithdrawableValue, Floor)` — but only when the source is genuinely liquidity-limited. A full-position short-circuit (`realizable >= totalAssets()`) returns the plain balance on fully-liquid sources, avoiding the ~1-share under-report the virtual-offset share round-trip would otherwise introduce. `maxWithdraw` inherits the clamp because OZ derives it as `previewRedeem(maxRedeem(owner))`, so the `withdraw` entrypoint's `ERC4626ExceededMaxWithdraw` guard is liquidity-aware too.
- `previewRedeem`/`previewWithdraw` stay liquidity-agnostic (EIP-4626 requires previews to ignore withdrawal limits). Exit execution paths are unchanged — they already fail on a short source; finding #4 was about the views.

Accepted tradeoff (documented): on OZ-style sources whose own `maxRedeem` floors ~1 share below `balanceOf` even at full liquidity (e.g. MetaMorpho), the clamp lands a sub-`1e-12`-token dust below `balanceOf`, so a one-call `redeem(balanceOf)` can hit `ERC4626ExceededMaxRedeem`. Callers should exit via `redeem(maxRedeem(owner))` (the EIP-4626-recommended pattern); a follow-up call clears the dust. `redeem` remains the guaranteed exit. The exact-out `withdraw` share-rounding boundary near `maxWithdraw` is unchanged and remains the one tolerated artifact.

Scope is the exit **views** only. `@custom:version` is held at `1.0.0` (subsystem is pre-release). `script/deploy/healthCheckInvariants.ts` was reviewed: no change needed (this adds an interface method + internal view logic only — no deployed-contract topology, constructor, selector, or storage change; the Vault Wrapper is outside the Diamond the health-check covers).

Testing: added `MockLiquidityCappedERC4626` (models an Aave-style withdrawal cap — assets stay on the vault, only a policy-limited amount may leave), adapter and wrapper unit tests, and a third stateful invariant suite that fuzzes the source's liquidity cap up and down while a `redeem` bounded to `maxRedeem` runs under `fail-on-revert` (0 reverts; ~80% of executed redeems occur while the clamp is actively binding). The Morpho Arbitrum fork scenario was updated to exit via `redeem(maxRedeem)` and to assert the drain residue is dust (`convertToAssets(totalSupply()) <= 10 wei`) instead of exactly 0. Full subsystem suite: 349 tests passing.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
