### PR TITLE
fix(safe): resolve whitelist pair selectors via registry + 4byte, color cut actions (EXSC-804)

### DIFF
--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -203,6 +203,25 @@ describe('formatBatchSetContractSelectorWhitelist', () => {
     return infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
   }
 
+  it('keeps case-variant base58 contracts in separate groups', async () => {
+    // Base58 is case-sensitive, so these are two different Tron contracts.
+    const tronA = 'TQ2Fh2FLdWkhCPMTGKBHGNhCzWNwLoxdYY'
+    const tronB = 'TQ2fh2fLdWkhCPMTGKBHGNhCzWNwLoxdYY'
+    stubFourByte({ [FALLBACK_ONLY]: FALLBACK_ONLY_SIGNATURE })
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatBatchSetContractSelectorWhitelist(
+      [[tronA, tronB], [FALLBACK_ONLY, TRANSFER], false],
+      'tron'
+    )
+    const output = infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(output).toContain(tronA)
+    expect(output).toContain(tronB)
+    // One "Contract:" line per address — a merged group would print only one.
+    expect(output.match(/Contract:/g)?.length).toBe(2)
+  })
+
   it('resolves a selector missing from whitelist.json via the 4byte lookup', async () => {
     stubFourByte({
       [FALLBACK_ONLY]: FALLBACK_ONLY_SIGNATURE,

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -1,19 +1,30 @@
 /**
  * Tests for role-name resolution and role-change display in safe-decode-utils.
- * Covers getRoleName (hash -> OZ AccessControl role name) and formatRoleChange
- * (the grantRole / revokeRole / renounceRole display path).
+ * Covers getRoleName (hash -> OZ AccessControl role name), formatRoleChange
+ * (the grantRole / revokeRole / renounceRole display path) and the selector
+ * resolution behind formatBatchSetContractSelectorWhitelist.
  */
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
 import {
   describe,
   expect,
   it,
   afterEach,
+  beforeEach,
   spyOn,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 import { consola } from 'consola'
+import { toFunctionSelector } from 'viem'
 
-import { getRoleName, formatRoleChange } from './safe-decode-utils'
+import {
+  getRoleName,
+  formatRoleChange,
+  formatBatchSetContractSelectorWhitelist,
+} from './safe-decode-utils'
 
 const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
 // OpenZeppelin AccessControl role hashes (public, keccak256 of role names) —
@@ -129,5 +140,106 @@ describe('decodeTransactionData', () => {
     } finally {
       globalThis.fetch = originalFetch
     }
+  })
+})
+describe('formatBatchSetContractSelectorWhitelist', () => {
+  // Addresses absent from config/whitelist.json, so every selector below takes
+  // the fallback path the whitelist lookup alone cannot answer.
+  const CONTRACT = '0xEe80aaE1e39b1d25b9FC99c8edF02bCd81f9eA30'
+  // Deliberately absent from every local source, so only the 4byte lookup
+  // can name it.
+  const FALLBACK_ONLY_SIGNATURE = 'fallbackOnlyProbe(uint256,address)'
+  const FALLBACK_ONLY = toFunctionSelector(FALLBACK_ONLY_SIGNATURE)
+  const TRANSFER = toFunctionSelector('transfer(address,uint256)')
+  const UNKNOWN_SELECTOR = '0xdeadbeef'
+
+  let cacheDir: string
+  let originalCachePath: string | undefined
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'selector-cache-'))
+    originalCachePath = process.env.SELECTOR_SIGNATURE_CACHE_PATH
+    process.env.SELECTOR_SIGNATURE_CACHE_PATH = path.join(
+      cacheDir,
+      'selector-signatures.json'
+    )
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalCachePath === undefined)
+      delete process.env.SELECTOR_SIGNATURE_CACHE_PATH
+    else process.env.SELECTOR_SIGNATURE_CACHE_PATH = originalCachePath
+    fs.rmSync(cacheDir, { recursive: true, force: true })
+    spyOn(consola, 'info').mockRestore()
+  })
+
+  const stubFourByte = (signatures: Record<string, string>): (() => number) => {
+    let calls = 0
+    globalThis.fetch = (() => {
+      calls++
+      const fnResults: Record<string, { name: string }[]> = {}
+      for (const [selector, name] of Object.entries(signatures))
+        fnResults[selector.toLowerCase()] = [{ name }]
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ ok: true, result: { function: fnResults } }),
+      })
+    }) as unknown as typeof fetch
+    return () => calls
+  }
+
+  const capture = async (selectors: string[]): Promise<string> => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatBatchSetContractSelectorWhitelist(
+      [selectors.map(() => CONTRACT), selectors, false],
+      'mainnet'
+    )
+    return infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+  }
+
+  it('resolves a selector missing from whitelist.json via the 4byte lookup', async () => {
+    stubFourByte({
+      [FALLBACK_ONLY]: FALLBACK_ONLY_SIGNATURE,
+    })
+    const output = await capture([FALLBACK_ONLY])
+    expect(output).toContain(FALLBACK_ONLY_SIGNATURE)
+    expect(output).toContain('via 4byte.sourcify.dev')
+    expect(output).not.toContain('signature unknown')
+  })
+
+  it('prefers the local registry and never calls 4byte for a locally-known selector', async () => {
+    const callCount = stubFourByte({})
+    const output = await capture([TRANSFER])
+    expect(output).toContain('transfer(address,uint256)')
+    expect(output).toContain('via well-known')
+    expect(callCount()).toBe(0)
+  })
+
+  it('batches every unresolved selector of the call into one request', async () => {
+    const callCount = stubFourByte({
+      [FALLBACK_ONLY]: FALLBACK_ONLY_SIGNATURE,
+    })
+    await capture([FALLBACK_ONLY, TRANSFER, UNKNOWN_SELECTOR])
+    expect(callCount()).toBe(1)
+  })
+
+  it('reports a selector no source can resolve as unknown', async () => {
+    stubFourByte({})
+    const output = await capture([UNKNOWN_SELECTOR])
+    expect(output).toContain(UNKNOWN_SELECTOR)
+    expect(output).toContain('signature unknown')
+  })
+
+  it('drops a 4byte signature that does not hash back to its selector', async () => {
+    stubFourByte({ [FALLBACK_ONLY]: 'transfer(address,uint256)' })
+    const output = await capture([FALLBACK_ONLY])
+    expect(output).toContain('signature unknown')
+    expect(output).not.toContain('transfer(address,uint256)')
   })
 })

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -276,11 +276,20 @@ async function getPeripheryDeploymentCheckSuffix(
   return ` \u001b[31m(❌ mismatch: expected ${expectedDisplay})\u001b[0m`
 }
 
