### PR TITLE
fix(VaultWrapper): clamp adapter maxWithdrawableValue to source maxWithdraw

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -27,15 +27,14 @@ future release adds cost-aware exit pricing.
 ## Source liquidity view
 
 `maxWithdrawableValue` is the source-liquidity signal behind the wrapper's
-liquidity-aware `maxRedeem`/`maxWithdraw`: the source's floor valuation
-(`convertToAssets`) of `min(holder position, source.maxRedeem)`, then clamped to
-`source.maxWithdraw`. The `maxWithdraw` clamp matters because the wrapper exits
-via exact-asset `withdraw` (bounded by `maxWithdraw`), and EIP-4626 permits that
-limit to be tighter than `convertToAssets(maxRedeem)` — reading the redeem axis
-alone would over-report and revert an exit within the wrapper's reported max. It
-equals the full position value on a source with no active liquidity limit, and
-shrinks to what the source can currently honor under a limit (an Aave-style
-utilization cap, a paused source).
+liquidity-aware `maxRedeem`/`maxWithdraw`: the source's `maxWithdraw` for the
+holder — the assets it can honor on exit right now, already capped by both the
+holder's position and current withdrawal liquidity. The wrapper always exits via
+exact-asset `withdraw` (bounded by `maxWithdraw`), so this reads that axis rather
+than the source's share-side `maxRedeem`, which EIP-4626 lets diverge and which
+the wrapper never exercises. It equals the full position value on a source with
+no active liquidity limit, and shrinks to what the source can currently honor
+under a limit (an Aave-style utilization cap, a paused source).
 
 ## Functions
 
