### PR TITLE
chore(ci): route scheduled-job Slack output to #dev-sc-github-ci-notifications (EXSC-788)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,10 +202,10 @@ SLACK_WEBHOOK_SC_GENERAL=
 # Leave any unset to fall back to manual copy-paste (/tmp/audit-request-{pr}.md).
 WEBHOOK_DEV_SC_AUDIT=
 WEBHOOK_DEV_SC_AUDIT_BURRASEC=
-# proposal-created / please-sign notifications from multiNetworkExecution.sh
-WEBHOOK_DEV_SC_MULTISIG_PROPOSALS=
 # scheduled-job output (deferred-cleanup reconcile TTL alert); only delivered when CI is set
 WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS=
+# proposal-created / please-sign notifications from multiNetworkExecution.sh
+WEBHOOK_DEV_SC_MULTISIG_PROPOSALS=
 
 # the path to the foundry.toml file
 FOUNDRY_TOML_FILE_PATH="foundry.toml"

--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,8 @@ WEBHOOK_DEV_SC_AUDIT=
 WEBHOOK_DEV_SC_AUDIT_BURRASEC=
 # proposal-created / please-sign notifications from multiNetworkExecution.sh
 WEBHOOK_DEV_SC_MULTISIG_PROPOSALS=
+# scheduled-job output (deferred-cleanup reconcile TTL alert); only delivered when CI is set
+WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS=
 
 # the path to the foundry.toml file
 FOUNDRY_TOML_FILE_PATH="foundry.toml"

--- a/.github/workflows/reconcileParkedTasks.yml
+++ b/.github/workflows/reconcileParkedTasks.yml
@@ -14,7 +14,8 @@
 #   state machine. RPCs are fetched from MongoDB (fallback: public RPCs from networks.json).
 # - Triggers: weekly cron (Mon 08:00 UTC) + workflow_dispatch (manual). Upstream-only (skips on forks).
 # - Known limitations: needs MONGODB_URI (queue + RPCs); WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS optional
-#   (the TTL alert is skipped gracefully if the webhook secret is unset).
+#   (the TTL alert is skipped gracefully if the webhook secret is unset). Slack delivery also
+#   requires CI to be set, so a local run of the same script logs the alert instead of posting it.
 
 name: Reconcile Deferred Diamond-Cleanup Queue
 

--- a/.github/workflows/reconcileParkedTasks.yml
+++ b/.github/workflows/reconcileParkedTasks.yml
@@ -13,9 +13,10 @@
 #   an audit label only) and revert-detection is skipped; run locally with tunnel access for the full
 #   state machine. RPCs are fetched from MongoDB (fallback: public RPCs from networks.json).
 # - Triggers: weekly cron (Mon 08:00 UTC) + workflow_dispatch (manual). Upstream-only (skips on forks).
-# - Known limitations: needs MONGODB_URI (queue + RPCs); WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS optional
-#   (the TTL alert is skipped gracefully if the webhook secret is unset). Slack delivery also
-#   requires CI to be set, so a local run of the same script logs the alert instead of posting it.
+# - Known limitations: needs MONGODB_URI (queue + RPCs) and, because this run applies, a populated
+#   WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS — the job fails rather than staying green while the
+#   backstop alert is dropped. Slack delivery also requires CI to be set, so a local run of the
+#   same script logs the alert instead of posting it.
 
 name: Reconcile Deferred Diamond-Cleanup Queue
 
@@ -73,7 +74,7 @@ jobs:
           MONGODB_URI: ${{ secrets.MONGODB_URI }} # un-gated deferred-cleanup queue + RPC fallback
           # Script reads WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS (local .env convention); the GH
           # secret follows the repo's SLACK_WEBHOOK_* naming — bridge one to the other.
-          WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }} # TTL alert (optional)
+          WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }} # TTL alert (required for this applied run)
 
       # A silently-broken cron defeats the cold-network backstop — surface run failures to Slack.
       - name: Notify Slack on failure

