### PR TITLE
chore: whitelist sushiswap RedSnwapper on X Layer

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -2056,6 +2056,15 @@
             }
           }
         ],
+        "xlayer": [
+          {
+            "address": "0xac4c6e212a361c968f1725b4d055b47e63f80b75",
+            "functions": {
+              "0x5f3bd1c8": "snwap(address,uint256,address,address,uint256,address,bytes)",
+              "0xd33721a5": "snwapMultiple((address,uint256,address)[],(address,address,uint256)[],(address,uint256,bytes)[])"
+            }
+          }
+        ],
         "boba": [
           {
             "address": "0x85cd07ea01423b1e937929b44e4ad8c40bbb5e71",


### PR DESCRIPTION
## Summary
Adds the SushiSwap `xlayer` (chain 196) entry to `config/whitelist.json`, whitelisting the RedSnwapper router.

- **Address:** `0xac4c6e212a361c968f1725b4d055b47e63f80b75`
- **Selectors:** `0x5f3bd1c8` `snwap(...)`, `0xd33721a5` `snwapMultiple(...)`

## Verification
- RedSnwapper is deployed at that address on X Layer — confirmed via `eth_getCode` against two independent RPCs (`rpc.xlayer.tech`, `xlayerrpc.okx.com`).
- The deployed bytecode is **byte-identical** to the already-whitelisted Monad deployment, and both selectors are present in it. The entry is therefore a verbatim copy of the existing `monad` / `hemi` / `katana` entries.
- A live SushiSwap `swap/v7` quote on chain 196 returns `tx.to` = this address with calldata beginning `0x5f3bd1c8`.

## Context
Paired backend PR: https://github.com/lifinance/lifi-backend/pull/8821

⚠️ This PR should reach production **before** the backend PR — X Layer is enabled on merge there, and swaps would revert calldata validation until this whitelist is live.

Linear: https://linear.app/lifi-linear/issue/EXBE-521/be-enable-sushiswap-on-x-layer