### PR TITLE
refactor(VaultWrapper): remove duplicated logic in LiFiVaultWrapper (Ref EXSC-777)

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -385,7 +385,7 @@ contract LiFiVaultWrapper is
     /// @notice Returns the configured rate (bps) for a fee type.
     /// @param _feeType The FeeType ordinal (0-3).
     /// @return The fee rate in basis points.
-    function feeRate(uint8 _feeType) external view returns (uint16) {
+    function feeRate(uint8 _feeType) public view returns (uint16) {
         if (_feeType >= FEE_TYPE_COUNT) revert InvalidFeeType(_feeType);
         return _feeConfig.rateBps[_feeType];
     }
@@ -394,8 +394,7 @@ contract LiFiVaultWrapper is
     /// @param _feeType The FeeType ordinal (0-3).
     /// @return True if the fee type is enabled.
     function feeEnabled(uint8 _feeType) external view returns (bool) {
-        if (_feeType >= FEE_TYPE_COUNT) revert InvalidFeeType(_feeType);
-        return _feeConfig.rateBps[_feeType] != 0;
+        return feeRate(_feeType) != 0;
     }
 
     /// ERC-4626 entrypoints (reentrancy-guarded) ///

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -830,14 +830,7 @@ contract LiFiVaultWrapper is
             ) {
                 uint256 supply = totalSupply();
                 if (supply != 0) {
-                    uint192 currentPps = SafeCast.toUint192(
-                        LibVaultWrapperMath.pricePerShare(
-                            supply,
-                            totalAssets(),
-                            _decimalsOffset(),
-                            Math.Rounding.Ceil
-                        )
-                    );
+                    uint192 currentPps = _ceilPps(supply, totalAssets());
                     // Up-only: anchoring below the stored watermark would let the owner
                     // toggle the fee off/on at a trough and charge the recovery back to
                     // the old peak — the double-charge the watermark exists to prevent.
@@ -1096,14 +1089,7 @@ contract LiFiVaultWrapper is
         // supply is sub-floor escapes the performance fee, which is bounded (a sub-floor vault
         // is dust) and consistent with the "no depositor transacts below the floor" invariant.
         if (perfEnabled && supply < MIN_SHARE_SUPPLY) {
-            perfHighWaterMarkPps = SafeCast.toUint192(
-                LibVaultWrapperMath.pricePerShare(
-                    supply,
-                    assets,
-                    _decimalsOffset(),
-                    Math.Rounding.Ceil
-                )
-            );
+            perfHighWaterMarkPps = _ceilPps(supply, assets);
             return;
         }
 
@@ -1112,21 +1098,36 @@ contract LiFiVaultWrapper is
             _mint(address(this), perfShares);
             _bookDilution(FeeType.Performance, perfShares);
             supply += perfShares;
-            // Ceil, not floor: a floored post-dilution price can fall a full pps step below the
-            // price the fee was just charged at, re-opening that step to be charged again on the
-            // next crossing (severe for low-decimal assets, where a step is a coarse slice of
-            // AUM). Rounding up keeps the watermark at/above the crystallization price, at most
-            // under-charging by one sub-step — the holder-favouring direction the rest of the
-            // fee math already rounds in.
-            perfHighWaterMarkPps = SafeCast.toUint192(
+            perfHighWaterMarkPps = _ceilPps(supply, assets);
+        }
+    }
+
+    /// @dev The price per share the performance-fee watermark is anchored at, narrowed to
+    ///      the watermark's storage width. Ceil, not floor: a floored post-dilution price
+    ///      can fall a full pps step below the price the fee was just charged at, re-opening
+    ///      that step to be charged again on the next crossing (severe for low-decimal
+    ///      assets, where a step is a coarse slice of AUM). Rounding up keeps the watermark
+    ///      at/above the crystallization price, at most under-charging by one sub-step — the
+    ///      holder-favouring direction the rest of the fee math already rounds in. Prices
+    ///      through `_decimalsOffset()`, so it is only valid once `initialize` has written
+    ///      `shareDecimalsOffset` (the provisional anchor there uses the pure floored
+    ///      overload instead).
+    /// @param _supply The share supply to price against.
+    /// @param _assets The gross assets to price against.
+    /// @return The ceil-rounded price per share, scaled by `LibVaultWrapperMath.PPS_SCALE`.
+    function _ceilPps(
+        uint256 _supply,
+        uint256 _assets
+    ) private view returns (uint192) {
+        return
+            SafeCast.toUint192(
                 LibVaultWrapperMath.pricePerShare(
-                    supply,
-                    assets,
+                    _supply,
+                    _assets,
                     _decimalsOffset(),
                     Math.Rounding.Ceil
                 )
             );
-        }
     }
 
     /// @dev Single source of the management-fee computation, shared by `_accrueFees` and the

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -818,15 +818,12 @@ contract LiFiVaultWrapper is
     ) external onlyOwner nonReentrant {
         _accrueFees();
 
-        uint8 idx = uint8(_feeType);
         if (_newRateBps != 0) {
             (uint16 minBps, uint16 maxBps) = ILiFiVaultWrapperFactory(FACTORY)
                 .feeBounds(_feeType);
             if (_newRateBps < minBps || _newRateBps > maxBps)
                 revert FeeRateOutOfBounds(_newRateBps, minBps, maxBps);
-            if (
-                _feeType == FeeType.Performance && _feeConfig.rateBps[idx] == 0
-            ) {
+            if (_feeType == FeeType.Performance && _rate(_feeType) == 0) {
                 uint256 supply = totalSupply();
                 if (supply != 0) {
                     uint192 currentPps = _ceilPps(supply, totalAssets());
@@ -839,7 +836,7 @@ contract LiFiVaultWrapper is
                 }
             }
         }
-        _feeConfig.rateBps[idx] = _newRateBps;
+        _feeConfig.rateBps[uint8(_feeType)] = _newRateBps;
 
         emit FeeConfigUpdated(_feeType, _newRateBps);
     }
@@ -1058,8 +1055,8 @@ contract LiFiVaultWrapper is
     ///      crystallization price (rounded up) only when shares were actually minted — an
     ///      uncharged gain stays chargeable, unlike elapsed time.
     function _accrueFees() private {
-        bool mgmtEnabled = _feeConfig.rateBps[uint8(FeeType.Management)] != 0;
-        bool perfEnabled = _feeConfig.rateBps[uint8(FeeType.Performance)] != 0;
+        bool mgmtEnabled = _rate(FeeType.Management) != 0;
+        bool perfEnabled = _rate(FeeType.Performance) != 0;
         if (!mgmtEnabled && !perfEnabled) {
             lastMgmtAccrual = uint64(block.timestamp);
             return;
@@ -1141,7 +1138,7 @@ contract LiFiVaultWrapper is
         uint256 _supply,
         uint256 _assets
     ) private view returns (uint256 feeShares) {
-        uint16 rateBps = _feeConfig.rateBps[uint8(FeeType.Management)];
+        uint16 rateBps = _rate(FeeType.Management);
         if (
             lastMgmtAccrual == 0 ||
             rateBps == 0 ||
@@ -1177,7 +1174,7 @@ contract LiFiVaultWrapper is
         uint256 _supply,
         uint256 _assets
     ) private view returns (uint256) {
-        uint16 rateBps = _feeConfig.rateBps[uint8(FeeType.Performance)];
+        uint16 rateBps = _rate(FeeType.Performance);
         if (rateBps == 0) return 0;
 
         uint256 hwm = perfHighWaterMarkPps;

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -470,12 +470,7 @@ contract LiFiVaultWrapper is
     ///      the standard entrypoint actually returns, so it also catches an integrator
     ///      fee-rate change landing between the caller's quote and execution.
 
-    /// @notice Deposits exactly `_assets` for `_receiver`, reverting if fewer than
-    ///         `_minShares` shares are minted.
-    /// @param _assets The exact asset amount to deposit.
-    /// @param _receiver The share receiver.
-    /// @param _minShares The minimum acceptable amount of shares minted.
-    /// @return shares The shares actually minted.
+    /// @inheritdoc ILiFiVaultWrapper
     function deposit(
         uint256 _assets,
         address _receiver,
@@ -485,12 +480,7 @@ contract LiFiVaultWrapper is
         if (shares < _minShares) revert SlippageExceeded(shares, _minShares);
     }
 
-    /// @notice Mints exactly `_shares` for `_receiver`, reverting if more than
-    ///         `_maxAssets` assets are pulled.
-    /// @param _shares The exact share amount to mint.
-    /// @param _receiver The share receiver.
-    /// @param _maxAssets The maximum acceptable amount of assets pulled.
-    /// @return assets The assets actually pulled.
+    /// @inheritdoc ILiFiVaultWrapper
     function mint(
         uint256 _shares,
         address _receiver,
@@ -500,13 +490,7 @@ contract LiFiVaultWrapper is
         if (assets > _maxAssets) revert SlippageExceeded(assets, _maxAssets);
     }
 
-    /// @notice Withdraws exactly `_assets` to `_receiver`, reverting if more than
-    ///         `_maxShares` shares are burned.
-    /// @param _assets The exact asset amount to withdraw.
-    /// @param _receiver The asset receiver.
-    /// @param _owner The share owner being exited.
-    /// @param _maxShares The maximum acceptable amount of shares burned.
-    /// @return shares The shares actually burned.
+    /// @inheritdoc ILiFiVaultWrapper
     function withdraw(
         uint256 _assets,
         address _receiver,
@@ -517,13 +501,7 @@ contract LiFiVaultWrapper is
         if (shares > _maxShares) revert SlippageExceeded(shares, _maxShares);
     }
 
-    /// @notice Redeems exactly `_shares` to `_receiver`, reverting if fewer than
-    ///         `_minAssets` assets are paid out.
-    /// @param _shares The exact share amount to redeem.
-    /// @param _receiver The asset receiver.
-    /// @param _owner The share owner being exited.
-    /// @param _minAssets The minimum acceptable amount of assets paid out.
-    /// @return assets The assets actually paid out.
+    /// @inheritdoc ILiFiVaultWrapper
     function redeem(
         uint256 _shares,
         address _receiver,

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -985,28 +985,24 @@ contract LiFiVaultWrapper is
 
     /// @dev Entry screen: the share receiver must be allowed by the gate (which is
     ///      expected to fold its own sanctions view into `isAllowed`). No-op when no
-    ///      gate is set.
+    ///      gate is set. Reverting form of `_depositAllowed`, so the entry predicate
+    ///      has one definition shared with the `maxDeposit`/`maxMint` views.
     /// @param _receiver The share receiver of the deposit/mint.
     function _checkDepositAccess(address _receiver) private view {
-        address gate = accessGate;
-        if (gate == address(0)) return;
-        if (!IAccessGate(gate).isAllowed(_receiver))
-            revert AccountNotAllowed(_receiver);
+        if (!_depositAllowed(_receiver)) revert AccountNotAllowed(_receiver);
     }
 
     /// @dev Exit screen: sanctions-only, so any non-sanctioned holder can always exit
     ///      (even after falling off an allowlist). Screens the share owner (freezes a
     ///      sanctioned holder's funds) AND the asset receiver (never pays assets out to a
     ///      sanctioned address; a non-sanctioned owner just picks another receiver).
-    ///      No-op when no gate is set.
+    ///      No-op when no gate is set. Reverting form of `_sanctioned`, so the exit
+    ///      predicate has one definition shared with the `maxWithdraw`/`maxRedeem` views.
     /// @param _owner The share owner being exited.
     /// @param _receiver The asset receiver of the exit.
     function _checkExitAccess(address _owner, address _receiver) private view {
-        address gate = accessGate;
-        if (gate == address(0)) return;
-        if (IAccessGate(gate).isSanctioned(_owner))
-            revert AccountSanctioned(_owner);
-        if (_receiver != _owner && IAccessGate(gate).isSanctioned(_receiver))
+        if (_sanctioned(_owner)) revert AccountSanctioned(_owner);
+        if (_receiver != _owner && _sanctioned(_receiver))
             revert AccountSanctioned(_receiver);
     }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-777](https://linear.app/lifi-linear/issue/EXSC-777/s151-internal-ai-review) — this PR carries the *simplification* findings from that internal AI review pass (its security findings are tracked separately). Referenced rather than closed: EXSC-777 is already Done and covers the whole review pass, not just this refactor.

# Why did I implement it this way?

Five behavior-preserving simplifications to `LiFiVaultWrapper`, one per commit so each can be reviewed or reverted on its own. They all remove a second copy of something that already had a definition: the reverting access-gate checks re-implemented the `_depositAllowed`/`_sanctioned` predicates that the `max*` views use; the performance-fee watermark was written from three sites that each repeated the same `SafeCast.toUint192(pricePerShare(..., Ceil))` expression; `feeEnabled` repeated `feeRate`'s bounds check; four sites still inlined `_feeConfig.rateBps[uint8(...)]` instead of going through `_rate()`; and the four EIP-5143 overloads re-typed NatSpec that `ILiFiVaultWrapper` already carries. Net -29 lines with no storage-layout, inheritance-list, ABI, event, or revert change — `feeRate` moves from `external` to `public` (identical selector and ABI entry) only so `feeEnabled` can call it internally.

The watermark extraction is the one worth a close read, since the Ceil convention there was the subject of two recent fixes (dcadc70, f2a0a01): the rationale comment moved onto the new `_ceilPps` helper so all three write paths share one documented convention, and `initialize`'s provisional anchor is deliberately left on the pure floored overload. I verified the helper is still test-bound by mutating it to `Math.Rounding.Floor`, which fails 3 tests. For the NatSpec change I diffed `forge inspect` output before and after: devdoc is byte-identical and userdoc strictly gains the interface's "(EIP-5143 slippage-guarded …)" clause.

Each candidate came from a lens-based review pass and then an adversarial verifier tasked with refuting behavior-equivalence rather than confirming it. Three further candidates were rejected on that basis and are not in this PR: swapping `_saturatingAddUint128`/the decimals-offset clamp to OZ `Math` helpers (no LOC win, +72 bytes against ~1.1 KB of EIP-170 headroom), dropping `distributeFees`' all-zero early return (it is what keeps the call a no-op on the implementation contract while its CREATE3-predicted factory has no code, as `BeaconUpgrade.t.sol` sets up), and replacing the `_routeThroughAdapter` assembly with OZ `Address.functionDelegateCall` (OZ v5 rewrites empty-returndata failures into `Errors.FailedCall()`, so a Vyper `assert` or bare `require` in a yield source would stop bubbling verbatim).

`@custom:version` is deliberately left at 1.0.0: the subsystem has not shipped, so bumping an unreleased contract to 1.0.1 would add noise the eventual audit-log entry has to reconcile. The version-control CI job only runs on non-draft PRs targeting `main`, so it does not gate this one — happy to bump if you'd rather have it.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

No tests were added: every change is behavior-preserving, so the existing suite is the check that matters (338/338 pass on `test/solidity/VaultWrapper/**`, unchanged from the base branch). Note one pre-existing, seed-dependent failure in `testFuzz_DilutionShares_NoRevert` — it reproduces identically on `dev-vault-wrapper` with the same fuzz seed, because the fuzzer is free to pick `_decimalsOffset` up to 255 and `_totalSupply` near `uint256` max, so `_totalSupply + 10 ** offset` overflows on inputs the production offset range (6..18) cannot reach. Not touched here; worth bounding that test's inputs in a follow-up.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>