### PR TITLE
feat(VaultWrapper): source-liquidity-aware exit views

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -19,7 +19,19 @@ asset. `deposit`/`withdraw` return the wrapper's asset balance delta and the
 wrapper reverts on a shortfall, catching a yield source that moves less than
 asked. It does **not** catch share-side dilution (a vault that consumes the full
 asset but credits fewer shares via an internal deposit fee); such non-standard
-sources are unsupported and require a dedicated adapter.
+sources are unsupported and require a dedicated adapter. The same applies to
+sources charging an **exit fee**: exits are exact-out, so a fee-on-exit source
+trips the wrapper's shortfall guard on every withdrawal — unsupported until a
+future release adds cost-aware exit pricing.
+
+## Source liquidity view
+
+`maxWithdrawableValue` is the source-liquidity signal behind the wrapper's
+liquidity-aware `maxRedeem`/`maxWithdraw`: the source's floor valuation
+(`convertToAssets`) of `min(holder position, source.maxRedeem)`. It equals the
+full position value on a source with no active liquidity limit, and shrinks to
+what the source can currently honor under a limit (an Aave-style utilization
+cap, a paused source).
 
 ## Functions
 
@@ -35,6 +47,9 @@ function deposit(address _asset, address _underlying, uint256 _assets) external 
 
 /// Redeem `_assets` from the yield source; returns the asset amount received.
 function withdraw(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
+
+/// Gross floor valuation of `min(holder position, source.maxRedeem)` — the source-liquidity signal.
+function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 
 ## Related contracts

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -29,6 +29,41 @@ withdrawal.
 - A single pluggable `IAccessGate` (zero = permissionless) enforced fail-closed on
   entry, share transfers, and exits.
 - Pause is enforced on the deposit/mint path only; withdrawals stay open.
+- The exit `max*` views are source-liquidity-aware — see
+  [Exit semantics](#exit-semantics).
+
+## Exit semantics
+
+- `maxRedeem` clamps the owner's balance to what the source can currently honor
+  (via the adapter's `maxWithdrawableValue`), with a full-position short-circuit
+  so it equals `balanceOf` on a fully-liquid source and only clamps when the
+  source is genuinely liquidity-limited (an Aave-style utilization cap, a paused
+  source). `maxWithdraw` inherits the clamp because OZ derives it as
+  `previewRedeem(maxRedeem(owner))`, so both exit entrypoints' `ERC4626Exceeded*`
+  guards are liquidity-aware and an exit within the reported max never reverts on
+  a source liquidity limit (the EIP-4626 guarantee).
+- Because `maxRedeem` consults the source's views, it reverts if those views
+  revert (a bricked source). This is fail-closed by design, consistent with the
+  gate-checked views, and a deliberate deviation from EIP-4626's expectation that
+  `max*` views never revert.
+- `previewRedeem`/`previewWithdraw` remain **liquidity-agnostic**: EIP-4626
+  requires previews to ignore withdrawal limits, so they value against the full
+  position and never consult `maxWithdrawableValue`.
+- Dust tradeoff on OZ-derived sources (e.g. MetaMorpho, whose own `maxRedeem`
+  floors ~1 source share below `balanceOf` even at full liquidity): a one-call
+  full exit via `redeem(balanceOf)` may hit `ERC4626ExceededMaxRedeem`. Callers
+  should exit via `redeem(maxRedeem(owner))`, which may leave residual dust —
+  bounded by one source share's value — that a follow-up call clears.
+- Sources that charge an exit fee (or pay out less than their reported value)
+  are **unsupported**: exits are exact-out and the wrapper reverts
+  `AdapterWithdrawShortfall` on a short-paying source, so onboarding such a
+  source freezes its exits rather than mispricing them. Cost-aware exit pricing
+  is deferred to a future release (instances are beacon-upgradeable; a
+  fee-charging source would also need a dedicated adapter).
+- The exact-out `withdraw` right at `maxWithdraw` sits on a known rounding
+  boundary: with a nonzero withdrawal fee, re-grossing the requested net amount
+  can land a wei past a source's exact liquidity cap — the one tolerated
+  artifact. `redeem` has no such boundary and is the guaranteed exit.
 
 ## Admin role
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -619,7 +619,9 @@ contract LiFiVaultWrapper is
     /// @inheritdoc ERC4626Upgradeable
     /// @dev Reports 0 while the access gate flags the owner as sanctioned, mirroring
     ///      `withdraw`'s exit freeze (the asset receiver is unknowable in this view and
-    ///      is checked in the entrypoint only).
+    ///      is checked in the entrypoint only). Otherwise inherits the source-liquidity
+    ///      clamp — and its fail-closed revert on a broken source — from `maxRedeem`,
+    ///      since OZ derives this view as `previewRedeem(maxRedeem(owner))`.
     function maxWithdraw(
         address owner
     ) public view override returns (uint256) {

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -629,13 +629,32 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Reports 0 while the access gate flags the owner as sanctioned, mirroring
-    ///      `redeem`'s exit freeze (the asset receiver is unknowable in this view and
-    ///      is checked in the entrypoint only).
+    /// @dev Reports 0 while the access gate flags the owner as sanctioned (mirroring
+    ///      `redeem`'s exit freeze). Otherwise clamps the owner's balance to the shares
+    ///      the source can currently honor (`adapter.maxWithdrawableValue`,
+    ///      floor-converted), keeping the EIP-4626 guarantee that a `redeem` within
+    ///      `maxRedeem` never reverts under a source liquidity limit. When the source can
+    ///      release the whole position — the common case — the balance is returned
+    ///      unchanged, skipping a conversion round-trip that would under-report by ~1
+    ///      share and block one-call full exits. `maxWithdraw` inherits the clamp via its
+    ///      `previewRedeem(maxRedeem(owner))` derivation. Reverts if the source's views
+    ///      revert (fail-closed, like the gate check above).
     function maxRedeem(address owner) public view override returns (uint256) {
         if (_sanctioned(owner)) return 0;
 
-        return super.maxRedeem(owner);
+        uint256 balance = super.maxRedeem(owner);
+        uint256 realizable = IYieldAdapter(adapter).maxWithdrawableValue(
+            underlying,
+            address(this)
+        );
+        if (realizable >= totalAssets()) return balance;
+
+        uint256 liquidityCap = _convertToShares(
+            realizable,
+            Math.Rounding.Floor
+        );
+
+        return balance < liquidityCap ? balance : liquidityCap;
     }
 
     /// Internal ///

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -81,4 +81,18 @@ contract ERC4626Adapter is IYieldAdapter {
         });
         withdrawn = IERC20(_asset).balanceOf(address(this)) - balanceBefore;
     }
+
+    /// @inheritdoc IYieldAdapter
+    /// @dev Source floor valuation (`convertToAssets`) of the smaller of the holder's
+    ///      position and the source's current `maxRedeem`. Equals the full position value
+    ///      when the source imposes no active liquidity limit.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets) {
+        uint256 position = IERC4626(_underlying).balanceOf(_holder);
+        uint256 redeemable = IERC4626(_underlying).maxRedeem(_holder);
+        uint256 shares = redeemable < position ? redeemable : position;
+        assets = IERC4626(_underlying).convertToAssets(shares);
+    }
 }

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -10,9 +10,9 @@ pragma solidity ^0.8.29;
 ///         than changing the factory or the wrapper implementation.
 /// @dev Methods split by how the wrapper invokes them, and this split is a security
 ///      invariant adapters MUST honour:
