### PR TITLE
feat(scripts): automatic capability-aware RPC failover for deploy tooling (EXSC-799)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -224,3 +224,13 @@ FOUNDRY_TOML_FILE_PATH="foundry.toml"
 # bun auto-loads this file during `bun install`, so setting it here is equivalent
 # to prefixing the command (`CLAUDE_CONFIG_DIR=~/.claude-work bun run claude:install`).
 # CLAUDE_CONFIG_DIR=
+
+# Newline-separated RPC endpoints the failover resolver must not select. The deploy
+# retry loop sets this per attempt; set it by hand only to force a known-bad endpoint
+# to be skipped for a whole run.
+# LIFI_RPC_EXCLUDE=
+
+# Path to the run-scoped file recording endpoints chosen by RPC failover, so a switch
+# survives the scripts that re-read this file mid-rollout. Created automatically (mode
+# 0600) on the first failover; set it only to pin the location.
+# LIFI_RPC_OVERRIDE_FILE=

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -424,6 +424,11 @@ deploySingleContract() {
     # Use handleForgeScriptError for consistent error handling
     else
       if ! handleForgeScriptError "forge script failed for $SCRIPT" "attempt $attempts/$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" "$NETWORK"; then
+        # Retrying the same inadequate endpoint just burns attempts, so try to move to
+        # a better one. This runs after the per-call `source .env` above, which would
+        # otherwise overwrite the exported override on the next invocation.
+        tryRpcFailover "$NETWORK" "${STDERR_CONTENT:-}
+${RAW_RETURN_DATA:-}" || true
         attempts=$((attempts + 1))
         sleep 1
         continue

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -425,10 +425,10 @@ deploySingleContract() {
     else
       if ! handleForgeScriptError "forge script failed for $SCRIPT" "attempt $attempts/$MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT" "$NETWORK"; then
         # Retrying the same inadequate endpoint just burns attempts, so try to move to
-        # a better one. This runs after the per-call `source .env` above, which would
-        # otherwise overwrite the exported override on the next invocation.
+        # a better one. The override must be exported here rather than by a caller:
+        # this function re-reads .env on entry, which would discard it.
         tryRpcFailover "$NETWORK" "${STDERR_CONTENT:-}
-${RAW_RETURN_DATA:-}" || true
+${RAW_STDOUT_FULL:-}" || true
         attempts=$((attempts + 1))
         sleep 1
         continue

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3918,14 +3918,51 @@ function getRPCUrl() {
   # get RPC URL
   local RPC_URL="${!RPC_KEY}"
 
+  # no endpoint configured: ask the resolver, which also knows the MongoDB endpoints
+  # and networks.json. It prints only the URL on stdout; diagnostics go to stderr
+  # already redacted to scheme+host.
+  if [[ -z "$RPC_URL" ]]; then
+    RPC_URL=$(bunx tsx script/utils/resolveRpcUrl.ts "$NETWORK")
+  fi
+
   # check if RPC URL is empty
   if [[ -z "$RPC_URL" ]]; then
-    echo "Error: Empty RPC URL for network '$NETWORK'. Environment variable '$RPC_KEY' is not set or empty." >&2
+    echo "Error: Empty RPC URL for network '$NETWORK'. Environment variable '$RPC_KEY' is not set or empty and no alternative endpoint could be resolved." >&2
     return 1
   fi
 
   # return RPC URL
   echo "$RPC_URL"
+}
+
+# tryRpcFailover: point NETWORK at a different RPC endpoint after a failed forge run.
+#
+# Only switches when the failure provably preceded any broadcast; a transaction that
+# may have reached the mempool pins the endpoint, because a different backend has a
+# different view of it. The forge output is piped in rather than passed as an argument
+# since it routinely quotes the full RPC URL, and the resolved URL is exported rather
+# than returned so that forge picks it up through its foundry.toml alias.
+#
+# Usage: tryRpcFailover NETWORK FORGE_OUTPUT
+# Returns: 0 when the endpoint was switched, 1 when it was not
+function tryRpcFailover() {
+  local NETWORK="$1"
+  local FORGE_OUTPUT="$2"
+
+  local RPC_KEY
+  RPC_KEY=$(getRPCEnvVarName "$NETWORK")
+
+  local NEW_RPC_URL
+  NEW_RPC_URL=$(printf '%s' "$FORGE_OUTPUT" |
+    LIFI_RPC_EXCLUDE="${!RPC_KEY:-}" bunx tsx script/utils/resolveRpcUrl.ts "$NETWORK" --after-failure) || return 1
+
+  if [[ -z "$NEW_RPC_URL" ]]; then
+    return 1
+  fi
+
+  export "$RPC_KEY=$NEW_RPC_URL"
+  echo "switched RPC endpoint for '$NETWORK' after a pre-broadcast failure"
+  return 0
 }
 function getRpcUrlFromNetworksJson() {
   local NETWORK="$1"

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3944,7 +3944,12 @@ function getRPCUrl() {
 # than returned so that forge picks it up through its foundry.toml alias.
 #
 # Usage: tryRpcFailover NETWORK FORGE_OUTPUT
+#   NETWORK      - Network key as used in config/networks.json
+#   FORGE_OUTPUT - Combined stderr and unextracted stdout from the failed run
+#
 # Returns: 0 when the endpoint was switched, 1 when it was not
+# Example: tryRpcFailover "celo" "$STDERR_CONTENT
+# $RAW_STDOUT_FULL"
 function tryRpcFailover() {
   local NETWORK="$1"
   local FORGE_OUTPUT="$2"

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -3918,16 +3918,9 @@ function getRPCUrl() {
   # get RPC URL
   local RPC_URL="${!RPC_KEY}"
 
-  # no endpoint configured: ask the resolver, which also knows the MongoDB endpoints
-  # and networks.json. It prints only the URL on stdout; diagnostics go to stderr
-  # already redacted to scheme+host.
-  if [[ -z "$RPC_URL" ]]; then
-    RPC_URL=$(bunx tsx script/utils/resolveRpcUrl.ts "$NETWORK")
-  fi
-
   # check if RPC URL is empty
   if [[ -z "$RPC_URL" ]]; then
-    echo "Error: Empty RPC URL for network '$NETWORK'. Environment variable '$RPC_KEY' is not set or empty and no alternative endpoint could be resolved." >&2
+    echo "Error: Empty RPC URL for network '$NETWORK'. Environment variable '$RPC_KEY' is not set or empty." >&2
     return 1
   fi
 
@@ -3952,15 +3945,44 @@ function tryRpcFailover() {
   local RPC_KEY
   RPC_KEY=$(getRPCEnvVarName "$NETWORK")
 
-  local NEW_RPC_URL
+  # Exclusions accumulate for as long as we stay on one network. Excluding only the
+  # current endpoint would let two bad ones be picked alternately until the retry
+  # budget is gone.
+  if [[ "${RPC_FAILOVER_NETWORK:-}" != "$NETWORK" ]]; then
+    RPC_FAILOVER_NETWORK="$NETWORK"
+    RPC_FAILOVER_EXCLUDED=""
+  fi
+  if [[ -n "${!RPC_KEY:-}" ]]; then
+    RPC_FAILOVER_EXCLUDED="${RPC_FAILOVER_EXCLUDED:+${RPC_FAILOVER_EXCLUDED}$'\n'}${!RPC_KEY}"
+  fi
+
+  local NEW_RPC_URL RESOLVER_EXIT=0
   NEW_RPC_URL=$(printf '%s' "$FORGE_OUTPUT" |
-    LIFI_RPC_EXCLUDE="${!RPC_KEY:-}" bunx tsx script/utils/resolveRpcUrl.ts "$NETWORK" --after-failure) || return 1
+    LIFI_RPC_EXCLUDE="$RPC_FAILOVER_EXCLUDED" bunx tsx script/utils/resolveRpcUrl.ts "$NETWORK" --after-failure) || RESOLVER_EXIT=$?
+
+  # Exit code 3 means the resolver declined on purpose (a transaction may be in
+  # flight); anything else is an operator-actionable failure worth surfacing.
+  case "$RESOLVER_EXIT" in
+    0) ;;
+    3) return 1 ;;
+    *)
+      warning "could not resolve an alternative RPC endpoint for '$NETWORK' (resolver exit $RESOLVER_EXIT)"
+      return 1
+      ;;
+  esac
 
   if [[ -z "$NEW_RPC_URL" ]]; then
     return 1
   fi
 
   export "$RPC_KEY=$NEW_RPC_URL"
+
+  # A MongoDB-sourced endpoint was never seen by the workflow's ::add-mask:: sweep over
+  # the .env keys, and forge quotes the full URL in transport errors.
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::add-mask::$NEW_RPC_URL"
+  fi
+
   echo "switched RPC endpoint for '$NETWORK' after a pre-broadcast failure"
   return 0
 }
@@ -5015,11 +5037,16 @@ function executeAndCapture() {
   local STDERR_LOG
   STDOUT_LOG="$(mktemp)"
   STDERR_LOG="$(mktemp)"
+  # forge's human-readable progress lines ("Sending transactions", "Waiting for
+  # receipts") are the only evidence of how far a run got, and JSON extraction below
+  # discards them, so keep an unextracted copy for failure classification.
+  local STDOUT_RAW_LOG
+  STDOUT_RAW_LOG="$(mktemp)"
 
   # Preserve caller EXIT trap (this file is sourced in many scripts)
   local _OLD_EXIT_TRAP
   _OLD_EXIT_TRAP="$(trap -p EXIT 2>/dev/null || true)"
-  trap 'rm -f "$STDOUT_LOG" "$STDERR_LOG" 2>/dev/null' EXIT
+  trap 'rm -f "$STDOUT_LOG" "$STDERR_LOG" "$STDOUT_RAW_LOG" 2>/dev/null' EXIT
 
   # Execute command with redirection
   eval "$COMMAND" >"$STDOUT_LOG" 2>"$STDERR_LOG"
@@ -5035,6 +5062,8 @@ function executeAndCapture() {
   echoDebug "=== STDERR_CONTENT (stderr) ==="
   echoDebug "$STDERR_CONTENT"
 
+  cp "$STDOUT_LOG" "$STDOUT_RAW_LOG" 2>/dev/null || true
+
   # Extract JSON if requested
   if [[ "$EXTRACT_JSON" == "true" ]]; then
     RAW_RETURN_DATA=$(extractJsonFromForgeOutput "$RAW_RETURN_DATA")
@@ -5046,9 +5075,10 @@ function executeAndCapture() {
   local JSON_RESULT
   JSON_RESULT=$(jq -n \
     --rawfile stdout "$STDOUT_LOG" \
+    --rawfile stdoutRaw "$STDOUT_RAW_LOG" \
     --rawfile stderr "$STDERR_LOG" \
     --argjson returnCode "$RETURN_CODE" \
-    '{stdout: $stdout, stderr: $stderr, returnCode: $returnCode}')
+    '{stdout: $stdout, stdoutRaw: $stdoutRaw, stderr: $stderr, returnCode: $returnCode}')
 
   # Explicit cleanup + restore previous EXIT trap
   rm -f "$STDOUT_LOG" "$STDERR_LOG" 2>/dev/null
@@ -5091,10 +5121,11 @@ function parseExecuteCommandResult() {
 
   # Parse JSON result and merge into single object using jq
   local PARSED
-  PARSED=$(echo "$RESULT" | jq -c '{stdout: .stdout, stderr: .stderr, returnCode: .returnCode}')
+  PARSED=$(echo "$RESULT" | jq -c '{stdout: .stdout, stdoutRaw: .stdoutRaw, stderr: .stderr, returnCode: .returnCode}')
 
   # Extract and set variables from merged JSON object
   RAW_RETURN_DATA=$(echo "$PARSED" | jq -r '.stdout')
+  RAW_STDOUT_FULL=$(echo "$PARSED" | jq -r '.stdoutRaw // ""')
   STDERR_CONTENT=$(echo "$PARSED" | jq -r '.stderr')
   RETURN_CODE=$(echo "$PARSED" | jq -r '.returnCode')
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -10,6 +10,13 @@
 # to this file read so later `source`d scripts do not export unrelated locals by default.
 set -a
 source .env
+
+# Every script that re-sources this file re-reads .env, which would snap a failed-over
+# endpoint back to the one already proven inadequate. Re-applying the overrides here
+# keeps a switch made during deployment effective for the diamondCut that follows.
+if [[ -n "${LIFI_RPC_OVERRIDE_FILE:-}" && -f "${LIFI_RPC_OVERRIDE_FILE:-}" ]]; then
+  source "$LIFI_RPC_OVERRIDE_FILE"
+fi
 set +a
 
 NETWORKS_JSON_FILE_PATH="config/networks.json"
@@ -3945,16 +3952,18 @@ function tryRpcFailover() {
   local RPC_KEY
   RPC_KEY=$(getRPCEnvVarName "$NETWORK")
 
-  # Exclusions accumulate for as long as we stay on one network. Excluding only the
-  # current endpoint would let two bad ones be picked alternately until the retry
-  # budget is gone.
-  if [[ "${RPC_FAILOVER_NETWORK:-}" != "$NETWORK" ]]; then
-    RPC_FAILOVER_NETWORK="$NETWORK"
-    RPC_FAILOVER_EXCLUDED=""
+  # Exclusions accumulate per network, so returning to a network later in the same
+  # shell still remembers what already failed there. Excluding only the current
+  # endpoint would let two bad ones be picked alternately until the retry budget is
+  # gone; sharing one list across networks would exclude another chain's endpoints.
+  local EXCLUDED_KEY="RPC_FAILOVER_EXCLUDED_${RPC_KEY}"
+  local EXCLUDED="${!EXCLUDED_KEY:-}"
+  local CURRENT="${!RPC_KEY:-}"
+  if [[ -n "$CURRENT" ]] && ! printf '%s\n' "$EXCLUDED" | grep -qxF "$CURRENT"; then
+    EXCLUDED="${EXCLUDED:+${EXCLUDED}$'\n'}${CURRENT}"
+    printf -v "$EXCLUDED_KEY" '%s' "$EXCLUDED"
   fi
-  if [[ -n "${!RPC_KEY:-}" ]]; then
-    RPC_FAILOVER_EXCLUDED="${RPC_FAILOVER_EXCLUDED:+${RPC_FAILOVER_EXCLUDED}$'\n'}${!RPC_KEY}"
-  fi
+  local RPC_FAILOVER_EXCLUDED="$EXCLUDED"
 
   local NEW_RPC_URL RESOLVER_EXIT=0
   NEW_RPC_URL=$(printf '%s' "$FORGE_OUTPUT" |
@@ -3976,6 +3985,17 @@ function tryRpcFailover() {
   fi
 
   export "$RPC_KEY=$NEW_RPC_URL"
+
+  # Persist for scripts sourced later in the rollout (diamondUpdateFacet and friends),
+  # which re-read .env on entry. Owner-only: the value is a credential.
+  if [[ -z "${LIFI_RPC_OVERRIDE_FILE:-}" ]]; then
+    LIFI_RPC_OVERRIDE_FILE="$(mktemp -t lifi-rpc-override)"
+    export LIFI_RPC_OVERRIDE_FILE
+  fi
+  chmod 600 "$LIFI_RPC_OVERRIDE_FILE" 2>/dev/null || true
+  grep -v "^${RPC_KEY}=" "$LIFI_RPC_OVERRIDE_FILE" > "${LIFI_RPC_OVERRIDE_FILE}.tmp" 2>/dev/null || true
+  mv "${LIFI_RPC_OVERRIDE_FILE}.tmp" "$LIFI_RPC_OVERRIDE_FILE" 2>/dev/null || true
+  printf '%s=%q\n' "$RPC_KEY" "$NEW_RPC_URL" >> "$LIFI_RPC_OVERRIDE_FILE"
 
   # A MongoDB-sourced endpoint was never seen by the workflow's ::add-mask:: sweep over
   # the .env keys, and forge quotes the full URL in transport errors.
@@ -5081,7 +5101,7 @@ function executeAndCapture() {
     '{stdout: $stdout, stdoutRaw: $stdoutRaw, stderr: $stderr, returnCode: $returnCode}')
 
   # Explicit cleanup + restore previous EXIT trap
-  rm -f "$STDOUT_LOG" "$STDERR_LOG" 2>/dev/null
+  rm -f "$STDOUT_LOG" "$STDERR_LOG" "$STDOUT_RAW_LOG" 2>/dev/null
   if [[ -n "$_OLD_EXIT_TRAP" ]]; then
     eval "$_OLD_EXIT_TRAP"
   else

--- a/script/utils/resolveRpcUrl.test.ts
+++ b/script/utils/resolveRpcUrl.test.ts
@@ -36,8 +36,10 @@ async function runCli(
     cwd: REPO_ROOT,
     env: {
       ...process.env,
-      // Keep the run hermetic: no MongoDB lookup, no inherited endpoint config.
+      // Keep the run hermetic: no MongoDB lookup, and no exclusion list inherited from
+      // the developer's or runner's environment, which would silently change results.
       MONGODB_URI: '',
+      LIFI_RPC_EXCLUDE: '',
       ...env,
     },
     stdout: 'pipe',

--- a/script/utils/resolveRpcUrl.test.ts
+++ b/script/utils/resolveRpcUrl.test.ts
@@ -97,10 +97,12 @@ describe('resolveRpcUrl CLI', () => {
       try {
         const result = await runCli(['celo'], { ETH_NODE_URI_CELO: url })
 
+        // The guarantee is that no key-bearing URL escapes, not that a diagnostic was
+        // emitted: consola's level varies with the environment, so asserting the
+        // presence of a log line would make this test report on the runner instead.
         expect(result.stderr).not.toContain('secret-api-key')
         expect(result.stderr).not.toMatch(URL_WITH_PATH_OR_QUERY)
-        // The redacted form is expected and allowed.
-        expect(result.stderr).toContain(server.url.origin)
+        expect(result.stdout).toBe(url)
       } finally {
         server.stop(true)
       }

--- a/script/utils/resolveRpcUrl.test.ts
+++ b/script/utils/resolveRpcUrl.test.ts
@@ -138,10 +138,11 @@ describe('resolveRpcUrl CLI', () => {
   )
 
   it(
-    'skips an excluded endpoint',
+    'skips an endpoint excluded via the environment',
     async () => {
       const server = healthyServer()
-      const url = `${server.url.origin}/only-candidate`
+      // A comma in the query string would be shredded by a comma-separated list.
+      const url = `${server.url.origin}/only-candidate?methods=eth_call,eth_getLogs`
       try {
         const result = await runCli(['definitelynotanetwork'], {
           ETH_NODE_URI_DEFINITELYNOTANETWORK: url,

--- a/script/utils/resolveRpcUrl.test.ts
+++ b/script/utils/resolveRpcUrl.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Contract tests for the `resolveRpcUrl` CLI.
+ *
+ * Bash callers capture stdout with a command substitution, so the guarantees under test
+ * are: stdout carries the URL and nothing else, diagnostics stay on stderr with no
+ * secret in them, and a failure exits non-zero instead of printing a broken URL.
+ *
+ * The CLI is spawned as a subprocess because those guarantees are properties of the
+ * process, not of a function. MongoDB is disabled via an empty `MONGODB_URI` so no test
+ * touches the network beyond loopback.
+ */
+
+import { join } from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved, import/order
+} from 'bun:test'
+
+const CLI_PATH = join(import.meta.dir, 'resolveRpcUrl.ts')
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+
+interface ICliResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+async function runCli(
+  args: string[],
+  env: Record<string, string>
+): Promise<ICliResult> {
+  const proc = Bun.spawn(['bunx', 'tsx', CLI_PATH, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      // Keep the run hermetic: no MongoDB lookup, no inherited endpoint config.
+      MONGODB_URI: '',
+      ...env,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+/** Matches a URL that exposes more than scheme+host, i.e. a path or query that can hold an API key. */
+const URL_WITH_PATH_OR_QUERY = /https?:\/\/[^\s'"]+[/?][^\s'"]+/
+
+const healthyServer = () =>
+  Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const body = (await req.json()) as { method: string; id: number }
+      const result =
+        body.method === 'eth_getBlockByNumber'
+          ? { baseFeePerGas: '0x1', mixHash: '0x0', number: '0x1' }
+          : body.method === 'eth_feeHistory'
+          ? { baseFeePerGas: ['0x1'] }
+          : '0x1'
+      return Response.json({ jsonrpc: '2.0', id: body.id, result })
+    },
+  })
+
+describe('resolveRpcUrl CLI', () => {
+  it(
+    'prints the resolved URL on stdout and nothing else',
+    async () => {
+      const server = healthyServer()
+      // A key with a path segment: if the CLI ever echoes the URL to stderr, the
+      // secret-guard assertion below catches it.
+      const url = `${server.url.origin}/secret-api-key`
+      try {
+        const result = await runCli(['celo'], { ETH_NODE_URI_CELO: url })
+
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBe(url)
+      } finally {
+        server.stop(true)
+      }
+    },
+    { timeout: 30_000 }
+  )
+
+  it(
+    'never writes a full RPC URL to stderr',
+    async () => {
+      const server = healthyServer()
+      const url = `${server.url.origin}/secret-api-key`
+      try {
+        const result = await runCli(['celo'], { ETH_NODE_URI_CELO: url })
+
+        expect(result.stderr).not.toContain('secret-api-key')
+        expect(result.stderr).not.toMatch(URL_WITH_PATH_OR_QUERY)
+        // The redacted form is expected and allowed.
+        expect(result.stderr).toContain(server.url.origin)
+      } finally {
+        server.stop(true)
+      }
+    },
+    { timeout: 30_000 }
+  )
+
+  it(
+    'exits non-zero with empty stdout when the only endpoint is dead',
+    async () => {
+      // An unknown network has no networks.json entry, so the dead env var is the
+      // only candidate and the failure path is unambiguous.
+      const result = await runCli(['definitelynotanetwork'], {
+        ETH_NODE_URI_DEFINITELYNOTANETWORK: 'http://127.0.0.1:1/dead',
+      })
+
+      expect(result.exitCode).not.toBe(0)
+      // stdout must stay empty so a bash command substitution yields "" and the
+      // caller's error path runs, rather than a broken URL being used.
+      expect(result.stdout).toBe('')
+    },
+    { timeout: 30_000 }
+  )
+
+  it(
+    'exits non-zero for a network with no configured endpoint at all',
+    async () => {
+      const result = await runCli(['definitelynotanetwork'], {})
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toContain('no usable RPC endpoint')
+    },
+    { timeout: 30_000 }
+  )
+
+  it(
+    'skips an excluded endpoint',
+    async () => {
+      const server = healthyServer()
+      const url = `${server.url.origin}/only-candidate`
+      try {
+        const result = await runCli(['definitelynotanetwork'], {
+          ETH_NODE_URI_DEFINITELYNOTANETWORK: url,
+          LIFI_RPC_EXCLUDE: url,
+        })
+
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stdout).toBe('')
+      } finally {
+        server.stop(true)
+      }
+    },
+    { timeout: 30_000 }
+  )
+
+  it(
+    'resolves the excluded endpoint when it is not excluded (control for the test above)',
+    async () => {
+      const server = healthyServer()
+      const url = `${server.url.origin}/only-candidate`
+      try {
+        const result = await runCli(['definitelynotanetwork'], {
+          ETH_NODE_URI_DEFINITELYNOTANETWORK: url,
+        })
+
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBe(url)
+      } finally {
+        server.stop(true)
+      }
+    },
+    { timeout: 30_000 }
+  )
+})

--- a/script/utils/resolveRpcUrl.ts
+++ b/script/utils/resolveRpcUrl.ts
@@ -81,7 +81,9 @@ async function fetchMongoRpcs(network: string): Promise<IMongoRpc[]> {
     const doc = await client
       .db('blockchain-configs')
       .collection('RpcEndpoints')
-      .findOne({ chainName: network })
+      // Connect and server-selection timeouts do not bound the query itself; without
+      // this an established but unresponsive server would stall the deploy indefinitely.
+      .findOne({ chainName: network }, { timeoutMS: MONGO_TIMEOUT_MS })
 
     if (!doc || !Array.isArray(doc.rpcs)) return []
 

--- a/script/utils/resolveRpcUrl.ts
+++ b/script/utils/resolveRpcUrl.ts
@@ -162,10 +162,24 @@ const main = defineCommand({
       process.exit(1)
     }
 
+    // Capabilities are reported because a chain-wide gap explains a deploy failure that
+    // no further failover can fix: no candidate serving eth_feeHistory, or none with a
+    // 1559-deserializable block, means the chain needs legacy transactions.
+    const missing = (
+      ['feeHistory', 'eip1559Block', 'gasPrice'] as const
+    ).filter((capability) => !selection.capabilities[capability])
+    const chainWide = missing.filter(
+      (capability) => !selection.chainCapabilities[capability]
+    )
+
     logger.info(
       `resolved RPC for '${network}': ${redactRpcUrl(selection.url)} (source: ${
         selection.source
-      })`
+      })${missing.length ? `; endpoint lacks ${missing.join(', ')}` : ''}${
+        chainWide.length
+          ? `; no endpoint on this chain provides ${chainWide.join(', ')}`
+          : ''
+      }`
     )
     process.stdout.write(selection.url)
   },

--- a/script/utils/resolveRpcUrl.ts
+++ b/script/utils/resolveRpcUrl.ts
@@ -18,7 +18,11 @@ import { MongoClient } from 'mongodb'
 import networksConfig from '../../config/networks.json'
 import { withSrvDnsFallback } from '../deploy/shared/mongo-srv-dns'
 
-import { redactRpcUrl, resolveEndpoint } from './rpcFailover'
+import {
+  classifyForgeFailure,
+  redactRpcUrl,
+  resolveEndpoint,
+} from './rpcFailover'
 import { getRPCEnvVarName } from './utils'
 
 config()
@@ -34,6 +38,17 @@ const MONGO_TIMEOUT_MS = 8_000 // 8 seconds; a deploy must not stall on config l
  * Entries are newline-separated because a URL query string may legally contain commas.
  */
 const EXCLUDE_ENV_VAR = 'LIFI_RPC_EXCLUDE'
+
+/** Exit code telling the caller to retry on the same endpoint rather than switch. */
+const EXIT_NO_FAILOVER = 3
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return ''
+  let text = ''
+  process.stdin.setEncoding('utf8')
+  for await (const chunk of process.stdin) text += chunk
+  return text
+}
 
 interface IMongoRpc {
   url: string
@@ -103,10 +118,28 @@ const main = defineCommand({
       description: 'Network key as used in config/networks.json',
       required: true,
     },
+    'after-failure': {
+      type: 'boolean',
+      description:
+        'Read a failed forge run from stdin and only resolve when the failure provably preceded any broadcast',
+      required: false,
+    },
   },
   async run({ args }) {
     const network = String(args.network)
     const envUrl = process.env[getRPCEnvVarName(network)]
+
+    // Forge output arrives on stdin, not as an argument: it routinely quotes the full
+    // RPC URL in transport errors, which would then be visible in the process table.
+    if (args['after-failure']) {
+      const failureClass = classifyForgeFailure(await readStdin())
+      if (failureClass !== 'preBroadcast') {
+        logger.info(
+          `not switching RPC endpoint for '${network}': failure classified as ${failureClass}, a transaction may already be in flight`
+        )
+        process.exit(EXIT_NO_FAILOVER)
+      }
+    }
     const networksJsonUrl = (
       networksConfig as Record<string, { rpcUrl?: string } | undefined>
     )[network]?.rpcUrl
@@ -115,7 +148,11 @@ const main = defineCommand({
       envUrl,
       mongoRpcs: await fetchMongoRpcs(network),
       networksJsonUrl,
-      exclude: process.env[EXCLUDE_ENV_VAR]?.split('\n')
+      exclude: [
+        ...(process.env[EXCLUDE_ENV_VAR]?.split('\n') ?? []),
+        // The endpoint that just failed must not be selected again.
+        ...(args['after-failure'] && envUrl ? [envUrl] : []),
+      ]
         .map((entry) => entry.trim())
         .filter(Boolean),
     })

--- a/script/utils/resolveRpcUrl.ts
+++ b/script/utils/resolveRpcUrl.ts
@@ -1,0 +1,134 @@
+/**
+ * CLI that prints the best usable RPC URL for a network on stdout.
+ *
+ * Called by `getRPCUrl` in `script/helperFunctions.sh` and by the deploy retry loop.
+ * Candidates are gathered from the `ETH_NODE_URI_<NETWORK>` env var, the MongoDB
+ * `RpcEndpoints` collection and `config/networks.json`, then probed and ranked by
+ * `rpcFailover.ts`.
+ *
+ * stdout carries the resolved URL and nothing else, so callers can capture it with a
+ * command substitution. Every diagnostic goes to stderr and is redacted to scheme+host.
+ */
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import { config } from 'dotenv'
+import { MongoClient } from 'mongodb'
+
+import networksConfig from '../../config/networks.json'
+import { withSrvDnsFallback } from '../deploy/shared/mongo-srv-dns'
+
+import { redactRpcUrl, resolveEndpoint } from './rpcFailover'
+import { getRPCEnvVarName } from './utils'
+
+config()
+
+// Diagnostics must not pollute stdout: the caller reads stdout as the resolved URL.
+const logger = consola.create({ stdout: process.stderr })
+
+const MONGO_TIMEOUT_MS = 8_000 // 8 seconds; a deploy must not stall on config lookup
+
+/**
+ * Endpoints to skip arrive through the environment rather than a CLI flag: an RPC URL
+ * passed as an argument is visible in the process table to every user on the machine.
+ */
+const EXCLUDE_ENV_VAR = 'LIFI_RPC_EXCLUDE'
+
+interface IMongoRpc {
+  url: string
+  priority: number
+}
+
+/**
+ * Reads the alternative endpoints recorded for a network.
+ *
+ * `isActive` is deliberately not used as a filter: it is unset on every document in the
+ * collection, so filtering on it would discard all endpoints.
+ *
+ * @param network - Network key as used in `config/networks.json`
+ * @returns Endpoints for the network, or an empty array when MongoDB is unreachable or
+ *   has no document for it. Never throws — a config lookup must not break a deploy.
+ */
+async function fetchMongoRpcs(network: string): Promise<IMongoRpc[]> {
+  const uri = process.env.MONGODB_URI
+  if (!uri) {
+    logger.debug('MONGODB_URI is not set; skipping MongoDB endpoints')
+    return []
+  }
+
+  const client = new MongoClient(uri, {
+    serverSelectionTimeoutMS: MONGO_TIMEOUT_MS,
+    connectTimeoutMS: MONGO_TIMEOUT_MS,
+  })
+  try {
+    await withSrvDnsFallback(() => client.connect())
+    const doc = await client
+      .db('blockchain-configs')
+      .collection('RpcEndpoints')
+      .findOne({ chainName: network })
+
+    if (!doc || !Array.isArray(doc.rpcs)) return []
+
+    return doc.rpcs
+      .filter(
+        (entry: unknown): entry is IMongoRpc =>
+          typeof entry === 'object' &&
+          entry !== null &&
+          typeof (entry as IMongoRpc).url === 'string'
+      )
+      .map((entry) => ({
+        url: entry.url,
+        priority: Number.isFinite(entry.priority) ? entry.priority : 0,
+      }))
+  } catch {
+    // The error text can quote the connection string, so it is never logged.
+    logger.warn(
+      'could not read RPC endpoints from MongoDB; using local sources'
+    )
+    return []
+  } finally {
+    await client.close().catch(() => undefined)
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'resolveRpcUrl',
+    description: 'Print the best usable RPC URL for a network',
+  },
+  args: {
+    network: {
+      type: 'positional',
+      description: 'Network key as used in config/networks.json',
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const network = String(args.network)
+    const envUrl = process.env[getRPCEnvVarName(network)]
+    const networksJsonUrl = (
+      networksConfig as Record<string, { rpcUrl?: string } | undefined>
+    )[network]?.rpcUrl
+
+    const selection = await resolveEndpoint({
+      envUrl,
+      mongoRpcs: await fetchMongoRpcs(network),
+      networksJsonUrl,
+      exclude: process.env[EXCLUDE_ENV_VAR]?.split(',').filter(Boolean),
+    })
+
+    if (!selection) {
+      logger.error(`no usable RPC endpoint found for network '${network}'`)
+      process.exit(1)
+    }
+
+    logger.info(
+      `resolved RPC for '${network}': ${redactRpcUrl(selection.url)} (source: ${
+        selection.source
+      })`
+    )
+    process.stdout.write(selection.url)
+  },
+})
+
+void runMain(main)

--- a/script/utils/resolveRpcUrl.ts
+++ b/script/utils/resolveRpcUrl.ts
@@ -31,6 +31,7 @@ const MONGO_TIMEOUT_MS = 8_000 // 8 seconds; a deploy must not stall on config l
 /**
  * Endpoints to skip arrive through the environment rather than a CLI flag: an RPC URL
  * passed as an argument is visible in the process table to every user on the machine.
+ * Entries are newline-separated because a URL query string may legally contain commas.
  */
 const EXCLUDE_ENV_VAR = 'LIFI_RPC_EXCLUDE'
 
@@ -114,7 +115,9 @@ const main = defineCommand({
       envUrl,
       mongoRpcs: await fetchMongoRpcs(network),
       networksJsonUrl,
-      exclude: process.env[EXCLUDE_ENV_VAR]?.split(',').filter(Boolean),
+      exclude: process.env[EXCLUDE_ENV_VAR]?.split('\n')
+        .map((entry) => entry.trim())
+        .filter(Boolean),
     })
 
     if (!selection) {

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the capability-aware RPC endpoint resolver.
+ *
+ * Covers candidate collection and deduplication, endpoint probing, ranking, and the
+ * classification that decides whether a failed deploy may switch endpoints at all.
+ */
+
 import {
   describe,
   expect,
@@ -5,6 +12,7 @@ import {
   // eslint-disable-next-line import/no-unresolved, import/order
 } from 'bun:test'
 
+import { sleep } from './delay'
 import {
   classifyForgeFailure,
   collectCandidates,
@@ -314,8 +322,7 @@ describe('classifyForgeFailure', () => {
   })
 
   // A transaction that reached the mempool must pin the endpoint regardless of what
-  // else the output says: switching backends mid-sequence is what produced the
-  // moonbeam -32603 stall during the FeeForwarder rollout.
+  // else the output says.
   it('lets post-broadcast win when both signatures are present', () => {
     const mixed = 'missing field `mixHash`\nlater: already known'
     expect(classifyForgeFailure(mixed)).toBe('postBroadcast')
@@ -458,7 +465,7 @@ describe('probeRpcEndpoint', () => {
     const server = Bun.serve({
       port: 0,
       fetch: async () => {
-        await new Promise((resolve) => setTimeout(resolve, 5_000))
+        await sleep(5_000)
         return Response.json({ jsonrpc: '2.0', id: 1, result: '0x1' })
       },
     })
@@ -732,10 +739,9 @@ describe('regressions found in adversarial review', () => {
 })
 
 /**
- * Verbatim `forge script --broadcast --slow --json` output (forge 1.7.1) captured
- * against a mock node driven into each failure mode. Hand-written approximations were
- * how an earlier version of this suite came to "cover" a guard that could never fire:
- * under --json forge suppresses the progress lines those fixtures relied on.
+ * Verbatim `forge script --broadcast --slow --json` output (forge 1.7.1), captured
+ * against a mock node driven into each failure mode. Approximations are not usable
+ * here: --json suppresses the progress lines an approximation would tend to include.
  */
 const REAL_FORGE_OUTPUT = {
   // Endpoint answers everything except eth_feeHistory (the celo production symptom).

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -283,10 +283,6 @@ describe('classifyForgeFailure', () => {
       'error sending request: dns error: failed to lookup address information',
     ],
     ['timeout', 'error sending request: operation timed out'],
-    [
-      'no output',
-      'No JSON output received. This usually indicates a connection/RPC error.',
-    ],
   ])(
     'classifies %s as pre-broadcast (safe to switch endpoint)',
     (_label, output) => {
@@ -601,34 +597,6 @@ describe('resolveEndpoint (negative controls)', () => {
 })
 
 describe('regressions found in adversarial review', () => {
-  // A transport error while submitting a signed transaction is ambiguous: the node may
-  // have accepted it and only the reply was lost. Treating it as pre-broadcast would
-  // resubmit through a different backend — the exact stuck-nonce failure this module
-  // exists to prevent.
-  it.each([
-    [
-      'timeout after submission started',
-      'Sending transactions [0/1]\nError: Failed to send transaction: error sending request for url (...): operation timed out',
-    ],
-    [
-      'connection dropped while waiting for a receipt',
-      'Waiting for receipts.\nError: error sending request: Connection refused',
-    ],
-    [
-      'transport error after the run was saved',
-      'Transactions saved to: /broadcast/Deploy.s.sol/1/run-latest.json\nerror sending request',
-    ],
-    [
-      'transport error alongside a transaction hash',
-      'hash: 0x2ab1f0dbb2be3d1a94e2a4b13b52c8dcb1b8cf7a2a8f2fd50c6cd7f2ef47a9b1\nerror sending request',
-    ],
-  ])(
-    'treats a transport failure as post-broadcast when %s',
-    (_label, output) => {
-      expect(classifyForgeFailure(output)).toBe('postBroadcast')
-    }
-  )
-
   it.each([
     ['geth known transaction', 'known transaction: 0xabc'],
     ['besu uppercase code', 'TRANSACTION_ALREADY_KNOWN'],
@@ -729,25 +697,6 @@ describe('regressions found in adversarial review', () => {
     expect(best?.chainCapabilities.eip1559Block).toBe(true)
   })
 
-  it('always reports capabilities matching the selected endpoint probe', () => {
-    const candidates: IRpcCandidate[] = [
-      { url: 'https://a.example.com', source: 'env', priority: 0 },
-      { url: 'https://b.example.com', source: 'mongo', priority: 5 },
-    ]
-    const probes = [
-      probe('https://a.example.com', { feeHistory: false }),
-      probe('https://b.example.com'),
-    ]
-    const best = selectBestCandidate(candidates, probes)
-    const winnerProbe = probes.find((entry) => entry.url === best?.url)
-
-    expect(best?.capabilities).toEqual({
-      feeHistory: winnerProbe?.feeHistory as boolean,
-      eip1559Block: winnerProbe?.eip1559Block as boolean,
-      gasPrice: winnerProbe?.gasPrice as boolean,
-    })
-  })
-
   it('lets a lost gasPrice probe change the ranking outcome', () => {
     const candidates: IRpcCandidate[] = [
       { url: 'https://a.example.com', source: 'env', priority: 0 },
@@ -776,6 +725,120 @@ describe('regressions found in adversarial review', () => {
     const result = collectCandidates({
       envUrl: 'https://rpc.example.com/r?b=2&a=1',
       exclude: ['https://rpc.example.com/r?a=1&b=2'],
+    })
+
+    expect(result).toEqual([])
+  })
+})
+
+/**
+ * Verbatim `forge script --broadcast --slow --json` output (forge 1.7.1) captured
+ * against a mock node driven into each failure mode. Hand-written approximations were
+ * how an earlier version of this suite came to "cover" a guard that could never fire:
+ * under --json forge suppresses the progress lines those fixtures relied on.
+ */
+const REAL_FORGE_OUTPUT = {
+  // Endpoint answers everything except eth_feeHistory (the celo production symptom).
+  noFeeHistory:
+    'Error: Failed to get EIP-1559 fees; server returned an error response: error code -32601: the method eth_feeHistory does not exist/is not available',
+
+  // Block has no mixHash, or mixHash: null (the moonbeam / fuse / moonriver symptom).
+  noMixHash:
+    'Error: Failed to deploy script:\nEVM error; header validation error: `prevrandao` not set\n',
+
+  // Node accepted eth_sendRawTransaction, then died before replying.
+  killedDuringSend:
+    'Error: Failed to send transaction after 4 attempts Err(error sending request for url (http://127.0.0.1:8599/)\n\nContext:\n- Error #0: client error (SendRequest)\n- Error #1: connection closed before message completed)\n\nContext:\n- Error #0: client error (Connect)\n- Error #1: tcp connect error\n- Error #2: Connection refused (os error 61)\n',
+
+  // Node died while forge polled for the receipt of an accepted transaction.
+  killedDuringPoll:
+    'ERROR alloy_rpc_client::poller: failed to poll err=error sending request for url (http://127.0.0.1:8599/)\nWarning: Some transactions were discarded by the RPC node. Use `--resume` to retry these transactions.\n',
+
+  // Successful broadcast: the artifact path has no dry-run segment.
+  broadcastArtifact:
+    '{"status":"success","transactions":"/tmp/fp/broadcast/D.s.sol/42220/run-latest.json","sensitive":"/tmp/fp/cache/D.s.sol/42220/run-latest.json"}',
+
+  // Simulation only: same file name, under dry-run/. Nothing was submitted.
+  dryRunArtifact:
+    'SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet configuration(s) to the previous command.\n\nTransactions saved to: /tmp/fp/broadcast/D.s.sol/42220/dry-run/run-latest.json\n',
+}
+
+describe('classifyForgeFailure against real forge output', () => {
+  it('allows failover when the endpoint lacks eth_feeHistory', () => {
+    expect(classifyForgeFailure(REAL_FORGE_OUTPUT.noFeeHistory)).toBe(
+      'preBroadcast'
+    )
+  })
+
+  it('allows failover when the chain has no mixHash', () => {
+    expect(classifyForgeFailure(REAL_FORGE_OUTPUT.noMixHash)).toBe(
+      'preBroadcast'
+    )
+  })
+
+  // These two are the dangerous direction: the transaction may be in the mempool.
+  it('refuses failover when the node died mid-send', () => {
+    expect(classifyForgeFailure(REAL_FORGE_OUTPUT.killedDuringSend)).toBe(
+      'postBroadcast'
+    )
+  })
+
+  it('refuses failover when the node died while polling for a receipt', () => {
+    expect(classifyForgeFailure(REAL_FORGE_OUTPUT.killedDuringPoll)).toBe(
+      'postBroadcast'
+    )
+  })
+
+  it('refuses failover once a broadcast artifact has been written', () => {
+    expect(
+      classifyForgeFailure(
+        `${REAL_FORGE_OUTPUT.broadcastArtifact}\nerror sending request`
+      )
+    ).toBe('postBroadcast')
+  })
+
+  // A dry run writes the same file name under dry-run/ and submits nothing, so it must
+  // not pin the endpoint.
+  it('still allows failover after a simulation-only run', () => {
+    expect(
+      classifyForgeFailure(
+        `${REAL_FORGE_OUTPUT.dryRunArtifact}\nError: error sending request for url (x)`
+      )
+    ).toBe('preBroadcast')
+  })
+
+  it('treats a bare transport error with no broadcast marker as pre-broadcast', () => {
+    expect(
+      classifyForgeFailure(
+        'Error: error sending request for url (x)\n\nContext:\n- Error #2: Connection refused (os error 61)'
+      )
+    ).toBe('preBroadcast')
+  })
+})
+
+describe('URL normalization keeps distinct API keys distinct', () => {
+  it('does not collapse a plus-encoded key into a percent-encoded one', () => {
+    const result = collectCandidates({
+      envUrl: 'https://h.io/r?dkey=AB+CD',
+      mongoRpcs: [{ url: 'https://h.io/r?dkey=AB%20CD', priority: 1 }],
+    })
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not exclude one encoding when the other was excluded', () => {
+    const result = collectCandidates({
+      envUrl: 'https://h.io/r?dkey=AB+CD',
+      exclude: ['https://h.io/r?dkey=AB%20CD'],
+    })
+
+    expect(result).toHaveLength(1)
+  })
+
+  it('still treats a reordered query as the same endpoint', () => {
+    const result = collectCandidates({
+      envUrl: 'https://h.io/r?b=2&a=1',
+      exclude: ['https://h.io/r?a=1&b=2'],
     })
 
     expect(result).toEqual([])

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -1,0 +1,588 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved, import/order
+} from 'bun:test'
+
+import {
+  classifyForgeFailure,
+  collectCandidates,
+  probeRpcEndpoint,
+  redactRpcUrl,
+  selectBestCandidate,
+  type IRpcCandidate,
+  resolveEndpoint,
+  type IRpcProbe,
+} from './rpcFailover'
+
+const probe = (url: string, over: Partial<IRpcProbe> = {}): IRpcProbe => ({
+  url,
+  live: true,
+  feeHistory: true,
+  eip1559Block: true,
+  gasPrice: true,
+  ...over,
+})
+
+describe('redactRpcUrl', () => {
+  it('keeps only scheme and host so API keys in the path never surface', () => {
+    expect(
+      redactRpcUrl('https://lb.drpc.org/ogrpc?network=celo&dkey=SECRET')
+    ).toBe('https://lb.drpc.org')
+    expect(redactRpcUrl('https://eth.example.com/v2/abc123def')).toBe(
+      'https://eth.example.com'
+    )
+  })
+
+  it('preserves a non-default port because it identifies the endpoint', () => {
+    expect(redactRpcUrl('http://127.0.0.1:8545/key')).toBe(
+      'http://127.0.0.1:8545'
+    )
+  })
+
+  it('never echoes the input when it cannot be parsed', () => {
+    expect(redactRpcUrl('not a url at all')).toBe('<unparseable-url>')
+  })
+
+  it('redacts basic-auth credentials embedded in the authority', () => {
+    expect(redactRpcUrl('https://user:pass@rpc.example.com/path')).toBe(
+      'https://rpc.example.com'
+    )
+  })
+})
+
+describe('collectCandidates', () => {
+  it('unions env, mongo and networks.json in trust order', () => {
+    const result = collectCandidates({
+      envUrl: 'https://env.example.com',
+      mongoRpcs: [
+        { url: 'https://low.example.com', priority: 1 },
+        { url: 'https://high.example.com', priority: 9 },
+      ],
+      networksJsonUrl: 'https://njson.example.com',
+    })
+
+    expect(result.map((c) => c.url)).toEqual([
+      'https://env.example.com',
+      'https://high.example.com',
+      'https://low.example.com',
+      'https://njson.example.com',
+    ])
+    expect(result.map((c) => c.source)).toEqual([
+      'env',
+      'mongo',
+      'mongo',
+      'networksJson',
+    ])
+  })
+
+  it('deduplicates the same endpoint across sources, keeping the most trusted', () => {
+    const result = collectCandidates({
+      envUrl: 'https://same.example.com',
+      mongoRpcs: [{ url: 'https://same.example.com/', priority: 5 }],
+      networksJsonUrl: 'https://same.example.com',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.source).toBe('env')
+  })
+
+  it('treats host case and trailing slashes as the same endpoint', () => {
+    const result = collectCandidates({
+      envUrl: 'https://Same.Example.com/',
+      mongoRpcs: [{ url: 'https://same.example.com', priority: 5 }],
+    })
+
+    expect(result).toHaveLength(1)
+  })
+
+  it('drops excluded endpoints so a failed one is never retried', () => {
+    const result = collectCandidates({
+      envUrl: 'https://broken.example.com',
+      mongoRpcs: [{ url: 'https://good.example.com', priority: 1 }],
+      exclude: ['https://broken.example.com'],
+    })
+
+    expect(result.map((c) => c.url)).toEqual(['https://good.example.com'])
+  })
+
+  it('matches exclusions using the same normalization as dedup', () => {
+    const result = collectCandidates({
+      mongoRpcs: [{ url: 'https://Broken.example.com/', priority: 1 }],
+      exclude: ['https://broken.example.com'],
+    })
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('ignores empty or malformed sources rather than throwing', () => {
+    const result = collectCandidates({
+      envUrl: '',
+      mongoRpcs: [{ url: 'not-a-url', priority: 1 }],
+      networksJsonUrl: undefined,
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('ignores non-http schemes', () => {
+    const result = collectCandidates({ envUrl: 'ws://rpc.example.com' })
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('selectBestCandidate', () => {
+  const candidates: IRpcCandidate[] = [
+    { url: 'https://a.example.com', source: 'env', priority: 0 },
+    { url: 'https://b.example.com', source: 'mongo', priority: 5 },
+    { url: 'https://c.example.com', source: 'networksJson', priority: 0 },
+  ]
+
+  it('rejects a dead endpoint even when it is the most trusted', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { live: false }),
+      probe('https://b.example.com'),
+      probe('https://c.example.com'),
+    ])
+
+    expect(best?.url).toBe('https://b.example.com')
+  })
+
+  it('prefers more capabilities over more trust (the celo case)', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { feeHistory: false }),
+      probe('https://b.example.com', { feeHistory: false }),
+      probe('https://c.example.com'),
+    ])
+
+    expect(best?.url).toBe('https://c.example.com')
+    expect(best?.source).toBe('networksJson')
+  })
+
+  it('falls back to trust then priority when capabilities tie', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com'),
+      probe('https://b.example.com'),
+      probe('https://c.example.com'),
+    ])
+
+    expect(best?.url).toBe('https://a.example.com')
+  })
+
+  it('orders equally-capable mongo endpoints by descending priority', () => {
+    const mongoOnly: IRpcCandidate[] = [
+      { url: 'https://low.example.com', source: 'mongo', priority: 1 },
+      { url: 'https://high.example.com', source: 'mongo', priority: 9 },
+    ]
+    const best = selectBestCandidate(mongoOnly, [
+      probe('https://low.example.com'),
+      probe('https://high.example.com'),
+    ])
+
+    expect(best?.url).toBe('https://high.example.com')
+  })
+
+  // The moonbeam/fuse case: mixHash is absent chain-wide, so requiring it would
+  // reject every candidate and hard-fail a chain that deploys fine with --legacy.
+  it('still returns a live endpoint when NO candidate has a capability', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { eip1559Block: false }),
+      probe('https://b.example.com', { eip1559Block: false }),
+      probe('https://c.example.com', { eip1559Block: false }),
+    ])
+
+    expect(best).not.toBeNull()
+    expect(best?.url).toBe('https://a.example.com')
+    expect(best?.chainCapabilities.eip1559Block).toBe(false)
+  })
+
+  it('reports chain capabilities as the union across candidates', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', {
+        feeHistory: false,
+        eip1559Block: false,
+      }),
+      probe('https://b.example.com', { feeHistory: true, eip1559Block: false }),
+      probe('https://c.example.com', {
+        feeHistory: false,
+        eip1559Block: false,
+      }),
+    ])
+
+    expect(best?.chainCapabilities).toEqual({
+      feeHistory: true,
+      eip1559Block: false,
+    })
+  })
+
+  it('computes the capability union from live endpoints only', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { feeHistory: false }),
+      probe('https://b.example.com', { live: false, feeHistory: true }),
+      probe('https://c.example.com', { feeHistory: false }),
+    ])
+
+    expect(best?.chainCapabilities.feeHistory).toBe(false)
+  })
+
+  it('returns null when every candidate is dead rather than a broken URL', () => {
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { live: false }),
+      probe('https://b.example.com', { live: false }),
+      probe('https://c.example.com', { live: false }),
+    ])
+
+    expect(best).toBeNull()
+  })
+
+  it('returns null for an empty candidate list', () => {
+    expect(selectBestCandidate([], [])).toBeNull()
+  })
+
+  it('ignores probes with no matching candidate', () => {
+    const best = selectBestCandidate(
+      [candidates[0] as IRpcCandidate],
+      [probe('https://a.example.com'), probe('https://orphan.example.com')]
+    )
+
+    expect(best?.url).toBe('https://a.example.com')
+  })
+})
+
+describe('classifyForgeFailure', () => {
+  it.each([
+    [
+      'missing field `mixHash`',
+      'Failed to get EIP-1559 fees; deserialization error: missing field `mixHash`',
+    ],
+    [
+      'feeHistory unsupported',
+      'server returned an error response: error code -32601: method eth_feeHistory does not exist',
+    ],
+    [
+      'connection refused',
+      'error sending request: tcp connect error: Connection refused (os error 61)',
+    ],
+    [
+      'dns failure',
+      'error sending request: dns error: failed to lookup address information',
+    ],
+    ['timeout', 'error sending request: operation timed out'],
+    [
+      'no output',
+      'No JSON output received. This usually indicates a connection/RPC error.',
+    ],
+  ])(
+    'classifies %s as pre-broadcast (safe to switch endpoint)',
+    (_label, output) => {
+      expect(classifyForgeFailure(output)).toBe('preBroadcast')
+    }
+  )
+
+  it.each([
+    [
+      'already known',
+      'server returned an error response: error code -32603: already known',
+    ],
+    ['nonce too low', 'server returned an error response: nonce too low'],
+    ['replacement underpriced', 'replacement transaction underpriced'],
+    ['already imported', 'Transaction with the same hash was already imported'],
+  ])(
+    'classifies %s as post-broadcast (never switch endpoint)',
+    (_label, output) => {
+      expect(classifyForgeFailure(output)).toBe('postBroadcast')
+    }
+  )
+
+  it('classifies an unrecognised failure as unknown', () => {
+    expect(classifyForgeFailure('EvmError: Revert')).toBe('unknown')
+  })
+
+  it('classifies empty output as unknown', () => {
+    expect(classifyForgeFailure('')).toBe('unknown')
+  })
+
+  // A transaction that reached the mempool must pin the endpoint regardless of what
+  // else the output says: switching backends mid-sequence is what produced the
+  // moonbeam -32603 stall during the FeeForwarder rollout.
+  it('lets post-broadcast win when both signatures are present', () => {
+    const mixed = 'missing field `mixHash`\nlater: already known'
+    expect(classifyForgeFailure(mixed)).toBe('postBroadcast')
+  })
+
+  it('matches case-insensitively', () => {
+    expect(classifyForgeFailure('ALREADY KNOWN')).toBe('postBroadcast')
+    expect(classifyForgeFailure('CONNECTION REFUSED')).toBe('preBroadcast')
+  })
+})
+
+describe('probeRpcEndpoint', () => {
+  const startServer = (
+    handler: (method: string) => unknown | { error: unknown }
+  ) => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const body = (await req.json()) as { method: string; id: number }
+        const outcome = handler(body.method)
+        if (outcome && typeof outcome === 'object' && 'error' in outcome)
+          return Response.json({
+            jsonrpc: '2.0',
+            id: body.id,
+            error: outcome.error,
+          })
+        return Response.json({ jsonrpc: '2.0', id: body.id, result: outcome })
+      },
+    })
+    return server
+  }
+
+  const fullBlock = {
+    baseFeePerGas: '0x1',
+    mixHash: '0x0',
+    number: '0x1',
+  }
+
+  it('reports every capability for a healthy endpoint', async () => {
+    const server = startServer((method) => {
+      if (method === 'eth_blockNumber') return '0x1'
+      if (method === 'eth_feeHistory') return { baseFeePerGas: ['0x1'] }
+      if (method === 'eth_getBlockByNumber') return fullBlock
+      return '0x1'
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result).toMatchObject({
+        live: true,
+        feeHistory: true,
+        eip1559Block: true,
+        gasPrice: true,
+      })
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // celo: answers eth_blockNumber fine but has no eth_feeHistory, which is exactly
+  // why a liveness-only health check selects a broken endpoint.
+  it('detects a live endpoint that lacks eth_feeHistory', async () => {
+    const server = startServer((method) => {
+      if (method === 'eth_feeHistory')
+        return { error: { code: -32601, message: 'method not found' } }
+      if (method === 'eth_getBlockByNumber') return fullBlock
+      return '0x1'
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result.live).toBe(true)
+      expect(result.feeHistory).toBe(false)
+      expect(result.eip1559Block).toBe(true)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // moonbeam/fuse: baseFeePerGas present, mixHash absent.
+  it('detects a block that forge cannot deserialize as EIP-1559', async () => {
+    const server = startServer((method) => {
+      if (method === 'eth_getBlockByNumber')
+        return { baseFeePerGas: '0x1', number: '0x1' }
+      if (method === 'eth_feeHistory') return { baseFeePerGas: ['0x1'] }
+      return '0x1'
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result.live).toBe(true)
+      expect(result.eip1559Block).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('marks an endpoint dead when it is unreachable', async () => {
+    const result = await probeRpcEndpoint('http://127.0.0.1:1/', 500)
+    expect(result.live).toBe(false)
+    expect(result.feeHistory).toBe(false)
+  })
+
+  it('marks an endpoint dead on a non-2xx response', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => new Response('nope', { status: 503 }),
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result.live).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('marks an endpoint dead when eth_blockNumber errors', async () => {
+    const server = startServer(() => ({
+      error: { code: -32000, message: 'unsupported' },
+    }))
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result.live).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('survives a malformed JSON response instead of throwing', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => new Response('<html>not json</html>', { status: 200 }),
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href)
+      expect(result.live).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('times out a hanging endpoint rather than blocking the run', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5_000))
+        return Response.json({ jsonrpc: '2.0', id: 1, result: '0x1' })
+      },
+    })
+    try {
+      const started = Date.now()
+      const result = await probeRpcEndpoint(server.url.href, 300)
+      expect(result.live).toBe(false)
+      expect(Date.now() - started).toBeLessThan(3_000)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // The probe result is a fixed set of booleans plus the URL it belongs to. Carrying a
+  // free-form error string would let a transport error quoting the full URL (forge does
+  // exactly this) escape into logs downstream.
+  it('exposes no free-form error text that could carry the URL into logs', async () => {
+    const result = await probeRpcEndpoint('http://127.0.0.1:1/secret-key', 300)
+
+    expect(Object.keys(result).sort()).toEqual([
+      'eip1559Block',
+      'feeHistory',
+      'gasPrice',
+      'live',
+      'url',
+    ])
+    expect(Object.entries(result).filter(([key]) => key !== 'url')).toEqual([
+      ['live', false],
+      ['feeHistory', false],
+      ['eip1559Block', false],
+      ['gasPrice', false],
+    ])
+  })
+})
+
+describe('resolveEndpoint (negative controls)', () => {
+  const healthyServer = () =>
+    Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const body = (await req.json()) as { method: string; id: number }
+        const result =
+          body.method === 'eth_getBlockByNumber'
+            ? { baseFeePerGas: '0x1', mixHash: '0x0', number: '0x1' }
+            : body.method === 'eth_feeHistory'
+            ? { baseFeePerGas: ['0x1'] }
+            : '0x1'
+        return Response.json({ jsonrpc: '2.0', id: body.id, result })
+      },
+    })
+
+  // Guards the whole point of the feature: if failover silently does nothing, the
+  // resolver returns the dead primary and this fails.
+  it('recovers via an alternative when the primary endpoint is dead', async () => {
+    const server = healthyServer()
+    const deadPrimary = 'http://127.0.0.1:1/dead'
+    try {
+      const selection = await resolveEndpoint({
+        envUrl: deadPrimary,
+        mongoRpcs: [{ url: server.url.href, priority: 5 }],
+        timeoutMs: 500,
+      })
+
+      expect(selection).not.toBeNull()
+      expect(selection?.url).not.toBe(deadPrimary)
+      expect(selection?.url).toBe(server.url.href)
+      expect(selection?.source).toBe('mongo')
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // The celo case end-to-end: the primary is live but cannot serve eth_feeHistory.
+  it('switches away from a live endpoint that lacks a capability an alternative has', async () => {
+    const good = healthyServer()
+    const noFeeHistory = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const body = (await req.json()) as { method: string; id: number }
+        if (body.method === 'eth_feeHistory')
+          return Response.json({
+            jsonrpc: '2.0',
+            id: body.id,
+            error: { code: -32601, message: 'method not found' },
+          })
+        const result =
+          body.method === 'eth_getBlockByNumber'
+            ? { baseFeePerGas: '0x1', mixHash: '0x0', number: '0x1' }
+            : '0x1'
+        return Response.json({ jsonrpc: '2.0', id: body.id, result })
+      },
+    })
+    try {
+      const selection = await resolveEndpoint({
+        envUrl: noFeeHistory.url.href,
+        mongoRpcs: [{ url: good.url.href, priority: 1 }],
+        timeoutMs: 1_000,
+      })
+
+      expect(selection?.url).toBe(good.url.href)
+      expect(selection?.chainCapabilities.feeHistory).toBe(true)
+    } finally {
+      good.stop(true)
+      noFeeHistory.stop(true)
+    }
+  })
+
+  it('returns null rather than a broken URL when every candidate is dead', async () => {
+    const selection = await resolveEndpoint({
+      envUrl: 'http://127.0.0.1:1/dead-a',
+      mongoRpcs: [{ url: 'http://127.0.0.1:2/dead-b', priority: 1 }],
+      timeoutMs: 300,
+    })
+
+    expect(selection).toBeNull()
+  })
+
+  it('returns null when there are no candidates at all', async () => {
+    expect(await resolveEndpoint({})).toBeNull()
+  })
+
+  it('does not return an endpoint that was excluded, even if it is the only live one', async () => {
+    const server = healthyServer()
+    try {
+      const selection = await resolveEndpoint({
+        envUrl: server.url.href,
+        exclude: [server.url.href],
+        timeoutMs: 500,
+      })
+
+      expect(selection).toBeNull()
+    } finally {
+      server.stop(true)
+    }
+  })
+})

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -807,6 +807,14 @@ describe('classifyForgeFailure against real forge output', () => {
     ).toBe('preBroadcast')
   })
 
+  // A checkout under a directory called dry-run must not hide a real broadcast.
+  it('still refuses failover when the repo path contains a dry-run directory', () => {
+    const output =
+      '{"status":"success","transactions":"/Users/x/dry-run/fp/broadcast/D.s.sol/42220/run-latest.json"}\nerror sending request'
+
+    expect(classifyForgeFailure(output)).toBe('postBroadcast')
+  })
+
   it('treats a bare transport error with no broadcast marker as pre-broadcast', () => {
     expect(
       classifyForgeFailure(

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -337,7 +337,7 @@ describe('classifyForgeFailure', () => {
 describe('probeRpcEndpoint', () => {
   const startServer = (
     handler: (method: string) => unknown | { error: unknown }
-  ) => {
+  ): ReturnType<typeof Bun.serve> => {
     const server = Bun.serve({
       port: 0,
       fetch: async (req) => {
@@ -502,7 +502,7 @@ describe('probeRpcEndpoint', () => {
 })
 
 describe('resolveEndpoint (negative controls)', () => {
-  const healthyServer = () =>
+  const healthyServer = (): ReturnType<typeof Bun.serve> =>
     Bun.serve({
       port: 0,
       fetch: async (req) => {

--- a/script/utils/rpcFailover.test.ts
+++ b/script/utils/rpcFailover.test.ts
@@ -16,6 +16,18 @@ import {
   type IRpcProbe,
 } from './rpcFailover'
 
+/**
+ * Returns a loopback URL whose port is guaranteed closed: the server is bound (so the
+ * OS picked a free port) and then stopped. Hard-coding a "surely dead" port instead
+ * would make these tests depend on what happens to be listening on the machine.
+ */
+const closedUrl = async (path = ''): Promise<string> => {
+  const server = Bun.serve({ port: 0, fetch: () => new Response('') })
+  const url = `${server.url.origin}${path}`
+  server.stop(true)
+  return url
+}
+
 const probe = (url: string, over: Partial<IRpcProbe> = {}): IRpcProbe => ({
   url,
   live: true,
@@ -214,6 +226,7 @@ describe('selectBestCandidate', () => {
     expect(best?.chainCapabilities).toEqual({
       feeHistory: true,
       eip1559Block: false,
+      gasPrice: true,
     })
   })
 
@@ -402,7 +415,7 @@ describe('probeRpcEndpoint', () => {
   })
 
   it('marks an endpoint dead when it is unreachable', async () => {
-    const result = await probeRpcEndpoint('http://127.0.0.1:1/', 500)
+    const result = await probeRpcEndpoint(await closedUrl('/'), 500)
     expect(result.live).toBe(false)
     expect(result.feeHistory).toBe(false)
   })
@@ -467,7 +480,7 @@ describe('probeRpcEndpoint', () => {
   // free-form error string would let a transport error quoting the full URL (forge does
   // exactly this) escape into logs downstream.
   it('exposes no free-form error text that could carry the URL into logs', async () => {
-    const result = await probeRpcEndpoint('http://127.0.0.1:1/secret-key', 300)
+    const result = await probeRpcEndpoint(await closedUrl('/secret-key'), 300)
 
     expect(Object.keys(result).sort()).toEqual([
       'eip1559Block',
@@ -505,7 +518,7 @@ describe('resolveEndpoint (negative controls)', () => {
   // resolver returns the dead primary and this fails.
   it('recovers via an alternative when the primary endpoint is dead', async () => {
     const server = healthyServer()
-    const deadPrimary = 'http://127.0.0.1:1/dead'
+    const deadPrimary = await closedUrl('/dead')
     try {
       const selection = await resolveEndpoint({
         envUrl: deadPrimary,
@@ -559,8 +572,8 @@ describe('resolveEndpoint (negative controls)', () => {
 
   it('returns null rather than a broken URL when every candidate is dead', async () => {
     const selection = await resolveEndpoint({
-      envUrl: 'http://127.0.0.1:1/dead-a',
-      mongoRpcs: [{ url: 'http://127.0.0.1:2/dead-b', priority: 1 }],
+      envUrl: await closedUrl('/dead-a'),
+      mongoRpcs: [{ url: await closedUrl('/dead-b'), priority: 1 }],
       timeoutMs: 300,
     })
 
@@ -584,5 +597,187 @@ describe('resolveEndpoint (negative controls)', () => {
     } finally {
       server.stop(true)
     }
+  })
+})
+
+describe('regressions found in adversarial review', () => {
+  // A transport error while submitting a signed transaction is ambiguous: the node may
+  // have accepted it and only the reply was lost. Treating it as pre-broadcast would
+  // resubmit through a different backend — the exact stuck-nonce failure this module
+  // exists to prevent.
+  it.each([
+    [
+      'timeout after submission started',
+      'Sending transactions [0/1]\nError: Failed to send transaction: error sending request for url (...): operation timed out',
+    ],
+    [
+      'connection dropped while waiting for a receipt',
+      'Waiting for receipts.\nError: error sending request: Connection refused',
+    ],
+    [
+      'transport error after the run was saved',
+      'Transactions saved to: /broadcast/Deploy.s.sol/1/run-latest.json\nerror sending request',
+    ],
+    [
+      'transport error alongside a transaction hash',
+      'hash: 0x2ab1f0dbb2be3d1a94e2a4b13b52c8dcb1b8cf7a2a8f2fd50c6cd7f2ef47a9b1\nerror sending request',
+    ],
+  ])(
+    'treats a transport failure as post-broadcast when %s',
+    (_label, output) => {
+      expect(classifyForgeFailure(output)).toBe('postBroadcast')
+    }
+  )
+
+  it.each([
+    ['geth known transaction', 'known transaction: 0xabc'],
+    ['besu uppercase code', 'TRANSACTION_ALREADY_KNOWN'],
+    ['nonce too high', 'server returned an error response: nonce too high'],
+    ['parity old nonce', 'OldNonce'],
+    ['already in the pool', 'transaction already in the pool'],
+    ['bare underpriced', 'transaction underpriced'],
+  ])('recognises %s as post-broadcast', (_label, output) => {
+    expect(classifyForgeFailure(output)).toBe('postBroadcast')
+  })
+
+  it('lets a mempool signature outrank a transport signature in mixed output', () => {
+    expect(
+      classifyForgeFailure(
+        'error sending request for url (...)\nknown transaction: 0xabc'
+      )
+    ).toBe('postBroadcast')
+  })
+
+  it('still allows failover for a fee-estimation failure with no broadcast evidence', () => {
+    expect(
+      classifyForgeFailure(
+        'Error: Failed to get EIP-1559 fees; deserialization error: missing field `mixHash`'
+      )
+    ).toBe('preBroadcast')
+  })
+
+  // A rate limiter answering HTTP 200 with a JSON body that has neither result nor
+  // error would otherwise probe as fully capable and outrank healthy endpoints.
+  it('treats a 200 response with no result as a failed call', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: () => Response.json({ message: 'Too Many Requests' }),
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href, 1_000)
+      expect(result.live).toBe(false)
+      expect(result.feeHistory).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  it('treats a null result as a failed call', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const body = (await req.json()) as { id: number }
+        return Response.json({ jsonrpc: '2.0', id: body.id, result: null })
+      },
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href, 1_000)
+      expect(result.live).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // Present-but-null fails forge's deserialization exactly like a missing field.
+  it('does not count a null mixHash as EIP-1559 support', async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        const body = (await req.json()) as { method: string; id: number }
+        const result =
+          body.method === 'eth_getBlockByNumber'
+            ? { baseFeePerGas: '0x1', mixHash: null, number: '0x1' }
+            : '0x1'
+        return Response.json({ jsonrpc: '2.0', id: body.id, result })
+      },
+    })
+    try {
+      const result = await probeRpcEndpoint(server.url.href, 1_000)
+      expect(result.live).toBe(true)
+      expect(result.eip1559Block).toBe(false)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  // chainCapabilities is a union and may describe an endpoint that was not selected,
+  // so a caller deciding how to transact must read the winner's own capabilities.
+  it('reports the selected endpoint capabilities separately from the union', () => {
+    const candidates: IRpcCandidate[] = [
+      { url: 'https://a.example.com', source: 'env', priority: 0 },
+      { url: 'https://b.example.com', source: 'mongo', priority: 5 },
+    ]
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { eip1559Block: false, gasPrice: true }),
+      probe('https://b.example.com', { eip1559Block: true, gasPrice: false }),
+    ])
+
+    // Both score 2, so trust selects the env endpoint...
+    expect(best?.url).toBe('https://a.example.com')
+    // ...whose own block is not 1559-capable, even though the chain supports it.
+    expect(best?.capabilities.eip1559Block).toBe(false)
+    expect(best?.chainCapabilities.eip1559Block).toBe(true)
+  })
+
+  it('always reports capabilities matching the selected endpoint probe', () => {
+    const candidates: IRpcCandidate[] = [
+      { url: 'https://a.example.com', source: 'env', priority: 0 },
+      { url: 'https://b.example.com', source: 'mongo', priority: 5 },
+    ]
+    const probes = [
+      probe('https://a.example.com', { feeHistory: false }),
+      probe('https://b.example.com'),
+    ]
+    const best = selectBestCandidate(candidates, probes)
+    const winnerProbe = probes.find((entry) => entry.url === best?.url)
+
+    expect(best?.capabilities).toEqual({
+      feeHistory: winnerProbe?.feeHistory as boolean,
+      eip1559Block: winnerProbe?.eip1559Block as boolean,
+      gasPrice: winnerProbe?.gasPrice as boolean,
+    })
+  })
+
+  it('lets a lost gasPrice probe change the ranking outcome', () => {
+    const candidates: IRpcCandidate[] = [
+      { url: 'https://a.example.com', source: 'env', priority: 0 },
+      { url: 'https://b.example.com', source: 'mongo', priority: 5 },
+    ]
+    const best = selectBestCandidate(candidates, [
+      probe('https://a.example.com', { gasPrice: false }),
+      probe('https://b.example.com'),
+    ])
+
+    expect(best?.url).toBe('https://b.example.com')
+  })
+
+  // An authenticated and an anonymous URL for the same host are different endpoints;
+  // collapsing them drops the only candidate that can authenticate.
+  it('does not collapse a credentialed URL into an anonymous one', () => {
+    const result = collectCandidates({
+      envUrl: 'https://rpc.example.com/v1',
+      mongoRpcs: [{ url: 'https://user:key@rpc.example.com/v1', priority: 5 }],
+    })
+
+    expect(result).toHaveLength(2)
+  })
+
+  it('excludes an endpoint written with a different query-parameter order', () => {
+    const result = collectCandidates({
+      envUrl: 'https://rpc.example.com/r?b=2&a=1',
+      exclude: ['https://rpc.example.com/r?a=1&b=2'],
+    })
+
+    expect(result).toEqual([])
   })
 })

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -246,7 +246,8 @@ export async function probeRpcEndpoint(
 
   // A field present but null fails forge's deserialization exactly like a missing one,
   // so only a real hex string counts as support.
-  const hasHexField = (field: string) => typeof header?.[field] === 'string'
+  const hasHexField = (field: string): boolean =>
+    typeof header?.[field] === 'string'
 
   return {
     url,
@@ -297,7 +298,7 @@ export function selectBestCandidate(
 
   if (scored.length === 0) return null
 
-  const capabilityCount = (probe: IRpcProbe) =>
+  const capabilityCount = (probe: IRpcProbe): number =>
     CAPABILITY_KEYS.filter((key) => probe[key]).length
 
   const best = scored.reduce((winner, entry) => {

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -341,7 +341,11 @@ function mentionsRealBroadcastArtifact(output: string): boolean {
     let match = pattern.exec(output)
     while (match !== null) {
       const path = match[1] ?? ''
-      if (path && !path.includes('/dry-run/')) return true
+      // A dry run writes the same file name one directory deeper, under `dry-run/`.
+      // Only that final segment counts: a checkout living under some unrelated
+      // `dry-run` directory would otherwise hide a real broadcast.
+      const isDryRun = /(^|\/)dry-run\/[^/]+$/.test(path)
+      if (path && !isDryRun) return true
       match = pattern.exec(output)
     }
   }

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -1,0 +1,347 @@
+/**
+ * Capability-aware selection of an RPC endpoint from several candidate sources.
+ *
+ * Import this when a script needs to pick a usable endpoint for a network rather than
+ * trusting a single configured URL. Endpoints are ranked by the capabilities they are
+ * observed to have, so an endpoint that answers `eth_blockNumber` but cannot serve
+ * `eth_feeHistory` loses to one that can.
+ *
+ * All helpers here are transport-only and hold no network config; `resolveRpcUrl.ts`
+ * supplies the candidates and owns the MongoDB lookup.
+ */
+
+import { fetchWithTimeout } from './fetchWithTimeout'
+
+/** Where a candidate endpoint came from, in ascending order of trust. */
+export type RpcSource = 'networksJson' | 'mongo' | 'env'
+
+export interface IRpcCandidate {
+  url: string
+  source: RpcSource
+  priority: number
+}
+
+export interface IRpcProbe {
+  url: string
+  live: boolean
+  feeHistory: boolean
+  /** Block carries both `baseFeePerGas` and `mixHash`, the pair forge's 1559 path deserializes. */
+  eip1559Block: boolean
+  gasPrice: boolean
+}
+
+export interface IRpcSelection {
+  url: string
+  source: RpcSource
+  /** Union over live candidates: a capability absent here is a chain property, not a defect. */
+  chainCapabilities: { feeHistory: boolean; eip1559Block: boolean }
+}
+
+/** How a forge failure constrains endpoint switching. */
+export type ForgeFailureClass = 'preBroadcast' | 'postBroadcast' | 'unknown'
+
+const SOURCE_TRUST: Record<RpcSource, number> = {
+  env: 2,
+  mongo: 1,
+  networksJson: 0,
+}
+
+const PROBE_TIMEOUT_MS = 5_000 // 5 seconds; a candidate slower than this is not worth deploying through
+
+/**
+ * Reduces an RPC URL to scheme and host.
+ *
+ * RPC URLs embed API keys in their path or query string, so this is the only form that
+ * may be logged.
+ *
+ * @param url - Any candidate URL
+ * @returns `scheme://host[:port]`, or a placeholder when the input cannot be parsed
+ */
+export function redactRpcUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.protocol}//${parsed.host}`
+  } catch {
+    return '<unparseable-url>'
+  }
+}
+
+/**
+ * Canonical form used to decide whether two candidate URLs are the same endpoint.
+ * Returns null for anything that is not an http(s) URL.
+ */
+function normalizeUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    const path = parsed.pathname.replace(/\/+$/, '')
+    return `${parsed.protocol}//${parsed.host.toLowerCase()}${path}${
+      parsed.search
+    }`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Builds the deduplicated candidate list for a network.
+ *
+ * @param input.envUrl - Value of `ETH_NODE_URI_<NETWORK>`, if set
+ * @param input.mongoRpcs - Entries from the `RpcEndpoints` collection. `isActive` is
+ *   deliberately not consulted: it is unset on every document in the collection.
+ * @param input.networksJsonUrl - `rpcUrl` from `config/networks.json`
+ * @param input.exclude - Endpoints already known to have failed this run
+ * @returns Candidates ordered by trust, then descending priority. Unparseable and
+ *   non-http entries are dropped rather than throwing.
+ */
+export function collectCandidates(input: {
+  envUrl?: string
+  mongoRpcs?: { url: string; priority: number }[]
+  networksJsonUrl?: string
+  exclude?: string[]
+}): IRpcCandidate[] {
+  const excluded = new Set(
+    (input.exclude ?? [])
+      .map(normalizeUrl)
+      .filter((value): value is string => value !== null)
+  )
+
+  const ordered: IRpcCandidate[] = [
+    ...(input.envUrl
+      ? [{ url: input.envUrl, source: 'env' as const, priority: 0 }]
+      : []),
+    ...[...(input.mongoRpcs ?? [])]
+      .sort((a, b) => b.priority - a.priority)
+      .map((entry) => ({
+        url: entry.url,
+        source: 'mongo' as const,
+        priority: entry.priority,
+      })),
+    ...(input.networksJsonUrl
+      ? [
+          {
+            url: input.networksJsonUrl,
+            source: 'networksJson' as const,
+            priority: 0,
+          },
+        ]
+      : []),
+  ]
+
+  const seen = new Set<string>()
+  const result: IRpcCandidate[] = []
+  for (const candidate of ordered) {
+    const key = normalizeUrl(candidate.url)
+    if (key === null || excluded.has(key) || seen.has(key)) continue
+    seen.add(key)
+    result.push(candidate)
+  }
+  return result
+}
+
+interface IJsonRpcOutcome {
+  ok: boolean
+  result?: unknown
+}
+
+async function callJsonRpc(
+  url: string,
+  method: string,
+  params: unknown[],
+  timeoutMs: number
+): Promise<IJsonRpcOutcome> {
+  try {
+    const response = await fetchWithTimeout(
+      url,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+      },
+      timeoutMs
+    )
+    if (!response.ok) return { ok: false }
+    const payload = (await response.json()) as {
+      result?: unknown
+      error?: unknown
+    }
+    if (payload.error !== undefined) return { ok: false }
+    return { ok: true, result: payload.result }
+  } catch {
+    // Transport errors are swallowed on purpose: their message quotes the full URL,
+    // API key included, and must never reach a log.
+    return { ok: false }
+  }
+}
+
+/**
+ * Probes a single endpoint for the capabilities a deploy depends on.
+ *
+ * Never throws and never surfaces the transport error, which would carry the URL.
+ *
+ * @param url - Endpoint to probe
+ * @param timeoutMs - Per-call timeout; defaults to 5s
+ * @returns Capability flags. An endpoint that fails `eth_blockNumber` is reported dead
+ *   with every other capability false.
+ */
+export async function probeRpcEndpoint(
+  url: string,
+  timeoutMs: number = PROBE_TIMEOUT_MS
+): Promise<IRpcProbe> {
+  const dead: IRpcProbe = {
+    url,
+    live: false,
+    feeHistory: false,
+    eip1559Block: false,
+    gasPrice: false,
+  }
+
+  const liveness = await callJsonRpc(url, 'eth_blockNumber', [], timeoutMs)
+  if (!liveness.ok) return dead
+
+  const [feeHistory, block, gasPrice] = await Promise.all([
+    callJsonRpc(url, 'eth_feeHistory', ['0x1', 'latest', []], timeoutMs),
+    callJsonRpc(url, 'eth_getBlockByNumber', ['latest', false], timeoutMs),
+    callJsonRpc(url, 'eth_gasPrice', [], timeoutMs),
+  ])
+
+  const header = block.ok
+    ? (block.result as Record<string, unknown> | null)
+    : null
+
+  return {
+    url,
+    live: true,
+    feeHistory: feeHistory.ok,
+    eip1559Block:
+      header?.baseFeePerGas !== undefined && header?.mixHash !== undefined,
+    gasPrice: gasPrice.ok,
+  }
+}
+
+const CAPABILITY_KEYS = ['feeHistory', 'eip1559Block', 'gasPrice'] as const
+
+/**
+ * Picks the best endpoint from probed candidates.
+ *
+ * Ranking is by observed capabilities, then trust, then priority. Capabilities are
+ * compared against what the other candidates managed, never against a fixed
+ * requirement: when a whole chain lacks one (moonbeam and fuse have no `mixHash` on
+ * any endpoint), every candidate ties and selection falls through to trust — so such a
+ * chain still gets an endpoint instead of a hard failure.
+ *
+ * @param candidates - Candidates in trust order
+ * @param probes - Probe results, matched to candidates by URL
+ * @returns The winner plus the chain's capability union, or null if none is live
+ */
+export function selectBestCandidate(
+  candidates: IRpcCandidate[],
+  probes: IRpcProbe[]
+): IRpcSelection | null {
+  const probeByUrl = new Map(probes.map((probe) => [probe.url, probe]))
+
+  const scored = candidates
+    .map((candidate) => ({
+      candidate,
+      probe: probeByUrl.get(candidate.url),
+    }))
+    .filter(
+      (entry): entry is { candidate: IRpcCandidate; probe: IRpcProbe } =>
+        entry.probe !== undefined && entry.probe.live
+    )
+
+  if (scored.length === 0) return null
+
+  const capabilityCount = (probe: IRpcProbe) =>
+    CAPABILITY_KEYS.filter((key) => probe[key]).length
+
+  const best = scored.reduce((winner, entry) => {
+    const byCapability =
+      capabilityCount(entry.probe) - capabilityCount(winner.probe)
+    if (byCapability !== 0) return byCapability > 0 ? entry : winner
+
+    const byTrust =
+      SOURCE_TRUST[entry.candidate.source] -
+      SOURCE_TRUST[winner.candidate.source]
+    if (byTrust !== 0) return byTrust > 0 ? entry : winner
+
+    return entry.candidate.priority > winner.candidate.priority ? entry : winner
+  })
+
+  return {
+    url: best.candidate.url,
+    source: best.candidate.source,
+    chainCapabilities: {
+      feeHistory: scored.some((entry) => entry.probe.feeHistory),
+      eip1559Block: scored.some((entry) => entry.probe.eip1559Block),
+    },
+  }
+}
+
+// A transaction that reached the mempool pins the endpoint: a different backend has a
+// different view of it, which is how switching mid-sequence produced a stuck pending
+// nonce on moonbeam during the FeeForwarder v2.0.0 rollout.
+const POST_BROADCAST_SIGNATURES = [
+  /already known/i,
+  /nonce too low/i,
+  /replacement transaction underpriced/i,
+  /already imported/i,
+]
+
+const PRE_BROADCAST_SIGNATURES = [
+  /missing field `?mixHash`?/i,
+  /failed to get eip-?1559 fees/i,
+  /-32601/,
+  /method .* does not exist/i,
+  /method not found/i,
+  /connection refused/i,
+  /dns error/i,
+  /operation timed out/i,
+  /\btimed out\b/i,
+  /error sending request/i,
+  /no json output received/i,
+]
+
+/**
+ * Classifies a failed forge run by whether a transaction may already be in flight.
+ *
+ * @param output - Combined stderr and raw return data from the run
+ * @returns `postBroadcast` if anything suggests a transaction reached the mempool,
+ *   `preBroadcast` for a recognised connection or fee-estimation failure, otherwise
+ *   `unknown`. Callers must only switch endpoints on `preBroadcast`.
+ */
+export function classifyForgeFailure(output: string): ForgeFailureClass {
+  if (POST_BROADCAST_SIGNATURES.some((pattern) => pattern.test(output)))
+    return 'postBroadcast'
+  if (PRE_BROADCAST_SIGNATURES.some((pattern) => pattern.test(output)))
+    return 'preBroadcast'
+  return 'unknown'
+}
+
+/**
+ * Resolves the best endpoint for a network by probing all candidates concurrently.
+ *
+ * @param input.envUrl - Value of `ETH_NODE_URI_<NETWORK>`, if set
+ * @param input.mongoRpcs - Entries from the `RpcEndpoints` collection
+ * @param input.networksJsonUrl - `rpcUrl` from `config/networks.json`
+ * @param input.exclude - Endpoints already known to have failed this run
+ * @param input.timeoutMs - Per-probe timeout
+ * @returns The selected endpoint, or null when no candidate is usable
+ */
+export async function resolveEndpoint(input: {
+  envUrl?: string
+  mongoRpcs?: { url: string; priority: number }[]
+  networksJsonUrl?: string
+  exclude?: string[]
+  timeoutMs?: number
+}): Promise<IRpcSelection | null> {
+  const candidates = collectCandidates(input)
+  if (candidates.length === 0) return null
+
+  const probes = await Promise.all(
+    candidates.map((candidate) =>
+      probeRpcEndpoint(candidate.url, input.timeoutMs)
+    )
+  )
+  return selectBestCandidate(candidates, probes)
+}

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -353,10 +353,9 @@ function mentionsRealBroadcastArtifact(output: string): boolean {
 }
 
 /**
- * Evidence that forge got as far as submitting a transaction, taken from observed
- * `forge script --broadcast --slow --json` output rather than from its documentation:
- * under `--json` the human-readable progress lines are suppressed, so the markers that
- * survive are the send/poll errors and the broadcast artifact path.
+ * Evidence that forge got as far as submitting a transaction. Under `--json` the
+ * human-readable progress lines are suppressed, so the markers that survive a broadcast
+ * are the send/poll errors and the artifact path.
  *
  * Once any of these appear a transport failure is ambiguous — the node may have
  * accepted the transaction and only the response was lost — so the endpoint is pinned.
@@ -366,16 +365,15 @@ const BROADCAST_EVIDENCE = [
   /transactions were discarded by the rpc node/i,
   /failed to poll/i,
   /onchain execution complete/i,
-  // Progress lines, suppressed by --json but present on the callers that omit it.
-  // A simulation prints "SIMULATION COMPLETE" instead, so these do not match a dry run.
+  // Present only when a caller omits --json. A simulation prints "SIMULATION COMPLETE"
+  // instead, so these never match a dry run.
   /sending transactions?\b/i,
   /waiting for receipts?/i,
   /sequence #/i,
 ]
 
 // A transaction that reached the mempool pins the endpoint: a different backend has a
-// different view of it, which is how switching mid-sequence produced a stuck pending
-// nonce on moonbeam during the FeeForwarder v2.0.0 rollout.
+// different view of it, so switching mid-sequence can strand the pending nonce.
 const POST_BROADCAST_SIGNATURES = [
   /already known/i,
   /known transaction/i,
@@ -390,9 +388,9 @@ const POST_BROADCAST_SIGNATURES = [
 ]
 
 /**
- * Failures that provably precede submission. Each is a string forge was observed to
- * emit: the fee-estimation errors come from an endpoint without `eth_feeHistory`, and
- * the header-validation error from a chain whose blocks carry no `mixHash`.
+ * Failures that provably precede submission: fee estimation on an endpoint that cannot
+ * serve a fee history, and header validation on a chain whose blocks omit the field
+ * forge's EIP-1559 path requires.
  */
 const PRE_BROADCAST_SIGNATURES = [
   /failed to get eip-?1559 fees/i,

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -91,11 +91,14 @@ function normalizeUrl(url: string): string | null {
     const parsed = new URL(url)
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
 
-    const params = [...parsed.searchParams.entries()].sort(
-      ([aKey, aValue], [bKey, bValue]) =>
-        aKey.localeCompare(bKey) || aValue.localeCompare(bValue)
-    )
-    const query = params.map(([key, value]) => `${key}=${value}`).join('&')
+    // Sorted over the RAW pairs: decoding would make "AB+CD" and "AB%20CD" — two
+    // genuinely different API keys — look like the same endpoint.
+    const query = parsed.search
+      .replace(/^\?/, '')
+      .split('&')
+      .filter(Boolean)
+      .sort()
+      .join('&')
     const credentials = parsed.username
       ? `${parsed.username}:${parsed.password}@`
       : ''
@@ -323,18 +326,47 @@ export function selectBestCandidate(
 }
 
 /**
- * Evidence that forge got as far as submitting a transaction. Once any of these appear,
- * a transport failure is ambiguous — the node may have accepted the transaction and
- * only the response was lost — so the endpoint must be treated as pinned.
+ * Paths forge prints for a broadcast it actually performed. A dry run writes the same
+ * file name under a `dry-run/` directory, which is why the path is inspected rather
+ * than matched as a bare string.
+ */
+const BROADCAST_ARTIFACT_PATTERNS = [
+  /"transactions"\s*:\s*"([^"]+)"/gi,
+  /transactions saved to:\s*(\S+)/gi,
+]
+
+function mentionsRealBroadcastArtifact(output: string): boolean {
+  for (const pattern of BROADCAST_ARTIFACT_PATTERNS) {
+    pattern.lastIndex = 0
+    let match = pattern.exec(output)
+    while (match !== null) {
+      const path = match[1] ?? ''
+      if (path && !path.includes('/dry-run/')) return true
+      match = pattern.exec(output)
+    }
+  }
+  return false
+}
+
+/**
+ * Evidence that forge got as far as submitting a transaction, taken from observed
+ * `forge script --broadcast --slow --json` output rather than from its documentation:
+ * under `--json` the human-readable progress lines are suppressed, so the markers that
+ * survive are the send/poll errors and the broadcast artifact path.
+ *
+ * Once any of these appear a transport failure is ambiguous — the node may have
+ * accepted the transaction and only the response was lost — so the endpoint is pinned.
  */
 const BROADCAST_EVIDENCE = [
+  /failed to send transaction/i,
+  /transactions were discarded by the rpc node/i,
+  /failed to poll/i,
+  /onchain execution complete/i,
+  // Progress lines, suppressed by --json but present on the callers that omit it.
+  // A simulation prints "SIMULATION COMPLETE" instead, so these do not match a dry run.
   /sending transactions?\b/i,
   /waiting for receipts?/i,
-  /transactions saved to/i,
   /sequence #/i,
-  /transaction[_ ]?hash/i,
-  /pending transaction/i,
-  /\bhash:\s*0x[0-9a-f]{64}/i,
 ]
 
 // A transaction that reached the mempool pins the endpoint: a different backend has a
@@ -353,18 +385,25 @@ const POST_BROADCAST_SIGNATURES = [
   /underpriced/i,
 ]
 
+/**
+ * Failures that provably precede submission. Each is a string forge was observed to
+ * emit: the fee-estimation errors come from an endpoint without `eth_feeHistory`, and
+ * the header-validation error from a chain whose blocks carry no `mixHash`.
+ */
 const PRE_BROADCAST_SIGNATURES = [
-  /missing field `?mixHash`?/i,
   /failed to get eip-?1559 fees/i,
+  /header validation error/i,
+  /prevrandao. not set/i,
+  /failed to deploy script/i,
+  /missing field `?mixHash`?/i,
   /-32601/,
-  /method .* does not exist/i,
+  /the method .* does not exist/i,
   /method not found/i,
   /connection refused/i,
   /dns error/i,
   /operation timed out/i,
   /\btimed out\b/i,
   /error sending request/i,
-  /no json output received/i,
 ]
 
 /**
@@ -375,12 +414,14 @@ const PRE_BROADCAST_SIGNATURES = [
  * canonical ambiguous case, because the node may have accepted it and lost the reply.
  * Broadcast evidence therefore outranks every transport pattern.
  *
- * @param output - Combined stderr and raw return data from the run
+ * @param output - Combined stderr and unextracted stdout from the run. Passing forge's
+ *   JSON-extracted stdout instead would drop the broadcast markers entirely.
  * @returns `postBroadcast` if a transaction may have reached the mempool,
  *   `preBroadcast` for a recognised failure that provably precedes submission,
  *   otherwise `unknown`. Callers must only switch endpoints on `preBroadcast`.
  */
 export function classifyForgeFailure(output: string): ForgeFailureClass {
+  if (mentionsRealBroadcastArtifact(output)) return 'postBroadcast'
   if (BROADCAST_EVIDENCE.some((pattern) => pattern.test(output)))
     return 'postBroadcast'
   if (POST_BROADCAST_SIGNATURES.some((pattern) => pattern.test(output)))

--- a/script/utils/rpcFailover.ts
+++ b/script/utils/rpcFailover.ts
@@ -21,20 +21,29 @@ export interface IRpcCandidate {
   priority: number
 }
 
-export interface IRpcProbe {
-  url: string
-  live: boolean
+export interface IRpcCapabilities {
   feeHistory: boolean
   /** Block carries both `baseFeePerGas` and `mixHash`, the pair forge's 1559 path deserializes. */
   eip1559Block: boolean
   gasPrice: boolean
 }
 
+export interface IRpcProbe extends IRpcCapabilities {
+  url: string
+  live: boolean
+}
+
 export interface IRpcSelection {
   url: string
   source: RpcSource
-  /** Union over live candidates: a capability absent here is a chain property, not a defect. */
-  chainCapabilities: { feeHistory: boolean; eip1559Block: boolean }
+  /** Capabilities of the selected endpoint. Use this to decide how to transact through it. */
+  capabilities: IRpcCapabilities
+  /**
+   * Union over live candidates. A capability false here is absent chain-wide, which
+   * makes it a chain property rather than a defect of any one endpoint. Never use this
+   * to decide how to transact — it may describe an endpoint that was not selected.
+   */
+  chainCapabilities: IRpcCapabilities
 }
 
 /** How a forge failure constrains endpoint switching. */
@@ -52,7 +61,8 @@ const PROBE_TIMEOUT_MS = 5_000 // 5 seconds; a candidate slower than this is not
  * Reduces an RPC URL to scheme and host.
  *
  * RPC URLs embed API keys in their path or query string, so this is the only form that
- * may be logged.
+ * may be logged. Note the limit of that guarantee: providers that key on the hostname
+ * itself (QuickNode) still expose their endpoint identifier here.
  *
  * @param url - Any candidate URL
  * @returns `scheme://host[:port]`, or a placeholder when the input cannot be parsed
@@ -68,15 +78,33 @@ export function redactRpcUrl(url: string): string {
 
 /**
  * Canonical form used to decide whether two candidate URLs are the same endpoint.
- * Returns null for anything that is not an http(s) URL.
+ *
+ * Credentials are part of the identity: an authenticated and an anonymous URL for the
+ * same host are different endpoints, and collapsing them would drop the only candidate
+ * that can authenticate. Query parameters are sorted so that the same endpoint written
+ * with a different parameter order still matches an exclusion.
+ *
+ * @returns The canonical key, or null for anything that is not an http(s) URL
  */
 function normalizeUrl(url: string): string | null {
   try {
     const parsed = new URL(url)
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+
+    const params = [...parsed.searchParams.entries()].sort(
+      ([aKey, aValue], [bKey, bValue]) =>
+        aKey.localeCompare(bKey) || aValue.localeCompare(bValue)
+    )
+    const query = params.map(([key, value]) => `${key}=${value}`).join('&')
+    const credentials = parsed.username
+      ? `${parsed.username}:${parsed.password}@`
+      : ''
     const path = parsed.pathname.replace(/\/+$/, '')
-    return `${parsed.protocol}//${parsed.host.toLowerCase()}${path}${
-      parsed.search
+
+    return `${
+      parsed.protocol
+    }//${credentials}${parsed.host.toLowerCase()}${path}${
+      query ? `?${query}` : ''
     }`
   } catch {
     return null
@@ -165,7 +193,11 @@ async function callJsonRpc(
       result?: unknown
       error?: unknown
     }
+    // A rate limiter answering 200 with `{"message":"Too Many Requests"}` carries no
+    // error key either, so a present, non-null result is what makes a call successful.
     if (payload.error !== undefined) return { ok: false }
+    if (payload.result === undefined || payload.result === null)
+      return { ok: false }
     return { ok: true, result: payload.result }
   } catch {
     // Transport errors are swallowed on purpose: their message quotes the full URL,
@@ -209,17 +241,26 @@ export async function probeRpcEndpoint(
     ? (block.result as Record<string, unknown> | null)
     : null
 
+  // A field present but null fails forge's deserialization exactly like a missing one,
+  // so only a real hex string counts as support.
+  const hasHexField = (field: string) => typeof header?.[field] === 'string'
+
   return {
     url,
     live: true,
     feeHistory: feeHistory.ok,
-    eip1559Block:
-      header?.baseFeePerGas !== undefined && header?.mixHash !== undefined,
+    eip1559Block: hasHexField('baseFeePerGas') && hasHexField('mixHash'),
     gasPrice: gasPrice.ok,
   }
 }
 
 const CAPABILITY_KEYS = ['feeHistory', 'eip1559Block', 'gasPrice'] as const
+
+const capabilitiesOf = (probe: IRpcProbe): IRpcCapabilities => ({
+  feeHistory: probe.feeHistory,
+  eip1559Block: probe.eip1559Block,
+  gasPrice: probe.gasPrice,
+})
 
 /**
  * Picks the best endpoint from probed candidates.
@@ -232,7 +273,8 @@ const CAPABILITY_KEYS = ['feeHistory', 'eip1559Block', 'gasPrice'] as const
  *
  * @param candidates - Candidates in trust order
  * @param probes - Probe results, matched to candidates by URL
- * @returns The winner plus the chain's capability union, or null if none is live
+ * @returns The winner with its own capabilities and the chain's capability union, or
+ *   null if no candidate is live
  */
 export function selectBestCandidate(
   candidates: IRpcCandidate[],
@@ -271,21 +313,44 @@ export function selectBestCandidate(
   return {
     url: best.candidate.url,
     source: best.candidate.source,
+    capabilities: capabilitiesOf(best.probe),
     chainCapabilities: {
       feeHistory: scored.some((entry) => entry.probe.feeHistory),
       eip1559Block: scored.some((entry) => entry.probe.eip1559Block),
+      gasPrice: scored.some((entry) => entry.probe.gasPrice),
     },
   }
 }
+
+/**
+ * Evidence that forge got as far as submitting a transaction. Once any of these appear,
+ * a transport failure is ambiguous — the node may have accepted the transaction and
+ * only the response was lost — so the endpoint must be treated as pinned.
+ */
+const BROADCAST_EVIDENCE = [
+  /sending transactions?\b/i,
+  /waiting for receipts?/i,
+  /transactions saved to/i,
+  /sequence #/i,
+  /transaction[_ ]?hash/i,
+  /pending transaction/i,
+  /\bhash:\s*0x[0-9a-f]{64}/i,
+]
 
 // A transaction that reached the mempool pins the endpoint: a different backend has a
 // different view of it, which is how switching mid-sequence produced a stuck pending
 // nonce on moonbeam during the FeeForwarder v2.0.0 rollout.
 const POST_BROADCAST_SIGNATURES = [
   /already known/i,
-  /nonce too low/i,
-  /replacement transaction underpriced/i,
+  /known transaction/i,
+  /transaction_already_known/i,
+  /already in the pool/i,
+  /transaction already exists/i,
   /already imported/i,
+  /nonce too low/i,
+  /nonce too high/i,
+  /oldnonce/i,
+  /underpriced/i,
 ]
 
 const PRE_BROADCAST_SIGNATURES = [
@@ -305,12 +370,19 @@ const PRE_BROADCAST_SIGNATURES = [
 /**
  * Classifies a failed forge run by whether a transaction may already be in flight.
  *
+ * Transport failures are only safe to fail over from when nothing suggests a broadcast
+ * happened: `error sending request` while submitting a signed transaction is the
+ * canonical ambiguous case, because the node may have accepted it and lost the reply.
+ * Broadcast evidence therefore outranks every transport pattern.
+ *
  * @param output - Combined stderr and raw return data from the run
- * @returns `postBroadcast` if anything suggests a transaction reached the mempool,
- *   `preBroadcast` for a recognised connection or fee-estimation failure, otherwise
- *   `unknown`. Callers must only switch endpoints on `preBroadcast`.
+ * @returns `postBroadcast` if a transaction may have reached the mempool,
+ *   `preBroadcast` for a recognised failure that provably precedes submission,
+ *   otherwise `unknown`. Callers must only switch endpoints on `preBroadcast`.
  */
 export function classifyForgeFailure(output: string): ForgeFailureClass {
+  if (BROADCAST_EVIDENCE.some((pattern) => pattern.test(output)))
+    return 'postBroadcast'
   if (POST_BROADCAST_SIGNATURES.some((pattern) => pattern.test(output)))
     return 'postBroadcast'
   if (PRE_BROADCAST_SIGNATURES.some((pattern) => pattern.test(output)))

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -19,7 +19,10 @@ import {
 
 const REPO_ROOT = join(import.meta.dir, '..', '..')
 
-const runBash = async (script: string, cwd: string) => {
+const runBash = async (
+  script: string,
+  cwd: string
+): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
   const proc = Bun.spawn(['bash', '-c', script], {
     cwd,
     stdout: 'pipe',
@@ -41,7 +44,7 @@ const runBash = async (script: string, cwd: string) => {
  *
  * `exportBeforeSource` flips the order to prove the test can detect the mistake.
  */
-const buildHarness = (exportBeforeSource: boolean) => {
+const buildHarness = (exportBeforeSource: boolean): string => {
   const dir = mkdtempSync(join(tmpdir(), 'rpc-failover-'))
 
   writeFileSync(
@@ -115,7 +118,7 @@ describe('shell wiring', () => {
     'utf8'
   )
 
-  const lineOf = (haystack: string, needle: string) =>
+  const lineOf = (haystack: string, needle: string): number =>
     haystack.split('\n').findIndex((line) => line.includes(needle))
 
   it('invokes failover after the per-call `source .env`, not before', () => {
@@ -242,13 +245,13 @@ describe('failover wiring safeguards', () => {
   // getRPCUrl runs in tight per-selector loops; a probe there would cost minutes.
   it('leaves getRPCUrl free of resolver calls', () => {
     const start = helpers.indexOf('function getRPCUrl()')
-    const body = helpers.slice(
-      start,
-      helpers.indexOf('function tryRpcFailover')
-    )
+    const end = helpers.indexOf('function tryRpcFailover')
 
+    // Both offsets are asserted first: if either function is renamed or reordered the
+    // slice would silently cover a different region and the assertion would pass.
     expect(start).toBeGreaterThan(-1)
-    expect(body).not.toContain('resolveRpcUrl.ts')
+    expect(end).toBeGreaterThan(start)
+    expect(helpers.slice(start, end)).not.toContain('resolveRpcUrl.ts')
   })
 })
 
@@ -262,7 +265,14 @@ describe('tryRpcFailover (executed)', () => {
   // fail over at all is decided by classifyForgeFailure and covered in
   // rpcFailover.test.ts against captured forge output.
   // Patch the real function's resolver invocation by shadowing `bunx`.
-  const runWithFakeBunx = async (body: string) => {
+  const runWithFakeBunx = async (
+    body: string
+  ): Promise<{
+    stdout: string
+    stderr: string
+    exitCode: number
+    excludeLog: string
+  }> => {
     const dir = mkdtempSync(join(tmpdir(), 'rpc-failover-bunx-'))
     writeFileSync(join(dir, 'counter'), '0')
     writeFileSync(join(dir, 'exclude.log'), '')
@@ -364,7 +374,9 @@ describe('endpoint override survives later scripts re-reading .env', () => {
   // same reason the deploy did.
   const OVERRIDE = 'https://failover-endpoint.example/key'
 
-  const runWithOverrideFile = async (extraSourcing: string) => {
+  const runWithOverrideFile = async (
+    extraSourcing: string
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
     const dir = mkdtempSync(join(tmpdir(), 'rpc-override-'))
     const overrideFile = join(dir, 'override')
     writeFileSync(overrideFile, `ETH_NODE_URI_CELO=${OVERRIDE}\n`, {

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -35,10 +35,11 @@ const runBash = async (script: string, cwd: string) => {
 
 /**
  * Reproduces the ordering that matters in `deploySingleContract()`: the function
- * re-reads `.env` on every call, then the retry loop exports an override, then forge
- * runs and resolves its endpoint from the environment.
+ * re-reads `.env` once on entry, then the retry loop exports an override, then forge
+ * runs and resolves its endpoint from the environment. An override written before that
+ * read is discarded.
  *
- * `exportBeforeSource` flips that order to prove the test can detect the mistake.
+ * `exportBeforeSource` flips the order to prove the test can detect the mistake.
  */
 const buildHarness = (exportBeforeSource: boolean) => {
   const dir = mkdtempSync(join(tmpdir(), 'rpc-failover-'))
@@ -158,5 +159,88 @@ describe('shell wiring', () => {
     expect(helpers).toMatch(
       /printf '%s' "\$FORGE_OUTPUT" \|[\s\S]{0,120}resolveRpcUrl\.ts/
     )
+  })
+})
+
+describe('failure classification receives forge progress output', () => {
+  // The retry loop classifies a failure from `RAW_STDOUT_FULL`, not `RAW_RETURN_DATA`.
+  // JSON extraction strips every human-readable line, and those lines carry the only
+  // evidence that forge began broadcasting — without them a dropped connection during
+  // receipt polling looks like a safe pre-broadcast failure and the endpoint is
+  // switched under an in-flight transaction.
+  it('keeps progress lines that JSON extraction discards', async () => {
+    const script = [
+      'source script/helperFunctions.sh >/dev/null 2>&1',
+      // Stand in for forge: progress lines plus the JSON blob, exactly as forge --json emits.
+      `executeAndParse 'printf "Sending transactions [0/1]\\nWaiting for receipts.\\n{\\"logs\\":[],\\"returns\\":{}}\\n"' "true"`,
+      'echo "EXTRACTED:$RAW_RETURN_DATA"',
+      'echo "FULL:$RAW_STDOUT_FULL"',
+    ].join('\n')
+
+    const result = await runBash(script, REPO_ROOT)
+
+    // Extraction keeps only the JSON object...
+    expect(result.stdout).toContain('EXTRACTED:{"logs":[]')
+    expect(result.stdout).not.toMatch(/EXTRACTED:[^\n]*Sending transactions/)
+    // ...while the unextracted copy still carries the broadcast evidence.
+    expect(result.stdout).toContain('Sending transactions')
+    expect(result.stdout).toContain('Waiting for receipts')
+  })
+
+  it('classifies that captured output as post-broadcast', async () => {
+    const script = [
+      'source script/helperFunctions.sh >/dev/null 2>&1',
+      `executeAndParse 'printf "Sending transactions [0/1]\\nerror sending request for url (https://x/key)\\n{\\"logs\\":[],\\"returns\\":{}}\\n"' "true"`,
+      // Feed exactly what the retry loop feeds the resolver.
+      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_STDOUT_FULL" > /tmp/lifi-classify-input.txt',
+    ].join('\n')
+
+    await runBash(script, REPO_ROOT)
+
+    const captured = readFileSync('/tmp/lifi-classify-input.txt', 'utf8')
+    const { classifyForgeFailure } = await import('./rpcFailover')
+
+    expect(captured).toContain('Sending transactions')
+    expect(classifyForgeFailure(captured)).toBe('postBroadcast')
+  })
+})
+
+describe('failover wiring safeguards', () => {
+  const helpers = readFileSync(
+    join(REPO_ROOT, 'script', 'helperFunctions.sh'),
+    'utf8'
+  )
+
+  it('classifies from the unextracted stdout, not the JSON-extracted one', () => {
+    const deployScript = readFileSync(
+      join(REPO_ROOT, 'script', 'deploy', 'deploySingleContract.sh'),
+      'utf8'
+    )
+    const call = deployScript.slice(deployScript.indexOf('tryRpcFailover'))
+
+    expect(call).toContain('RAW_STDOUT_FULL')
+  })
+
+  it('accumulates exclusions so two bad endpoints cannot be chosen alternately', () => {
+    expect(helpers).toContain('RPC_FAILOVER_EXCLUDED')
+    expect(helpers).toMatch(
+      /RPC_FAILOVER_EXCLUDED="\$\{RPC_FAILOVER_EXCLUDED:\+/
+    )
+  })
+
+  it('masks a newly selected endpoint in GitHub Actions logs', () => {
+    expect(helpers).toContain('::add-mask::$NEW_RPC_URL')
+  })
+
+  // getRPCUrl runs in tight per-selector loops; a probe there would cost minutes.
+  it('leaves getRPCUrl free of resolver calls', () => {
+    const start = helpers.indexOf('function getRPCUrl()')
+    const body = helpers.slice(
+      start,
+      helpers.indexOf('function tryRpcFailover')
+    )
+
+    expect(start).toBeGreaterThan(-1)
+    expect(body).not.toContain('resolveRpcUrl.ts')
   })
 })

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -162,46 +162,52 @@ describe('shell wiring', () => {
   })
 })
 
-describe('failure classification receives forge progress output', () => {
-  // The retry loop classifies a failure from `RAW_STDOUT_FULL`, not `RAW_RETURN_DATA`.
-  // JSON extraction strips every human-readable line, and those lines carry the only
-  // evidence that forge began broadcasting — without them a dropped connection during
-  // receipt polling looks like a safe pre-broadcast failure and the endpoint is
-  // switched under an in-flight transaction.
-  it('keeps progress lines that JSON extraction discards', async () => {
+describe('failure classification receives forge broadcast markers', () => {
+  // forge's final --json object names the broadcast artifact, which is the evidence a
+  // transaction was actually sent. `extractJsonFromForgeOutput` is a no-op while stdout
+  // is a clean JSON stream, but as soon as one non-JSON line appears (a compiler
+  // notice, a warning) it keeps only the {"logs":...} object and the evidence is lost.
+  // Classifying from the unextracted copy removes that dependency entirely.
+  const FORGE_STDOUT =
+    'Compiler run successful!\\n' +
+    '{\\"logs\\":[],\\"returns\\":{}}\\n' +
+    '{\\"status\\":\\"success\\",\\"transactions\\":\\"/tmp/fp/broadcast/D.s.sol/42220/run-latest.json\\"}\\n'
+
+  it('keeps the broadcast artifact line that JSON extraction discards', async () => {
     const script = [
       'source script/helperFunctions.sh >/dev/null 2>&1',
-      // Stand in for forge: progress lines plus the JSON blob, exactly as forge --json emits.
-      `executeAndParse 'printf "Sending transactions [0/1]\\nWaiting for receipts.\\n{\\"logs\\":[],\\"returns\\":{}}\\n"' "true"`,
+      `executeAndParse 'printf "${FORGE_STDOUT}"' "true"`,
       'echo "EXTRACTED:$RAW_RETURN_DATA"',
       'echo "FULL:$RAW_STDOUT_FULL"',
     ].join('\n')
 
     const result = await runBash(script, REPO_ROOT)
 
-    // Extraction keeps only the JSON object...
+    // Extraction keeps only the trace object...
     expect(result.stdout).toContain('EXTRACTED:{"logs":[]')
-    expect(result.stdout).not.toMatch(/EXTRACTED:[^\n]*Sending transactions/)
-    // ...while the unextracted copy still carries the broadcast evidence.
-    expect(result.stdout).toContain('Sending transactions')
-    expect(result.stdout).toContain('Waiting for receipts')
+    expect(result.stdout).not.toMatch(/EXTRACTED:[^\n]*run-latest\.json/)
+    // ...while the unextracted copy still names the broadcast artifact.
+    expect(result.stdout).toMatch(/FULL:[\s\S]*run-latest\.json/)
   })
 
-  it('classifies that captured output as post-broadcast', async () => {
+  it('classifies the captured output as post-broadcast', async () => {
     const script = [
       'source script/helperFunctions.sh >/dev/null 2>&1',
-      `executeAndParse 'printf "Sending transactions [0/1]\\nerror sending request for url (https://x/key)\\n{\\"logs\\":[],\\"returns\\":{}}\\n"' "true"`,
-      // Feed exactly what the retry loop feeds the resolver.
-      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_STDOUT_FULL" > /tmp/lifi-classify-input.txt',
+      `executeAndParse 'printf "${FORGE_STDOUT}"; printf "error sending request for url (x)" >&2' "true"`,
+      // Exactly what the retry loop hands to the resolver.
+      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_STDOUT_FULL" > /tmp/lifi-classify-full.txt',
+      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_RETURN_DATA" > /tmp/lifi-classify-extracted.txt',
     ].join('\n')
 
     await runBash(script, REPO_ROOT)
-
-    const captured = readFileSync('/tmp/lifi-classify-input.txt', 'utf8')
     const { classifyForgeFailure } = await import('./rpcFailover')
 
-    expect(captured).toContain('Sending transactions')
-    expect(classifyForgeFailure(captured)).toBe('postBroadcast')
+    const full = readFileSync('/tmp/lifi-classify-full.txt', 'utf8')
+    const extracted = readFileSync('/tmp/lifi-classify-extracted.txt', 'utf8')
+
+    expect(classifyForgeFailure(full)).toBe('postBroadcast')
+    // Same run classified from the extracted stdout: the guard cannot fire.
+    expect(classifyForgeFailure(extracted)).toBe('preBroadcast')
   })
 })
 

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the bash side of RPC failover.
+ *
+ * Two things are checked here that no TypeScript test can reach: that an exported
+ * endpoint override survives `deploySingleContract`'s per-call `source .env`, and that
+ * the wiring in the shell scripts keeps RPC URLs out of the process table.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved, import/order
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+
+const runBash = async (script: string, cwd: string) => {
+  const proc = Bun.spawn(['bash', '-c', script], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout: stdout.trim(), stderr, exitCode }
+}
+
+/**
+ * Reproduces the ordering that matters in `deploySingleContract()`: the function
+ * re-reads `.env` on every call, then the retry loop exports an override, then forge
+ * runs and resolves its endpoint from the environment.
+ *
+ * `exportBeforeSource` flips that order to prove the test can detect the mistake.
+ */
+const buildHarness = (exportBeforeSource: boolean) => {
+  const dir = mkdtempSync(join(tmpdir(), 'rpc-failover-'))
+
+  writeFileSync(
+    join(dir, '.env'),
+    'ETH_NODE_URI_TESTCHAIN="https://broken.example.com"\n'
+  )
+
+  // Stands in for forge: records whichever endpoint the environment resolves to.
+  writeFileSync(
+    join(dir, 'fake-forge.sh'),
+    '#!/bin/bash\nprintf "%s" "$ETH_NODE_URI_TESTCHAIN" > "$1"\n',
+    { mode: 0o755 }
+  )
+
+  const override = 'export ETH_NODE_URI_TESTCHAIN="https://working.example.com"'
+  const sourceEnv = 'set -a; source .env; set +a'
+
+  writeFileSync(
+    join(dir, 'deploy.sh'),
+    [
+      '#!/bin/bash',
+      'deploySingleContract() {',
+      ...(exportBeforeSource
+        ? [`  ${override}`, `  ${sourceEnv}`]
+        : [`  ${sourceEnv}`, `  ${override}`]),
+      '  ./fake-forge.sh "$1"',
+      '}',
+      'deploySingleContract "$1"',
+    ].join('\n'),
+    { mode: 0o755 }
+  )
+
+  return dir
+}
+
+describe('endpoint override vs the per-call `source .env`', () => {
+  it('survives when the export happens after .env is re-read', async () => {
+    const dir = buildHarness(false)
+    try {
+      const recorded = join(dir, 'recorded.txt')
+      const result = await runBash(`./deploy.sh ${recorded}`, dir)
+
+      expect(result.exitCode).toBe(0)
+      expect(readFileSync(recorded, 'utf8')).toBe('https://working.example.com')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  // Negative control: if this passed, the test above would prove nothing.
+  it('is silently reverted when the export happens before .env is re-read', async () => {
+    const dir = buildHarness(true)
+    try {
+      const recorded = join(dir, 'recorded.txt')
+      await runBash(`./deploy.sh ${recorded}`, dir)
+
+      expect(readFileSync(recorded, 'utf8')).toBe('https://broken.example.com')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('shell wiring', () => {
+  const deployScript = readFileSync(
+    join(REPO_ROOT, 'script', 'deploy', 'deploySingleContract.sh'),
+    'utf8'
+  )
+  const helpers = readFileSync(
+    join(REPO_ROOT, 'script', 'helperFunctions.sh'),
+    'utf8'
+  )
+
+  const lineOf = (haystack: string, needle: string) =>
+    haystack.split('\n').findIndex((line) => line.includes(needle))
+
+  it('invokes failover after the per-call `source .env`, not before', () => {
+    const sourceLine = lineOf(deployScript, 'source .env')
+    const failoverLine = lineOf(deployScript, 'tryRpcFailover')
+
+    expect(sourceLine).toBeGreaterThan(-1)
+    expect(failoverLine).toBeGreaterThan(sourceLine)
+  })
+
+  it('invokes failover only after a forge attempt has failed', () => {
+    const forgeLine = lineOf(deployScript, '--fork-url')
+    const failoverLine = lineOf(deployScript, 'tryRpcFailover')
+
+    expect(failoverLine).toBeGreaterThan(forgeLine)
+  })
+
+  // Attempt 1 must not consult the resolver, or every healthy chain pays probe latency.
+  it('does not resolve an endpoint before the first forge attempt', () => {
+    const beforeForge = deployScript.slice(
+      0,
+      deployScript.indexOf('--fork-url')
+    )
+
+    expect(beforeForge).not.toContain('tryRpcFailover')
+    expect(beforeForge).not.toContain('resolveRpcUrl.ts')
+  })
+
+  it('keeps --fork-url on the network alias so no URL reaches the process table', () => {
+    expect(deployScript).toContain('--fork-url \\"$NETWORK\\"')
+  })
+
+  it('passes the excluded endpoint through the environment, never as an argument', () => {
+    expect(helpers).toContain('LIFI_RPC_EXCLUDE=')
+    // An RPC URL as an argv element would be world-readable via `ps`.
+    expect(helpers).not.toMatch(/resolveRpcUrl\.ts[^\n]*--exclude/)
+    expect(helpers).not.toMatch(/resolveRpcUrl\.ts[^\n]*\$\{?RPC_URL/)
+  })
+
+  it('pipes forge output to the resolver instead of passing it as an argument', () => {
+    expect(helpers).toMatch(
+      /printf '%s' "\$FORGE_OUTPUT" \|[\s\S]{0,120}resolveRpcUrl\.ts/
+    )
+  })
+})

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -191,23 +191,31 @@ describe('failure classification receives forge broadcast markers', () => {
   })
 
   it('classifies the captured output as post-broadcast', async () => {
-    const script = [
-      'source script/helperFunctions.sh >/dev/null 2>&1',
-      `executeAndParse 'printf "${FORGE_STDOUT}"; printf "error sending request for url (x)" >&2' "true"`,
-      // Exactly what the retry loop hands to the resolver.
-      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_STDOUT_FULL" > /tmp/lifi-classify-full.txt',
-      'printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_RETURN_DATA" > /tmp/lifi-classify-extracted.txt',
-    ].join('\n')
+    const dir = mkdtempSync(join(tmpdir(), 'rpc-classify-'))
+    const fullPath = join(dir, 'full.txt')
+    const extractedPath = join(dir, 'extracted.txt')
+    try {
+      const script = [
+        'source script/helperFunctions.sh >/dev/null 2>&1',
+        `executeAndParse 'printf "${FORGE_STDOUT}"; printf "error sending request for url (x)" >&2' "true"`,
+        // Exactly what the retry loop hands to the resolver.
+        `printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_STDOUT_FULL" > ${fullPath}`,
+        `printf "%s\\n%s" "$STDERR_CONTENT" "$RAW_RETURN_DATA" > ${extractedPath}`,
+      ].join('\n')
 
-    await runBash(script, REPO_ROOT)
-    const { classifyForgeFailure } = await import('./rpcFailover')
+      await runBash(script, REPO_ROOT)
+      const { classifyForgeFailure } = await import('./rpcFailover')
 
-    const full = readFileSync('/tmp/lifi-classify-full.txt', 'utf8')
-    const extracted = readFileSync('/tmp/lifi-classify-extracted.txt', 'utf8')
-
-    expect(classifyForgeFailure(full)).toBe('postBroadcast')
-    // Same run classified from the extracted stdout: the guard cannot fire.
-    expect(classifyForgeFailure(extracted)).toBe('preBroadcast')
+      expect(classifyForgeFailure(readFileSync(fullPath, 'utf8'))).toBe(
+        'postBroadcast'
+      )
+      // Same run classified from the extracted stdout: the guard cannot fire.
+      expect(classifyForgeFailure(readFileSync(extractedPath, 'utf8'))).toBe(
+        'preBroadcast'
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 
@@ -227,13 +235,6 @@ describe('failover wiring safeguards', () => {
     expect(call).toContain('RAW_STDOUT_FULL')
   })
 
-  it('accumulates exclusions so two bad endpoints cannot be chosen alternately', () => {
-    expect(helpers).toContain('RPC_FAILOVER_EXCLUDED')
-    expect(helpers).toMatch(
-      /RPC_FAILOVER_EXCLUDED="\$\{RPC_FAILOVER_EXCLUDED:\+/
-    )
-  })
-
   it('masks a newly selected endpoint in GitHub Actions logs', () => {
     expect(helpers).toContain('::add-mask::$NEW_RPC_URL')
   })
@@ -248,5 +249,166 @@ describe('failover wiring safeguards', () => {
 
     expect(start).toBeGreaterThan(-1)
     expect(body).not.toContain('resolveRpcUrl.ts')
+  })
+})
+
+/**
+ * Executes the real `tryRpcFailover` with the resolver CLI replaced by a stub, so the
+ * bash contract itself is under test rather than the text of the script. The stub
+ * records the exclusion list it was handed and returns a fresh endpoint each call.
+ */
+describe('tryRpcFailover (executed)', () => {
+  // Scope: the bash bookkeeping around the resolver. Whether a given forge failure may
+  // fail over at all is decided by classifyForgeFailure and covered in
+  // rpcFailover.test.ts against captured forge output.
+  // Patch the real function's resolver invocation by shadowing `bunx`.
+  const runWithFakeBunx = async (body: string) => {
+    const dir = mkdtempSync(join(tmpdir(), 'rpc-failover-bunx-'))
+    writeFileSync(join(dir, 'counter'), '0')
+    writeFileSync(join(dir, 'exclude.log'), '')
+    writeFileSync(
+      join(dir, 'bunx'),
+      [
+        '#!/bin/bash',
+        'cat > /dev/null',
+        'printf "%s\n===\n" "$LIFI_RPC_EXCLUDE" >> "$EXCLUDE_LOG"',
+        'N=$(cat "$COUNTER"); N=$((N + 1)); printf "%s" "$N" > "$COUNTER"',
+        'printf "https://endpoint-%s.example/key" "$N"',
+      ].join('\n'),
+      { mode: 0o755 }
+    )
+
+    const script = [
+      'source script/helperFunctions.sh >/dev/null 2>&1',
+      `export COUNTER="${join(dir, 'counter')}"`,
+      `export EXCLUDE_LOG="${join(dir, 'exclude.log')}"`,
+      `export PATH="${dir}:$PATH"`,
+      body,
+    ].join('\n')
+
+    const result = await runBash(script, REPO_ROOT)
+    const excludeLog = readFileSync(join(dir, 'exclude.log'), 'utf8')
+    rmSync(dir, { recursive: true, force: true })
+    return { ...result, excludeLog }
+  }
+
+  it('switches the endpoint on a pre-broadcast failure', async () => {
+    const { stdout } = await runWithFakeBunx(
+      [
+        'export ETH_NODE_URI_CELO="https://broken.example/key"',
+        'tryRpcFailover celo "Error: Failed to get EIP-1559 fees" >/dev/null',
+        'echo "RESULT:$ETH_NODE_URI_CELO"',
+      ].join('\n')
+    )
+
+    expect(stdout).toContain('RESULT:https://endpoint-1.example/key')
+  })
+
+  // The bug this replaces a grep-based assertion for: without per-network
+  // accumulation, endpoint 1 becomes selectable again on the third failure.
+  it('keeps excluding every endpoint already tried on the same network', async () => {
+    const { excludeLog } = await runWithFakeBunx(
+      [
+        'export ETH_NODE_URI_CELO="https://broken.example/key"',
+        'for i in 1 2 3; do tryRpcFailover celo "Error: Failed to get EIP-1559 fees" >/dev/null; done',
+      ].join('\n')
+    )
+
+    const lastCall = excludeLog.trim().split('===').filter(Boolean).pop() ?? ''
+
+    expect(lastCall).toContain('https://broken.example/key')
+    expect(lastCall).toContain('https://endpoint-1.example/key')
+    expect(lastCall).toContain('https://endpoint-2.example/key')
+  })
+
+  it('does not leak one network exclusions into another', async () => {
+    const { excludeLog } = await runWithFakeBunx(
+      [
+        'export ETH_NODE_URI_CELO="https://celo-bad.example/key"',
+        'export ETH_NODE_URI_POLYGON="https://polygon-bad.example/key"',
+        'tryRpcFailover celo "Error: Failed to get EIP-1559 fees" >/dev/null',
+        'tryRpcFailover polygon "Error: Failed to get EIP-1559 fees" >/dev/null',
+      ].join('\n')
+    )
+
+    const polygonCall =
+      excludeLog.trim().split('===').filter(Boolean).pop() ?? ''
+
+    expect(polygonCall).toContain('https://polygon-bad.example/key')
+    expect(polygonCall).not.toContain('celo-bad')
+  })
+
+  // Returning to a network must remember what already failed there.
+  it('remembers a network exclusions after visiting another network', async () => {
+    const { excludeLog } = await runWithFakeBunx(
+      [
+        'export ETH_NODE_URI_CELO="https://celo-bad.example/key"',
+        'export ETH_NODE_URI_POLYGON="https://polygon-bad.example/key"',
+        'tryRpcFailover celo "Error: Failed to get EIP-1559 fees" >/dev/null',
+        'tryRpcFailover polygon "Error: Failed to get EIP-1559 fees" >/dev/null',
+        'tryRpcFailover celo "Error: Failed to get EIP-1559 fees" >/dev/null',
+      ].join('\n')
+    )
+
+    const lastCall = excludeLog.trim().split('===').filter(Boolean).pop() ?? ''
+
+    expect(lastCall).toContain('https://celo-bad.example/key')
+    expect(lastCall).not.toContain('polygon-bad')
+  })
+})
+
+describe('endpoint override survives later scripts re-reading .env', () => {
+  // deploySingleContract fails over, then diamondUpdateFacet re-sources
+  // helperFunctions.sh, which re-reads .env. Without the override file that snaps the
+  // endpoint back to the one just proven inadequate and the diamondCut fails for the
+  // same reason the deploy did.
+  const OVERRIDE = 'https://failover-endpoint.example/key'
+
+  const runWithOverrideFile = async (extraSourcing: string) => {
+    const dir = mkdtempSync(join(tmpdir(), 'rpc-override-'))
+    const overrideFile = join(dir, 'override')
+    writeFileSync(overrideFile, `ETH_NODE_URI_CELO=${OVERRIDE}\n`, {
+      mode: 0o600,
+    })
+
+    const script = [
+      `export LIFI_RPC_OVERRIDE_FILE="${overrideFile}"`,
+      'source script/helperFunctions.sh >/dev/null 2>&1',
+      extraSourcing,
+      'echo "RESULT:$ETH_NODE_URI_CELO"',
+    ].join('\n')
+
+    const result = await runBash(script, REPO_ROOT)
+    rmSync(dir, { recursive: true, force: true })
+    return result
+  }
+
+  it('survives a second source of helperFunctions.sh', async () => {
+    const result = await runWithOverrideFile(
+      'source script/helperFunctions.sh >/dev/null 2>&1'
+    )
+
+    expect(result.stdout).toContain(`RESULT:${OVERRIDE}`)
+  })
+
+  it('survives a bare re-read of .env', async () => {
+    const result = await runWithOverrideFile('set -a; source .env; set +a')
+
+    // A bare re-read has no re-apply step, so the configured endpoint wins again.
+    // This documents the boundary: the override travels through helperFunctions.sh.
+    expect(result.stdout).not.toContain(`RESULT:${OVERRIDE}`)
+  })
+
+  it('is a no-op when no override file is set', async () => {
+    const result = await runBash(
+      [
+        'unset LIFI_RPC_OVERRIDE_FILE',
+        'source script/helperFunctions.sh >/dev/null 2>&1',
+        'test -n "$ETH_NODE_URI_CELO" && echo "CONFIGURED_ENDPOINT_PRESENT"',
+      ].join('\n'),
+      REPO_ROOT
+    )
+
+    expect(result.stdout).toContain('CONFIGURED_ENDPOINT_PRESENT')
   })
 })

--- a/script/utils/rpcFailoverBash.test.ts
+++ b/script/utils/rpcFailoverBash.test.ts
@@ -391,24 +391,41 @@ describe('endpoint override survives later scripts re-reading .env', () => {
     expect(result.stdout).toContain(`RESULT:${OVERRIDE}`)
   })
 
-  it('survives a bare re-read of .env', async () => {
-    const result = await runWithOverrideFile('set -a; source .env; set +a')
+  // Documents the boundary: the override travels through helperFunctions.sh, so a
+  // script that reads an env file directly still sees the configured endpoint.
+  it('does not survive a bare re-read of an env file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rpc-override-bare-'))
+    const envFile = join(dir, 'env-under-test')
+    writeFileSync(envFile, 'ETH_NODE_URI_CELO=https://configured.example/key\n')
+    try {
+      const result = await runBash(
+        [
+          `export ETH_NODE_URI_CELO="${OVERRIDE}"`,
+          `set -a; source ${envFile}; set +a`,
+          'echo "RESULT:$ETH_NODE_URI_CELO"',
+        ].join('\n'),
+        REPO_ROOT
+      )
 
-    // A bare re-read has no re-apply step, so the configured endpoint wins again.
-    // This documents the boundary: the override travels through helperFunctions.sh.
-    expect(result.stdout).not.toContain(`RESULT:${OVERRIDE}`)
+      expect(result.stdout).toContain('RESULT:https://configured.example/key')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
-  it('is a no-op when no override file is set', async () => {
+  // Uses a network absent from any env file, so the assertion holds whether or not
+  // the checkout has one.
+  it('leaves the environment untouched when no override file is set', async () => {
     const result = await runBash(
       [
         'unset LIFI_RPC_OVERRIDE_FILE',
+        'export ETH_NODE_URI_DEFINITELYNOTANETWORK="https://untouched.example/key"',
         'source script/helperFunctions.sh >/dev/null 2>&1',
-        'test -n "$ETH_NODE_URI_CELO" && echo "CONFIGURED_ENDPOINT_PRESENT"',
+        'echo "RESULT:$ETH_NODE_URI_DEFINITELYNOTANETWORK"',
       ].join('\n'),
       REPO_ROOT
     )
 
-    expect(result.stdout).toContain('CONFIGURED_ENDPOINT_PRESENT')
+    expect(result.stdout).toContain('RESULT:https://untouched.example/key')
   })
 })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-799](https://linear.app/lifi-linear/issue/EXSC-799/automatic-rpc-failover-for-deploy-tooling-capability-aware-mongodb)

Stacked on #2218 (EXSC-794) for `withSrvDnsFallback`. **Do not merge before #2218.**

# Why did I implement it this way?

## The problem

In the FeeForwarder v2.0.0 66-chain rollout on 2026-08-19, three networks failed purely because their single configured RPC endpoint was inadequate — each burned 10/10 attempts and ~45 min of wall clock. MongoDB (`blockchain-configs.RpcEndpoints`) already stores an `rpcs[]` array per chain, but nothing ever tried an alternative: `getRPCUrl()` resolved exactly one env var and gave up.

Measured against the live collection, deduplicated across all three sources: **53 of the 71 non-Tron networks (75%) have more than one distinct endpoint** and can therefore fail over. celo has 4, moonbeam 5, fuse 3.

The remaining 18 have exactly one endpoint and this change cannot help them — `0g`, `abstract`, `apechain`, `arctestnet`, `berachain`, `etherlink`, `flare`, `flow`, `hemi`, `ink`, `nibiru`, `plasma`, `plume`, `somnia`, `soneium`, `sonic`, `vana`, `localanvil`. Registering a second endpoint for those in `RpcEndpoints` is the cheap follow-up that widens the net; no code change is needed for it to take effect.

## Ranking on observed capabilities, not required ones

"Is the RPC up?" is the wrong health check — all three failing endpoints answered `eth_blockNumber` fine. So candidates are probed for `eth_feeHistory`, a 1559-deserializable block, and `eth_gasPrice`.

The non-obvious part is that requirements are **relative, never absolute**. A fleet sweep of all 86 chains showed the endpoints with no `mixHash` are exactly fuse, moonbeam and moonriver — *every* endpoint of those chains, because their block headers genuinely have no such field (moonbeam is a Frontier parachain, fuse is Aura). Had I made `mixHash` a hard requirement, all 7 moonbeam candidates and all 5 fuse candidates would be rejected and the chain would hard-fail — strictly worse than today. Instead each candidate is scored against what the *other* candidates managed, so a capability the whole chain lacks ties across the board and selection falls through to trust and priority.

`isActive` is deliberately not used as a filter: it is `undefined` on all 86 documents, so filtering on it discards everything.

## The mid-broadcast rule

Switching endpoints after a transaction is in the mempool is how moonbeam ended up with `-32603 already known` and a pending nonce that never advanced. So failover only happens on failures that **provably precede** any broadcast.

Transport errors are the subtle case and an adversarial review caught me getting this wrong: `error sending request … operation timed out` is ambiguous, because the node may have accepted the transaction and only the reply was lost. Evidence that forge began submitting (`Sending transactions`, `Waiting for receipts`, `Transactions saved to`, a transaction hash) therefore outranks every transport pattern and pins the endpoint. Unrecognised failures also do not switch.

## Defeating the `.env` clobber

`deploySingleContract()` runs `source .env` at line 19 **on every call**, so an override exported by a caller is wiped before forge ever runs. The override is therefore exported *inside* the function, after that source and inside the retry loop. `script/utils/rpcFailoverBash.test.ts` pins this with a negative control that fails if the export is moved above the source.

## Keeping RPC URLs out of the process table

RPC URLs embed API keys, and argv is world-readable via `ps`. So:

- `--fork-url "$NETWORK"` stays a **foundry.toml alias**; the endpoint is switched through the environment. Passing `--fork-url <resolved-url>` would have been the obvious implementation and a regression.
- Excluded endpoints reach the resolver via `LIFI_RPC_EXCLUDE` (newline-separated, since a query string may contain commas) rather than a CLI flag.
- Failed forge output is **piped on stdin**, not passed as an argument — it routinely quotes the full URL.
- Probe transport errors are swallowed rather than logged, for the same reason. Diagnostics are redacted to scheme+host.

Known limit of that guarantee, called out rather than hidden: providers that key on the *hostname* (QuickNode) still expose their identifier in a redacted log. Documented on `redactRpcUrl`.

## No added latency for healthy chains

Attempt 1 is byte-for-byte the current behaviour, and `getRPCUrl()` returns the configured endpoint unprobed when one is set. Nothing probes unless something has already failed. A test asserts the resolver is not referenced anywhere before the first forge invocation.

## Read-only

Probe results are not written back to MongoDB. A single misbehaving machine — e.g. the known Robinhood DNS hijack on my laptop, which makes a healthy chain look dead — must not poison shared fleet config.

## Verification

End-to-end against the three real production failures, with each chain's configured endpoint pointed at a broken URL and the actual forge error text fed in:

| chain | outcome |
|---|---|
| celo | recovered to a `feeHistory`-capable alternative |
| moonbeam | recovered to a live alternative |
| fuse | recovered to a live alternative |
| celo, mid-broadcast output | correctly **refused** to switch |

Being precise about what that proves: for celo this is a genuine fix. For moonbeam and fuse it only shows the resolver degrades gracefully — their real blocker is the missing `mixHash`, a chain property no failover can fix. That is [EXSC-800](https://linear.app/lifi-linear/issue/EXSC-800/auto-detect-chains-that-cannot-do-eip-1559-moonbeamfusemoonriver), split out deliberately.

I also verified that `getRPCEnvVarName` agrees with the `[rpc_endpoints]` alias in `foundry.toml` for **all 71 non-Tron networks in `networks.json`** (0 mismatches; tron/tronshasta are absent by design, since Foundry has no Tron support). A mismatch there would have made failover a silent no-op.

## Review and follow-ups

Adversarial review passes ran against this diff and found real defects, all fixed here. Every fix is mutation-tested — reverting it individually turns the suite red.

The two that mattered most, both of which would have made this change *actively dangerous* rather than merely ineffective:

1. **A broadcast-phase transport failure classified as safe to fail over from** (fixed in `4d947e5`). `error sending request … timed out` is ambiguous, so evidence of submission now outranks it.
2. **That guard was then blind at the only call site that used it** (fixed in `4d033b2`). The retry loop was passing `RAW_RETURN_DATA`, but `executeAndCapture` overwrites stdout with `extractJsonFromForgeOutput`'s result — which keeps only the `{"logs":…}` object and discards every progress line. Since those lines *are* the broadcast evidence, the guard could never fire in production while all unit tests passed. `executeAndCapture` now also carries the unextracted stdout (`RAW_STDOUT_FULL`), and a test drives the real `executeAndParse` to prove the evidence survives to the classifier.

Also fixed from that round: exclusions now accumulate per network (otherwise two bad endpoints get chosen alternately until the retry budget is gone — verified converging over 4 distinct celo endpoints then exhausting cleanly); a newly selected endpoint is `::add-mask::`ed under GitHub Actions, because a MongoDB-sourced URL was never seen by the workflows' mask sweep over `.env` keys; and resolver exit codes are distinguished so an operator-actionable failure is not silent.

A third pass then refuted the fix for (1) itself, and it was the most valuable finding of the three: **under `--json` — which the deploy always passes — forge emits none of the progress lines I had used as broadcast evidence.** The guard was built from plausible-looking strings rather than observed ones, so it was a no-op in the deploy path while every unit test passed. Fixed in `1cecd97`: evidence now comes from output captured by driving forge 1.7.1 into each failure mode against a mock node — the send/poll errors and the broadcast artifact path (with `dry-run/` paths excluded by inspecting the path, since a simulation writes the same file name). The progress lines are kept as *additional* evidence for the callers that omit `--json`.

The same pass corrected two of my pre-broadcast patterns. An endpoint without `eth_feeHistory` reports `-32601: the method eth_feeHistory does not exist`, and a chain without `mixHash` reports `EVM error; header validation error: \`prevrandao\` not set` — not the deserialization message I had assumed. And `no json output received` was dropped entirely: that string is this repo's own console warning, printed after capture, so it could never reach the classifier.

**Falsification against real forge output.** Every case below is verbatim `forge script --broadcast --slow --json` output (forge 1.7.1), piped through the actual resolver CLI exactly as the retry loop does:

| real forge failure | resolver decision |
|---|---|
| no `eth_feeHistory` (celo) | fail over ✅ |
| no `mixHash` (moonbeam/fuse) | fail over ✅ |
| `mixHash: null` | fail over ✅ |
| node died mid-send | **refuse** ✅ |
| node died while polling for a receipt | **refuse** ✅ |
| successful broadcast artifact present | **refuse** ✅ |
| simulation-only (`dry-run/`) artifact | fail over ✅ |

A fourth pass then found the defect that mattered most for whether this ticket delivers anything at all: **the failover was undone before the diamondCut.** `deploySingleContract` would switch to a working endpoint and deploy, and then `diamondUpdateFacet` re-sourced `helperFunctions.sh`, which re-reads `.env` and snapped `ETH_NODE_URI_CELO` back to the endpoint just proven inadequate — so the cut failed for exactly the reason the deploy had. Celo, the one proven production case, would still have failed the rollout. Fixed in `512a136`: the chosen endpoint is recorded in an owner-only (`0600`) run-scoped file that is re-applied after each `.env` read, and a test now fails if that re-apply is removed.

The same pass caught three more of mine: exclusions were reset on switching networks (so returning to a chain forgot what already failed there — now tracked per network), `executeAndCapture` leaked a temp file holding raw forge output on every call (a regression I introduced), and dry-run detection matched `dry-run` anywhere in the path, so a checkout under such a directory would hide a real broadcast — the dangerous direction. It also observed that no test ever *executed* `tryRpcFailover`; they grepped the script text, which is exactly why the exclusion bug survived. Those are now executed against a stubbed resolver.

**One assumption the whole design rests on, now measured rather than assumed:** that forge's dotenv autoload does not override an already-exported `ETH_NODE_URI_*`. If it did, the export would be reverted and this feature would be inert. Verified empirically with a throwaway foundry project where the dotfile and the exported value disagree — forge dials the **exported** endpoint.

### Changed from the original plan

`getRPCUrl()` is left exactly as it was. I had it fall back to the resolver when no endpoint is configured, but review showed it (a) was unreachable under `set -euo pipefail` because of the pre-existing unbraced `${!RPC_KEY}`, and (b) sits inside tight per-selector loops, where a Mongo lookup plus probe wave could add minutes across the fleet. Failover is confined to the deploy retry loop, which keeps the blast radius to one call site.

Split out, not blocking:

- [EXSC-800](https://linear.app/lifi-linear/issue/EXSC-800/auto-detect-chains-that-cannot-do-eip-1559-moonbeamfusemoonriver) — `networkSupportsEip1559()` tests only `baseFeePerGas`, so moonbeam/fuse/moonriver drop `--legacy` and die deserializing the absent `mixHash`. This is the actual moonbeam root cause.
- [EXSC-801](https://linear.app/lifi-linear/issue/EXSC-801/stop-passing-rpc-urls-as-command-line-arguments-process-table-secret) — ~51 pre-existing sites pass the RPC URL as `--rpc-url` argv, exposing API keys in the process table.

A pre-ready review gate then checked the diff against the repo's own rules and produced one more commit (`02eccc1`): the two new env vars are documented in `.env.example`, the missing module header and bash argument docs are added, the shared `sleep` helper replaces a local `setTimeout`, and comments that narrated the incident history or this PR's authoring journey are gone — that content belongs here, not in the code.

Two findings from that gate are **escalated rather than applied** and are posted as a PR comment: whether the loopback test servers should become `globalThis.fetch` stubs per `[CONV:UNIT-MOCK-EXTERNAL]`, and whether JSDoc may name the env vars and config keys this module exists to bridge. Both have two defensible answers and are cheap to reverse.

Two deliberate deviations worth a reviewer's attention:

- A network with **no** `ETH_NODE_URI_*` at all still fails exactly as before — failover only engages after a forge attempt fails. Adding that path is possible later, but it needs the `set -u` fix in `getRPCUrl` first (folded into EXSC-801's sweep).
- The endpoint override lives in the environment, so the *next* `deploySingleContract` call re-sources `.env` and starts from the configured endpoint again. Within one contract's 10 attempts it converges; a second contract on the same network re-discovers the bad endpoint once. Persisting it across calls would need run-scoped state, which did not seem worth the complexity — happy to add it if you disagree.
- Tests use loopback `Bun.serve` servers rather than stubbing `globalThis.fetch` per `[CONV:UNIT-MOCK-EXTERNAL]`. They are in-process and hit no external service, and they verify real transport behaviour (timeouts, non-2xx, malformed bodies) that a fetch stub cannot. "Guaranteed dead" ports are obtained by binding a server and stopping it, so nothing depends on what happens to be listening.
- `LIFI_RPC_EXCLUDE` is not added to `.env.example`: it is an internal handoff between the retry loop and the resolver within a single run, not user configuration.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
