### PR TITLE
fix(clear-signing): use ERC-7730 chainId format for destinationChainId (EXSC-793)

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -18,7 +18,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -85,7 +85,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -174,7 +174,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -241,7 +241,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -314,7 +314,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -381,7 +381,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -448,7 +448,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -521,7 +521,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -594,7 +594,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -667,7 +667,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -734,7 +734,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -807,7 +807,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -880,7 +880,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -947,7 +947,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1014,7 +1014,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1089,7 +1089,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1164,7 +1164,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1239,7 +1239,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1314,7 +1314,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1387,7 +1387,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1460,7 +1460,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1533,7 +1533,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1600,7 +1600,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1673,7 +1673,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1740,7 +1740,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1807,7 +1807,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1874,7 +1874,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -1941,7 +1941,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2014,7 +2014,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2081,7 +2081,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2148,7 +2148,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2215,7 +2215,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2282,7 +2282,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2349,7 +2349,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2416,7 +2416,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2492,7 +2492,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2588,7 +2588,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2690,7 +2690,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2786,7 +2786,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2888,7 +2888,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -2984,7 +2984,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3080,7 +3080,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3182,7 +3182,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3284,7 +3284,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3386,7 +3386,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3482,7 +3482,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3584,7 +3584,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3686,7 +3686,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3782,7 +3782,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3878,7 +3878,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -3974,7 +3974,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4070,7 +4070,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4166,7 +4166,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4262,7 +4262,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4364,7 +4364,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4466,7 +4466,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4568,7 +4568,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4664,7 +4664,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4766,7 +4766,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4862,7 +4862,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -4958,7 +4958,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5054,7 +5054,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5150,7 +5150,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5252,7 +5252,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5348,7 +5348,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5444,7 +5444,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5540,7 +5540,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5636,7 +5636,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5732,7 +5732,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {
@@ -5828,7 +5828,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "raw",
+          "format": "chainId",
           "visible": "always"
         },
         {

--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -24,7 +24,7 @@ All non-packed variants share the standard `ILiFi.BridgeData` struct:
   "interpolatedIntent": "Bridge {_bridgeData.minAmount} via <Bridge> to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
   "fields": [
     { "path": "_bridgeData.minAmount",          "label": "Amount to Bridge",   "format": "tokenAmount", "params": { "tokenPath": "_bridgeData.sendingAssetId" }, "visible": "always" },
-    { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw",         "visible": "always" },
+    { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId",     "visible": "always" },
     { "path": "_bridgeData.receiver",           "label": "Recipient",         "format": "addressName", "params": { "types": ["eoa","contract"], "sources": ["local","ens"] }, "visible": "always" },
     /* hidden plumbing: transactionId, bridge, integrator, referrer, hasSourceSwaps, hasDestinationCall */
   ]
@@ -92,7 +92,7 @@ The seven existing `display.formats` entries from the current registry descripto
 
 1. **Verb is "Bridge", not "Send"** — clear-signing is a hand-curated security primitive; the verb should match the user's mental model of "moving funds across chains" rather than the developer-facing `start*` naming.
 2. **Bridge name embedded in `interpolatedIntent`** — the bridge identity is the single most important security signal in a bridge tx (Across vs. Mayan vs. Hop have very different trust + finality models). Since wallets prefer `interpolatedIntent` over `intent`, placing the bridge name only in `intent` would effectively hide it from users in the happy path. The cost is ~6-12 extra characters per template, which still fits on a single Ledger Nano X screen for every bridge name in our diamond.
-3. **`destinationChainId` as `raw`** — ERC-7730 v2 has no first-class `chainId` formatter. Wallets that know the [chainID registry](https://chainlist.org/) will pretty-print it; others show the integer. Acceptable trade-off vs. introducing per-chain string tables we'd have to maintain.
+3. **`destinationChainId` as `chainId`** — the ERC-7730 v2 integer format that renders an EIP-155 chain id as the network's name, so the wallet shows "Polygon" instead of `137`. LI.FI's non-EVM destinations use synthetic ids outside EIP-155 (e.g. Solana); wallets fall back to rendering those numerically.
 4. **All `BridgeData` plumbing fields hidden** (`transactionId`, `bridge` (free-text), `integrator`, `referrer`, `hasSourceSwaps`, `hasDestinationCall`) — these carry no user-facing decision content.
 5. **Swap-data array tail hidden** — for `swapAndStart*` we hide `_swapData.[].callData`, `callTo`, `approveTo`, `requiresDeposit` since they're opaque to a non-technical signer. The aggregate effect is captured by `_bridgeData.minAmount`.
 

--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -31,7 +31,7 @@ All non-packed variants share the standard `ILiFi.BridgeData` struct:
 }
 ```
 
-Reads on a hardware wallet as one sentence: *"Bridge 100 USDC via Across to chain 137 for vitalik.eth"*.
+Reads on a hardware wallet as one sentence: *"Bridge 100 USDC via Across to chain Polygon for vitalik.eth"*. A destination the wallet cannot name — any non-EVM synthetic id — falls back to the integer.
 
 Note the bridge name (`<Bridge>`) is a literal substituted at descriptor-generation time, not a `{path}` placeholder resolved by the wallet — it's constant per selector and doesn't change between transactions.
 

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -145,6 +145,15 @@ function collectFns(): IAbiFn[] {
       fnNames.add(item.name)
     }
   }
+  // An empty `out/` yields zero functions, zero template failures, and an empty
+  // proposal written over the committed one — a silent wipe that reads as success.
+  if (Object.keys(out).length === 0) {
+    console.error(
+      `\n❌ buildClearSigningProposal: no facet artifacts found under ${OUT_DIR}.\n   fix:    run \`forge build\` first, then re-run this generator.\n`
+    )
+    process.exit(1)
+  }
+
   return Object.values(out).sort((a, b) =>
     collectionSignature(a).localeCompare(collectionSignature(b))
   )
@@ -275,9 +284,9 @@ const RECEIVER_FIELD: IField = {
 const CHAIN_FIELD: IField = {
   path: '_bridgeData.destinationChainId',
   label: 'Destination Chain',
-  // No first-class "chainId" formatter in ERC-7730 v2; raw uint is rendered as-is.
-  // Wallets that know the chain registry can pretty-print it themselves.
-  format: 'raw',
+  // Non-EVM destinations use synthetic ids outside EIP-155, which wallets fall
+  // back to rendering numerically.
+  format: 'chainId',
   visible: 'always',
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-793/clear-signing-render-destinationchainid-with-the-erc-7730-chainid

# Why did I implement it this way?

Ambire reported (via Rico, [#dev-sc](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1787100035904229)) that `_bridgeData.destinationChainId` in our ERC-7730 descriptor is declared `"format": "raw"`, so wallets render it as a bare integer instead of resolving it to a network name.

The report is correct. Our descriptor declares the **v2** schema (`erc7730-v2.schema.json`), and v2 defines a first-class integer format `chainId` — *"The field should be displayed as a Blockchain explicit name, as defined in EIP-155, based on the chain id value."* The generator comment asserting no such formatter exists predates v2. It takes no `params`, so the change is a one-word swap in `CHAIN_FIELD` plus a regeneration.

- `tasks/buildClearSigningProposal.ts` — `CHAIN_FIELD.format`: `raw` → `chainId`.
- `config/clearSigningProposal.json` — regenerated (`bunx tsx tasks/buildClearSigningProposal.ts`); the diff is exactly 70 `raw` → `chainId` lines, nothing else.
- `docs/ClearSigningProposal.md` — the example block and design-note #3 asserted the "no chainId formatter" rationale; both updated.

Also folded in one guard found while doing this: with an empty `out/`, `collectFns()` skipped every facet, `main()` found zero template failures, and the generator **overwrote the committed proposal with 0 entries and exited 0**. That silent wipe now hard-fails with a "run `forge build` first" message. Verified by moving `out/` aside: exit non-zero, committed JSON untouched.

Registry propagation is automatic — `syncLedgerClearSigning.yml` opens the upstream PR against `ethereum/clear-signing-erc7730-registry` on merge to main.

Validation (local, against the upstream v2 schema with ajv):

| descriptor variant | schema result |
| --- | --- |
| registry as published today | VALID |
| registry + our regenerated formats (`chainId`) | VALID |
| same with `chainid` (lowercase, as written in the report) | INVALID |
| same with a bogus format name | INVALID |

The last two are the negative controls proving the format enum is actually enforced — and that the correct spelling is camelCase `chainId`.

Non-EVM destinations use synthetic chain ids outside EIP-155 (e.g. Solana), which wallets fall back to rendering numerically. That is no worse than today's `raw` for those routes, and strictly better for every EVM route.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
