### PR TITLE
fix(tron): support SymbiosisFacet v2.0.0 constructor in Tron deploy script (EXSC-795)

### DIFF
--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -143,9 +143,11 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
         `backendSigner.${environment} not found in config/global.json`
       )
 
-    // Normalize before validating: Tron's zero address has a base58 encoding
-    // (T9yD14...) as well as the EVM hex one, and a raw string compare would
-    // read that as a configured router.
+    // The deployer's energy estimation ABI-encodes these via ethers, which
+    // rejects Tron base58, so every address is normalized to EVM hex. The
+    // checks below rely on that too: Tron's zero address also has a base58
+    // encoding (T9yD14...), which a raw string compare would read as a
+    // configured router.
     const constructorArgs = [
       tronAddressToHex(tronWeb, metaRouter),
       tronAddressToHex(tronWeb, gateway),

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -143,6 +143,34 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
         `backendSigner.${environment} not found in config/global.json`
       )
 
+    // Normalize before validating: Tron's zero address has a base58 encoding
+    // (T9yD14...) as well as the EVM hex one, and a raw string compare would
+    // read that as a configured router.
+    const constructorArgs = [
+      tronAddressToHex(tronWeb, metaRouter),
+      tronAddressToHex(tronWeb, gateway),
+      tronAddressToHex(tronWeb, onchainSwapV3),
+      tronAddressToHex(tronWeb, onchainSwapV3Gateway),
+      tronAddressToHex(tronWeb, backendSigner),
+    ]
+    const [, , onchainSwapV3Hex, onchainSwapV3GatewayHex, backendSignerHex] =
+      constructorArgs
+
+    // Mirror the constructor's own checks so a misconfiguration fails here
+    // rather than after paying for the deployment.
+    if (
+      (onchainSwapV3Hex === ZERO_ADDRESS) !==
+      (onchainSwapV3GatewayHex === ZERO_ADDRESS)
+    )
+      throw new Error(
+        'onchainSwapV3 and onchainSwapV3Gateway must both be set or both be zero in config/symbiosis.json'
+      )
+
+    if (backendSignerHex === ZERO_ADDRESS)
+      throw new Error(
+        `backendSigner.${environment} in config/global.json is the zero address`
+      )
+
     // Convert addresses to Tron format for display
     const metaRouterTron = evmHexToTronBase58(tronWeb, metaRouter)
     const gatewayTron = evmHexToTronBase58(tronWeb, gateway)
