### PR TITLE
feat(deploy): add companion + reverse-dependency deploy reminders (EXSC-785)

### DIFF
--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -106,6 +106,27 @@ deploySingleContract() {
     warning "$REFUND_REMINDER"
   fi
 
+  # Non-fatal reminder: warn if this facet declares a companion periphery contract
+  # (config/global.json -> facetPeripheryCouplings) that is absent from this network's deploy log.
+  # Deploying the facet before its Receiver is the normal order, so this is a nudge, not a gate -
+  # the facet-required-periphery health-check invariant is the enforcing check.
+  # Best-effort only - any failure here must never interrupt the deployment.
+  local COMPANION_REMINDER
+  COMPANION_REMINDER=$(bunx tsx script/deploy/resources/facetCompanionReminder.ts "$CONTRACT" "$NETWORK" "$ENVIRONMENT" 2>/dev/null || true)
+  if [[ -n "$COMPANION_REMINDER" ]]; then
+    warning "$COMPANION_REMINDER"
+  fi
+
+  # Non-fatal reminder: warn which already-deployed contracts bind this one immutably at
+  # construction and therefore need a redeploy afterwards (Executor -> all Receiver... contracts,
+  # ERC20Proxy -> Executor -> all Receiver... contracts). Derived from deployRequirements.json.
+  # Best-effort only - any failure here must never interrupt the deployment.
+  local DEPENDENCY_REMINDER
+  DEPENDENCY_REMINDER=$(bunx tsx script/deploy/resources/contractDependencyReminder.ts "$CONTRACT" "$NETWORK" "$ENVIRONMENT" 2>/dev/null || true)
+  if [[ -n "$DEPENDENCY_REMINDER" ]]; then
+    warning "$DEPENDENCY_REMINDER"
+  fi
+
   # check if deploy script exists
   if ! checkIfFileExists "$FULL_SCRIPT_PATH" >/dev/null; then
     error "could not find deploy script for $CONTRACT in this path: $FULL_SCRIPT_PATH". Aborting deployment.

--- a/script/deploy/resources/contractDependencyReminder.test.ts
+++ b/script/deploy/resources/contractDependencyReminder.test.ts
@@ -48,9 +48,8 @@ describe('collectTransitiveDependents', () => {
       B: { contractAddresses: { A: {} } },
     }
 
-    // Sorted by contract name; A appears as its own transitive dependent through B.
+    // A is the contract being redeployed, so it is never reported as its own dependent.
     expect(collectTransitiveDependents('A', cyclic)).toEqual([
-      { contract: 'A', via: ['B'] },
       { contract: 'B', via: [] },
     ])
   })

--- a/script/deploy/resources/contractDependencyReminder.test.ts
+++ b/script/deploy/resources/contractDependencyReminder.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  buildDependencyReminder,
+  collectTransitiveDependents,
+  type IDependencyEntry,
+} from './contractDependencyReminder'
+
+const REQUIREMENTS: Record<string, IDependencyEntry> = {
+  Executor: { contractAddresses: { ERC20Proxy: {} } },
+  ReceiverAcrossV4: { contractAddresses: { Executor: {} } },
+  ReceiverStargateV2: { contractAddresses: { Executor: {} } },
+  SomeFacet: {},
+}
+
+describe('collectTransitiveDependents', () => {
+  it('finds direct dependents', () => {
+    expect(collectTransitiveDependents('Executor', REQUIREMENTS)).toEqual([
+      { contract: 'ReceiverAcrossV4', via: [] },
+      { contract: 'ReceiverStargateV2', via: [] },
+    ])
+  })
+
+  it('walks the graph transitively with the path recorded', () => {
+    expect(collectTransitiveDependents('ERC20Proxy', REQUIREMENTS)).toEqual([
+      { contract: 'Executor', via: [] },
+      { contract: 'ReceiverAcrossV4', via: ['Executor'] },
+      { contract: 'ReceiverStargateV2', via: ['Executor'] },
+    ])
+  })
+
+  it('returns nothing for a contract nobody depends on', () => {
+    expect(collectTransitiveDependents('SomeFacet', REQUIREMENTS)).toEqual([])
+  })
+
+  it('is cycle-safe', () => {
+    const cyclic = {
+      A: { contractAddresses: { B: {} } },
+      B: { contractAddresses: { A: {} } },
+    }
+
+    // Sorted by contract name; A appears as its own transitive dependent through B.
+    expect(collectTransitiveDependents('A', cyclic)).toEqual([
+      { contract: 'A', via: ['B'] },
+      { contract: 'B', via: [] },
+    ])
+  })
+})
+
+describe('buildDependencyReminder', () => {
+  const ADDR = '0x1111111111111111111111111111111111111111'
+
+  it('lists only dependents deployed on this network', () => {
+    const reminder = buildDependencyReminder(
+      'Executor',
+      'mainnet',
+      { ReceiverAcrossV4: ADDR },
+      REQUIREMENTS
+    )
+
+    expect(reminder).toContain('Redeploying Executor')
+    expect(reminder).toContain('ReceiverAcrossV4')
+    expect(reminder).not.toContain('ReceiverStargateV2')
+  })
+
+  it('shows the transitive path for indirect dependents', () => {
+    const reminder = buildDependencyReminder(
+      'ERC20Proxy',
+      'mainnet',
+      { Executor: ADDR, ReceiverAcrossV4: ADDR },
+      REQUIREMENTS
+    )
+
+    expect(reminder).toContain('Executor')
+    expect(reminder).toContain('ReceiverAcrossV4 (via Executor)')
+  })
+
+  it('returns null when no dependent is deployed', () => {
+    expect(
+      buildDependencyReminder('Executor', 'mainnet', {}, REQUIREMENTS)
+    ).toBeNull()
+  })
+
+  it('returns null for a contract nobody depends on', () => {
+    expect(
+      buildDependencyReminder(
+        'SomeFacet',
+        'mainnet',
+        { ReceiverAcrossV4: ADDR },
+        REQUIREMENTS
+      )
+    ).toBeNull()
+  })
+})
+
+describe('real deployRequirements.json reverse graph', () => {
+  it('Executor dependents include every coupled receiver with an entry', () => {
+    const dependents = collectTransitiveDependents('Executor').map(
+      (d) => d.contract
+    )
+
+    expect(dependents).toContain('ReceiverAcrossV4')
+    expect(dependents).toContain('ReceiverStargateV2')
+    expect(dependents).toContain('ReceiverChainflip')
+    expect(dependents).toContain('ReceiverOIF')
+  })
+
+  it('ERC20Proxy dependents include the receivers transitively via Executor', () => {
+    const dependents = collectTransitiveDependents('ERC20Proxy')
+    const receiver = dependents.find((d) => d.contract === 'ReceiverAcrossV4')
+
+    expect(dependents.map((d) => d.contract)).toContain('Executor')
+    expect(receiver?.via).toEqual(['Executor'])
+  })
+})
+
+describe('CLI smoke test', () => {
+  // deploySingleContract.sh runs this CLI behind `2>/dev/null || true`, so a crash (bad import,
+  // syntax error) would silently disable the reminder forever. Spawning the real entry point
+  // proves it executes and prints for a known dependent in the deploy log.
+  const cliPath = join(import.meta.dir, 'contractDependencyReminder.ts')
+
+  it('exits 0 and prints the reminder when a deployed dependent exists', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dependency-cli-'))
+    mkdirSync(join(root, 'deployments'))
+    writeFileSync(
+      join(root, 'deployments', 'smokenet.json'),
+      JSON.stringify({
+        ReceiverAcrossV4: '0x1111111111111111111111111111111111111111',
+      })
+    )
+
+    const result = Bun.spawnSync(
+      [process.execPath, cliPath, 'Executor', 'smokenet', 'production'],
+      { cwd: root }
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.toString()).toContain('ReceiverAcrossV4')
+  })
+
+  it('exits 0 and prints nothing without arguments', () => {
+    const result = Bun.spawnSync([process.execPath, cliPath])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.toString().trim()).toBe('')
+  })
+})

