### PR TITLE
fix(scripts): retry mongodb+srv connects via public DNS on SRV failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ SC_MONGODB_URI=""
 # never dragged into an urgent signing set.
 DRAIN_PARKED_TASKS=""
 
+# Optional. Only used as a fallback: if the local resolver cannot deliver a usable
+# SRV record for a "mongodb+srv://" URI, the tooling retries the connection against
+# these DNS servers (defaults to 1.1.1.1,8.8.8.8). See docs/Setup.md.
+MONGODB_DNS_SERVERS=""
+
 # MongoDB Configuration Note:
 # MONGODB_URI is required for deployment logging
 # All deployment logs are stored in MongoDB (database: contract-deployments)

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -200,16 +200,20 @@ perfectly healthy from the shell.
 The tooling handles this on its own: the connection is retried once against public
 DNS servers, with a `WARN` naming the resolver that failed. Set
 `MONGODB_DNS_SERVERS` (comma-separated) if 1.1.1.1 / 8.8.8.8 are unreachable on
-your network, or fix it at the OS level with
+your network, or fix it at the OS level — on macOS, with `<service>` being your
+network service name as listed by `networksetup -listallnetworkservices`:
 
 ```bash
-networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8
+networksetup -setdnsservers "<service>" 1.1.1.1 8.8.8.8   # e.g. "Wi-Fi"
+networksetup -setdnsservers "<service>" empty              # restore DHCP-provided DNS
 ```
 