@@ -196,16 +224,6 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       })
     } else
       try {
-        // The deployer's energy estimation ABI-encodes these via ethers, which
-        // rejects Tron base58 - normalize every address to EVM hex first.
-        const constructorArgs = [
-          tronAddressToHex(tronWeb, metaRouter),
-          tronAddressToHex(tronWeb, gateway),
-          tronAddressToHex(tronWeb, onchainSwapV3),
-          tronAddressToHex(tronWeb, onchainSwapV3Gateway),
-          tronAddressToHex(tronWeb, backendSigner),
-        ]
-
         // Deploy using new utility
         const result = await deployContractWithLogging(
           deployer,
@@ -247,9 +265,11 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
+    const deferCut = process.env.DEFER_CUT === 'true'
+
     if (dryRun)
       consola.info('Dry run - skipping diamondCut proposal for SymbiosisFacet')
-    else if (process.env.DEFER_CUT === 'true')
+    else if (deferCut)
       consola.info(
         'DEFER_CUT=true - facet deployed, skipping diamondCut proposal'
       )
@@ -269,6 +289,8 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
     consola.success(
       dryRun
         ? '\nDry run completed successfully! (no Safe tx created)'
+        : deferCut
+        ? '\nDeployment completed successfully! (diamondCut proposal deferred)'
         : '\nDeployment and proposal completed successfully!'
     )
   } catch (error: any) {

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -3,6 +3,7 @@
 import {
   MIN_BALANCE_WARNING,
   TronContractDeployer,
+  ZERO_ADDRESS,
   createTronWeb,
   evmHexToTronBase58,
   tronAddressToHex,
@@ -123,6 +124,25 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
         'Symbiosis metaRouter or gateway not found for tron in config/symbiosis.json'
       )
 
+    // The OnchainSwapV3 (syBTC -> Bitcoin) path has no Tron deployment, and the
+    // constructor accepts address(0) for it. backendSigner is not optional
+    // though - the constructor reverts on a zero signer even when that path is
+    // unreachable.
+    const onchainSwapV3 = tronSymbiosisConfig.onchainSwapV3 ?? ZERO_ADDRESS
+    const onchainSwapV3Gateway =
+      tronSymbiosisConfig.onchainSwapV3Gateway ?? ZERO_ADDRESS
+
+    const globalConfig = await Bun.file('config/global.json').json()
+    const backendSigner =
+      environment === EnvironmentEnum.production
+        ? globalConfig.backendSigner?.production
+        : globalConfig.backendSigner?.staging
+
+    if (!backendSigner)
+      throw new Error(
+        `backendSigner.${environment} not found in config/global.json`
+      )
+
     // Convert addresses to Tron format for display
     const metaRouterTron = evmHexToTronBase58(tronWeb, metaRouter)
     const gatewayTron = evmHexToTronBase58(tronWeb, gateway)
@@ -130,6 +150,17 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
     consola.info('\nSymbiosis Configuration:')
     consola.info(`MetaRouter: ${metaRouterTron} (hex: ${metaRouter})`)
     consola.info(`Gateway: ${gatewayTron} (hex: ${gateway})`)
+    const unusedSuffix = (address: string) =>
+      address === ZERO_ADDRESS ? ' (not configured)' : ''
+    consola.info(
+      `OnchainSwapV3: ${onchainSwapV3}${unusedSuffix(onchainSwapV3)}`
+    )
+    consola.info(
+      `OnchainSwapV3Gateway: ${onchainSwapV3Gateway}${unusedSuffix(
+        onchainSwapV3Gateway
+      )}`
+    )
+    consola.info(`BackendSigner: ${backendSigner}`)
 
     // Prepare deployment plan
     const contracts = ['SymbiosisFacet']
@@ -143,11 +174,14 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
     // Deploy SymbiosisFacet
     consola.info('\nDeploying SymbiosisFacet...')
 
-    const { exists, address, shouldRedeploy } = await checkExistingDeployment(
-      network,
-      'SymbiosisFacet',
-      dryRun
-    )
+    // checkExistingDeployment prompts "Redeploy?" whenever an address is already
+    // recorded, and without a TTY that prompt cancels the whole process before we
+    // can branch on the answer - so a non-interactive redeploy has to skip it.
+    const forceRedeploy = process.env.FORCE_REDEPLOY === 'true'
+
+    const { exists, address, shouldRedeploy } = forceRedeploy
+      ? { exists: false, address: null, shouldRedeploy: true }
+      : await checkExistingDeployment(network, 'SymbiosisFacet', dryRun)
 
     let facetAddress: string
     if (exists && !shouldRedeploy && address) {
@@ -162,8 +196,15 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       })
     } else
       try {
-        // Constructor arguments for SymbiosisFacet
-        const constructorArgs = [metaRouter, gateway]
+        // The deployer's energy estimation ABI-encodes these via ethers, which
+        // rejects Tron base58 - normalize every address to EVM hex first.
+        const constructorArgs = [
+          tronAddressToHex(tronWeb, metaRouter),
+          tronAddressToHex(tronWeb, gateway),
+          tronAddressToHex(tronWeb, onchainSwapV3),
+          tronAddressToHex(tronWeb, onchainSwapV3Gateway),
+          tronAddressToHex(tronWeb, backendSigner),
+        ]
 
         // Deploy using new utility
         const result = await deployContractWithLogging(
@@ -206,7 +247,13 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
       selectors
     )
 
-    if (!dryRun)
+    if (dryRun)
+      consola.info('Dry run - skipping diamondCut proposal for SymbiosisFacet')
+    else if (process.env.DEFER_CUT === 'true')
+      consola.info(
+        'DEFER_CUT=true - facet deployed, skipping diamondCut proposal'
+      )
+    else
       await proposeDiamondCut({
         facetName: 'SymbiosisFacet',
         facetAddressHex: tronAddressToHex(
@@ -216,8 +263,6 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
         diamondAddress,
         network: network,
       })
-    else
-      consola.info('Dry run - skipping diamondCut proposal for SymbiosisFacet')
 
     printDeploymentSummary(deploymentResults, dryRun)
 

--- a/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
+++ b/script/deploy/tron/deploy-and-register-symbiosis-facet.ts
@@ -175,8 +175,8 @@ async function deployAndRegisterSymbiosisFacet(options: { dryRun?: boolean }) {
     consola.info('\nDeploying SymbiosisFacet...')
 
     // checkExistingDeployment prompts "Redeploy?" whenever an address is already
-    // recorded, and without a TTY that prompt cancels the whole process before we
-    // can branch on the answer - so a non-interactive redeploy has to skip it.
+    // recorded, and with no TTY that prompt never resolves - the run just hangs.
+    // A non-interactive redeploy therefore has to skip the check entirely.
     const forceRedeploy = process.env.FORCE_REDEPLOY === 'true'
 
     const { exists, address, shouldRedeploy } = forceRedeploy


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-795](https://linear.app/lifi-linear/issue/EXSC-795/sc-tron-symbiosisfacet-deploy-script-does-not-support-the-v200)

# Why did I implement it this way?

`script/deploy/tron/deploy-and-register-symbiosis-facet.ts` on `main` still passes the SymbiosisFacet **v1.0.0** constructor arguments (`[metaRouter, gateway]`), while `SymbiosisFacet` is now v2.0.0 with a five-argument constructor. Running the script unchanged against v2.0.0 deploys a facet with mis-encoded constructor data.

SymbiosisFacet v2.0.0 is already deployed and registered on Tron (`TMY1N6rC61Fu1C8qvZEhwb3WLR7iY1ERuW`, see `deployments/tron.json`). That deploy was only possible via a local, uncommitted edit in the `contracts-tron` fork checkout, which never landed upstream — so the deploy is currently not reproducible from `main`. This PR ports that fix. **Deploy-tooling only: no contract change and no on-chain action.**

### Constructor arguments

| Parameter | Source | Value on Tron |
|---|---|---|
| `_symbiosisMetaRouter` | `config/symbiosis.json` → `tron.metaRouter` | `0x0863786bbf4561f4a2a8be5a9ddf152afd8ae25c` |
| `_symbiosisGateway` | `config/symbiosis.json` → `tron.gateway` | `0x49e1816a2cf475515e7c80c9f0f0e16ae499198b` |
| `_onchainSwapV3` | `config/symbiosis.json` → `tron.onchainSwapV3`, default `address(0)` | `0x0000000000000000000000000000000000000000` |
| `_onchainSwapV3Gateway` | `config/symbiosis.json` → `tron.onchainSwapV3Gateway`, default `address(0)` | `0x0000000000000000000000000000000000000000` |
| `_backendSigner` | `config/global.json` → `backendSigner.<environment>` | `0xaf4b7a83591a6c4c8b9d1341c3f08bbc3b800fc5` |

The OnchainSwapV3 (syBTC → Bitcoin) router has no Tron deployment, so it and its gateway default to `address(0)` — the v2.0.0 constructor explicitly permits that. `_backendSigner` is not optional: the constructor reverts on a zero signer even when the OnchainSwapV3 path is unreachable, so it is read per environment from `config/global.json` (the same signer every EVM chain uses). Both OnchainSwapV3 addresses stay overridable from `config/symbiosis.json` in case Tron ever gets that deployment.

All five addresses are normalised with `tronAddressToHex` before being passed to the deployer, because its energy estimation ABI-encodes the arguments through ethers, which rejects Tron base58. This mirrors `deploy-and-register-near-intents-facet.ts`.

### Two env flags

Both default to off and change nothing for an ordinary interactive run:

- `FORCE_REDEPLOY=true` skips `checkExistingDeployment`. That helper prompts `Redeploy?` whenever an address is already recorded, and with no TTY the prompt never resolves — the run just hangs (verified: `consola.prompt` with stdin closed blocks indefinitely). A non-interactive redeploy is otherwise impossible.
- `DEFER_CUT=true` deploys the facet but skips the `diamondCut` proposal, for deploys whose cut is deliberately deferred and coordinated separately.

Neither flag exists elsewhere in the repo yet. Happy to drop `DEFER_CUT` or lift both into the shared helpers for all Tron facet scripts if you'd prefer that over a per-script escape hatch.

### Pre-flight validation

The script mirrors the constructor's own checks so a misconfiguration fails before the deployment is paid for: `onchainSwapV3` and `onchainSwapV3Gateway` must be both set or both zero (the constructor reverts `InvalidConfig` on a mismatched pair), and `backendSigner` must be non-zero. Both run on `tronAddressToHex`-normalized values, so Tron's base58 zero address (`T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb`) is caught as well as the EVM hex one.

### Verification

- I decoded the constructor arguments actually appended to the creation bytecode of the deployed `TMY1N6rC61Fu1C8qvZEhwb3WLR7iY1ERuW` (via TronGrid `wallet/getcontract`) and confirmed the script's argument resolution reproduces all five exactly — including the two zero addresses and the production `backendSigner`. The values are the ones in the table above.
- Exercised `tronAddressToHex` on each input shape (Tron base58, EVM hex, and `address(0)`) and confirmed each produces the expected 20-byte hex. The zero address is the one that needed proving: TronWeb's `toHex` short-circuits on hex input and the devkit's `41`-prefix strip leaves it intact.
- Probed both new checks against the real `config/symbiosis.json` / `config/global.json`: router-set/gateway-missing, gateway-set/router-missing, base58-zero router, hex-zero signer and base58-zero signer all fire; the real config and a both-set pair pass; and the happy path still reproduces the deployed constructor args.
- Cross-checked the key names and zero-address policy against the EVM path — `script/deploy/facets/DeploySymbiosisFacet.s.sol` and `script/deploy/resources/deployRequirements.json` — so both routes read the same `config/symbiosis.json` keys and treat `onchainSwapV3` / `onchainSwapV3Gateway` as optional-defaulting-to-zero and `backendSigner` as mandatory.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

There are no tests for the Tron deploy scripts (none of the sibling `deploy-and-register-*-facet.ts` scripts are covered), so I verified against the real deployed contract instead, as described above. A live dry-run was not possible from this session: it needs the production deployer key and an interactive confirmation prompt.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