--- a/.github/workflows/reconcileParkedTasks.yml
+++ b/.github/workflows/reconcileParkedTasks.yml
@@ -3,8 +3,9 @@
 #   truth: a facet no longer routed by the loupe is terminal (executed if its own proposal executed,
 #   else superseded); a proposed task whose proposal reverted while the facet is still present is
 #   re-queued. See script/deploy/safe/reconcile-parked-tasks.ts + docs/DeferredDiamondCleanupQueue.md §7/§8.
-# - TTL backstop: any open task older than the TTL (default 60d) is posted to the multisig-proposals
-#   Slack channel so a cold network that never gets another cut is never silently orphaned (§8).
+# - TTL backstop: any open task older than the TTL (default 60d) is posted to the
+#   github-ci-notifications Slack channel so a cold network that never gets another cut is never
+#   silently orphaned (§8).
 # - Runs with --yes so transitions are applied and the alert is sent. Transitions touch only the
 #   un-gated MONGODB_URI queue (status flips), never on-chain state or the signing store.
 # - Loupe-primary: SC_MONGODB_URI (the signing store) is NOT reachable from GitHub Actions (no tunnel),
@@ -12,7 +13,7 @@
 #   an audit label only) and revert-detection is skipped; run locally with tunnel access for the full
 #   state machine. RPCs are fetched from MongoDB (fallback: public RPCs from networks.json).
 # - Triggers: weekly cron (Mon 08:00 UTC) + workflow_dispatch (manual). Upstream-only (skips on forks).
-# - Known limitations: needs MONGODB_URI (queue + RPCs); WEBHOOK_DEV_SC_MULTISIG_PROPOSALS optional
+# - Known limitations: needs MONGODB_URI (queue + RPCs); WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS optional
 #   (the TTL alert is skipped gracefully if the webhook secret is unset).
 
 name: Reconcile Deferred Diamond-Cleanup Queue
@@ -69,16 +70,16 @@ jobs:
         run: bunx tsx script/deploy/safe/reconcile-parked-tasks.ts --yes
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }} # un-gated deferred-cleanup queue + RPC fallback
-          # Script reads WEBHOOK_DEV_SC_MULTISIG_PROPOSALS (local .env convention); the GH
+          # Script reads WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS (local .env convention); the GH
           # secret follows the repo's SLACK_WEBHOOK_* naming — bridge one to the other.
-          WEBHOOK_DEV_SC_MULTISIG_PROPOSALS: ${{ secrets.SLACK_WEBHOOK_DEV_SC_MULTISIG_PROPOSALS }} # TTL alert (optional)
+          WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }} # TTL alert (optional)
 
       # A silently-broken cron defeats the cold-network backstop — surface run failures to Slack.
       - name: Notify Slack on failure
         if: failure()
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/reconcileParkedTasks.yml
+++ b/.github/workflows/reconcileParkedTasks.yml
@@ -14,9 +14,9 @@
 #   state machine. RPCs are fetched from MongoDB (fallback: public RPCs from networks.json).
 # - Triggers: weekly cron (Mon 08:00 UTC) + workflow_dispatch (manual). Upstream-only (skips on forks).
 # - Known limitations: needs MONGODB_URI (queue + RPCs) and, because this run applies, a populated
-#   WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS — the job fails rather than staying green while the
-#   backstop alert is dropped. Slack delivery also requires CI to be set, so a local run of the
-#   same script logs the alert instead of posting it.
+#   WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS — a run that has an alert to post but no webhook fails
+#   instead of staying green while the backstop alert is dropped. Slack delivery also requires CI
+#   to be set, so a local run of the same script logs the alert instead of posting it.
 
 name: Reconcile Deferred Diamond-Cleanup Queue
 

--- a/.github/workflows/ticketLinkageMetric.yml
+++ b/.github/workflows/ticketLinkageMetric.yml
@@ -29,10 +29,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/ticket-linkage-metric.sh
 