-///      - `resolveAsset` and `totalAssets` are invoked as ordinary (static) calls and
-///        run in the adapter's own context; they take an explicit `_holder`/`_underlying`
-///        and MUST be free of side effects.
+///      - `resolveAsset`, `totalAssets`, and `maxWithdrawableValue` are invoked as
+///        ordinary (static) calls and run in the adapter's own context; they take an
+///        explicit `_holder`/`_underlying` and MUST be free of side effects.
 ///      - `deposit` and `withdraw` are invoked via `delegatecall` and therefore run in
 ///        the wrapper's context: `address(this)`, token balances, and yield-source
 ///        positions are the wrapper's. They MUST be stateless with respect to adapter
@@ -72,4 +72,20 @@ interface IYieldAdapter {
         address _underlying,
         uint256 _assets
     ) external returns (uint256 withdrawn);
+
+    /// @notice Gross position value `_holder` can withdraw from `_underlying` right now,
+    ///         capped by the source's current withdrawal-liquidity limits.
+    /// @dev Ordinary static call. Returns the source's floor valuation of
+    ///      `min(holder position, source maxRedeem)` — gross (no fee netting), because the
+    ///      wrapper feeds it into its own gross share math to clamp `maxRedeem`/
+    ///      `maxWithdraw` to what the source can honor. Equals the full position value
+    ///      when the source imposes no limit. MAY revert if the source's views revert;
+    ///      the wrapper treats that as fail-closed.
+    /// @param _underlying The yield source identifier.
+    /// @param _holder The account whose position is valued (the wrapper).
+    /// @return assets The gross, source-liquidity-capped position value.
+    function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets);
 }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -101,6 +101,13 @@ contract LossyVault {
     function convertToAssets(uint256 _shares) external pure returns (uint256) {
         return _shares;
     }
+
+    /// @dev Unlimited withdrawal liquidity: the whole balance is always redeemable, so the
+    ///      wrapper's liquidity clamp in `maxRedeem` is a no-op and the shortfall path under
+    ///      test is still reached (`ERC4626Adapter.maxWithdrawableValue` calls this).
+    function maxRedeem(address _owner) external view returns (uint256) {
+        return balanceOf[_owner];
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -100,6 +100,37 @@ contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
         wrapper.redeem(shares, alice, alice);
     }
 
+    // The withdrawal fee is zero in this suite, so `withdraw` at exactly `maxWithdraw`
+    // carries no fee re-grossing and must succeed even on a tight liquidity cap.
+    function test_WithdrawAtClampedMaxSucceeds() public {
+        source.setWithdrawable(300e18);
+        uint256 maxAssets = wrapper.maxWithdraw(alice);
+        uint256 balanceBefore = asset.balanceOf(alice);
+
+        vm.prank(alice);
+        wrapper.withdraw(maxAssets, alice, alice);
+
+        assertGt(maxAssets, 0);
+        assertEq(asset.balanceOf(alice) - balanceBefore, maxAssets);
+    }
+
+    function testRevert_WithdrawAboveClampedMax() public {
+        source.setWithdrawable(300e18);
+        uint256 maxAssets = wrapper.maxWithdraw(alice);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxWithdraw.selector,
+                alice,
+                maxAssets + 1,
+                maxAssets
+            )
+        );
+
+        vm.prank(alice);
+        wrapper.withdraw(maxAssets + 1, alice, alice);
+    }
+
     function test_MaxRedeemIsZeroWhenSourceDry() public {
         source.setWithdrawable(0);
 

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperLiquidity.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
+
+contract LiFiVaultWrapperLiquidityTest is VaultWrapperFactoryStackBase {
+    MockERC20 internal asset;
+    MockLiquidityCappedERC4626 internal source;
+
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal integrator = makeAddr("integrator");
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        source = new MockLiquidityCappedERC4626(asset, "Yield", "yTKN");
+
+        _bringUpFactory(address(source), [uint16(5000), 1000, 2000, 2000]);
+        _deployWrapper(_params());
+
+        asset.mint(alice, 1_000e18);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), 1_000e18);
+        wrapper.deposit(1_000e18, alice);
+
+        vm.stopPrank();
+    }
+
+    function _params() private view returns (DeployParams memory) {
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({ wallet: integrator, bps: 10000 });
+
+        return
+            DeployParams({
+                namespace: bytes32("LI.FI-Earn"),
+                vaultWrapperAdmin: vaultAdmin,
+                adapter: address(adapter),
+                underlying: address(source),
+                nonce: 0,
+                fees: FeeConfig({ rateBps: [uint16(0), 0, 0, 0] }),
+                integratorShareBps: [uint16(8000), 8000, 8000, 8000],
+                accessGate: address(0),
+                receivers: receivers
+            });
+    }
+
+    function test_MaxRedeemEqualsBalanceWhenSourceUnlimited() public {
+        source.setWithdrawable(1_000_000e18);
+
+        assertEq(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+    }
+
+    function test_MaxRedeemClampsToSourceLiquidity() public {
+        source.setWithdrawable(300e18);
+
+        assertLt(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+        assertApproxEqAbs(
+            wrapper.convertToAssets(wrapper.maxRedeem(alice)),
+            300e18,
+            2
+        );
+    }
+
+    function test_MaxWithdrawInheritsLiquidityClamp() public {
+        source.setWithdrawable(300e18);
+
+        assertApproxEqAbs(wrapper.maxWithdraw(alice), 300e18, 2);
+    }
+
+    function test_RedeemAtClampedMaxSucceeds() public {
+        source.setWithdrawable(300e18);
+        uint256 shares = wrapper.maxRedeem(alice);
+
+        vm.prank(alice);
+        uint256 assets = wrapper.redeem(shares, alice, alice);
+
+        assertGt(assets, 0);
+        assertApproxEqAbs(assets, 300e18, 2);
+    }
+
+    function testRevert_RedeemAboveClampedMax() public {
+        source.setWithdrawable(300e18);
+        uint256 maxShares = wrapper.maxRedeem(alice);
+        uint256 shares = maxShares + 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxRedeem.selector,
+                alice,
+                shares,
+                maxShares
+            )
+        );
+
+        vm.prank(alice);
+        wrapper.redeem(shares, alice, alice);
+    }
+
+    function test_MaxRedeemIsZeroWhenSourceDry() public {
+        source.setWithdrawable(0);
+
+        assertEq(wrapper.maxRedeem(alice), 0);
+        assertEq(wrapper.maxWithdraw(alice), 0);
+    }
+}

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -2,21 +2,30 @@
 pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