--- a/script/deploy/resources/contractDependencyReminder.test.ts
+++ b/script/deploy/resources/contractDependencyReminder.test.ts
@@ -149,7 +149,28 @@ describe('real deployRequirements.json reverse graph', () => {
   })
 
   it('excludes the timelock, which can repoint its diamond via setDiamondAddress', () => {
-    expect(collectTransitiveDependents('LiFiDiamond')).toEqual([])
+    expect(
+      collectTransitiveDependents('LiFiDiamond').map((d) => d.contract)
+    ).not.toContain('LiFiTimelockController')
+  })
+
+  it('covers the diamond bindings the requirements file omits', () => {
+    const dependents = collectTransitiveDependents('LiFiDiamond').map(
+      (d) => d.contract
+    )
+
+    expect(dependents).toContain('Permit2Proxy')
+    expect(dependents).toContain('GasZipPeriphery')
+    expect(dependents).not.toContain('LiFiTimelockController')
+  })
+
+  it('does not promise a health check for the diamond edges', () => {
+    const reminder = buildDependencyReminder('LiFiDiamond', 'mainnet', {
+      Permit2Proxy: '0x1111111111111111111111111111111111111111',
+    })
+
+    expect(reminder).toContain('Permit2Proxy')
+    expect(reminder).not.toContain('health check')
   })
 
   it('keeps every genuine cascade edge in the real graph', () => {

--- a/script/deploy/resources/contractDependencyReminder.test.ts
+++ b/script/deploy/resources/contractDependencyReminder.test.ts
@@ -56,6 +56,36 @@ describe('collectTransitiveDependents', () => {
   })
 })
 