-      - name: Post to Slack SC-general
+      - name: Post to Slack CI-notifications channel
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -44,7 +44,7 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/updateScriptConfigReminder.yml
+++ b/.github/workflows/updateScriptConfigReminder.yml
@@ -1,5 +1,5 @@
 # Notify SmartContract channel when .env.example changes
-# - posts a Slack reminder to sc-general so developers refresh their local .env after a config addition/rename
+# - posts a Slack reminder to dev-sc-github-ci-notifications so developers refresh their local .env after a config addition/rename
 # - triggers on push to main when .env.example is modified
 # - known limitations: only fires on main (not on PR review); the workflow does not verify that developers actually updated their .env
 
@@ -19,10 +19,10 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Reminder to Slack SC-general Channel
+      - name: Send Reminder to Slack CI-notifications Channel
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             text: "Hey team, please update your .env file (see <https://github.com/lifinance/contracts/blob/main/.env.example|.env.example> for latest changes)"

--- a/.github/workflows/weeklyCoverageReport.yml
+++ b/.github/workflows/weeklyCoverageReport.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/weeklyCoverageReport.yml
+++ b/.github/workflows/weeklyCoverageReport.yml
@@ -1,6 +1,6 @@
 # Weekly Test Coverage Report
 # - Runs the (Foundry) test-coverage measurement on a weekly schedule instead of on every PR and
-#   posts the result to the SC-general Slack channel.
+#   posts the result to the dev-sc-github-ci-notifications Slack channel.
 # - Replaces the per-commit coverage gate (enforceTestCoverage.yml, removed in EXSC-675): coverage
 #   is slow, non-parallelizable, and flaky on live-RPC fork tests, and never fails for low coverage
 #   since we sit well above target — so it belongs on a low-frequency reporting cadence, not the
@@ -24,8 +24,8 @@ concurrency:
 
 jobs:
   coverage-report:
-    # Upstream-only: the coverage run needs lifinance/contracts' MongoDB RPCs and the SC-general
-    # Slack webhook, which forks (e.g. contracts-tron, which syncs workflows) do not have.
+    # Upstream-only: the coverage run needs lifinance/contracts' MongoDB RPCs and the
+    # CI-notifications Slack webhook, which forks (e.g. contracts-tron, which syncs workflows) do not have.
     if: ${{ github.repository == 'lifinance/contracts' }}
     runs-on: ubuntu-latest
     permissions:

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -640,8 +640,10 @@ Three composed backstops, none silent:
    (match by facet+network) so the two paths don't double-propose.
 2. **TTL / age alert.** A scheduled job reads `parkedTasks`; any record `queued`
    longer than *N* days (default **30** `[unverified]` — team to set) → post to
-   `#dev-sc-multisig-proposals` via the existing webhook (Fact 12), naming the
-   network, facets, and origin PRs, prompting a deliberate `--auto --network X` drain.
+   `#dev-sc-github-ci-notifications` (`WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS`), naming
+   the network, facets, and origin PRs, prompting a deliberate `--auto --network X` drain.
+   `#dev-sc-multisig-proposals` stays reserved for please-sign announcements, so scheduled
+   job output never competes with the signing worklist.
 3. **Observability** (§9) makes the backlog visible on demand.
 
 **Deploy-log longevity hazard (important).** Because removal is now *deferred*

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -645,7 +645,9 @@ Three composed backstops, none silent:
    `#dev-sc-multisig-proposals` stays reserved for please-sign announcements, so scheduled
    job output never competes with the signing worklist. Delivery requires `CI`: a local run
    (including the full-tunnel one §7 recommends) prints the alert to the console instead of