-To confirm the diagnosis, compare the two resolvers directly:
+To confirm the diagnosis, run the same SRV query through the local resolver and
+through a public one — the first fails, the second returns the record count:
 
 ```bash
-node -e "require('dns').resolveSrv('_mongodb._tcp.<cluster>.mongodb.net',(e,r)=>console.log(e?e.code:r.length))"
+node -e "require('dns').resolveSrv('_mongodb._tcp.<cluster>.mongodb.net',(e,r)=>console.log('local:',e?e.code:r.length))"
+node -e "const d=require('dns');d.setServers(['1.1.1.1']);d.resolveSrv('_mongodb._tcp.<cluster>.mongodb.net',(e,r)=>console.log('public:',e?e.code:r.length))"
 ```
 
 ### Agent access

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -183,9 +183,39 @@ bun run safe:tunnel                       # ensure the tunnel, then exit
 bun run safe:tunnel bun confirm-safe-tx   # ensure, then run (any command)
 ```
 
+### `querySrv EBADRESP` when connecting to MongoDB
+
+If a Mongo-touching script fails immediately with
+
+```text
+Error: querySrv EBADRESP _mongodb._tcp.<cluster>.mongodb.net
+```
+
+the problem is the DNS resolver of the network you are on, not your credentials,
+the tunnel, or Atlas. Some routers re-encode SRV answers with a name-compression
+pointer in the target field, which RFC 2782 forbids; Node's resolver rejects those
+packets while `dig`, `host` and macOS's own resolver accept them — so DNS looks
+perfectly healthy from the shell.
+
+The tooling handles this on its own: the connection is retried once against public
+DNS servers, with a `WARN` naming the resolver that failed. Set
+`MONGODB_DNS_SERVERS` (comma-separated) if 1.1.1.1 / 8.8.8.8 are unreachable on
+your network, or fix it at the OS level with
+
+```bash
+networksetup -setdnsservers Wi-Fi 1.1.1.1 8.8.8.8
+```
+
+To confirm the diagnosis, compare the two resolvers directly:
+
+```bash
+node -e "require('dns').resolveSrv('_mongodb._tcp.<cluster>.mongodb.net',(e,r)=>console.log(e?e.code:r.length))"
+```
+
 ### Agent access
 
 Running an automated agent (Claude Code, Cursor, etc.) against this repo? The
 agent-specific guidance — what an agent must **not** do, and how commands differ
 in a non-interactive shell — is in **[Setup-agents.md](Setup-agents.md)**. The
 steps above are the human path.
+

--- a/script/deploy/query-deployment-logs.ts
+++ b/script/deploy/query-deployment-logs.ts
@@ -27,6 +27,7 @@ import {
   mongoEq,
   ValidationUtils,
 } from './shared/mongo-log-utils'
+import { withSrvDnsFallback } from './shared/mongo-srv-dns'
 
 const config: IConfig = {
   mongoUri: getEnvVar('MONGODB_URI'),
@@ -53,7 +54,7 @@ class DeploymentLogQuerier {
 
   public async connect(): Promise<void> {
     try {
-      await this.client.connect()
+      await withSrvDnsFallback(() => this.client.connect())
       this.db = this.client.db(this.config.databaseName)
       const collectionName = this.environment
       this.collection = this.db.collection<IDeploymentRecord>(collectionName)

--- a/script/deploy/safe/parked-tasks.ts
+++ b/script/deploy/safe/parked-tasks.ts
@@ -44,6 +44,7 @@ import { type Address } from 'viem'
 
 import { type EnvironmentEnum } from '../../common/types'
 import { getEnvVar } from '../../utils/utils'
+import { withSrvDnsFallback } from '../shared/mongo-srv-dns'
 
 /** Database for the deferred diamond-cleanup queue inside the non-sensitive `MONGODB_URI` cluster. */
 const PARKED_TASKS_DB_NAME = 'deferred-cleanup'
@@ -271,7 +272,7 @@ export async function getParkedTasksCollection(): Promise<{
     .db(PARKED_TASKS_DB_NAME)
     .collection<IParkedTask>(PARKED_TASKS_COLLECTION_NAME)
   try {
-    await ensureParkedTasksIndexes(parkedTasks)
+    await withSrvDnsFallback(() => ensureParkedTasksIndexes(parkedTasks))
     return { client, parkedTasks }
   } catch (error) {
     await client.close()

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -49,6 +49,7 @@ import {
   getTransportConfigFromRpcUrl,
   getViemChainForNetworkName,
 } from '../../utils/viemScriptHelpers'
+import { withSrvDnsFallback } from '../shared/mongo-srv-dns'
 
 import { SAFE_SINGLETON_ABI } from './config'
 import {
@@ -1463,7 +1464,7 @@ export async function getSafeMongoCollection(): Promise<{
     serverSelectionTimeoutMS: 10_000, // 10 seconds
   })
   try {
-    await client.connect()
+    await withSrvDnsFallback(() => client.connect())
   } catch (error) {
     await client.close().catch(() => undefined)
     const detail = error instanceof Error ? error.message : String(error)

--- a/script/deploy/safe/timelock-queue.ts
+++ b/script/deploy/safe/timelock-queue.ts
@@ -27,6 +27,7 @@ import {
 } from 'viem'
 
 import { getEnvVar } from '../../utils/utils'
+import { withSrvDnsFallback } from '../shared/mongo-srv-dns'
 
 import {
   TIMELOCK_SCHEDULE_BATCH_ABI,
@@ -122,7 +123,7 @@ export async function getTimelockQueueCollection(): Promise<{
     TIMELOCK_QUEUE_COLLECTION_NAME
   )
   try {
-    await ensureTimelockQueueIndexes(timelockQueue)
+    await withSrvDnsFallback(() => ensureTimelockQueueIndexes(timelockQueue))
     return { client, timelockQueue }
   } catch (error) {
     await client.close()

--- a/script/deploy/shared/deployment-cache.ts
+++ b/script/deploy/shared/deployment-cache.ts
@@ -15,6 +15,7 @@ import type { EnvironmentEnum } from '../../common/types'
 import { sleep } from '../../utils/delay'
 
 import { type IDeploymentRecord, type IConfig } from './mongo-log-utils'
+import { withSrvDnsFallback } from './mongo-srv-dns'
 
 /**
  * Metadata for the deployment cache
@@ -443,7 +444,7 @@ export class DeploymentCache {
       const client = new MongoClient(this.mongoConfig.mongoUri)
 
       try {
-        await client.connect()
+        await withSrvDnsFallback(() => client.connect())
         const collection = client
           .db(this.mongoConfig.databaseName)
           .collection<IDeploymentRecord>(environment)

--- a/script/deploy/shared/mongo-log-utils.ts
+++ b/script/deploy/shared/mongo-log-utils.ts
@@ -13,6 +13,8 @@ import {
 import type { EnvironmentEnum } from '../../common/types'
 import { sleep } from '../../utils/delay'
 
+import { withSrvDnsFallback } from './mongo-srv-dns'
+
 /**
  * Represents a deployment record stored in MongoDB
  * @interface IDeploymentRecord
@@ -171,8 +173,9 @@ export class DatabaseConnectionManager {
 
     while (retryCount < maxRetries)
       try {
-        this.client = new MongoClient(this.config.mongoUri)
-        await this.client.connect()
+        const client = new MongoClient(this.config.mongoUri)
+        this.client = client
+        await withSrvDnsFallback(() => client.connect())
         this.db = this.client.db(this.config.databaseName)
         this.isConnected = true
         // Use stderr so stdout stays JSON-only when used from bash (e.g. query-deployment-logs batch)

--- a/script/deploy/shared/mongo-srv-dns.test.ts
+++ b/script/deploy/shared/mongo-srv-dns.test.ts
@@ -1,0 +1,125 @@
+import dns from 'node:dns'
+
+import {
+  describe,
+  expect,
+  it,
+  afterEach,
+  // eslint-disable-next-line import/no-unresolved, import/order
+} from 'bun:test'
+
+import {
+  withSrvDnsFallback,
+  resetSrvDnsFallbackForTests,
+} from './mongo-srv-dns'
+
+function makeSrvError(code = 'EBADRESP'): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(
+    `querySrv ${code} _mongodb._tcp.cluster.example.mongodb.net`
+  )
+  error.syscall = 'querySrv'
+  error.code = code
+  return error
+}
+
+describe('withSrvDnsFallback', () => {
+  const originalServers = dns.getServers()
+  const originalEnv = process.env.MONGODB_DNS_SERVERS
+
+  afterEach(() => {
+    dns.setServers(originalServers)
+    resetSrvDnsFallbackForTests()
+    if (originalEnv === undefined) delete process.env.MONGODB_DNS_SERVERS
+    else process.env.MONGODB_DNS_SERVERS = originalEnv
+  })
+
+  it('returns the result without touching DNS servers when connect succeeds', async () => {
+    const before = dns.getServers()
+
+    const result = await withSrvDnsFallback(async () => 'connected')
+
+    expect(result).toBe('connected')
+    expect(dns.getServers()).toEqual(before)
+  })
+
+  it('retries with fallback DNS servers after an SRV lookup failure', async () => {
+    process.env.MONGODB_DNS_SERVERS = '1.1.1.1,8.8.8.8'
+    let attempts = 0
+
+    const result = await withSrvDnsFallback(async () => {
+      attempts++
+      if (attempts === 1) throw makeSrvError()
+      return 'connected'
+    })
+
+    expect(result).toBe('connected')
+    expect(attempts).toBe(2)
+    expect(dns.getServers()).toEqual(['1.1.1.1', '8.8.8.8'])
+  })
+
+  it('rethrows errors that are not SRV lookup failures', async () => {
+    const before = dns.getServers()
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
+    await expect(
+      withSrvDnsFallback(async () => {
+        throw new Error('Authentication failed.')
+      })
+    ).rejects.toThrow('Authentication failed.')
+
+    expect(dns.getServers()).toEqual(before)
+  })
+
+  it('rethrows when the retry also fails', async () => {
+    process.env.MONGODB_DNS_SERVERS = '1.1.1.1'
+    let attempts = 0
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
+    await expect(
+      withSrvDnsFallback(async () => {
+        attempts++
+        throw makeSrvError()
+      })
+    ).rejects.toThrow('querySrv EBADRESP')
+
+    expect(attempts).toBe(2)
+  })
+
+  it('does not retry a second time once the fallback is already applied', async () => {
+    process.env.MONGODB_DNS_SERVERS = '1.1.1.1'
+    await withSrvDnsFallback(async () => 'warm-up')
+
+    let firstCallAttempts = 0
+    await withSrvDnsFallback(async () => {
+      firstCallAttempts++
+      if (firstCallAttempts === 1) throw makeSrvError()
+      return 'connected'
+    })
+
+    let secondCallAttempts = 0
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
+    await expect(
+      withSrvDnsFallback(async () => {
+        secondCallAttempts++
+        throw makeSrvError()
+      })
+    ).rejects.toThrow('querySrv EBADRESP')
+
+    expect(secondCallAttempts).toBe(1)
+  })
+
+  it('rethrows the original error when the configured server list is empty', async () => {
+    process.env.MONGODB_DNS_SERVERS = ' , '
+    let attempts = 0
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
+    await expect(
+      withSrvDnsFallback(async () => {
+        attempts++
+        throw makeSrvError()
+      })
+    ).rejects.toThrow('querySrv EBADRESP')
+
+    expect(attempts).toBe(1)
+  })
+})

--- a/script/deploy/shared/mongo-srv-dns.test.ts
+++ b/script/deploy/shared/mongo-srv-dns.test.ts
@@ -108,6 +108,23 @@ describe('withSrvDnsFallback', () => {
     expect(secondCallAttempts).toBe(1)
   })
 
+  it('rethrows the original error when the configured servers are not valid IPs', async () => {
+    process.env.MONGODB_DNS_SERVERS = 'not-an-ip'
+    const before = dns.getServers()
+    let attempts = 0
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
+    await expect(
+      withSrvDnsFallback(async () => {
+        attempts++
+        throw makeSrvError()
+      })
+    ).rejects.toThrow('querySrv EBADRESP')
+
+    expect(attempts).toBe(1)
+    expect(dns.getServers()).toEqual(before)
+  })
+
   it('rethrows the original error when the configured server list is empty', async () => {
     process.env.MONGODB_DNS_SERVERS = ' , '
     let attempts = 0

--- a/script/deploy/shared/mongo-srv-dns.test.ts
+++ b/script/deploy/shared/mongo-srv-dns.test.ts
@@ -111,15 +111,16 @@ describe('withSrvDnsFallback', () => {
   it('rethrows the original error when the configured servers are not valid IPs', async () => {
     process.env.MONGODB_DNS_SERVERS = 'not-an-ip'
     const before = dns.getServers()
+    const srvError = makeSrvError()
     let attempts = 0
 
     // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
     await expect(
       withSrvDnsFallback(async () => {
         attempts++
-        throw makeSrvError()
+        throw srvError
       })
-    ).rejects.toThrow('querySrv EBADRESP')
+    ).rejects.toBe(srvError)
 
     expect(attempts).toBe(1)
     expect(dns.getServers()).toEqual(before)
@@ -127,15 +128,16 @@ describe('withSrvDnsFallback', () => {
 
   it('rethrows the original error when the configured server list is empty', async () => {
     process.env.MONGODB_DNS_SERVERS = ' , '
+    const srvError = makeSrvError()
     let attempts = 0
 
     // eslint-disable-next-line @typescript-eslint/await-thenable -- expect().rejects is thenable at runtime
     await expect(
       withSrvDnsFallback(async () => {
         attempts++
-        throw makeSrvError()
+        throw srvError
       })
-    ).rejects.toThrow('querySrv EBADRESP')
+    ).rejects.toBe(srvError)
 
     expect(attempts).toBe(1)
   })

--- a/script/deploy/shared/mongo-srv-dns.ts
+++ b/script/deploy/shared/mongo-srv-dns.ts
@@ -1,0 +1,75 @@
+import dns from 'node:dns'
+
+import { consola } from 'consola'
+
+/**
+ * `mongodb+srv://` connections resolve an SRV record before anything else. Some
+ * routers re-encode SRV answers with a name-compression pointer in the target
+ * field, which RFC 2782 forbids: Node's resolver rejects those packets outright
+ * (`querySrv EBADRESP`) while `dig`, `host` and the macOS system resolver accept
+ * them - so DNS looks healthy from the shell while every Mongo command fails.
+ */
+
+const DEFAULT_FALLBACK_DNS_SERVERS = ['1.1.1.1', '8.8.8.8']
+
+let fallbackApplied = false
+
+const isSrvLookupError = (error: unknown): boolean =>
+  (error as NodeJS.ErrnoException | undefined)?.syscall === 'querySrv'
+
+const getFallbackDnsServers = (): string[] => {
+  const configured = process.env.MONGODB_DNS_SERVERS
+  if (configured === undefined) return DEFAULT_FALLBACK_DNS_SERVERS
+
+  return configured
+    .split(',')
+    .map((server) => server.trim())
+    .filter((server) => server.length > 0)
+}
+
+/**
+ * Runs a MongoDB connect call, retrying it once against public DNS servers when the
+ * local resolver could not deliver a usable SRV record.
+ *
+ * The switch is deliberately failure-triggered rather than applied up front: pointing
+ * the process at public resolvers unconditionally would bypass any split-horizon DNS
+ * used for internal endpoints. It happens at most once, and the process keeps using
+ * the fallback servers afterwards.
+ *
+ * @param connect - Callback performing the connect (e.g. `() => client.connect()`)
+ * @returns Whatever the connect callback resolves to
+ *
+ * @example
+ * ```typescript
+ * const client = new MongoClient(mongoUri)
+ * await withSrvDnsFallback(() => client.connect())
+ * ```
+ */
+export const withSrvDnsFallback = async <T>(
+  connect: () => Promise<T>
+): Promise<T> => {
+  try {
+    return await connect()
+  } catch (error) {
+    if (fallbackApplied || !isSrvLookupError(error)) throw error
+
+    const fallbackServers = getFallbackDnsServers()
+    if (fallbackServers.length === 0) throw error
+
+    const localServers = dns.getServers().join(', ')
+    consola.warn(
+      `MongoDB SRV lookup failed via the local DNS resolver (${localServers}). ` +
+        `Retrying via ${fallbackServers.join(', ')} - ` +
+        `set MONGODB_DNS_SERVERS to override.`
+    )
+    dns.setServers(fallbackServers)
+    fallbackApplied = true
+
+    return await connect()
+  }
+}
+
+/** @internal Test-only hook to clear the once-per-process latch. */
+export const resetSrvDnsFallbackForTests = (): void => {
+  fallbackApplied = false
+}