-function formatBatchSetContractSelectorWhitelist(
+/**
+ * Renders the contract/selector pairs of a `batchSetContractSelectorWhitelist`
+ * call. Signatures are resolved per pair from `config/whitelist.json` first —
+ * the only source that ties a signature to this contract on this network, and
+ * so the only one that earns the ✓ — then from the shared selector registry,
+ * then from the batched 4byte lookup. Without the latter two, a pair missing
+ * from this network's whitelist entry leaves the signer eyeballing a raw
+ * selector.
+ */
+export async function formatBatchSetContractSelectorWhitelist(
   args: readonly unknown[],
   network?: string,
   indent?: string
-): void {
+): Promise<void> {
   const pre = indent ?? ''
   if (!args || args.length < 3) {
     consola.warn('Invalid arguments for batchSetContractSelectorWhitelist')
@@ -305,14 +314,39 @@ function formatBatchSetContractSelectorWhitelist(
     const selectorList = contractToSelectors.get(contract)
     if (selectorList) selectorList.push(selector)
   }
+
+  // Grouping keys are lowercased, which mangles a base58 Tron address — so
+  // both the lookup below and the rendering use the address as passed in.
+  const rows = [...contractToSelectors.entries()].map(
+    ([contract, selectorList]) => ({
+      contract: contracts.find((c) => c.toLowerCase() === contract) || contract,
+      selectorList,
+    })
+  )
+
+  // One batched lookup for everything neither whitelist.json nor the local
+  // registry can answer, so rendering below stays synchronous per selector.
+  const fourByteSignatures = network
+    ? await resolveSelectorsViaFourByte(
+        rows.flatMap(({ contract, selectorList }) =>
+          selectorList.filter(
+            (selector) =>
+              !lookupWhitelistMetaForContractSelector(
+                network,
+                contract,
+                selector
+              ).signature?.trim() && !getLocalSelectorInfo(selector)
+          )
+        )
+      )
+    : new Map<string, string>()
+
   const actionText = whitelisted ? 'Adding pairs' : 'Removing pairs'
   const actionColor = whitelisted ? '\u001b[32m' : '\u001b[33m'
   consola.info(`${pre}Action: ${actionColor}${actionText}\u001b[0m`)
   consola.info(`${pre}Total pairs: ${contracts.length}`)
   consola.info(`${pre}Pairs:`)
-  contractToSelectors.forEach((selectorList, contract) => {
-    const originalContract =
-      contracts.find((c) => c.toLowerCase() === contract) || contract
+  rows.forEach(({ contract: originalContract, selectorList }) => {
     let contractLabel = ''
     if (network) {
       const meta = lookupWhitelistMetaForContractSelector(
@@ -344,18 +378,32 @@ function formatBatchSetContractSelectorWhitelist(
         selector
       )
       const signature = meta.signature?.trim()
-      if (!signature) {
+      if (signature) {
+        const expected = computeSelectorFromSignature(signature)
+        const ok = expected.toLowerCase() === selector.toLowerCase()
+        const status = ok ? '\u001b[32m✓\u001b[0m' : '\u001b[31m✗\u001b[0m'
+        const mismatch = ok ? '' : ` \u001b[31m(expected ${expected})\u001b[0m`
         consola.info(
-          `${pre}      - \u001b[33m${selector}\u001b[0m \u001b[90m(signature unknown in whitelist)\u001b[0m`
+          `${pre}      - \u001b[33m${selector}\u001b[0m \u001b[36m${signature}\u001b[0m ${status}${mismatch}`
         )
         return
       }
-      const expected = computeSelectorFromSignature(signature)
-      const ok = expected.toLowerCase() === selector.toLowerCase()
-      const status = ok ? '\u001b[32m✓\u001b[0m' : '\u001b[31m✗\u001b[0m'
-      const mismatch = ok ? '' : ` \u001b[31m(expected ${expected})\u001b[0m`
+
+      const local = getLocalSelectorInfo(selector)
+      const fallbackSignature =
+        local?.signature ?? fourByteSignatures.get(selector.toLowerCase())
+      if (!fallbackSignature) {
+        consola.info(
+          `${pre}      - \u001b[33m${selector}\u001b[0m \u001b[90m(signature unknown)\u001b[0m`
+        )
+        return
+      }
+      // Sourced outside this network's whitelist entry, so the signature is
+      // not evidence that this contract exposes it — label the origin rather
+      // than showing the ✓ the whitelist path earns.
+      const source = local?.source ?? '4byte.sourcify.dev'
       consola.info(
-        `${pre}      - \u001b[33m${selector}\u001b[0m \u001b[36m${signature}\u001b[0m ${status}${mismatch}`
+        `${pre}      - \u001b[33m${selector}\u001b[0m \u001b[36m${fallbackSignature}\u001b[0m \u001b[90m(via ${source})\u001b[0m`
       )
     })
   })
@@ -777,7 +825,7 @@ export async function formatDecodedTxDataForDisplay(
       decoded?.functionName === 'batchSetContractSelectorWhitelist' &&
       decoded.args
     ) {
-      formatBatchSetContractSelectorWhitelist(decoded.args, network, pre)
+      await formatBatchSetContractSelectorWhitelist(decoded.args, network, pre)
       return
     }
 

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -304,22 +304,28 @@ export async function formatBatchSetContractSelectorWhitelist(
     )
     return
   }
+  // Case folding is only safe for hex addresses. Base58 is case-sensitive, so
+  // folding a Tron address risks merging two distinct contracts into one group
+  // and attributing the merged selectors to whichever address came first.
+  const groupingKey = (address: string): string =>
+    address.startsWith('0x') || address.startsWith('0X')
+      ? address.toLowerCase()
+      : address
   const contractToSelectors = new Map<string, string[]>()
   for (let i = 0; i < contracts.length; i++) {
-    const contract = contracts[i]?.toLowerCase()
+    const contract = contracts[i]
     const selector = selectors[i]
     if (!contract || !selector) continue
-    if (!contractToSelectors.has(contract))
-      contractToSelectors.set(contract, [])
-    const selectorList = contractToSelectors.get(contract)
+    const key = groupingKey(contract)
+    if (!contractToSelectors.has(key)) contractToSelectors.set(key, [])
+    const selectorList = contractToSelectors.get(key)
     if (selectorList) selectorList.push(selector)
   }
 
-  // Grouping keys are lowercased, which mangles a base58 Tron address — so
-  // both the lookup below and the rendering use the address as passed in.
+  // Every lookup and the rendering use the address as supplied, not the key.
   const rows = [...contractToSelectors.entries()].map(
-    ([contract, selectorList]) => ({
-      contract: contracts.find((c) => c.toLowerCase() === contract) || contract,
+    ([key, selectorList]) => ({
+      contract: contracts.find((c) => groupingKey(c) === key) || key,
       selectorList,
     })
   )

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -2300,10 +2300,12 @@ export async function decodeDiamondCut(
   indent?: string
 ) {
   const pre = indent ?? ''
+  // Green / yellow / red by escalating impact, so a Remove stands out in a cut
+  // that mixes actions.
   const actionMap: Record<number, string> = {
-    0: 'Add',
-    1: 'Replace',
-    2: 'Remove',
+    0: '\u001b[32mAdd\u001b[0m',
+    1: '\u001b[33mReplace\u001b[0m',
+    2: '\u001b[31mRemove\u001b[0m',
   }
 
   // Create selector map for efficient lookup


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-804](https://linear.app/lifi-linear/issue/EXSC-804/safe-signing-display-whitelist-selectors-fall-back-to-registry-4byte)

# Why did I implement it this way?

`decodeTransactionData` already resolves a call's selector through the shared selector registry (local sources → batched `4byte.sourcify.dev` lookup, disk-cached), which is why the outer `batchSetContractSelectorWhitelist` decodes fine. The inner contract/selector pairs never reached that registry: `formatBatchSetContractSelectorWhitelist` looked only at the network-scoped entry in `config/whitelist.json` and printed `(signature unknown in whitelist)` on a miss — so on a whitelist proposal, the one call where the selector list *is* the payload, the signer was left eyeballing bare 4-byte values.

Seen on an ApeChain removal proposal: `0xe0cbc5f2`, `0xeedd56e1`, `0x0e8ae67f`, `0x332d746b` and `0x2646478b` all rendered as unknown, though four resolve from `whitelist.json` itself through the registry's address-agnostic map and all five from the 4byte API.

Resolution order per pair is now whitelist entry → local registry → 4byte:

- The whitelist entry stays first and is the only source that keeps the `✓`/`✗` verification, because it is the only one that ties a signature to *this* contract on *this* network. A registry or 4byte match names the function but is not evidence that this address exposes it, so those render with a dim `(via <source>)` origin tag instead of a checkmark.
- Selectors the first two sources can't answer are collected across the whole call and fetched in **one** batched request before rendering, so per-selector rendering stays synchronous and a large batch costs at most one round trip (usually zero — the registry answers from `whitelist.json`).
- 4byte results keep the registry's existing `selector == keccak(signature)` check, so a colliding or poisoned entry degrades to `(signature unknown)` rather than a wrong-but-plausible name.
- Pairs are grouped per contract under a case-safe key — hex addresses fold to lowercase as before, base58 keeps its casing — and every lookup and the rendering use the address as supplied. Folding case on base58 could merge two distinct Tron contracts into one group and attribute the merged selectors to whichever address came first (found by CodeRabbit; the fold predates this PR). The added test fails on the old lowercase-everything key and passes on the new one.

**Also in this PR** — the `diamondCut` action label is now colored by escalating impact (Add green / Replace yellow / Remove red), so a Remove stands out in a cut that mixes actions. Same display surface, same signing session, three lines in `decodeDiamondCut`.

Verified against the real ApeChain payload: all five pairs now render with their signatures (contract labels included), and the same payload on a network where those addresses aren't whitelisted renders them via the registry fallback instead of as unknown.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