@@ -52,7 +51,7 @@ function deposit(address _asset, address _underlying, uint256 _assets) external 
 /// Redeem `_assets` from the yield source; returns the asset amount received.
 function withdraw(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
 
-/// Gross floor valuation of `min(holder position, source.maxRedeem)`, clamped to `source.maxWithdraw` — the source-liquidity signal.
+/// The source's `maxWithdraw` for the holder — the exit-liquidity signal (the wrapper exits via `withdraw`, not `redeem`).
 function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 

--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -28,10 +28,14 @@ future release adds cost-aware exit pricing.
 
 `maxWithdrawableValue` is the source-liquidity signal behind the wrapper's
 liquidity-aware `maxRedeem`/`maxWithdraw`: the source's floor valuation
-(`convertToAssets`) of `min(holder position, source.maxRedeem)`. It equals the
-full position value on a source with no active liquidity limit, and shrinks to
-what the source can currently honor under a limit (an Aave-style utilization
-cap, a paused source).
+(`convertToAssets`) of `min(holder position, source.maxRedeem)`, then clamped to
+`source.maxWithdraw`. The `maxWithdraw` clamp matters because the wrapper exits
+via exact-asset `withdraw` (bounded by `maxWithdraw`), and EIP-4626 permits that
+limit to be tighter than `convertToAssets(maxRedeem)` — reading the redeem axis
+alone would over-report and revert an exit within the wrapper's reported max. It
+equals the full position value on a source with no active liquidity limit, and
+shrinks to what the source can currently honor under a limit (an Aave-style
+utilization cap, a paused source).
 
 ## Functions
 
@@ -48,7 +52,7 @@ function deposit(address _asset, address _underlying, uint256 _assets) external 
 /// Redeem `_assets` from the yield source; returns the asset amount received.
 function withdraw(address _asset, address _underlying, uint256 _assets) external returns (uint256 withdrawn)
 
-/// Gross floor valuation of `min(holder position, source.maxRedeem)` — the source-liquidity signal.
+/// Gross floor valuation of `min(holder position, source.maxRedeem)`, clamped to `source.maxWithdraw` — the source-liquidity signal.
 function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -25,7 +25,7 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 1.0.0
+/// @custom:version 1.0.1
 contract ERC4626Adapter is IYieldAdapter {
     /// @inheritdoc IYieldAdapter
     function resolveAsset(
@@ -84,8 +84,13 @@ contract ERC4626Adapter is IYieldAdapter {
 
     /// @inheritdoc IYieldAdapter
     /// @dev Source floor valuation (`convertToAssets`) of the smaller of the holder's
-    ///      position and the source's current `maxRedeem`. Equals the full position value
-    ///      when the source imposes no active liquidity limit.
+    ///      position and the source's current `maxRedeem`, then clamped to the source's
+    ///      `maxWithdraw`. The wrapper always exits via exact-asset `IERC4626.withdraw`
+    ///      (which the source bounds by `maxWithdraw`), so the redeem-derived value alone
+    ///      would over-report on a source whose `maxWithdraw` is tighter than
+    ///      `convertToAssets(maxRedeem)` — EIP-4626 permits the two limits to diverge, and
+    ///      an over-report would revert an exit within the wrapper's reported max. Equals
+    ///      the full position value when the source imposes no active liquidity limit.
     function maxWithdrawableValue(
         address _underlying,
         address _holder
@@ -94,5 +99,8 @@ contract ERC4626Adapter is IYieldAdapter {
         uint256 redeemable = IERC4626(_underlying).maxRedeem(_holder);
         uint256 shares = redeemable < position ? redeemable : position;
         assets = IERC4626(_underlying).convertToAssets(shares);
+
+        uint256 withdrawable = IERC4626(_underlying).maxWithdraw(_holder);
+        if (withdrawable < assets) assets = withdrawable;
     }
 }

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -25,7 +25,7 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 1.0.1
+/// @custom:version 1.0.0
 contract ERC4626Adapter is IYieldAdapter {
     /// @inheritdoc IYieldAdapter
     function resolveAsset(
@@ -83,24 +83,19 @@ contract ERC4626Adapter is IYieldAdapter {
     }
 
     /// @inheritdoc IYieldAdapter
-    /// @dev Source floor valuation (`convertToAssets`) of the smaller of the holder's
-    ///      position and the source's current `maxRedeem`, then clamped to the source's
-    ///      `maxWithdraw`. The wrapper always exits via exact-asset `IERC4626.withdraw`
-    ///      (which the source bounds by `maxWithdraw`), so the redeem-derived value alone
-    ///      would over-report on a source whose `maxWithdraw` is tighter than
-    ///      `convertToAssets(maxRedeem)` — EIP-4626 permits the two limits to diverge, and
-    ///      an over-report would revert an exit within the wrapper's reported max. Equals
-    ///      the full position value when the source imposes no active liquidity limit.
+    /// @dev The source's `maxWithdraw` for the holder — the assets it can honor on exit
+    ///      right now, already capped by both the holder's position and the source's
+    ///      current withdrawal liquidity. This is the exact axis the wrapper exits on: it
+    ///      always redeems via exact-asset `IERC4626.withdraw`, which the source bounds by
+    ///      `maxWithdraw`. The source's share-side `maxRedeem` is deliberately not consulted
+    ///      — the wrapper never calls `redeem`, EIP-4626 lets the two limits diverge, and
+    ///      only `maxWithdraw` governs whether an exit reverts; folding `maxRedeem` in could
+    ///      only under-report an exit the source would honor. Equals the full position value
+    ///      when the source imposes no active liquidity limit.
     function maxWithdrawableValue(
         address _underlying,
         address _holder
     ) external view returns (uint256 assets) {
-        uint256 position = IERC4626(_underlying).balanceOf(_holder);
-        uint256 redeemable = IERC4626(_underlying).maxRedeem(_holder);
-        uint256 shares = redeemable < position ? redeemable : position;
-        assets = IERC4626(_underlying).convertToAssets(shares);
-
-        uint256 withdrawable = IERC4626(_underlying).maxWithdraw(_holder);
-        if (withdrawable < assets) assets = withdrawable;
+        assets = IERC4626(_underlying).maxWithdraw(_holder);
     }
 }

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -75,15 +75,14 @@ interface IYieldAdapter {
 
     /// @notice Gross position value `_holder` can withdraw from `_underlying` right now,
     ///         capped by the source's current withdrawal-liquidity limits.
-    /// @dev Ordinary static call. Returns the source's floor valuation of
-    ///      `min(holder position, source maxRedeem)`, clamped to the source's `maxWithdraw`
-    ///      — gross (no fee netting), because the wrapper feeds it into its own gross share
-    ///      math to clamp `maxRedeem`/`maxWithdraw` to what the source can honor. The clamp
-    ///      to `maxWithdraw` matters because the wrapper exits via exact-asset `withdraw`,
-    ///      which the source bounds by `maxWithdraw`, and EIP-4626 permits that limit to be
-    ///      tighter than `convertToAssets(maxRedeem)`. Equals the full position value when
-    ///      the source imposes no limit. MAY revert if the source's views revert; the
-    ///      wrapper treats that as fail-closed.
+    /// @dev Ordinary static call. Returns the source's `maxWithdraw` for the holder — the
+    ///      assets it can honor on exit right now, capped by both position and withdrawal
+    ///      liquidity — gross (no fee netting), because the wrapper feeds it into its own
+    ///      gross share math to clamp `maxRedeem`/`maxWithdraw`. The wrapper exits via
+    ///      exact-asset `withdraw`, so `maxWithdraw` — not the source's share-side
+    ///      `maxRedeem`, which EIP-4626 lets diverge — is the axis that governs a revert.
+    ///      Equals the full position value when the source imposes no limit. MAY revert if
+    ///      the source's view reverts; the wrapper treats that as fail-closed.
     /// @param _underlying The yield source identifier.
     /// @param _holder The account whose position is valued (the wrapper).
     /// @return assets The gross, source-liquidity-capped position value.

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -76,11 +76,14 @@ interface IYieldAdapter {
     /// @notice Gross position value `_holder` can withdraw from `_underlying` right now,
     ///         capped by the source's current withdrawal-liquidity limits.
     /// @dev Ordinary static call. Returns the source's floor valuation of
-    ///      `min(holder position, source maxRedeem)` — gross (no fee netting), because the
-    ///      wrapper feeds it into its own gross share math to clamp `maxRedeem`/
-    ///      `maxWithdraw` to what the source can honor. Equals the full position value
-    ///      when the source imposes no limit. MAY revert if the source's views revert;
-    ///      the wrapper treats that as fail-closed.
+    ///      `min(holder position, source maxRedeem)`, clamped to the source's `maxWithdraw`
+    ///      — gross (no fee netting), because the wrapper feeds it into its own gross share
+    ///      math to clamp `maxRedeem`/`maxWithdraw` to what the source can honor. The clamp
+    ///      to `maxWithdraw` matters because the wrapper exits via exact-asset `withdraw`,
+    ///      which the source bounds by `maxWithdraw`, and EIP-4626 permits that limit to be
+    ///      tighter than `convertToAssets(maxRedeem)`. Equals the full position value when
+    ///      the source imposes no limit. MAY revert if the source's views revert; the
+    ///      wrapper treats that as fail-closed.
     /// @param _underlying The yield source identifier.
     /// @param _holder The account whose position is valued (the wrapper).
     /// @return assets The gross, source-liquidity-capped position value.

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -104,8 +104,13 @@ contract LossyVault {
 
     /// @dev Unlimited withdrawal liquidity: the whole balance is always redeemable, so the
     ///      wrapper's liquidity clamp in `maxRedeem` is a no-op and the shortfall path under
-    ///      test is still reached (`ERC4626Adapter.maxWithdrawableValue` calls this).
+    ///      test is still reached (`ERC4626Adapter.maxWithdrawableValue` reads both
+    ///      `maxRedeem` and `maxWithdraw`).
     function maxRedeem(address _owner) external view returns (uint256) {
+        return balanceOf[_owner];
+    }
+
+    function maxWithdraw(address _owner) external view returns (uint256) {
         return balanceOf[_owner];
     }
 }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -102,10 +102,10 @@ contract LossyVault {
         return _shares;
     }
 
-    /// @dev Unlimited withdrawal liquidity: the whole balance is always redeemable, so the
-    ///      wrapper's liquidity clamp in `maxRedeem` is a no-op and the shortfall path under
-    ///      test is still reached (`ERC4626Adapter.maxWithdrawableValue` reads both
-    ///      `maxRedeem` and `maxWithdraw`).
+    /// @dev Unlimited withdrawal liquidity: the whole balance is always withdrawable, so the
+    ///      wrapper's liquidity clamp is a no-op and the shortfall path under test is still
+    ///      reached. `ERC4626Adapter.maxWithdrawableValue` reads `maxWithdraw`; `maxRedeem`
+    ///      is retained for any consumer that still reads the share axis.
     function maxRedeem(address _owner) external view returns (uint256) {
         return balanceOf[_owner];
     }

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperWithdrawAxis.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperWithdrawAxis.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
+import { MockWithdrawCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockWithdrawCappedERC4626.sol";
+
+/// @notice Exercises the wrapper against a source whose withdraw axis is tighter than its
+///         redeem axis (`maxWithdraw < convertToAssets(maxRedeem)`). The wrapper exits via
+///         exact-asset `withdraw`, so `maxRedeem` must clamp to the withdraw axis for the
+///         EIP-4626 guarantee (a redeem within the reported max never reverts) to hold.
+contract LiFiVaultWrapperWithdrawAxisTest is VaultWrapperFactoryStackBase {
+    MockERC20 internal asset;
+    MockWithdrawCappedERC4626 internal source;
+
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal integrator = makeAddr("integrator");
+    address internal alice = makeAddr("alice");
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        source = new MockWithdrawCappedERC4626(asset, "Yield", "yTKN");
+
+        _bringUpFactory(address(source), [uint16(5000), 1000, 2000, 2000]);
+        _deployWrapper(_params());
+
+        asset.mint(alice, 1_000e18);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), 1_000e18);
+        wrapper.deposit(1_000e18, alice);
+        vm.stopPrank();
+    }
+
+    function _params() private view returns (DeployParams memory) {
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({ wallet: integrator, bps: 10000 });
+
+        return
+            DeployParams({
+                namespace: bytes32("LI.FI-Earn"),
+                vaultWrapperAdmin: vaultAdmin,
+                adapter: address(adapter),
+                underlying: address(source),
+                nonce: 0,
+                fees: FeeConfig({ rateBps: [uint16(0), 0, 0, 0] }),
+                integratorShareBps: [uint16(8000), 8000, 8000, 8000],
+                accessGate: address(0),
+                receivers: receivers
+            });
+    }
+
+    function test_MaxRedeemClampsToWithdrawAxis() public {
+        source.setWithdrawCap(300e18);
+
+        assertLt(wrapper.maxRedeem(alice), wrapper.balanceOf(alice));
+        assertApproxEqAbs(
+            wrapper.convertToAssets(wrapper.maxRedeem(alice)),
+            300e18,
+            2
+        );
+    }
+
+    function test_RedeemAtClampedMaxSucceeds() public {
+        source.setWithdrawCap(300e18);
+        uint256 shares = wrapper.maxRedeem(alice);
+
+        vm.prank(alice);
+        uint256 assets = wrapper.redeem(shares, alice, alice);
+
+        assertApproxEqAbs(assets, 300e18, 2);
+    }
+}

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -8,6 +8,7 @@ import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { MockERC4626Underlying } from "../mocks/MockERC4626Underlying.sol";
 import { MockLiquidityCappedERC4626 } from "../mocks/MockLiquidityCappedERC4626.sol";
+import { MockWithdrawCappedERC4626 } from "../mocks/MockWithdrawCappedERC4626.sol";
 
 contract ERC4626AdapterTest is Test {
     ERC4626Adapter internal adapter;
@@ -71,6 +72,30 @@ contract ERC4626AdapterTest is Test {
         capped.setWithdrawable(300e18);
 
         // Position is worth 1_000e18 but only 300e18 is currently withdrawable.
+        assertEq(
+            adapter.maxWithdrawableValue(address(capped), address(this)),
+            300e18
+        );
+    }
+
+    function test_MaxWithdrawableValueClampsToWithdrawAxis() public {
+        MockWithdrawCappedERC4626 capped = new MockWithdrawCappedERC4626(
+            asset,
+            "WithdrawCapped",
+            "wcTKN"
+        );
+        asset.mint(address(this), 1_000e18);
+        asset.approve(address(capped), 1_000e18);
+        capped.deposit(1_000e18, address(this));
+        capped.setWithdrawCap(300e18);
+
+        // maxRedeem is unrestricted (full balance, worth 1_000e18), but withdraw is capped
+        // at 300e18. The adapter must report the withdraw-axis limit, since the wrapper
+        // exits via `withdraw`; reading maxRedeem alone would over-report 1_000e18.
+        assertEq(
+            capped.convertToAssets(capped.maxRedeem(address(this))),
+            1_000e18
+        );
         assertEq(
             adapter.maxWithdrawableValue(address(capped), address(this)),
             300e18

--- a/test/solidity/VaultWrapper/mocks/MockWithdrawCappedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockWithdrawCappedERC4626.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+
+/// @notice ERC-4626 whose withdraw axis is capped tighter than its redeem axis: an
+///         asset-denominated `withdrawCap` bounds `maxWithdraw` and reverts `withdraw`
+///         past it, while `maxRedeem`/`redeem` stay unrestricted. EIP-4626 permits the two
+///         limits to diverge, so `convertToAssets(maxRedeem)` can exceed `maxWithdraw`.
+///         MockLiquidityCappedERC4626 cannot model this (it derives both limits from one
+///         cap); this source exists to prove the adapter must read the withdraw axis,
+///         since the wrapper always exits via `withdraw`.
+contract MockWithdrawCappedERC4626 is MockERC4626 {
+    error WithdrawExceedsCap();
+
+    uint256 public withdrawCap;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol
+    ) MockERC4626(_asset, _name, _symbol) {}
+
+    function setWithdrawCap(uint256 _assets) external {
+        withdrawCap = _assets;
+    }
+
+    function maxWithdraw(
+        address owner
+    ) public view override returns (uint256) {
+        uint256 own = convertToAssets(balanceOf[owner]);
+        return own < withdrawCap ? own : withdrawCap;
+    }
+
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public override returns (uint256) {
+        if (assets > maxWithdraw(owner)) revert WithdrawExceedsCap();
+
+        return super.withdraw(assets, receiver, owner);
+    }
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-803](https://linear.app/lifi-linear/issue/EXSC-803/vault-wrapper-adapter-maxwithdrawablevalue-reads-wrong-source)

# Why did I implement it this way?

`ERC4626Adapter.maxWithdrawableValue` derived the exit-liquidity bound from the source's `maxRedeem` (`convertToAssets(min(position, maxRedeem))`), but the wrapper always exits via exact-asset `IERC4626.withdraw`, which the source bounds by `maxWithdraw`. EIP-4626 treats the two limits as independent and permits `maxWithdraw` to be tighter than `convertToAssets(maxRedeem)`, so on such a source the adapter over-reported and a redeem within the wrapper's reported `maxRedeem` reverted at the source — re-breaking the exact guarantee the source-liquidity-aware exit views (#2214) were built to restore. Low severity, no fund loss (the revert fails safe), but it defeats the liquidity clamp on any source whose two axes diverge.

The fix reads `source.maxWithdraw(holder)` directly — the sole axis the wrapper's exit actually enforces, since it never calls `redeem`. `maxWithdraw` already caps by both the holder's position and current withdrawal liquidity, so the previous `balanceOf`/`maxRedeem`/`convertToAssets` trio collapses to a single source call (fewer reads per exit than before this fix, not more). Reading only `maxWithdraw` is also strictly more accurate: folding `maxRedeem` back in via a `min` could only under-report an exit the source would honor, and provides no safety on the wrapper's exit path. A non-compliant source that over-reports `maxWithdraw` is still bounded — the wrapper's `maxRedeem` short-circuit caps exits at the holder's actual shares and `AdapterWithdrawShortfall` catches a short-paying `withdraw`.

The single-cap `MockLiquidityCappedERC4626` can't reproduce the original bug (it derives both limits from one cap, so the axes never diverge), so this adds `MockWithdrawCappedERC4626` where the withdraw axis is tighter than the redeem axis, plus an adapter unit test and a wrapper-level regression test proving a redeem at the reported max no longer reverts. `LossyVault` gains a `maxWithdraw` so the adapter's read resolves. No version bump: the subsystem is unreleased, so per-change semver bumps are dropped as pre-deployment work (matches #2227).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