-   posting it, so a rehearsal cannot page the team. Export `CI=1` to force delivery.
+   posting it, so a rehearsal cannot page the team. Export `CI=1` to force delivery. On the
+   scheduled run an unset webhook fails the job instead of dropping the alert, so the backstop
+   cannot go quiet behind a green check.
 3. **Observability** (§9) makes the backlog visible on demand.
 
 **Deploy-log longevity hazard (important).** Because removal is now *deferred*

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -643,7 +643,9 @@ Three composed backstops, none silent:
    `#dev-sc-github-ci-notifications` (`WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS`), naming
    the network, facets, and origin PRs, prompting a deliberate `--auto --network X` drain.
    `#dev-sc-multisig-proposals` stays reserved for please-sign announcements, so scheduled
-   job output never competes with the signing worklist.
+   job output never competes with the signing worklist. Delivery requires `CI`: a local run
+   (including the full-tunnel one §7 recommends) prints the alert to the console instead of
+   posting it, so a rehearsal cannot page the team. Export `CI=1` to force delivery.
 3. **Observability** (§9) makes the backlog visible on demand.
 
 **Deploy-log longevity hazard (important).** Because removal is now *deferred*

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -4,8 +4,9 @@
  * The two pure decisions are exercised directly: {@link reconcileDecision} maps a
  * task's status + on-chain/proposal truth to a lifecycle transition, and
  * {@link computeTtlAlerts} / {@link formatTtlAlertMessage} surface open tasks that
- * have aged past the TTL. The live CLI (Mongo/loupe/Slack wiring) is unit-test
- * exempt, mirroring the store's `getParkedTasksCollection()` carve-out.
+ * have aged past the TTL, and {@link ttlAlertDelivery} decides whether an alert is
+ * posted, logged, or treated as a misconfiguration. The live CLI (Mongo/loupe/Slack
+ * wiring) is unit-test exempt, mirroring the store's `getParkedTasksCollection()` carve-out.
  */
 
 import {
@@ -23,6 +24,7 @@ import {
   computeTtlAlerts,
   formatTtlAlertMessage,
   reconcileDecision,
+  ttlAlertDelivery,
 } from './reconcile-parked-tasks'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -183,5 +185,32 @@ describe('formatTtlAlertMessage', () => {
     expect(msg).toContain('65d')
     expect(msg).toContain('https://gh/pull/1')
     expect(msg).toContain('https://gh/pull/2')
+  })
+})
+
+describe('ttlAlertDelivery', () => {
+  it('stays silent on a dry-run even when everything else is configured', () => {
+    expect(ttlAlertDelivery(false, true, 'https://hooks.slack/x')).toBe(
+      'dry-run'
+    )
+  })
+
+  it('logs instead of posting on a local run, keeping rehearsals off the channel', () => {
+    expect(ttlAlertDelivery(true, false, 'https://hooks.slack/x')).toBe('local')
+  })
+
+  it('posts on the applied unattended run', () => {
+    expect(ttlAlertDelivery(true, true, 'https://hooks.slack/x')).toBe('send')
+  })
+
+  it.each([undefined, ''])(
+    'reports a missing webhook (%p) rather than dropping the alert silently',
+    (webhook) => {
+      expect(ttlAlertDelivery(true, true, webhook)).toBe('misconfigured')
+    }
+  )
+
+  it('does not report a misconfiguration on a local run with no webhook', () => {
+    expect(ttlAlertDelivery(true, false, undefined)).toBe('local')
   })
 })

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -309,7 +309,8 @@ async function runTtlAlert(
     )
     return
   }
-  if (delivery === 'misconfigured' || !webhookUrl)
+  // 'misconfigured' — an unattended run reaching here has no webhook to post to.
+  if (!webhookUrl)
     throw new Error(
       'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset, so the TTL alert cannot be delivered. Set the SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS repository secret.'
     )

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -15,7 +15,7 @@
  *     detects reverts; without it (loupe-only) a gone facet is `superseded`.
  *
  *  2. **TTL alert** — surface open tasks that have aged past the TTL (default 60d)
