### PR TITLE
fix(VaultWrapper): correct performance-fee watermark anchoring

### DIFF
--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -77,7 +77,12 @@ custody contract must never be left ownerless.
 deployed. It sets the identity (`underlying` / `adapter` / `owner` / `factory`),
 the initial fee configuration, receivers, and access gate; resolves the ERC-20
 asset via the adapter; derives the virtual-share offset from the asset decimals;
-and anchors the performance watermark at the empty-vault share price.
+and sets a provisional performance watermark at the empty-vault share price. That
+par value is only a placeholder: while total supply is below `MIN_SHARE_SUPPLY`
+(no real holders), each accrual re-floats the watermark to the live price and
+skips the performance fee, so assets donated to the instance's predicted address
+become the first real depositor's baseline instead of being charged to them as
+fabricated gain.
 
 ## Upgradeability and the FACTORY binding
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -266,12 +266,13 @@ contract LiFiVaultWrapper is
             ? MIN_DECIMALS_OFFSET
             : derivedOffset;
 
-        // Anchor the performance watermark at the empty-vault share price, computed pure
-        // (supply and position are always 0 on a fresh single-shot-initialized proxy).
-        // Deliberately NOT read through the adapter: an underlying whose empty-position
-        // query reverts must not brick deployment. Assets donated to the predicted
-        // address before deployment therefore count as gain at the first accrual —
-        // charging a donation is harmless and disarms watermark-seeding games.
+        // Provisional anchor at the empty-vault share price, computed pure (supply and
+        // position are always 0 on a fresh single-shot-initialized proxy). Deliberately NOT
+        // read through the adapter: an underlying whose empty-position query reverts must not
+        // brick deployment. This par value is only a placeholder — `_accrueFees` re-floats the
+        // watermark to the live price on every accrual taken while supply is below the floor,
+        // so a donation to the predicted address is captured into the baseline (not booked as
+        // gain against the first depositor) the moment real supply is minted.
         perfHighWaterMarkPps = SafeCast.toUint192(
             LibVaultWrapperMath.pricePerShare(0, 0, _decimalsOffset())
         );
@@ -1062,9 +1063,12 @@ contract LiFiVaultWrapper is
     ///      accrue-at-old-rate-first guarantee). The cost is that elapsed time whose fee
     ///      floors to zero shares is dropped — at most ~one share's worth of assets per
     ///      accrual, favouring holders. The performance fee is charged AFTER the
-    ///      management dilution (perf is net of management), and its watermark ratchets
-    ///      to the post-crystallization share price only when shares were actually
-    ///      minted — an uncharged gain stays chargeable, unlike elapsed time.
+    ///      management dilution (perf is net of management). The watermark has two write
+    ///      paths: while supply is below the floor (no real holders), it floats to the live
+    ///      price and the perf fee is skipped, so a donation becomes the first depositor's
+    ///      baseline rather than their loss; at real supply it ratchets to the post-
+    ///      crystallization price (rounded up) only when shares were actually minted — an
+    ///      uncharged gain stays chargeable, unlike elapsed time.
     function _accrueFees() private {
         bool mgmtEnabled = _feeConfig.rateBps[uint8(FeeType.Management)] != 0;
         bool perfEnabled = _feeConfig.rateBps[uint8(FeeType.Performance)] != 0;
@@ -1084,11 +1088,18 @@ contract LiFiVaultWrapper is
             supply += mgmtShares;
         }
 