+describe('updatable dependency edges', () => {
+  // These dependents can repoint the address after deployment, so a redeploy of the dependency
+  // must not tell the deployer to redeploy them.
+  const UPDATABLE = {
+    LiFiDiamond: { contractAddresses: { DiamondCutFacet: {} } },
+    LiFiDiamondImmutable: { contractAddresses: { DiamondCutFacet: {} } },
+    LiFiTimelockController: { contractAddresses: { LiFiDiamond: {} } },
+  }
+
+  it('drops the diamond -> DiamondCutFacet edge', () => {
+    expect(collectTransitiveDependents('DiamondCutFacet', UPDATABLE)).toEqual(
+      []
+    )
+  })
+
+  it('drops the timelock -> LiFiDiamond edge', () => {
+    expect(collectTransitiveDependents('LiFiDiamond', UPDATABLE)).toEqual([])
+  })
+
+  it('still reports a same-named dependent when the edge is not excluded', () => {
+    const graph = {
+      LiFiTimelockController: { contractAddresses: { Executor: {} } },
+    }
+
+    expect(collectTransitiveDependents('Executor', graph)).toEqual([
+      { contract: 'LiFiTimelockController', via: [] },
+    ])
+  })
+})
+
 describe('buildDependencyReminder', () => {
   const ADDR = '0x1111111111111111111111111111111111111111'
 
@@ -112,6 +142,23 @@ describe('real deployRequirements.json reverse graph', () => {
     expect(dependents).toContain('ReceiverStargateV2')
     expect(dependents).toContain('ReceiverChainflip')
     expect(dependents).toContain('ReceiverOIF')
+  })
+
+  it('excludes DiamondCutFacet: a diamond replaces it with an ordinary cut', () => {
+    expect(collectTransitiveDependents('DiamondCutFacet')).toEqual([])
+  })
+
+  it('excludes the timelock, which can repoint its diamond via setDiamondAddress', () => {
+    expect(collectTransitiveDependents('LiFiDiamond')).toEqual([])
+  })
+
+  it('keeps every genuine cascade edge in the real graph', () => {
+    const executorDependents = collectTransitiveDependents('Executor').map(
+      (d) => d.contract
+    )
+
+    expect(executorDependents).not.toContain('LiFiDiamond')
+    expect(executorDependents.length).toBeGreaterThanOrEqual(4)
   })
 
   it('ERC20Proxy dependents include the receivers transitively via Executor', () => {

--- a/script/deploy/resources/contractDependencyReminder.ts
+++ b/script/deploy/resources/contractDependencyReminder.ts
@@ -1,0 +1,152 @@
+/**
+ * Reverse-dependency reminder for contract redeployments (EXSC-785).
+ *
+ * `deployRequirements.json` → `contractAddresses` records the FORWARD dependency edge: deploying
+ * `ReceiverAcrossV4` needs the `Executor` address, deploying `Executor` needs `ERC20Proxy` — each
+ * bound immutably at construction. The REVERSE edge is what a redeployment needs: redeploying the
+ * Executor invalidates every deployed Receiver's immutable binding, and redeploying the ERC20Proxy
+ * transitively invalidates the Executor and thus every Receiver.
+ *
+ * This reminder walks that reverse graph and lists every dependent present in the network's deploy
+ * log — the contracts that must themselves be redeployed and re-registered afterwards.
+ * `contractSpecificReminders.sh` states the same rule as static prose for `Executor` and
+ * `ERC20Proxy`; deriving it from the graph keeps it correct as `deployRequirements.json` grows and
+ * narrows it to the dependents actually present on the target network.
+ *
+ * Non-fatal by design (same tier as `facetCompanionReminder`): the `receiver-executor-binding` and
+ * `executor-erc20proxy-binding` health-check invariants are the enforcing gate after the fact.
+ *
+ * CLI (invoked from deploySingleContract.sh, best-effort — never blocks a deploy):
+ *   bunx tsx script/deploy/resources/contractDependencyReminder.ts <ContractName> <network> <environment>
+ * Prints the reminder when deployed dependents exist, otherwise prints nothing. Always exits 0.
+ */
+import { realpathSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+import deployRequirementsJson from './deployRequirements.json'
+import { isValidNetworkName, readDeployLog } from './facetCompanionReminder'
+
+/** The subset of a `deployRequirements.json` entry this module consumes. */
+export interface IDependencyEntry {
+  contractAddresses?: Record<string, unknown>
+}
+
+/** One dependent of the deployed contract: which contract, and through which chain of edges. */
+export interface ITransitiveDependent {
+  contract: string
+  /** Dependency path from the redeployed contract to this dependent (exclusive of both ends). */
+  via: string[]
+}
+
+/**
+ * Walk the reverse dependency graph: every contract whose `contractAddresses` names
+ * `contractName`, directly or through intermediates (ERC20Proxy → Executor → Receivers).
+ * Pure; cycle-safe; sorted by contract name.
+ */
+export function collectTransitiveDependents(
+  contractName: string,
+  deployRequirements: Record<
+    string,
+    IDependencyEntry
+  > = deployRequirementsJson as Record<string, IDependencyEntry>
+): ITransitiveDependent[] {
+  const dependentsOf = (name: string): string[] =>
+    Object.entries(deployRequirements)
+      .filter(([, entry]) =>
+        Object.keys(entry.contractAddresses ?? {}).includes(name)
+      )
+      .map(([dependent]) => dependent)
+
+  const results = new Map<string, string[]>()
+  const queue: Array<{ contract: string; via: string[] }> = dependentsOf(
+    contractName
+  ).map((contract) => ({ contract, via: [] }))
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current || results.has(current.contract)) continue
+    results.set(current.contract, current.via)
+
+    for (const dependent of dependentsOf(current.contract))
+      if (!results.has(dependent))
+        queue.push({
+          contract: dependent,
+          via: [...current.via, current.contract],
+        })
+  }
+
+  return [...results.entries()]
+    .map(([contract, via]) => ({ contract, via }))
+    .sort((a, b) => a.contract.localeCompare(b.contract))
+}
+
+/**
+ * Build the redeploy-cascade reminder for one contract, or null when no deployed dependent
+ * exists on this network.
+ *
+ * @param contractName - the contract being (re)deployed
+ * @param network - network key as in `config/networks.json`
+ * @param deployedContracts - the network's deploy log (contract name → address)
+ * @param deployRequirements - registry override, for tests
+ */
+export function buildDependencyReminder(
+  contractName: string,
+  network: string,
+  deployedContracts: Record<string, string>,
+  deployRequirements?: Record<string, IDependencyEntry>
+): string | null {
+  const dependents = collectTransitiveDependents(
+    contractName,
+    deployRequirements
+  ).filter((dependent) => deployedContracts[dependent.contract])
+
+  if (dependents.length === 0) return null
+
+  const list = dependents
+    .map((dependent) =>
+      dependent.via.length === 0
+        ? dependent.contract
+        : `${dependent.contract} (via ${dependent.via.join(' → ')})`
+    )
+    .join(', ')
+
+  return (
+    `⚠️  Redeploying ${contractName} invalidates immutable bindings on ${network}: ` +
+    `${list} bind${dependents.length === 1 ? 's' : ''} it at construction. ` +
+    `Redeploy and re-register each dependent (diamondUpdatePeriphery) after this deployment, ` +
+    `or the binding health checks will flag this network.`
+  )
+}
+
+/**
+ * CLI entry: print the reminder for the given contract/network/environment. Best-effort by
+ * design — missing arguments, an unrecognised network name, or an unreadable log print nothing
+ * rather than interfering with the deploy.
+ */
+function runCli(): void {
+  const [contractName, network, environment] = process.argv.slice(2)
+  if (!contractName || !network) return
+  if (!isValidNetworkName(network)) return
+
+  const reminder = buildDependencyReminder(
+    contractName,
+    network,
+    readDeployLog(network, environment || 'production', process.cwd())
+  )
+  if (reminder) console.log(reminder)
+}
+
+/**
+ * Run the CLI only when this file is executed directly (bunx tsx ...), not when imported by tests.
+ */
+function isDirectRun(): boolean {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+if (isDirectRun()) runCli()

--- a/script/deploy/resources/contractDependencyReminder.ts
+++ b/script/deploy/resources/contractDependencyReminder.ts
@@ -2,16 +2,14 @@
  * Reverse-dependency reminder for contract redeployments (EXSC-785).
  *
  * `deployRequirements.json` → `contractAddresses` records the FORWARD dependency edge: deploying
- * `ReceiverAcrossV4` needs the `Executor` address, deploying `Executor` needs `ERC20Proxy` — each
- * bound immutably at construction. The REVERSE edge is what a redeployment needs: redeploying the
- * Executor invalidates every deployed Receiver's immutable binding, and redeploying the ERC20Proxy
- * transitively invalidates the Executor and thus every Receiver.
+ * `ReceiverAcrossV4` needs the `Executor` address, deploying `Executor` needs `ERC20Proxy`. The
+ * REVERSE edge is what a redeployment needs: a dependent that stored the address at construction
+ * and has no setter keeps pointing at the old contract forever, so it must itself be redeployed.
  *
- * This reminder walks that reverse graph and lists every dependent present in the network's deploy
- * log — the contracts that must themselves be redeployed and re-registered afterwards.
- * `contractSpecificReminders.sh` states the same rule as static prose for `Executor` and
- * `ERC20Proxy`; deriving it from the graph keeps it correct as `deployRequirements.json` grows and
- * narrows it to the dependents actually present on the target network.
+ * This reminder walks that reverse graph and lists every such dependent present in the network's
+ * deploy log. `contractSpecificReminders.sh` states the same rule as static prose for `Executor`
+ * and `ERC20Proxy`; deriving it from the graph keeps it correct as `deployRequirements.json` grows
+ * and narrows it to the dependents actually present on the target network.
  *
  * Non-fatal by design (same tier as `facetCompanionReminder`): the `receiver-executor-binding` and
  * `executor-erc20proxy-binding` health-check invariants are the enforcing gate after the fact.
@@ -39,9 +37,26 @@ export interface ITransitiveDependent {
 }
 
 /**
- * Walk the reverse dependency graph: every contract whose `contractAddresses` names
- * `contractName`, directly or through intermediates (ERC20Proxy → Executor → Receivers).
+ * Edges whose dependent can repoint the address after deployment, so redeploying the dependency
+ * forces no redeploy. `deployRequirements.json` records them as constructor inputs like any other,
+ * but a diamond reaches its `DiamondCutFacet` through mutable diamond storage (replaced with an
+ * ordinary `diamondCut`) and `LiFiTimelockController` exposes `setDiamondAddress`. Warning about
+ * these would tell a deployer to redeploy contracts that do not need it.
+ */
+const UPDATABLE_DEPENDENCIES: Record<string, readonly string[]> = {
+  LiFiDiamond: ['DiamondCutFacet'],
+  LiFiDiamondImmutable: ['DiamondCutFacet'],
+  LiFiTimelockController: ['LiFiDiamond'],
+}
+
+/**
+ * Walk the reverse dependency graph: every contract that stores `contractName` at construction
+ * with no way to update it, directly or through intermediates (ERC20Proxy → Executor → Receivers).
  * Pure; cycle-safe; sorted by contract name.
+ *
+ * @param contractName - the contract being (re)deployed
+ * @param deployRequirements - registry override, for tests
+ * @returns each dependent with the dependency path that reaches it
  */
 export function collectTransitiveDependents(
   contractName: string,
@@ -52,8 +67,10 @@ export function collectTransitiveDependents(
 ): ITransitiveDependent[] {
   const dependentsOf = (name: string): string[] =>
     Object.entries(deployRequirements)
-      .filter(([, entry]) =>
-        Object.keys(entry.contractAddresses ?? {}).includes(name)
+      .filter(
+        ([dependent, entry]) =>
+          Object.keys(entry.contractAddresses ?? {}).includes(name) &&
+          !(UPDATABLE_DEPENDENCIES[dependent] ?? []).includes(name)
       )
       .map(([dependent]) => dependent)
 
@@ -88,6 +105,7 @@ export function collectTransitiveDependents(
  * @param network - network key as in `config/networks.json`
  * @param deployedContracts - the network's deploy log (contract name → address)
  * @param deployRequirements - registry override, for tests
+ * @returns the human-facing reminder, or null when no dependent is deployed on this network
  */
 export function buildDependencyReminder(
   contractName: string,
@@ -111,8 +129,11 @@ export function buildDependencyReminder(
     .join(', ')
 
   return (
-    `⚠️  Redeploying ${contractName} invalidates immutable bindings on ${network}: ` +
-    `${list} bind${dependents.length === 1 ? 's' : ''} it at construction. ` +
+    `⚠️  Redeploying ${contractName} leaves stale references on ${network}: ` +
+    `${list} store${
+      dependents.length === 1 ? 's' : ''
+    } it at construction and cannot be ` +
+    `repointed afterwards. ` +
     `Redeploy and re-register each dependent (diamondUpdatePeriphery) after this deployment, ` +
     `or the binding health checks will flag this network.`
   )

--- a/script/deploy/resources/contractDependencyReminder.ts
+++ b/script/deploy/resources/contractDependencyReminder.ts
@@ -117,7 +117,14 @@ export function collectTransitiveDependents(
 
   while (queue.length > 0) {
     const current = queue.shift()
-    if (!current || results.has(current.contract)) continue
+    // A cycle can walk back to the deployed contract itself; it is the thing being redeployed,
+    // never its own dependent.
+    if (
+      !current ||
+      current.contract === contractName ||
+      results.has(current.contract)
+    )
+      continue
     results.set(current.contract, current.via)
 
     for (const dependent of dependentsOf(current.contract))

--- a/script/deploy/resources/contractDependencyReminder.ts
+++ b/script/deploy/resources/contractDependencyReminder.ts
@@ -11,8 +11,9 @@
  * and `ERC20Proxy`; deriving it from the graph keeps it correct as `deployRequirements.json` grows
  * and narrows it to the dependents actually present on the target network.
  *
- * Non-fatal by design (same tier as `facetCompanionReminder`): the `receiver-executor-binding` and
- * `executor-erc20proxy-binding` health-check invariants are the enforcing gate after the fact.
+ * Non-fatal by design (same tier as `facetCompanionReminder`). The `receiver-executor-binding` and
+ * `executor-erc20proxy-binding` invariants enforce the Executor edges after the fact; the diamond
+ * edges below have no health check, so for those this reminder is the only signal.
  *
  * CLI (invoked from deploySingleContract.sh, best-effort — never blocks a deploy):
  *   bunx tsx script/deploy/resources/contractDependencyReminder.ts <ContractName> <network> <environment>
@@ -50,6 +51,41 @@ const UPDATABLE_DEPENDENCIES: Record<string, readonly string[]> = {
 }
 
 /**
+ * Construction bindings that `deployRequirements.json` does not record as `contractAddresses`.
+ * Both contracts hold `address public immutable LIFI_DIAMOND` with no setter and their deploy
+ * scripts read the address straight from the deploy log, so a redeployed diamond leaves them
+ * pointing at the old one — but the requirements file lists only their `configData`, so the
+ * reverse walk cannot see the edge.
+ */
+const ADDITIONAL_CONSTRUCTOR_BINDINGS: Record<string, readonly string[]> = {
+  GasZipPeriphery: ['LiFiDiamond'],
+  Permit2Proxy: ['LiFiDiamond'],
+}
+
+/** Fold {@link ADDITIONAL_CONSTRUCTOR_BINDINGS} into the recorded graph. */
+function withAdditionalBindings(
+  base: Record<string, IDependencyEntry>
+): Record<string, IDependencyEntry> {
+  const merged: Record<string, IDependencyEntry> = { ...base }
+  for (const [dependent, dependencies] of Object.entries(
+    ADDITIONAL_CONSTRUCTOR_BINDINGS
+  ))
+    merged[dependent] = {
+      ...merged[dependent],
+      contractAddresses: {
+        ...(merged[dependent]?.contractAddresses ?? {}),
+        ...Object.fromEntries(dependencies.map((name) => [name, {}])),
+      },
+    }
+  return merged
+}
+
+/** The recorded graph plus the bindings the requirements file omits. */
+const DEFAULT_DEPLOY_REQUIREMENTS = withAdditionalBindings(
+  deployRequirementsJson as Record<string, IDependencyEntry>
+)
+
+/**
  * Walk the reverse dependency graph: every contract that stores `contractName` at construction
  * with no way to update it, directly or through intermediates (ERC20Proxy → Executor → Receivers).
  * Pure; cycle-safe; sorted by contract name.
@@ -63,7 +99,7 @@ export function collectTransitiveDependents(
   deployRequirements: Record<
     string,
     IDependencyEntry
-  > = deployRequirementsJson as Record<string, IDependencyEntry>
+  > = DEFAULT_DEPLOY_REQUIREMENTS
 ): ITransitiveDependent[] {
   const dependentsOf = (name: string): string[] =>
     Object.entries(deployRequirements)
@@ -134,8 +170,7 @@ export function buildDependencyReminder(
       dependents.length === 1 ? 's' : ''
     } it at construction and cannot be ` +
     `repointed afterwards. ` +
-    `Redeploy and re-register each dependent (diamondUpdatePeriphery) after this deployment, ` +
-    `or the binding health checks will flag this network.`
+    `Redeploy and re-register each dependent (diamondUpdatePeriphery) after this deployment.`
   )
 }
 

--- a/script/deploy/resources/facetCompanionReminder.test.ts
+++ b/script/deploy/resources/facetCompanionReminder.test.ts
@@ -1,0 +1,212 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import type { TFacetPeripheryCouplings } from '../shared/facetPeripheryCouplings'
+
+import {
+  buildCompanionReminder,
+  isValidNetworkName,
+  readDeployLog,
+} from './facetCompanionReminder'
+
+const COUPLINGS: TFacetPeripheryCouplings = {
+  AcrossFacetV4: { requires: 'ReceiverAcrossV4' },
+  AcrossFacetPackedV4: { requires: 'ReceiverAcrossV4' },
+  ChainflipFacet: {
+    requires: 'ReceiverChainflip',
+    notRequiredOn: { somechain: 'source-only there' },
+  },
+}
+
+describe('buildCompanionReminder', () => {
+  it('reminds when the companion is not in the deploy log', () => {
+    const reminder = buildCompanionReminder(
+      'AcrossFacetV4',
+      'robinhood',
+      { LiFiDiamond: '0xdiamond' },
+      COUPLINGS
+    )
+
+    expect(reminder).toContain('AcrossFacetV4')
+    expect(reminder).toContain('robinhood')
+    expect(reminder).toContain('ReceiverAcrossV4')
+  })
+
+  it('stays silent when the companion is already deployed', () => {
+    expect(
+      buildCompanionReminder(
+        'AcrossFacetV4',
+        'linea',
+        { ReceiverAcrossV4: '0xreceiver' },
+        COUPLINGS
+      )
+    ).toBeNull()
+  })
+
+  it('treats an empty-string deploy-log entry as not deployed', () => {
+    expect(
+      buildCompanionReminder(
+        'AcrossFacetV4',
+        'robinhood',
+        { ReceiverAcrossV4: '' },
+        COUPLINGS
+      )
+    ).toContain('ReceiverAcrossV4')
+  })
+
+  it('stays silent for a contract with no declared coupling', () => {
+    expect(
+      buildCompanionReminder('GenericSwapFacetV3', 'mainnet', {}, COUPLINGS)
+    ).toBeNull()
+  })
+
+  it('stays silent for a facet carved out on this network', () => {
+    expect(
+      buildCompanionReminder('ChainflipFacet', 'somechain', {}, COUPLINGS)
+    ).toBeNull()
+  })
+
+  it('still reminds for a carved-out facet on other networks', () => {
+    expect(
+      buildCompanionReminder('ChainflipFacet', 'mainnet', {}, COUPLINGS)
+    ).toContain('ReceiverChainflip')
+  })
+
+  it('also covers the packed variant of a facet family', () => {
+    expect(
+      buildCompanionReminder('AcrossFacetPackedV4', 'robinhood', {}, COUPLINGS)
+    ).toContain('AcrossFacetPackedV4')
+  })
+
+  it('falls back to the real registry when no override is passed', () => {
+    expect(buildCompanionReminder('AcrossFacetV4', 'robinhood', {})).toContain(
+      'ReceiverAcrossV4'
+    )
+  })
+})
+
+describe('readDeployLog', () => {
+  it('reads production addresses for a real network', () => {
+    const log = readDeployLog('mainnet', 'production', process.cwd())
+
+    expect(log['LiFiDiamond']).toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+
+  it('reads the staging log for a staging deploy', () => {
+    const log = readDeployLog('mainnet', 'staging', process.cwd())
+
+    expect(log['LiFiDiamond']).toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+
+  it('drops empty-string entries so they never count as deployed', () => {
+    const log = readDeployLog('mainnet', 'production', process.cwd())
+
+    expect(Object.values(log)).not.toContain('')
+  })
+
+  it('refuses a network name that could traverse out of deployments/', () => {
+    expect(isValidNetworkName('../../.env')).toBe(false)
+    expect(isValidNetworkName('mainnet/../secret')).toBe(false)
+    expect(isValidNetworkName('bsc-testnet')).toBe(true)
+    expect(isValidNetworkName('mainnet')).toBe(true)
+    expect(readDeployLog('../../.env', 'production', process.cwd())).toEqual({})
+  })
+
+  it('returns an empty map for a network with no deploy log', () => {
+    expect(
+      readDeployLog('networkthatdoesnotexist', 'production', process.cwd())
+    ).toEqual({})
+  })
+
+  it('returns an empty map when the log is not valid JSON', () => {
+    const root = mkdtempSync(join(tmpdir(), 'companion-reminder-'))
+    mkdirSync(join(root, 'deployments'))
+    writeFileSync(join(root, 'deployments', 'broken.json'), '{ not json')
+
+    expect(readDeployLog('broken', 'production', root)).toEqual({})
+  })
+
+  it('returns an empty map when the log is valid JSON but not an object', () => {
+    const root = mkdtempSync(join(tmpdir(), 'companion-reminder-'))
+    mkdirSync(join(root, 'deployments'))
+    writeFileSync(join(root, 'deployments', 'scalar.json'), 'null')
+
+    expect(readDeployLog('scalar', 'production', root)).toEqual({})
+  })
+
+  it('drops non-string entries', () => {
+    const root = mkdtempSync(join(tmpdir(), 'companion-reminder-'))
+    mkdirSync(join(root, 'deployments'))
+    writeFileSync(
+      join(root, 'deployments', 'mixed.json'),
+      JSON.stringify({ LiFiDiamond: '0xabc', SomeCount: 7, Nested: {} })
+    )
+
+    expect(readDeployLog('mixed', 'production', root)).toEqual({
+      LiFiDiamond: '0xabc',
+    })
+  })
+})
+
+describe('CLI smoke test', () => {
+  // deploySingleContract.sh runs this CLI behind `2>/dev/null || true`, so a crash (bad import,
+  // syntax error) would silently disable the reminder forever. Spawning the real entry point
+  // proves it executes and prints for a known-missing companion.
+  const cliPath = join(import.meta.dir, 'facetCompanionReminder.ts')
+
+  it('exits 0 and prints the reminder when the companion is missing from the log', () => {
+    const result = Bun.spawnSync([
+      process.execPath,
+      cliPath,
+      'AcrossFacetV4',
+      'smokenet',
+      'production',
+    ])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.toString()).toContain('AcrossFacetV4')
+    expect(result.stdout.toString()).toContain('ReceiverAcrossV4')
+  })
+
+  it('exits 0 and prints nothing without arguments', () => {
+    const result = Bun.spawnSync([process.execPath, cliPath])
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout.toString().trim()).toBe('')
+  })
+
+  // An empty ENVIRONMENT must select the production log, as documented; `??` would have let the
+  // empty string through to the suffix helper and silently read the staging log instead.
+  it('treats an empty environment argument as production', () => {
+    const root = mkdtempSync(join(tmpdir(), 'companion-env-'))
+    mkdirSync(join(root, 'deployments'))
+    writeFileSync(
+      join(root, 'deployments', 'envnet.json'),
+      JSON.stringify({
+        ReceiverAcrossV4: '0x1111111111111111111111111111111111111111',
+      })
+    )
+    writeFileSync(join(root, 'deployments', 'envnet.staging.json'), '{}')
+
+    const withEmpty = Bun.spawnSync(
+      [process.execPath, cliPath, 'AcrossFacetV4', 'envnet', ''],
+      { cwd: root }
+    )
+    const withStaging = Bun.spawnSync(
+      [process.execPath, cliPath, 'AcrossFacetV4', 'envnet', 'staging'],
+      { cwd: root }
+    )
+
+    expect(withEmpty.exitCode).toBe(0)
+    expect(withEmpty.stdout.toString().trim()).toBe('')
+    expect(withStaging.stdout.toString()).toContain('ReceiverAcrossV4')
+  })
+})

--- a/script/deploy/resources/facetCompanionReminder.ts
+++ b/script/deploy/resources/facetCompanionReminder.ts
@@ -67,15 +67,23 @@ export function buildCompanionReminder(
  * Network keys in `config/networks.json` are alphanumeric with optional `-`/`_` (e.g. `bsc-testnet`).
  * Reject anything else so a caller-supplied name can never traverse outside `deployments/`
  * (e.g. `../../.env`) once composed into a file path.
+ *
+ * @param name - the candidate network key
+ * @returns true when the name is a plain network key
  */
 export function isValidNetworkName(name: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(name)
 }
 
 /**
- * Read a network's deploy log. Returns an empty map when the name is not a plain network key, or
- * when the file is missing or unreadable — a brand-new network legitimately has no log yet, and
- * the reminder must never break a deploy.
+ * Read a network's deploy log.
+ *
+ * @param network - network key as in `config/networks.json`
+ * @param environment - `production` or `staging`; selects the log file suffix
+ * @param repoRoot - directory holding `deployments/`
+ * @returns contract name → address; empty when the name is not a plain network key, or the file is
+ *   missing or unreadable — a brand-new network legitimately has no log yet, and the reminder must
+ *   never break a deploy
  */
 export function readDeployLog(
   network: string,

--- a/script/deploy/resources/facetCompanionReminder.ts
+++ b/script/deploy/resources/facetCompanionReminder.ts
@@ -1,0 +1,144 @@
+/**
+ * Companion-periphery reminder for facet deployments (EXSC-785).
+ *
+ * A bridge facet only covers the source side; destination calls need its companion Receiver on the
+ * same chain. Rolling out a facet to a new chain and forgetting the Receiver silently disables
+ * destination swaps there.
+ *
+ * The deploy pipeline prints a NON-FATAL reminder when a facet being deployed has a declared
+ * companion (`config/global.json` → `facetPeripheryCouplings`) that is absent from the network's
+ * deploy log. Non-fatal by design: deploying the facet before its Receiver is the normal order, so
+ * this is a nudge, not a gate. The blocking check is the `facet-required-periphery` health-check
+ * invariant, which asserts on-chain registration after the fact.
+ *
+ * CLI (invoked from deploySingleContract.sh, best-effort — never blocks a deploy):
+ *   bunx tsx script/deploy/resources/facetCompanionReminder.ts <ContractName> <network> <environment>
+ * Prints the reminder when a companion is missing, otherwise prints nothing. Always exits 0.
+ */
+import { existsSync, readFileSync, realpathSync } from 'fs'
+import { isAbsolute, relative, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+import { DEPLOYMENT_FILE_SUFFIX } from '../shared/constants'
+import {
+  evaluateFacetPeripheryCouplings,
+  type TFacetPeripheryCouplings,
+} from '../shared/facetPeripheryCouplings'
+
+/**
+ * Build the reminder for one facet, or null when nothing is missing.
+ *
+ * @param contractName - the contract being deployed; non-facets simply have no coupling
+ * @param network - network key as in `config/networks.json`
+ * @param deployedContracts - the network's deploy log (contract name → address)
+ * @param couplings - registry override, for tests
+ * @returns the human-facing reminder, or null when no companion is required or all are present
+ */
+export function buildCompanionReminder(
+  contractName: string,
+  network: string,
+  deployedContracts: Record<string, string>,
+  couplings?: TFacetPeripheryCouplings
+): string | null {
+  const { required } = evaluateFacetPeripheryCouplings(
+    [contractName],
+    network,
+    couplings
+  )
+  if (required.length === 0) return null
+
+  const missing = required.filter(
+    (requirement) => !deployedContracts[requirement.companion]
+  )
+  if (missing.length === 0) return null
+
+  const wanted = [...new Set(missing.map((r) => r.companion))]
+  return (
+    `⚠️  ${contractName} handles the source side only — destination calls on ${network} need ` +
+    `${wanted.join(
+      ', '
+    )}, which is not in the deploy log. Deploy and register the companion ` +
+    `before enabling routes, or the health check will flag this network ` +
+    `(config/global.json → facetPeripheryCouplings).`
+  )
+}
+
+/**
+ * Network keys in `config/networks.json` are alphanumeric with optional `-`/`_` (e.g. `bsc-testnet`).
+ * Reject anything else so a caller-supplied name can never traverse outside `deployments/`
+ * (e.g. `../../.env`) once composed into a file path.
+ */
+export function isValidNetworkName(name: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(name)
+}
+
+/**
+ * Read a network's deploy log. Returns an empty map when the name is not a plain network key, or
+ * when the file is missing or unreadable — a brand-new network legitimately has no log yet, and
+ * the reminder must never break a deploy.
+ */
+export function readDeployLog(
+  network: string,
+  environment: string,
+  repoRoot: string
+): Record<string, string> {
+  if (!isValidNetworkName(network)) return {}
+
+  const deploymentsDir = resolve(repoRoot, 'deployments')
+  const path = resolve(
+    deploymentsDir,
+    `${network}.${DEPLOYMENT_FILE_SUFFIX(environment)}json`
+  )
+  // Belt-and-braces on top of the name check: the resolved path must stay inside deployments/,
+  // so no combination of inputs can make this read an arbitrary file.
+  const relativeToDir = relative(deploymentsDir, path)
+  if (relativeToDir.startsWith('..') || isAbsolute(relativeToDir)) return {}
+
+  if (!existsSync(path)) return {}
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
+    if (typeof parsed !== 'object' || parsed === null) return {}
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .filter(([, value]) => typeof value === 'string' && value.length > 0)
+        .map(([name, value]) => [name, value as string])
+    )
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * CLI entry: print the reminder for the given contract/network/environment. Best-effort by design —
+ * missing arguments, an unrecognised network name, or an unreadable log print nothing rather than
+ * interfering with the deploy.
+ */
+function runCli(): void {
+  const [contractName, network, environment] = process.argv.slice(2)
+  if (!contractName || !network) return
+  // A name that is not a plain network key would produce a reminder naming a network that cannot
+  // exist, so say nothing at all rather than emit confusing output.
+  if (!isValidNetworkName(network)) return
+
+  const reminder = buildCompanionReminder(
+    contractName,
+    network,
+    readDeployLog(network, environment || 'production', process.cwd())
+  )
+  if (reminder) console.log(reminder)
+}
+
+/**
+ * Run the CLI only when this file is executed directly (bunx tsx ...), not when imported by tests.
+ */
+function isDirectRun(): boolean {
+  const entry = process.argv[1]
+  if (!entry) return false
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+}
+
+if (isDirectRun()) runCli()


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-785](https://linear.app/lifi-linear/issue/EXSC-785/deploy-time-reminders-facetcompanionreminder-reverse-dependency) — subticket T3 of EXSC-782.

# Why did I implement it this way?

The health-check invariants (`facet-required-periphery`, `receiver-executor-binding`,
`executor-erc20proxy-binding`) already catch a missing companion or a stale immutable binding —
but only *after* the fact, on the next health-check run. These two reminders surface the same
information at the keyboard, at deploy time, where the mistake is cheap to avoid. Both are
non-fatal by design and follow the existing `facetRefundReminder.ts` pattern (pure builder +
best-effort CLI + `isDirectRun()` guard), so they slot into `deploySingleContract.sh` next to it
with no new machinery.

**`facetCompanionReminder`** — warns when a facet declaring a companion in
`config/global.json` → `facetPeripheryCouplings` is deployed to a network whose deploy log has no
such companion. Deliberately a nudge, not a gate: deploying the facet before its Receiver is the
normal order, so failing here would block legitimate deploys. `facet-required-periphery` remains
the enforcing check.

**`contractDependencyReminder`** — walks `deployRequirements.json` → `contractAddresses` in
reverse, transitively, and names the contracts that bind the deployed one immutably at
construction. `contractSpecificReminders.sh` already states this rule as static prose for
`Executor` and `ERC20Proxy`; deriving it from the dependency graph instead keeps it correct as the
requirements file grows, and narrows it to the dependents actually deployed on the target network
(on `avalanche` that is one contract, on `arbitrum` five).

Two deliberate scope decisions:

- The reminders only ever **read** `deployRequirements.json`. EXSC-784 writes `getter` annotations
  into that file; keeping this PR read-only means no conflict between the two.
- `readDeployLog` / `isValidNetworkName` live inside `facetCompanionReminder.ts` rather than a new
  `shared/deployLog.ts`, so this PR adds no shared module that the in-flight EXSC-783/784/786 PRs
  could collide with.

`buildCompanionReminder` is written against main's current couplings API (`requires: string`), not
the `requiresAnyOf: string[]` shape being explored on the EXSC-684 branch — so it stays correct
against `main` today and adapts trivially if that shape lands later.

## Verification

Beyond the 39 unit tests, both reminders were exercised through the **real**
`deploySingleContract` function (with `forge`/`cast` replaced by failing stubs so no broadcast was
possible):

- `AcrossFacetV4` → `avalanche` printed the companion reminder (`ReceiverAcrossV4` genuinely absent
  from that deploy log).
- `Executor` → `avalanche` printed the cascade reminder naming `ReceiverStargateV2` — the only
  Executor dependent actually deployed there; `arbitrum` correctly lists all five, and `ERC20Proxy`
  renders the transitive `(via Executor)` paths.
- **Non-fatal proven**: with the companion script made to throw, and again with the dependency
  script deleted outright, the deploy run reached the identical abort point with the identical
  exit code — only the reminder line disappeared.

A fleet-wide scan found **zero** networks that currently have a coupled facet deployed without its
companion, so this adds no noise to existing deploys; it fires on new-chain rollouts, which is the
case it exists for.

### One correctness fix worth calling out

The first version of the cascade advisor treated *every* `contractAddresses` edge as a redeploy
cascade. Three of the nine edges are not: `LiFiDiamond`/`LiFiDiamondImmutable` reach their
`DiamondCutFacet` through **mutable** diamond storage (replaced with an ordinary `diamondCut`), and
`LiFiTimelockController` exposes `setDiamondAddress`. Redeploying `DiamondCutFacet` therefore
printed confident, actionable, and **wrong** guidance — telling the deployer to redeploy the
Diamond and Timelock and to run `diamondUpdatePeriphery` on contracts that are not periphery.

Those edges are now excluded, and the message no longer claims "immutable": the property that
actually forces a redeploy is that the dependent **stores the address at construction and has no
setter**. That is true of the Receivers' `immutable` fields *and* of `Executor.erc20Proxy`, which
is a plain public field with no updater — so keying on the Solidity `immutable` keyword would have
silently dropped the `Executor → ERC20Proxy` edge that `executor-erc20proxy-binding` enforces.

The exclusion is a small explicit set in the module rather than a data annotation, because
`deployRequirements.json` has no field today that distinguishes the two edge kinds and this PR is
deliberately read-only on that file. **Worth a second opinion**: once EXSC-784's `getter`
annotations land, that set could likely be derived from the data instead.

### And the inverse gap

`deployRequirements.json` is also not a *complete* record of construction bindings.
`Permit2Proxy` and `GasZipPeriphery` both hold `address public immutable LIFI_DIAMOND` with no
setter, and their deploy scripts read that address from the deploy log — but the requirements file
lists only their `configData`, so the reverse walk could not see the edge. Redeploying
`LiFiDiamond` warned about nothing at all, and **no health-check invariant covers these edges**,
so there was no backstop either. A sweep of every `immutable` field in `src/Periphery` and
`src/Security` confirms these are the only two the file misses; both are now folded in, and the
message no longer promises a health check that does not exist for them.

Same caveat as above: the right long-term home for both lists is the requirements file itself.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