--- a/script/deploy/shared/mongo-srv-dns.ts
+++ b/script/deploy/shared/mongo-srv-dns.ts
@@ -57,12 +57,20 @@ export const withSrvDnsFallback = async <T>(
     if (fallbackServers.length === 0) throw error
 
     const localServers = dns.getServers().join(', ')
+    try {
+      dns.setServers(fallbackServers)
+    } catch {
+      consola.warn(
+        `Ignoring MONGODB_DNS_SERVERS - not a valid list of IP addresses: ` +
+          fallbackServers.join(', ')
+      )
+      throw error
+    }
     consola.warn(
       `MongoDB SRV lookup failed via the local DNS resolver (${localServers}). ` +
         `Retrying via ${fallbackServers.join(', ')} - ` +
         `set MONGODB_DNS_SERVERS to override.`
     )
-    dns.setServers(fallbackServers)
     fallbackApplied = true
 
     return await connect()

--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -34,6 +34,7 @@ import {
   mongoEq,
   RecordTransformer,
 } from './shared/mongo-log-utils'
+import { withSrvDnsFallback } from './shared/mongo-srv-dns'
 
 // Interface for index specifications with old names
 interface IIndexSpec {
@@ -98,7 +99,7 @@ class DeploymentLogManager {
 
     while (retryCount < maxRetries)
       try {
-        await this.client.connect()
+        await withSrvDnsFallback(() => this.client.connect())
         this.db = this.client.db(config.databaseName)
         const collectionName = this.environment
         this.collection = this.db.collection<IDeploymentRecord>(collectionName)

--- a/script/mongoDb/add-network-rpc.ts
+++ b/script/mongoDb/add-network-rpc.ts
@@ -4,6 +4,7 @@ import { consola } from 'consola'
 import { MongoClient } from 'mongodb'
 
 import { mongoEq } from '../deploy/shared/mongo-log-utils'
+import { withSrvDnsFallback } from '../deploy/shared/mongo-srv-dns'
 
 const main = defineCommand({
   meta: {
@@ -43,7 +44,7 @@ const main = defineCommand({
     const client = new MongoClient(MONGODB_URI)
     let exitCode = 0
     try {
-      await client.connect()
+      await withSrvDnsFallback(() => client.connect())
       const db = client.db('blockchain-configs')
       const collection = db.collection('RpcEndpoints')
 

--- a/script/mongoDb/fetch-rpcs.ts
+++ b/script/mongoDb/fetch-rpcs.ts
@@ -4,6 +4,7 @@ import { consola } from 'consola'
 import { config } from 'dotenv'
 import { MongoClient } from 'mongodb'
 
+import { withSrvDnsFallback } from '../deploy/shared/mongo-srv-dns'
 import { getRPCEnvVarName } from '../utils/utils'
 
 config()
@@ -25,7 +26,7 @@ async function fetchRpcEndpoints(): Promise<{
   const client = new MongoClient(MONGODB_URI)
 
   try {
-    await client.connect()
+    await withSrvDnsFallback(() => client.connect())
     const db = client.db('blockchain-configs')
     const collection = db.collection('RpcEndpoints')
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-794](https://linear.app/lifi-linear/issue/EXSC-794/retry-mongodbsrv-connections-via-public-dns-when-the-local-resolver)

# Why did I implement it this way?

Every `mongodb+srv://` script in this repo dies immediately with `Error: querySrv EBADRESP _mongodb._tcp.<cluster>.mongodb.net` on networks whose DNS forwarder re-encodes SRV answers with a name-compression pointer in the target field. RFC 2782 forbids compression there, so Node's c-ares resolver rejects the packet — while `dig`, `host` and the macOS system resolver accept it. The result is a failure that looks like broken credentials, a dead tunnel, or an Atlas outage, while DNS appears perfectly healthy from the shell. Captured on a router at `10.0.148.1`: it returns the SRV target as `rdlength 0x24` ending in a `c02a` pointer, where 1.1.1.1 and 8.8.8.8 return the fully expanded `rdlength 0x35`. Bun's resolver tolerates it, Node's does not — and our scripts run through `bunx tsx`, which spawns node, so they're on the failing path.

The fix is one shared helper, `withSrvDnsFallback()`, wrapped around the connect call at every `MongoClient` site. It retries exactly once against public DNS servers, and only when the error is an SRV lookup failure (`syscall === 'querySrv'`); anything else rethrows untouched. Three deliberate choices: the switch is failure-triggered rather than applied at startup, because unconditionally pointing the process at public resolvers would bypass split-horizon DNS for internal endpoints; it wraps the existing connect call instead of re-creating the client, which was verified to be reusable after an SRV failure; and `MONGODB_DNS_SERVERS` is available as an override for networks where 1.1.1.1 / 8.8.8.8 are themselves unreachable. Rebuilding a plain `mongodb://` seedlist by hand was rejected — it would hardcode shard hosts, `replicaSet` and `authSource` and silently rot when Atlas rescales.

Two sites (`timelock-queue`, `parked-tasks`) never call `client.connect()` explicitly and connect lazily on their first index-ensure, so the wrapper goes around that call instead; `createIndex` is idempotent, so the retry is safe.

Verified end-to-end on the affected network: `query-deployment-logs latest --no-use-cache` previously failed at SRV resolution and now emits the warning and fetches all 4356 records. The helper's own tests cover the success path, the retry, the non-SRV rethrow, the failing-retry rethrow, the once-per-process latch and an empty override list — and were checked against a deliberately broken implementation to confirm they actually fail when the fallback is removed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>