-        // While no holder shares exist, no performance fee can be owed, and any price rise is
-        // a donation to the (predicted) address, not yield. Float the watermark up to the
-        // current price so the first depositor's entry price becomes the baseline, instead of
-        // being booked as gain against their own principal on the next accrual.
-        if (perfEnabled && supply == 0) {
+        // Below the supply floor there are no real holders: no depositor can transact against
+        // a sub-floor supply (deposits enforce MIN_SHARE_SUPPLY; only floor-exempt exits reach
+        // it), so any price rise is a donation to the (predicted) address, not yield. A plain
+        // `supply == 0` guard is not enough — at dust supply the perf dilution floors to zero
+        // (`dilutionShares` ~ rate * supply, so it rounds to no shares while supply < 1/rate),
+        // leaving the watermark stale and the donation chargeable to the next real depositor.
+        // The floor (1e6) covers every rate: the widest sub-floor window is 1/rate = 1e4 at the
+        // 1 bps minimum. Float the watermark up to the current price so the first real
+        // depositor's entry price becomes the baseline. Trade-off: genuine yield earned while
+        // supply is sub-floor escapes the performance fee, which is bounded (a sub-floor vault
+        // is dust) and consistent with the "no depositor transacts below the floor" invariant.
+        if (perfEnabled && supply < MIN_SHARE_SUPPLY) {
             perfHighWaterMarkPps = SafeCast.toUint192(
                 LibVaultWrapperMath.pricePerShare(
                     supply,

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -58,7 +58,7 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      dust-denominator regime. EIP-5143 slippage overloads of
 ///      the four entrypoints bound the realized amount against in-flight share-price
 ///      or fee-rate changes.
-/// @custom:version 1.1.0
+/// @custom:version 1.0.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
     // OZ v5's Ownable/Ownable2Step keep `_owner`/`_pendingOwner` in fixed ERC-7201

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -58,7 +58,7 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      dust-denominator regime. EIP-5143 slippage overloads of
 ///      the four entrypoints bound the realized amount against in-flight share-price
 ///      or fee-rate changes.
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
     // OZ v5's Ownable/Ownable2Step keep `_owner`/`_pendingOwner` in fixed ERC-7201
@@ -833,7 +833,8 @@ contract LiFiVaultWrapper is
                         LibVaultWrapperMath.pricePerShare(
                             supply,
                             totalAssets(),
-                            _decimalsOffset()
+                            _decimalsOffset(),
+                            Math.Rounding.Ceil
                         )
                     );
                     // Up-only: anchoring below the stored watermark would let the owner
@@ -1083,16 +1084,39 @@ contract LiFiVaultWrapper is
             supply += mgmtShares;
         }
 
+        // While no holder shares exist, no performance fee can be owed, and any price rise is
+        // a donation to the (predicted) address, not yield. Float the watermark up to the
+        // current price so the first depositor's entry price becomes the baseline, instead of
+        // being booked as gain against their own principal on the next accrual.
+        if (perfEnabled && supply == 0) {
+            perfHighWaterMarkPps = SafeCast.toUint192(
+                LibVaultWrapperMath.pricePerShare(
+                    supply,
+                    assets,
+                    _decimalsOffset(),
+                    Math.Rounding.Ceil
+                )
+            );
+            return;
+        }
+
         uint256 perfShares = _pendingPerformanceFee(supply, assets);
         if (perfShares != 0) {
             _mint(address(this), perfShares);
             _bookDilution(FeeType.Performance, perfShares);
             supply += perfShares;
+            // Ceil, not floor: a floored post-dilution price can fall a full pps step below the
+            // price the fee was just charged at, re-opening that step to be charged again on the
+            // next crossing (severe for low-decimal assets, where a step is a coarse slice of
+            // AUM). Rounding up keeps the watermark at/above the crystallization price, at most
+            // under-charging by one sub-step — the holder-favouring direction the rest of the
+            // fee math already rounds in.
             perfHighWaterMarkPps = SafeCast.toUint192(
                 LibVaultWrapperMath.pricePerShare(
                     supply,
                     assets,
-                    _decimalsOffset()
+                    _decimalsOffset(),
+                    Math.Rounding.Ceil
                 )
             );
         }

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -11,7 +11,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 ///         dilution, and the fee-inclusive share/asset conversions. Centralizing the math
 ///         here gives auditing and fuzzing a single, side-effect-free surface; all state,
 ///         minting, and routing stay in the wrapper.
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 library LibVaultWrapperMath {
     using Math for uint256;
 
@@ -83,22 +83,48 @@ library LibVaultWrapperMath {
 
     /// @notice Price per share as a `PPS_SCALE`-scaled fixed-point value.
     /// @dev `convertToAssets(PPS_SCALE)` under OZ's virtual-offset convention:
-    ///      `pps = (totalAssets + 1) * PPS_SCALE / (totalSupply + 10**offset)`, rounded
-    ///      down. The same convention as the share/asset conversions so the performance
-    ///      watermark is measured on exactly the price depositors transact at.
+    ///      `pps = (totalAssets + 1) * PPS_SCALE / (totalSupply + 10**offset)`. The same
+    ///      convention as the share/asset conversions so the performance watermark is measured
+    ///      on exactly the price depositors transact at. Rounding is caller-chosen: gain
+    ///      measurement floors (under-measures, favouring holders); the high-water-mark ratchet
+    ///      ceils so a floored post-dilution price cannot fall a full step below the price the
+    ///      fee was crystallized at and re-charge that step on the next crossing.
     /// @param _totalSupply Current share supply.
     /// @param _totalAssets Gross assets under management.
     /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
+    /// @param _rounding Rounding direction for the division.
     /// @return The current price per share, scaled by `PPS_SCALE`.
+    function pricePerShare(
+        uint256 _totalSupply,
+        uint256 _totalAssets,
+        uint8 _decimalsOffset,
+        Math.Rounding _rounding
+    ) internal pure returns (uint256) {
+        return
+            (_totalAssets + 1).mulDiv(
+                PPS_SCALE,
+                _totalSupply + 10 ** _decimalsOffset,
+                _rounding
+            );
+    }
+
+    /// @notice `pricePerShare` with the floored measurement convention.
+    /// @dev The default used by gain measurement and the empty-vault anchor; the watermark
+    ///      ratchet calls the rounding-aware overload with `Math.Rounding.Ceil` instead.
+    /// @param _totalSupply Current share supply.
+    /// @param _totalAssets Gross assets under management.
+    /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
+    /// @return The current price per share, scaled by `PPS_SCALE`, rounded down.
     function pricePerShare(
         uint256 _totalSupply,
         uint256 _totalAssets,
         uint8 _decimalsOffset
     ) internal pure returns (uint256) {
         return
-            (_totalAssets + 1).mulDiv(
-                PPS_SCALE,
-                _totalSupply + 10 ** _decimalsOffset,
+            pricePerShare(
+                _totalSupply,
+                _totalAssets,
+                _decimalsOffset,
                 Math.Rounding.Floor
             );
     }

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -11,7 +11,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 ///         dilution, and the fee-inclusive share/asset conversions. Centralizing the math
 ///         here gives auditing and fuzzing a single, side-effect-free surface; all state,
 ///         minting, and routing stay in the wrapper.
-/// @custom:version 1.1.0
+/// @custom:version 1.0.0
 library LibVaultWrapperMath {
     using Math for uint256;
 

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
 import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";
@@ -121,13 +122,16 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         uint256 expectedHwm = LibVaultWrapperMath.pricePerShare(
             supply + expectedShares,
             assets,
-            wrapper.shareDecimalsOffset()
+            wrapper.shareDecimalsOffset(),
+            Math.Rounding.Ceil
         );
 
         _crystallize();
 
-        // The watermark equals the diluted (post-fee-mint) PPS, sitting below the
-        // pre-charge peak: holders' realized value is the new baseline.
+        // The watermark equals the diluted (post-fee-mint) PPS rounded up, sitting below the
+        // pre-charge peak: holders' realized value is the new baseline. Rounding up keeps a
+        // floored price from dropping a full step below the crystallization price and being
+        // re-charged on the next crossing.
         uint256 hwm = wrapper.perfHighWaterMarkPps();
         assertEq(hwm, expectedHwm);
         assertLt(hwm, ppsBeforeCharge);
@@ -254,8 +258,16 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         vm.prank(vaultAdmin);
         wrapper.setFeeRate(FeeType.Performance, PERF_RATE);
 
-        // The watermark re-anchored at the current (post-yield) PPS...
-        assertEq(wrapper.perfHighWaterMarkPps(), _pps());
+        // The watermark re-anchored at the current (post-yield) PPS, rounded up...
+        assertEq(
+            wrapper.perfHighWaterMarkPps(),
+            LibVaultWrapperMath.pricePerShare(
+                wrapper.totalSupply(),
+                wrapper.totalAssets(),
+                wrapper.shareDecimalsOffset(),
+                Math.Rounding.Ceil
+            )
+        );
         assertEq(_accruedFeeShares(), 0);
 
         // ...so crystallizing right away charges nothing...

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -32,7 +32,7 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
 
     /// @dev Credits the empty wrapper with a source-vault position without minting any
     ///      wrapper shares — the "donation to the predicted address" of the first defect.
-    function _donateToEmptyWrapper(uint256 _assets) internal {
+    function _donateToWrapperPosition(uint256 _assets) internal {
         asset.mint(address(this), _assets);
         asset.approve(address(underlying), _assets);
         underlying.deposit(_assets, address(wrapper));
@@ -50,7 +50,7 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
     function test_DonationToEmptyWrapperNotChargedToFirstDepositor() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
-        _donateToEmptyWrapper(1e15);
+        _donateToWrapperPosition(1e15);
         assertEq(wrapper.totalSupply(), 0);
         assertGt(wrapper.totalAssets(), 0);
 
@@ -68,6 +68,35 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
 
         // Alice keeps essentially her full principal (only sub-wei virtual-offset rounding
         // dust) — never the ~20% haircut the pre-fix watermark produced.
+        uint256 aliceAssets = wrapper.convertToAssets(
+            wrapper.balanceOf(alice)
+        );
+        assertGe(aliceAssets, (DEPOSIT * 9999) / 10_000);
+    }
+
+    function test_DustSupplyDonationNotChargedToNextDepositor() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        // Bob seeds then exits down to dust supply: exits are exempt from MIN_SHARE_SUPPLY,
+        // so an attacker can leave the vault holding a few shares of real supply — a regime
+        // where the perf dilution floors to zero and the watermark never ratchets.
+        _deposit(bob, DEPOSIT);
+        uint256 bobShares = wrapper.balanceOf(bob);
+        vm.prank(bob);
+        wrapper.redeem(bobShares - 1, bob, bob);
+
+        assertGt(wrapper.totalSupply(), 0);
+        assertLt(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+
+        _donateToWrapperPosition(1e15);
+
+        _deposit(alice, DEPOSIT);
+
+        // A later accrual at full supply must not book the donation as a gain against Alice.
+        _deposit(makeAddr("carol"), DEPOSIT);
+
+        assertEq(_accruedFeeShares(), 0);
+
         uint256 aliceAssets = wrapper.convertToAssets(
             wrapper.balanceOf(alice)
         );

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";
+import { FeeType, FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFeeTestBase } from "test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol";
+
+/// @notice Regression tests for two performance-fee watermark defects: (1) a pre-seed
+///         donation to the empty wrapper being booked as gain against the first depositor,
+///         and (2) the floored post-dilution watermark re-charging a full price step on
+///         low-decimal assets. Both are exercised through the public entrypoints so a
+///         reintroduction of either bug fails here.
+contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
+    uint16 internal constant PERF_RATE = 2000; // 20% of gains
+
+    function _newWrapperPerfOnly(
+        uint16 _rate
+    ) internal returns (LiFiVaultWrapper) {
+        uint16[4] memory rates = [_rate, 0, 0, 0];
+
+        return
+            _newWrapperWithSplits(
+                FeeConfig({ rateBps: rates }),
+                [SPLIT, SPLIT, SPLIT, SPLIT]
+            );
+    }
+
+    /// @dev Credits the empty wrapper with a source-vault position without minting any
+    ///      wrapper shares — the "donation to the predicted address" of the first defect.
+    function _donateToEmptyWrapper(uint256 _assets) internal {
+        asset.mint(address(this), _assets);
+        asset.approve(address(underlying), _assets);
+        underlying.deposit(_assets, address(wrapper));
+    }
+
+    function _parPps() internal view returns (uint256) {
+        return
+            LibVaultWrapperMath.pricePerShare(
+                0,
+                0,
+                wrapper.shareDecimalsOffset()
+            );
+    }
+
+    function test_DonationToEmptyWrapperNotChargedToFirstDepositor() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        _donateToEmptyWrapper(1e15);
+        assertEq(wrapper.totalSupply(), 0);
+        assertGt(wrapper.totalAssets(), 0);
+
+        _deposit(alice, DEPOSIT);
+
+        // The first deposit re-anchors the watermark to its (donation-inflated) entry price
+        // instead of leaving it at the empty-vault par anchor.
+        assertGt(wrapper.perfHighWaterMarkPps(), _parPps());
+
+        // A later deposit runs an accrual at non-zero supply; it must not book the donation
+        // as a gain against the shares already held.
+        _deposit(bob, DEPOSIT);
+
+        assertEq(_accruedFeeShares(), 0);
+
+        // Alice keeps essentially her full principal (only sub-wei virtual-offset rounding
+        // dust) — never the ~20% haircut the pre-fix watermark produced.
+        uint256 aliceAssets = wrapper.convertToAssets(
+            wrapper.balanceOf(alice)
+        );
+        assertGe(aliceAssets, (DEPOSIT * 9999) / 10_000);
+    }
+
+    function test_PricePerShareCeilRoundsUpAndDefaultFloors() public pure {
+        uint256 floored = LibVaultWrapperMath.pricePerShare(
+            2,
+            6,
+            0,
+            Math.Rounding.Floor
+        );
+        uint256 ceiled = LibVaultWrapperMath.pricePerShare(
+            2,
+            6,
+            0,
+            Math.Rounding.Ceil
+        );
+
+        // 7e18 / 3 is not exact: ceil is exactly one unit above floor.
+        assertEq(floored, 2333333333333333333);
+        assertEq(ceiled, 2333333333333333334);
+
+        // The parameterless overload keeps the floored measurement convention.
+        assertEq(LibVaultWrapperMath.pricePerShare(2, 6, 0), floored);
+    }
+}
+
+/// @notice Second defect in isolation: a 6-decimal asset (one price-per-share step is a
+///         whole unit of a 1M vault) taking frequent sub-step yield. Deployed through the
+///         real factory stack so `distributeFees` (a principal-free, permissionless accrual
+///         trigger) is available. The pre-fix floored watermark re-charged a full step each
+///         crossing, confiscating ~76% of the yield; the fix caps it at the configured 20%.
+contract PerfFeeLowDecimalOverchargeTest is VaultWrapperFeeTestBase {
+    uint16 internal constant PERF_RATE = 2000; // 20% of gains
+
+    function setUp() public override {
+        asset = new MockERC20("USD Coin", "USDC", 6);
+        underlying = new MockERC4626(asset, "Yield USDC", "yUSDC");
+        adapter = new ERC4626Adapter();
+        _stackWithFactory(FeeType.Performance, PERF_RATE, 5000);
+    }
+
+    function test_LowDecimalPerfFeeDoesNotOverchargeAcrossManyAccruals()
+        public
+    {
+        uint256 principal = 1_000_000e6;
+        _deposit(alice, principal);
+
+        uint256 drip = 210_000; // 0.21 USDC, below the 1 USDC price-per-share step
+        uint256 rounds = 400;
+        for (uint256 i = 0; i < rounds; i++) {
+            _simulateYield(drip);
+            wrapper.distributeFees();
+        }
+        wrapper.distributeFees();
+
+        uint256 totalYield = drip * rounds;
+
+        uint256 aliceShares = wrapper.balanceOf(alice);
+        vm.prank(alice);
+        uint256 aliceOut = wrapper.redeem(aliceShares, alice, alice);
+
+        // Holder keeps the large majority of the yield: the cap is 20% and the floored
+        // measurement only ever under-charges. The pre-fix re-flooring left the holder
+        // <25%; here they retain well over half.
+        assertGe(aliceOut, principal + (totalYield * 60) / 100);
+        assertLe(aliceOut, principal + totalYield);
+    }
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-802 — Vault Wrapper: fix performance-fee high-water-mark watermark defects (remediation of review findings on the performance fee, EXSC-556).

# Why did I implement it this way?

Two independent defects in the performance-fee high-water-mark (HWM) logic, both fixed at the watermark write sites plus a rounding-aware `pricePerShare` overload. Pre-deployment work, so no contract version bump.

**1. Pre-seed donation charged to the first depositor.** The HWM was anchored once at `initialize` to the empty-vault par price and only ratcheted while share supply was non-zero. Assets donated to the wrapper's (deterministic, `predictAddress`-able) position while it had no real holders therefore stayed uncaptured: the first real deposit priced against the donation-inflated AUM, and the next accrual booked that inflation as "gain" against the depositor's own principal — up to the full perf rate (~20% at the default rate, ~50% at the factory cap) of principal on zero real yield. `previewDeposit`/EIP-5143 do not protect the victim (the pending fee is still zero at deposit time).

Fix: on any accrual taken while `supply < MIN_SHARE_SUPPLY` (and the perf fee is enabled), re-anchor the HWM to the current price and skip the fee, so the first real depositor's entry price becomes the baseline. The guard is on the supply floor, not `== 0`: exits are floor-exempt, so an attacker can leave *dust* supply (a few shares) where the perf dilution floors to zero and the ratchet never fires — an exactly-zero guard leaves that window open. The floor (1e6) covers every rate, since the widest sub-floor window is `1/rate = 1e4` at the 1 bps minimum. Trade-off: genuine yield earned while supply is sub-floor escapes the perf fee — bounded (a sub-floor vault is dust) and consistent with the existing "no depositor transacts below the floor" invariant.

**2. Floored watermark re-charged a full price step.** After crystallizing a fee, the HWM was recomputed with floor rounding. A floored post-dilution price can fall a full price-per-share step below the price the fee was just charged at, re-opening that step to be charged again on the next crossing. Severe for low-decimal assets where one PPS step is a coarse slice of AUM: a 6-decimal 1M vault taking frequent sub-step yield was charged ~76% of the yield versus the configured 20% (reproduced at 400 accruals). No-op for large/infrequent yield, which is why existing 18-decimal tests did not surface it.

Fix: ratchet the HWM with `Math.Rounding.Ceil` (both `_accrueFees` and the `setFeeRate` enable re-anchor). The gain *measurement* stays floored (only ever under-charges). A new rounding-aware `pricePerShare` overload carries the direction; the parameterless overload keeps the floored measurement convention so every existing caller and the empty-vault anchor are unchanged.

Considered but rejected for (2): re-anchoring to the pre-dilution measurement price. It fixes the frequent-tiny case but under-charges the large-yield case (post-dilution is the semantically correct baseline; only its rounding direction was wrong). Ceil fixes the rounding without changing the semantics.

Tests: `test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol` covers the empty-vault donation, the dust-supply donation, the low-decimal over-charge, and the ceil/floor rounding contract; each was confirmed to fail against the corresponding pre-fix code. Two existing perf-fee tests were updated from the floored to the ceil'd watermark (off-by-one). Full VaultWrapper suite: 337 passing.

Known low-severity follow-up (not addressed here): in the sub-floor float and the normal ratchet, the watermark is written through `SafeCast.toUint192`. A donation large enough to push the price per share above `uint192` max would revert the cast and brick accrual for that instance. It requires a governance-allowlisted asset with an astronomic supply (>~6.3e27 whole tokens for an 18-decimal asset) and is present on both write paths, so it is a pre-existing edge rather than a regression; flagging for a separate saturating-cast change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