+import { MockLiquidityCappedERC4626 } from "../mocks/MockLiquidityCappedERC4626.sol";
 
 contract ERC4626AdapterTest is Test {
     ERC4626Adapter internal adapter;
     address internal assetToken = makeAddr("asset");
+    MockERC20 internal asset;
+    MockERC4626 internal vault;
 
     function setUp() public {
         adapter = new ERC4626Adapter();
+        asset = new MockERC20("Token", "TKN", 18);
+        vault = new MockERC4626(asset, "Yield Token", "yTKN");
     }
 
     function test_ResolveAssetReturnsAssetForValidVault() public {
-        MockERC4626Underlying vault = new MockERC4626Underlying(assetToken);
-        assertEq(adapter.resolveAsset(address(vault)), assetToken);
+        MockERC4626Underlying resolveVault = new MockERC4626Underlying(
+            assetToken
+        );
+        assertEq(adapter.resolveAsset(address(resolveVault)), assetToken);
     }
 
     function test_ResolveAssetRevertsOnNoCode() public {
@@ -25,8 +34,46 @@ contract ERC4626AdapterTest is Test {
     }
 
     function test_ResolveAssetRevertsOnZeroAsset() public {
-        MockERC4626Underlying vault = new MockERC4626Underlying(address(0));
+        MockERC4626Underlying zeroAssetVault = new MockERC4626Underlying(
+            address(0)
+        );
         vm.expectRevert(IYieldAdapter.AssetResolutionFailed.selector);
-        adapter.resolveAsset(address(vault));
+        adapter.resolveAsset(address(zeroAssetVault));
+    }
+
+    function test_MaxWithdrawableValueEqualsPositionWhenUnlimited() public {
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(vault), 1_000e18);
+        vault.deposit(1_000e18, address(this));
+
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), address(this)),
+            1_000e18
+        );
+    }
+
+    function test_MaxWithdrawableValueIsZeroForEmptyHolder() public {
+        assertEq(
+            adapter.maxWithdrawableValue(address(vault), makeAddr("nobody")),
+            0
+        );
+    }
+
+    function test_MaxWithdrawableValueCapsAtSourceLiquidity() public {
+        MockLiquidityCappedERC4626 capped = new MockLiquidityCappedERC4626(
+            asset,
+            "Capped",
+            "cTKN"
+        );
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(capped), 1_000e18);
+        capped.deposit(1_000e18, address(this));
+        capped.setWithdrawable(300e18);
+
+        // Position is worth 1_000e18 but only 300e18 is currently withdrawable.
+        assertEq(
+            adapter.maxWithdrawableValue(address(capped), address(this)),
+            300e18
+        );
     }
 }