- *     to the multisig-proposals Slack channel, so a cold network that never gets
+ *     to the github-ci-notifications Slack channel, so a cold network that never gets
  *     another cut is never silently orphaned (spec §8 backstop).
  *
  * The pure decisions ({@link reconcileDecision}, {@link computeTtlAlerts},
@@ -31,7 +31,7 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { getAddress } from 'viem'
 
-import { SlackNotifier } from '../../utils/slack-notifier'
+import { isUnattendedRun, SlackNotifier } from '../../utils/slack-notifier'
 import { getEnvVar } from '../../utils/utils'
 
 import { fetchOnChainFacets, resolveDiamondAddress } from './diamondRemovalDiff'
@@ -277,11 +277,17 @@ async function runTtlAlert(
     return
   }
   consola.warn(message)
-  const webhookUrl = process.env.WEBHOOK_DEV_SC_MULTISIG_PROPOSALS
-  if (apply && webhookUrl)
-    await new SlackNotifier(webhookUrl).sendNotificationWithRetry({
-      text: message,
-    })
+  const webhookUrl = process.env.WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS
+  if (!apply || !webhookUrl) return
+  if (!isUnattendedRun()) {
+    consola.info(
+      'Local run: alert logged only. Set CI=1 to deliver it to Slack.'
+    )
+    return
+  }
+  await new SlackNotifier(webhookUrl).sendNotificationWithRetry({
+    text: message,
+  })
 }
 
 const main = defineCommand({

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -278,7 +278,13 @@ async function runTtlAlert(
   }
   consola.warn(message)
   const webhookUrl = process.env.WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS
-  if (!apply || !webhookUrl) return
+  if (!apply) return
+  if (!webhookUrl) {
+    consola.info(
+      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset — alert logged only.'
+    )
+    return
+  }
   if (!isUnattendedRun()) {
     consola.info(
       'Local run: alert logged only. Set CI=1 to deliver it to Slack.'

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -160,6 +160,29 @@ export function formatTtlAlertMessage(
   return lines.join('\n')
 }
 
+export type TtlAlertDelivery = 'dry-run' | 'local' | 'misconfigured' | 'send'
+
+/**
+ * Decides what an applied run does with a computed TTL alert. A missing webhook on
+ * the unattended run is a misconfiguration rather than a skip: the scheduled job
+ * would otherwise stay green while the cold-network backstop it exists for is lost.
+ *
+ * @param apply - whether the run applies transitions (`--yes`) rather than dry-running.
+ * @param unattended - {@link isUnattendedRun} for this process.
+ * @param webhookUrl - `WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS`, if set.
+ * @returns which delivery path the caller must take.
+ */
+export function ttlAlertDelivery(
+  apply: boolean,
+  unattended: boolean,
+  webhookUrl: string | undefined
+): TtlAlertDelivery {
+  if (!apply) return 'dry-run'
+  if (!unattended) return 'local'
+  if (!webhookUrl) return 'misconfigured'
+  return 'send'
+}
+
 // ───────────────────────── live adapter (unit-test exempt) ─────────────────────
 
 type PendingTransactions = Awaited<
@@ -278,19 +301,18 @@ async function runTtlAlert(
   }
   consola.warn(message)
   const webhookUrl = process.env.WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS
-  if (!apply) return
-  if (!webhookUrl) {
-    consola.info(
-      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset — alert logged only.'
-    )
-    return
-  }
-  if (!isUnattendedRun()) {
+  const delivery = ttlAlertDelivery(apply, isUnattendedRun(), webhookUrl)
+  if (delivery === 'dry-run') return
+  if (delivery === 'local') {
     consola.info(
       'Local run: alert logged only. Set CI=1 to deliver it to Slack.'
     )
     return
   }
+  if (delivery === 'misconfigured' || !webhookUrl)
+    throw new Error(
+      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset, so the TTL alert cannot be delivered. Set the SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS repository secret.'
+    )
   await new SlackNotifier(webhookUrl).sendNotificationWithRetry({
     text: message,
   })

--- a/script/utils/slack-notifier.test.ts
+++ b/script/utils/slack-notifier.test.ts
@@ -173,7 +173,7 @@ describe('isUnattendedRun', () => {
     else process.env.CI = original
   })
 
-  it('is true under a scheduled CI run', () => {
+  it('is true under a GitHub Actions run, scheduled or dispatched', () => {
     process.env.CI = 'true'
     expect(isUnattendedRun()).toBe(true)
   })
@@ -186,5 +186,18 @@ describe('isUnattendedRun', () => {
   it('is false for an empty CI value', () => {
     process.env.CI = ''
     expect(isUnattendedRun()).toBe(false)
+  })
+
+  it.each(['false', 'FALSE', '0', 'no'])(
+    'treats CI=%s as an opt-out, not as CI',
+    (value) => {
+      process.env.CI = value
+      expect(isUnattendedRun()).toBe(false)
+    }
+  )
+
+  it('is true for any other non-empty value', () => {
+    process.env.CI = '1'
+    expect(isUnattendedRun()).toBe(true)
   })
 })

--- a/script/utils/slack-notifier.test.ts
+++ b/script/utils/slack-notifier.test.ts
@@ -12,7 +12,7 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { SlackNotifier } from './slack-notifier'
+import { isUnattendedRun, SlackNotifier } from './slack-notifier'
 import type { ISlackMessage } from './slack-notifier'
 
 const WEBHOOK = 'https://hooks.slack.com/services/T000/B000/xxx'
@@ -162,5 +162,29 @@ describe('SlackNotifier retry failure signaling', () => {
       caught = err
     }
     expect(String(caught)).toContain('Slack API error: 500')
+  })
+})
+
+describe('isUnattendedRun', () => {
+  const original = process.env.CI
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.CI
+    else process.env.CI = original
+  })
+
+  it('is true under a scheduled CI run', () => {
+    process.env.CI = 'true'
+    expect(isUnattendedRun()).toBe(true)
+  })
+
+  it('is false in a developer shell, so local runs stay off the channel', () => {
+    delete process.env.CI
+    expect(isUnattendedRun()).toBe(false)
+  })
+
+  it('is false for an empty CI value', () => {
+    process.env.CI = ''
+    expect(isUnattendedRun()).toBe(false)
   })
 })

--- a/script/utils/slack-notifier.ts
+++ b/script/utils/slack-notifier.ts
@@ -64,9 +64,16 @@ const SLACK_TEXT_LIMIT = 2900
  *
  * `.env` is symlinked across worktrees, so the webhook is always populated
  * locally — presence of the URL cannot stand in for this check.
+ *
+ * A wrapper that exports `CI=false`/`CI=0` is opting OUT, so a plain truthiness
+ * check on the variable would hand it delivery — the very outcome it asked to avoid.
+ *
+ * @returns `true` under GitHub Actions (scheduled or manually dispatched), `false`
+ * in a developer shell unless `CI` is exported by hand to force delivery.
  */
 export function isUnattendedRun(): boolean {
-  return Boolean(process.env.CI)
+  const ci = String(process.env.CI ?? '').toLowerCase()
+  return !['', '0', 'false', 'no'].includes(ci)
 }
 
 export class SlackNotifier {

--- a/script/utils/slack-notifier.ts
+++ b/script/utils/slack-notifier.ts
@@ -56,6 +56,19 @@ interface IProcessingStats {
 // posts instead of being dropped.
 const SLACK_TEXT_LIMIT = 2900
 
+/**
+ * Whether this process is the unattended scheduled run rather than a developer's
+ * shell. A local run reads its own console, so delivering its output to the shared
+ * channel only posts noise the team has to triage — and a rehearsal against a
+ * narrowed config posts alarms that are false by construction.
+ *
+ * `.env` is symlinked across worktrees, so the webhook is always populated
+ * locally — presence of the URL cannot stand in for this check.
+ */
+export function isUnattendedRun(): boolean {
+  return Boolean(process.env.CI)
+}
+
 export class SlackNotifier {
   private webhookUrl: string
   private startTime: Date


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge this before #2157.** #2157 adds the two reconcile alert send sites that actually
> spammed `#dev-sc-multisig-proposals`, and it must be rebased onto the gate this PR
> introduces so those sites land already routed to `#dev-sc-github-ci-notifications` and
> already behind `isUnattendedRun()`. Merging #2157 first re-opens the incident on `main`
> and turns a one-line `import` conflict into a re-litigation of the routing decision.

# Which Linear task belongs to this PR?

Fixes [EXSC-788](https://linear.app/lifi-linear/issue/EXSC-788/route-scheduled-job-slack-output-off-dev-sc-multisig-proposals)

# Why did I implement it this way?

`#dev-sc-multisig-proposals` is the signing worklist — humans scan it to know what to sign. The deferred-cleanup reconcile job posts its alerts there, which was never an audience decision: `docs/DeferredDiamondCleanupQueue.md` Fact 12 picked the webhook that already existed. The tell is that the same workflow already sent its own *failure* notification to `SLACK_WEBHOOK_SC_GENERAL`, so one file spoke to two channels for no principled reason.

On 2026-08-18 two local rehearsal runs against a temporarily narrowed `config/networks.json` posted `66 network(s) could not be reconciled` and `41 network(s)…` into the proposals channel. Both were report-only and false by construction (`bsc`, `celo`, `gnosis` are obviously live), but the team still had to triage them.

**Split by who has to act, not by "CI/CD" as a category:**

| Destination | What goes there | Changed here |
|---|---|---|
| `#dev-sc-github-ci-notifications` | scheduled-job output nobody must act on today | reconcileParkedTasks (+ its failure notify), weeklyCoverageReport, ticketLinkageMetric, updateScriptConfigReminder |
| `#dev-sc-multisig-proposals` | please-sign announcements only | unchanged — `multiNetworkExecution.sh`, drain alerts during a rollout |
| `#dev-sc-general` | needs a human now | unchanged — emergency pause, healthcheck, RPC checker, pause readiness |

Drain alerts (`drain-parked-tasks.ts`) deliberately stay on the proposals channel: they fire only during a real operator-driven rollout that creates proposals, so they belong with the signing flow, not with cron output.

**Why a `CI` gate and not just a new channel:** `.env` is symlinked across worktrees, so the webhook is always populated locally — webhook presence cannot distinguish the cron from a developer's shell. Without the gate, the next rehearsal spams whichever channel it points at. A local run now logs the alert and prints how to force delivery.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

## Prerequisite (done)

`SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS` exists as a repo secret in both `lifinance/contracts` and `lifinance/contracts-tron` (created 2026-08-18) — the four workflows would hard-fail on an empty webhook, so this had to land first. `contracts-tron` matters because it syncs workflows from here.

## ⚠️ This PR alone does not close the incident

It gates the one Slack send site that exists on `main` (`runTtlAlert`). The alerts that actually spammed the channel are added by #2157, which carries two further send sites, both ungated and still on the old webhook, and conflicts with this branch only on the `import` line. See the review-gate comment below — that coordination is unresolved.

## Verification

- `bun test` on `slack-notifier`, `reconcile-parked-tasks`, `drain-parked-tasks` — 54 pass, 0 fail.
- Gate proven in both directions at the network layer (counting `fetch` calls, not branch shape): local run → 0 calls; `CI=true` → 1 call.
- Mutation check: forcing `isUnattendedRun()` to `return true` fails 2 of the 3 new tests, so they can actually detect a broken gate.
- `bunx eslint` + `bunx tsc-files --noEmit` clean on all changed TS; all 4 workflows parse; `markdownlint-cli2` clean on the changed doc.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