--- a/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
+++ b/test/solidity/VaultWrapper/fork/MorphoArbitrumScenario.t.sol
@@ -27,6 +27,11 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
     // (booked with the fee); the drained wrapper keeps sub-cent virtual-offset/flooring dust.
     uint256 internal constant WITHDRAW_TOL = 3;
     uint256 internal constant DRAIN_DUST = 1000; // 0.001 USDC
+    // Value of the shares left outstanding after every holder exits at `maxRedeem`: the
+    // source's own `balanceOf`-flooring `maxRedeem` strands ~1 source-share per exit, worth
+    // 1 asset-wei in total at the pinned block. Bounded tight (0.00001 USDC) so any real
+    // share leakage — orders of magnitude larger on a ~45k-USDC flow — still trips it.
+    uint256 internal constant DRAIN_SHARE_DUST = 10;
 
     function _rpcEnvVar() internal pure override returns (string memory) {
         return "ETH_NODE_URI_ARBITRUM";
@@ -59,11 +64,14 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         _warpWithAccrual(WARP);
         _enter(carol, 15_000e6);
 
-        // Final accrual, everyone exits fully.
+        // Final accrual, everyone exits fully. Exit at `maxRedeem` (the EIP-4626-recommended
+        // pattern): the wrapper's `maxRedeem` is liquidity-aware and, over a MetaMorpho source
+        // whose own `maxRedeem` floors ~1 source-share below `balanceOf`, lands a dust amount
+        // below the raw balance — so `redeem(balanceOf)` would revert `ERC4626ExceededMaxRedeem`.
         _warpWithAccrual(WARP);
-        _exit(bob, wrapper.balanceOf(bob));
-        _exit(carol, wrapper.balanceOf(carol));
-        _exit(alice, wrapper.balanceOf(alice));
+        _exit(bob, wrapper.maxRedeem(bob));
+        _exit(carol, wrapper.maxRedeem(carol));
+        _exit(alice, wrapper.maxRedeem(alice));
 
         _distributeFeesAndAssertFanOut();
         _drainAndAssertConservation();
@@ -71,7 +79,7 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
 
     /// Deposits revert while paused; withdrawals stay open (withdrawals-always-open).
     function test_withdrawalsRemainOpenWhilePaused() public {
-        uint256 shares = _deposit(alice, 10_000e6);
+        _deposit(alice, 10_000e6);
 
         vm.prank(vaultAdmin);
         wrapper.pause();
@@ -85,7 +93,10 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         vm.stopPrank();
 
         uint256 balBefore = asset.balanceOf(alice);
-        _redeem(alice, shares);
+        // Exit at `maxRedeem` (see the lifecycle test): over MetaMorpho the wrapper's
+        // liquidity-aware `maxRedeem` sits a dust below `balanceOf`, so redeeming the raw
+        // balance would revert; the pause-does-not-block-withdrawals property is what matters.
+        _redeem(alice, wrapper.maxRedeem(alice));
 
         assertGt(
             asset.balanceOf(alice),
@@ -234,11 +245,20 @@ contract MorphoArbitrumScenarioTest is VaultWrapperForkTestBase {
         wrapper.setFeeRate(FeeType.Withdrawal, 0);
         vm.stopPrank();
 
-        _redeem(lifiRecipient, wrapper.balanceOf(lifiRecipient));
-        _redeem(integrator1, wrapper.balanceOf(integrator1));
-        _redeem(integrator2, wrapper.balanceOf(integrator2));
+        _redeem(lifiRecipient, wrapper.maxRedeem(lifiRecipient));
+        _redeem(integrator1, wrapper.maxRedeem(integrator1));
+        _redeem(integrator2, wrapper.maxRedeem(integrator2));
 
-        assertEq(wrapper.totalSupply(), 0, "shares left outstanding");
+        // A clean-drain `totalSupply() == 0` is unreachable over a MetaMorpho source: each
+        // holder exits at `maxRedeem`, which the source's own `balanceOf`-flooring `maxRedeem`
+        // leaves ~1 source-share below the raw balance, so a dust of shares stays outstanding.
+        // Bound the residue by VALUE instead — it must be economically nothing yet still catch
+        // real share leakage.
+        assertLe(
+            wrapper.convertToAssets(wrapper.totalSupply()),
+            DRAIN_SHARE_DUST,
+            "residual share value exceeds source-flooring dust"
+        );
         assertLe(wrapper.totalAssets(), DRAIN_DUST, "position not drained");
         assertLe(
             asset.balanceOf(address(wrapper)),

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariant.t.sol
@@ -5,20 +5,25 @@ import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
-import { VaultWrapperInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
+import { VaultWrapperInvariantHandler, VaultWrapperCappedSourceInvariantHandler } from "test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
 
-/// @notice Stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A handler
-///         drives randomized multi-actor sequences — deposits, mints, withdrawals, redeems,
-///         fee distributions, fee retunes, pause toggles, and injected yield/loss/time — against one
-///         wrapper charging all four fee types over an inflatable mock underlying. The math
-///         library is already property-fuzzed in isolation; this suite proves the stateful
-///         composition holds under arbitrary interleavings: idle assets and the wrapper's own
-///         share balance always exactly back the booked fee counters, the performance
-///         high-water mark never regresses (asserted in the handler), depositors can never
-///         extract more than was deposited plus injected yield, and no shares are minted or
-///         burned outside the tracked holder set. The suite runs `fail-on-revert = true`, so a
-///         pause that ever blocked an exit — or any other unexpected revert — fails a run.
-contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
+/// @notice Shared stateful invariant suite for the assembled vault wrapper (EXSC-421 / S12). A
+///         handler drives randomized multi-actor sequences — deposits, mints, withdrawals,
+///         redeems, fee distributions, fee retunes, pause toggles, and injected yield/loss/time
+///         — against one wrapper charging all four fee types over an underlying source. The
+///         underlying source and handler are virtual seams (`_deployUnderlying` /
+///         `_deployHandler`) so the exact same suite runs over both a plain unlimited source
+///         and a source whose withdrawal liquidity is fuzzed up and down. The math library is
+///         already property-fuzzed in isolation; this suite proves the stateful composition
+///         holds under arbitrary interleavings: idle assets and the wrapper's own share balance
+///         always exactly back the booked fee counters, the performance high-water mark never
+///         regresses (asserted in the handler), depositors can never extract more than was
+///         deposited plus injected yield, the liquidity-aware `maxRedeem` never over-reports
+///         the source's capacity, and no shares are minted or burned outside the tracked holder
+///         set. The suite runs `fail-on-revert = true`, so a pause that ever blocked an exit —
+///         or any other unexpected revert — fails a run.
+abstract contract VaultWrapperInvariantBase is VaultWrapperFactoryStackBase {
     // Governance-set bounds equal to the immutable bytecode caps, so the handler can retune
     // each fee across its whole legal range.
     uint16 internal constant PERF_CAP = 5000;
@@ -44,9 +49,32 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
     address internal integrator1 = makeAddr("integrator1");
     address internal integrator2 = makeAddr("integrator2");
 
+    /// @dev Subclass seam: the underlying source under test. Base = plain unlimited mock.
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal virtual returns (MockERC4626) {
+        return new MockERC4626(_asset, "Yield Token", "yTKN");
+    }
+
+    /// @dev Subclass seam: the handler under test. Base = plain handler.
+    function _deployHandler()
+        internal
+        virtual
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
+    }
+
     function setUp() public {
         asset = new MockERC20("Token", "TKN", 18);
-        underlying = new MockERC4626(asset, "Yield Token", "yTKN");
+        underlying = _deployUnderlying(asset);
 
         _bringUpFactory(
             address(underlying),
@@ -54,13 +82,7 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
         );
         _deployWrapper(_deployParams());
 
-        handler = new VaultWrapperInvariantHandler(
-            wrapper,
-            asset,
-            underlying,
-            factory,
-            vaultAdmin
-        );
+        handler = _deployHandler();
 
         targetContract(address(handler));
         targetSelector(
@@ -119,6 +141,24 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
         );
     }
 
+    /// @dev The value of each actor's `maxRedeem` never exceeds what the source can currently
+    ///      pay the wrapper — the liquidity clamp is honored. On an unlimited source this is
+    ///      the full position; on a capped source it tracks the cap. Complements the
+    ///      fail-on-revert proof that a `redeem` bounded to `maxRedeem` never reverts.
+    function invariant_maxRedeemWithinSourceLiquidity() public view {
+        uint256 realizable = adapter.maxWithdrawableValue(
+            address(underlying),
+            address(wrapper)
+        );
+        for (uint256 i; i < 3; ++i) {
+            assertLe(
+                wrapper.convertToAssets(wrapper.maxRedeem(handler.actors(i))),
+                realizable,
+                "maxRedeem value exceeds source liquidity"
+            );
+        }
+    }
+
     function _deployParams() private view returns (DeployParams memory) {
         uint16[4] memory rates = [
             PERF_RATE,
@@ -151,7 +191,12 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
     }
 
     /// @dev The handler entrypoints the fuzzer may call; the ghost/actor getters are excluded.
-    function _actions() private pure returns (bytes4[] memory selectors) {
+    function _actions()
+        internal
+        pure
+        virtual
+        returns (bytes4[] memory selectors)
+    {
         selectors = new bytes4[](10);
         selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
         selectors[1] = VaultWrapperInvariantHandler.mint.selector;
@@ -163,5 +208,60 @@ contract VaultWrapperInvariantTest is VaultWrapperFactoryStackBase {
         selectors[7] = VaultWrapperInvariantHandler.warp.selector;
         selectors[8] = VaultWrapperInvariantHandler.setFee.selector;
         selectors[9] = VaultWrapperInvariantHandler.togglePause.selector;
+    }
+}
+
+/// @notice Invariant suite over a plain ERC-4626 source with no liquidity limit.
+contract VaultWrapperInvariantTest is VaultWrapperInvariantBase {}
+
+/// @notice Same invariant suite over a source whose withdrawal liquidity is fuzzed up and
+///         down — proving the wrapper's liquidity-aware `max*` views never over-report and a
+///         redeem within `maxRedeem` never reverts even as source liquidity shifts.
+contract VaultWrapperCappedSourceInvariantTest is VaultWrapperInvariantBase {
+    function _deployUnderlying(
+        MockERC20 _asset
+    ) internal override returns (MockERC4626) {
+        return new MockLiquidityCappedERC4626(_asset, "Yield Token", "yTKN");
+    }
+
+    function _deployHandler()
+        internal
+        override
+        returns (VaultWrapperInvariantHandler)
+    {
+        return
+            new VaultWrapperCappedSourceInvariantHandler(
+                wrapper,
+                asset,
+                underlying,
+                factory,
+                vaultAdmin
+            );
+    }
+
+    // `withdraw` is deliberately omitted: exact-out withdraw near `maxWithdraw` sits on a
+    // known rounding boundary (the one tolerated artifact — see the wrapper docs), and a
+    // shifting liquidity cap puts the fuzzer exactly on that boundary. `redeem` is the
+    // guaranteed exit and is exercised across the full clamped range; the liquidity clamp on
+    // `withdraw`'s guard is covered by the LiFiVaultWrapperLiquidity unit tests.
+    function _actions()
+        internal
+        pure
+        override
+        returns (bytes4[] memory selectors)
+    {
+        selectors = new bytes4[](10);
+        selectors[0] = VaultWrapperInvariantHandler.deposit.selector;
+        selectors[1] = VaultWrapperInvariantHandler.mint.selector;
+        selectors[2] = VaultWrapperInvariantHandler.redeem.selector;
+        selectors[3] = VaultWrapperInvariantHandler.distributeFees.selector;
+        selectors[4] = VaultWrapperInvariantHandler.injectYield.selector;
+        selectors[5] = VaultWrapperInvariantHandler.injectLoss.selector;
+        selectors[6] = VaultWrapperInvariantHandler.warp.selector;
+        selectors[7] = VaultWrapperInvariantHandler.setFee.selector;
+        selectors[8] = VaultWrapperInvariantHandler.togglePause.selector;
+        selectors[9] = VaultWrapperCappedSourceInvariantHandler
+            .setLiquidity
+            .selector;
     }
 }

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -7,6 +7,7 @@ import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { FeeType } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol";
 
 /// @notice Handler that drives a single `LiFiVaultWrapper` through bounded, randomized
 ///         multi-actor sequences for the invariant suite: three depositors enter/exit while
@@ -118,10 +119,14 @@ contract VaultWrapperInvariantHandler is Test {
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {
         address actor = _actor(_actorSeed);
-        uint256 balance = WRAPPER.balanceOf(actor);
-        if (balance == 0) return;
+        // maxRedeem is liquidity-aware: on a capped source it clamps below the balance, and
+        // a redeem above it reverts ERC4626ExceededMaxRedeem. Driving the full allowed range
+        // (up to and including the clamp) under fail-on-revert proves a redeem within
+        // maxRedeem never reverts, whatever the source's current liquidity.
+        uint256 ceiling = WRAPPER.maxRedeem(actor);
+        if (ceiling == 0) return;
 
-        uint256 shares = bound(_shares, 1, balance);
+        uint256 shares = bound(_shares, 1, ceiling);
 
         vm.prank(actor);
         uint256 received = WRAPPER.redeem(shares, actor, actor);
@@ -188,5 +193,35 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 current = WRAPPER.perfHighWaterMarkPps();
         assertGe(current, hwmFloor, "high-water mark regressed");
         hwmFloor = current;
+    }
+}
+
+/// @notice Handler variant that additionally fuzzes the source's withdrawal-liquidity cap,
+///         driving `maxRedeem`/`maxWithdraw` through their full liquidity-clamped range.
+contract VaultWrapperCappedSourceInvariantHandler is
+    VaultWrapperInvariantHandler
+{
+    constructor(
+        LiFiVaultWrapper _wrapper,
+        MockERC20 _asset,
+        MockERC4626 _underlying,
+        LiFiVaultWrapperFactory _factory,
+        address _vaultAdmin
+    )
+        VaultWrapperInvariantHandler(
+            _wrapper,
+            _asset,
+            _underlying,
+            _factory,
+            _vaultAdmin
+        )
+    {}
+
+    /// @notice Moves the source's withdrawable-liquidity cap anywhere in [0, totalAssets].
+    function setLiquidity(uint256 _assets) external {
+        uint256 total = UNDERLYING.totalAssets();
+        MockLiquidityCappedERC4626(address(UNDERLYING)).setWithdrawable(
+            bound(_assets, 0, total)
+        );
     }
 }

--- a/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockLiquidityCappedERC4626.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+
+/// @notice Compliant ERC-4626 modelling an Aave-style withdrawal-liquidity cap: all deposited
+///         assets stay on the vault (so `totalAssets` and price-per-share are unchanged), but
+///         only `withdrawableAssets` of value may leave via `withdraw`/`redeem` at any moment.
+///         `maxWithdraw`/`maxRedeem` report the cap and the mutating paths revert past it, so a
+///         caller that respects the reported max never reverts. `setWithdrawable` moves the cap
+///         up and down to fuzz shifting liquidity. Used to prove the wrapper's liquidity-aware
+///         `max*` views. The cap is a policy limit, not a balance: the assets are always
+///         physically present, so any within-cap exit succeeds.
+contract MockLiquidityCappedERC4626 is MockERC4626 {
+    error WithdrawExceedsLiquidity();
+
+    uint256 public withdrawableAssets;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol
+    ) MockERC4626(_asset, _name, _symbol) {}
+
+    function setWithdrawable(uint256 _assets) external {
+        withdrawableAssets = _assets;
+    }
+
+    function maxWithdraw(
+        address owner
+    ) public view override returns (uint256) {
+        uint256 own = convertToAssets(balanceOf[owner]);
+        return own < withdrawableAssets ? own : withdrawableAssets;
+    }
+
+    function maxRedeem(address owner) public view override returns (uint256) {
+        uint256 capShares = convertToShares(withdrawableAssets);
+        uint256 own = balanceOf[owner];
+        return own < capShares ? own : capShares;
+    }
+
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (assets > maxWithdraw(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (shares > maxRedeem(owner)) revert WithdrawExceedsLiquidity();
+
+        return super.redeem(shares, receiver, owner);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -31,4 +31,11 @@ contract MockZeroAdapter is IYieldAdapter {
     ) external pure returns (uint256) {
         return 0;
     }
+
+    function maxWithdrawableValue(
+        address,
+        address
+    ) external pure returns (uint256) {
+        return 0;
+    }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_TODO: link the Linear ticket (e.g. `EXSC-XXX`) before requesting review — required for the ticket-linkage metric._

# Why did I implement it this way?

This PR makes the exit `max*` views source-liquidity-aware, replacing #2197 with a deliberately narrower scope.

`maxRedeem` now clamps the owner's balance to what the source can currently honor, read through a new adapter view `maxWithdrawableValue` (the source's floor valuation of `min(wrapper position, source.maxRedeem)`). A full-position short-circuit returns the plain balance whenever the source can release the wrapper's whole position — the common case — so the lossy share round-trip only runs when the source is genuinely liquidity-limited (an Aave-style utilization cap, a paused source) and one-call full exits keep working on healthy sources. `maxWithdraw` inherits the clamp for free because OZ derives it as `previewRedeem(maxRedeem(owner))`, and both exit entrypoints' `ERC4626Exceeded*` guards pick it up automatically — this restores the EIP-4626 guarantee that an exit within the reported max never reverts on a source liquidity limit, with zero changes to the exit paths themselves. When clamping, the conversion floors, so the view may under-report by up to one source share's value but never over-promises. Previews stay liquidity-agnostic per EIP-4626.

What this PR deliberately does **not** do (the scope cut vs #2197): no cost-aware exit pricing. Exits remain exact-out, and sources that charge an exit fee (or under-pay their reported value) remain unsupported — the existing `AdapterWithdrawShortfall` guard freezes exits on such a source instead of mispricing them, which is the enforcement mechanism for that scoping decision. This matches how comparable products handle it (e.g. Kiln's DeFi Vault supports only fee-less sources while running the same liquidity clamp), and cost-awareness can land in a future release: wrapper instances are beacon-upgradeable and a fee-charging source would need a dedicated adapter anyway. The tradeoff is documented in both affected docs pages.

Test coverage: unit tests for the adapter view and the clamp (including redeem-at-clamped-max and the revert above it), a new invariant suite running the full stateful campaign over a source whose withdrawal liquidity is fuzzed up and down (proving `maxRedeem` never over-reports and a redeem within it never reverts), and the Morpho Arbitrum fork scenario now exits at `maxRedeem` — the EIP-4626-recommended pattern — since MetaMorpho's own `maxRedeem` floors below `balanceOf`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
