### PR TITLE
fix(ci): keep reconcileParkedTasks alive when a network is retired (EXSC-807)

### DIFF
--- a/.agents/commands/deprecate-network.md
+++ b/.agents/commands/deprecate-network.md
@@ -18,6 +18,7 @@ This command completely removes a network (or multiple networks) from the codeba
 4. Removing the network entry from `script/deploy/_targetState.json` (removes both production and staging environments)
 5. Removing all deployment log files in `deployments/` directory that match the network name pattern
 6. Automatically updating the whitelist by running `bun update-whitelist-periphery`
+7. Cancelling any deferred diamond-cleanup task still parked on the network (manual queue transitions — there is no CLI for it)
 
 ## How to Use
 
@@ -116,14 +117,21 @@ When `/deprecate-network` is invoked with network names:
    - For deprecated networks: Move the network row(s) to the deprecated section
    - This is a manual step that must be done separately as the spreadsheet is not part of the codebase
 
-9. **Display summary**:
+9. **Cancel open parked diamond-cleanup tasks for the network**:
 
-   - List all networks successfully deprecated
-   - List all files removed
-   - List any warnings (e.g., network not found in networks.json, but found in foundry.toml)
-   - Display any errors encountered
+   - List them: `bunx tsx script/deploy/safe/list-parked-tasks.ts --network <network>`, and take every task still `queued` or `proposed`
+   - Those can never be drained once the network is gone — there is no RPC, no deploy log and no future diamond cut on it
+   - Abandon each one via the queue transitions in `script/deploy/safe/parked-tasks.ts`: `markCancelled` accepts only a `queued` task, so a `proposed` one needs `revertToQueued` first
+   - Leaving them open makes the weekly `reconcileParkedTasks` job report them as orphans every run
 
-10. **Search for remaining occurrences**:
+10. **Display summary**:
+
+    - List all networks successfully deprecated
+    - List all files removed
+    - List any warnings (e.g., network not found in networks.json, but found in foundry.toml)
+    - Display any errors encountered
+
+11. **Search for remaining occurrences**:
 
 - For each deprecated network, search the entire codebase for occurrences of the network name
 - Use case-insensitive search to find all matches (e.g., `grep -ri "fantom" --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=out --exclude-dir=cache --exclude-dir=broadcast --exclude-dir=typechain --exclude-dir=lib`)

--- a/.agents/commands/deprecate-network.md
+++ b/.agents/commands/deprecate-network.md
@@ -12,19 +12,20 @@ usage: /deprecate-network <network1> [network2] [network3] ...
 
 This command completely removes a network (or multiple networks) from the codebase by:
 
-1. Removing the network entry from `config/networks.json`
-2. Removing the RPC endpoint entry from `foundry.toml` under `[rpc_endpoints]`
-3. Removing the etherscan entry from `foundry.toml` under `[etherscan]`
-4. Removing the network entry from `script/deploy/_targetState.json` (removes both production and staging environments)
-5. Removing all deployment log files in `deployments/` directory that match the network name pattern
-6. Automatically updating the whitelist by running `bun update-whitelist-periphery`
-7. Cancelling any deferred diamond-cleanup task still parked on the network (manual queue transitions — there is no CLI for it)
+1. Cancelling any deferred diamond-cleanup task still parked on the network, first, while the config it depends on still exists (manual queue transitions — there is no CLI for it)
+2. Removing the network entry from `config/networks.json`
+3. Removing the RPC endpoint entry from `foundry.toml` under `[rpc_endpoints]`
+4. Removing the etherscan entry from `foundry.toml` under `[etherscan]`
+5. Removing the network entry from `script/deploy/_targetState.json` (removes both production and staging environments)
+6. Removing all deployment log files in `deployments/` directory that match the network name pattern
+7. Automatically updating the whitelist by running `bun update-whitelist-periphery`
 
 ## How to Use
 
 1. Type `/deprecate-network` followed by one or more network names (space-separated)
 2. The command will automatically:
    - Validate that the networks exist in `config/networks.json`
+   - Cancel any parked diamond-cleanup task still open on the networks
    - Remove network entries from `config/networks.json`
    - Remove RPC endpoint entries from `foundry.toml`
    - Remove etherscan entries from `foundry.toml`
@@ -57,21 +58,28 @@ When `/deprecate-network` is invoked with network names:
    - If a network doesn't exist, warn the user but continue with other networks
    - Display list of networks to be deprecated for confirmation
 
-2. **Remove from `config/networks.json`**:
+2. **Cancel open parked diamond-cleanup tasks** (before anything destructive):
+
+   - List them: `bunx tsx script/deploy/safe/list-parked-tasks.ts --network <network>`, and take every task still `queued` or `proposed`
+   - Those can never be drained once the network is gone — there is no RPC, no deploy log and no future diamond cut on it
+   - Abandon each one via the queue transitions in `script/deploy/safe/parked-tasks.ts`: `markCancelled` accepts only a `queued` task, so a `proposed` one needs `revertToQueued` first
+   - If a task will not transition, **abort the deprecation for that network** and report its `taskKey`. Removing the config first and failing here strands the task permanently — the weekly `reconcileParkedTasks` job then reports it as an orphan every run
+
+3. **Remove from `config/networks.json`**:
 
    - Read the JSON file
    - For each network, remove the entire network object (e.g., `"fantom": { ... }`)
    - Write the updated JSON back to the file
    - Preserve JSON formatting and indentation
 
-3. **Remove from `foundry.toml` - RPC endpoints**:
+4. **Remove from `foundry.toml` - RPC endpoints**:
 
    - Read `foundry.toml`
    - Locate the `[rpc_endpoints]` section
    - For each network, remove the line: `{network} = "${ETH_NODE_URI_{NETWORK}}"` (case-insensitive matching)
    - Preserve TOML formatting and comments
 
-4. **Remove from `foundry.toml` - Etherscan**:
+5. **Remove from `foundry.toml` - Etherscan**:
 
    - Locate the `[etherscan]` section
    - For each network, remove the entire etherscan entry block:
@@ -83,7 +91,7 @@ When `/deprecate-network` is invoked with network names:
    - Handle entries that may span multiple lines
    - Preserve TOML formatting and comments
 
-5. **Remove from `script/deploy/_targetState.json`**:
+6. **Remove from `script/deploy/_targetState.json`**:
 
    - Read the target state JSON file
    - For each network, remove the entire network entry (e.g., `"fantom": { ... }`)
@@ -93,7 +101,7 @@ When `/deprecate-network` is invoked with network names:
    - Preserve JSON formatting and indentation
    - If the network doesn't exist in target state, skip silently (not an error)
 
-6. **Remove deployment log files**:
+7. **Remove deployment log files**:
 
    - For each network, delete all files in `deployments/` directory matching:
      - `{network}.json`
@@ -103,26 +111,19 @@ When `/deprecate-network` is invoked with network names:
    - Use case-insensitive matching for network names
    - If a file doesn't exist, skip silently (not an error)
 
-7. **Update whitelist**:
+8. **Update whitelist**:
 
    - Automatically execute `bun update-whitelist-periphery` command
    - This ensures the whitelist configuration is updated to reflect the deprecated networks
    - If the command fails, report the error but don't abort (the network deprecation is already complete)
    - Display the command output for verification
 
-8. **Remind user to update Product Target Sheet**:
+9. **Remind user to update Product Target Sheet**:
 
    - Display a prominent reminder to manually update the Product Target State spreadsheet
    - The spreadsheet tracks contract deployments across networks: https://docs.google.com/spreadsheets/d/1jX1wfFkSn1s19I_KzMA7vB1kfgGxXUv7kRqwUGJJLF4/edit#gid=0
    - For deprecated networks: Move the network row(s) to the deprecated section
    - This is a manual step that must be done separately as the spreadsheet is not part of the codebase
-
-9. **Cancel open parked diamond-cleanup tasks for the network**:
-
-   - List them: `bunx tsx script/deploy/safe/list-parked-tasks.ts --network <network>`, and take every task still `queued` or `proposed`
-   - Those can never be drained once the network is gone — there is no RPC, no deploy log and no future diamond cut on it
-   - Abandon each one via the queue transitions in `script/deploy/safe/parked-tasks.ts`: `markCancelled` accepts only a `queued` task, so a `proposed` one needs `revertToQueued` first
-   - Leaving them open makes the weekly `reconcileParkedTasks` job report them as orphans every run
 
 10. **Display summary**:
 

--- a/.github/workflows/reconcileParkedTasks.yml
+++ b/.github/workflows/reconcileParkedTasks.yml
@@ -5,7 +5,9 @@
 #   re-queued. See script/deploy/safe/reconcile-parked-tasks.ts + docs/DeferredDiamondCleanupQueue.md §7/§8.
 # - TTL backstop: any open task older than the TTL (default 60d) is posted to the
 #   github-ci-notifications Slack channel so a cold network that never gets another cut is never
-#   silently orphaned (§8).
+#   silently orphaned (§8). The same alert lists tasks whose network has been retired from
+#   config/networks.json (unreconcilable orphans awaiting a cancel) and any network/environment
+#   group the sweep could not evaluate. Only the latter fails the run.
 # - Runs with --yes so transitions are applied and the alert is sent. Transitions touch only the
 #   un-gated MONGODB_URI queue (status flips), never on-chain state or the signing store.
 # - Loupe-primary: SC_MONGODB_URI (the signing store) is NOT reachable from GitHub Actions (no tunnel),
@@ -84,6 +86,8 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
+          # Surface a rejected/expired webhook instead of reporting a delivery that never happened.
+          errors: true
           payload: |
             {
               "text": ":warning: reconcile-parked-tasks run failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|run #${{ github.run_number }}>"

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -665,6 +665,19 @@ until executed" window (Fact 10). Two mitigations, both in this spec:
 - `/deprecate-contract`'s existing "don't delete `deployments/*.json` entries until
   executed" warning (Fact 10) is **strengthened** to "until the parked task retires."
 
+**Network-retirement hazard.** `/deprecate-network` removes the network from
+`config/networks.json` and its `deployments/*.json`, which takes away everything a
+parked task on that network needs: there is no RPC to read the loupe with, no deploy
+log to resolve the diamond from, and no future cut to ride along with. Such a task can
+never reach a terminal state on its own. The reconcile therefore partitions those tasks
+out **before** any I/O and reports them in the TTL alert as orphans to cancel, and
+treats a per-network error as a skip rather than an abort: otherwise a fleet loop that
+dies on its first unusable network takes the whole sweep — and this backstop alert,
+which runs after it — down with it.
+A network deprecation should still abandon the retired network's open tasks
+(`revertToQueued` then `markCancelled`, since `markCancelled` accepts only a `queued`
+task) rather than leave them for the alert to repeat.
+
 ---
 
 ## 9. Observability

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -22,7 +22,11 @@ import { EnvironmentEnum } from '../../common/types'
 import { type IParkedTask } from './parked-tasks'
 import {
   computeTtlAlerts,
+  formatOrphanedTaskMessage,
+  formatReconcileFailureMessage,
   formatTtlAlertMessage,
+  joinAlertSections,
+  partitionRetiredNetworks,
   reconcileDecision,
   ttlAlertDelivery,
 } from './reconcile-parked-tasks'
@@ -212,5 +216,113 @@ describe('ttlAlertDelivery', () => {
 
   it('does not report a misconfiguration on a local run with no webhook', () => {
     expect(ttlAlertDelivery(true, false, undefined)).toBe('local')
+  })
+})
+
+describe('partitionRetiredNetworks', () => {
+  const known = (n: string) => ['arbitrum', 'optimism'].includes(n)
+
+  it('keeps tasks whose network is still configured', () => {
+    const tasks = [
+      parked({ network: 'arbitrum' }),
+      parked({ network: 'optimism' }),
+    ]
+    const { reconcilable, orphaned } = partitionRetiredNetworks(tasks, known)
+    expect(reconcilable).toEqual(tasks)
+    expect(orphaned).toEqual([])
+  })
+
+  it('holds back a task on a retired network instead of letting it reach the loupe', () => {
+    const { reconcilable, orphaned } = partitionRetiredNetworks(
+      [
+        parked({ network: 'harmony', facetName: 'GenericSwapFacet' }),
+        parked({ network: 'arbitrum', facetName: 'AcrossFacetV3' }),
+      ],
+      known
+    )
+    expect(reconcilable.map((t) => t.network)).toEqual(['arbitrum'])
+    expect(orphaned).toEqual([
+      {
+        network: 'harmony',
+        environment: EnvironmentEnum.production,
+        facet: 'GenericSwapFacet',
+        status: 'queued',
+        prUrl: 'https://github.com/lifinance/contracts/pull/2046',
+      },
+    ])
+  })
+
+  it('reports every retired network, not just the first one reached', () => {
+    const { reconcilable, orphaned } = partitionRetiredNetworks(
+      ['evmos', 'harmony', 'moonbeam', 'okx', 'velas'].map((network) =>
+        parked({ network })
+      ),
+      known
+    )
+    expect(reconcilable).toEqual([])
+    expect(orphaned.map((o) => o.network)).toEqual([
+      'evmos',
+      'harmony',
+      'moonbeam',
+      'okx',
+      'velas',
+    ])
+  })
+})
+
+describe('formatOrphanedTaskMessage', () => {
+  it('returns an empty string when no task sits on a retired network', () => {
+    expect(formatOrphanedTaskMessage([])).toBe('')
+  })
+
+  it('names the network, facet, status and PR of each orphan', () => {
+    const msg = formatOrphanedTaskMessage([
+      {
+        network: 'harmony',
+        environment: EnvironmentEnum.production,
+        facet: 'GenericSwapFacet',
+        status: 'queued',
+        prUrl: 'https://gh/pull/2046',
+      },
+    ])
+    expect(msg).toContain('config/networks.json')
+    expect(msg).toContain('harmony')
+    expect(msg).toContain('GenericSwapFacet')
+    expect(msg).toContain('queued')
+    expect(msg).toContain('https://gh/pull/2046')
+  })
+})
+
+describe('formatReconcileFailureMessage', () => {
+  it('returns an empty string when every network reconciled', () => {
+    expect(formatReconcileFailureMessage([])).toBe('')
+  })
+
+  it('names the failed group, its task count and the underlying reason', () => {
+    const msg = formatReconcileFailureMessage([
+      {
+        network: 'zksync',
+        environment: EnvironmentEnum.production,
+        reason: 'HTTP request failed',
+        taskCount: 3,
+      },
+    ])
+    expect(msg).toContain('zksync')
+    expect(msg).toContain('3 task(s)')
+    expect(msg).toContain('HTTP request failed')
+  })
+})
+
+describe('joinAlertSections', () => {
+  it('drops empty sections so a single populated one carries no blank padding', () => {
+    expect(joinAlertSections('', 'orphans', '')).toBe('orphans')
+  })
+
+  it('separates populated sections with a blank line', () => {
+    expect(joinAlertSections('ttl', 'orphans')).toBe('ttl\n\norphans')
+  })
+
+  it('returns an empty string when there is nothing to report', () => {
+    expect(joinAlertSections('', '', '')).toBe('')
   })
 })

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -1,12 +1,15 @@
 /**
  * Tests for the deferred diamond-cleanup reconcile job (reconcile-parked-tasks.ts).
  *
- * The two pure decisions are exercised directly: {@link reconcileDecision} maps a
- * task's status + on-chain/proposal truth to a lifecycle transition, and
+ * The pure decisions are exercised directly: {@link reconcileDecision} maps a
+ * task's status + on-chain/proposal truth to a lifecycle transition,
  * {@link computeTtlAlerts} / {@link formatTtlAlertMessage} surface open tasks that
- * have aged past the TTL, and {@link ttlAlertDelivery} decides whether an alert is
- * posted, logged, or treated as a misconfiguration. The live CLI (Mongo/loupe/Slack
- * wiring) is unit-test exempt, mirroring the store's `getParkedTasksCollection()` carve-out.
+ * have aged past the TTL, {@link ttlAlertDelivery} decides whether an alert is
+ * posted, logged, or treated as a misconfiguration, and
+ * {@link partitionRetiredNetworks} / {@link redactErrorReason} plus the section
+ * formatters decide what an unreconcilable network contributes to the alert. The live
+ * CLI (Mongo/loupe/Slack wiring) is unit-test exempt, mirroring the store's
+ * `getParkedTasksCollection()` carve-out.
  */
 
 import {
@@ -27,6 +30,7 @@ import {
   formatTtlAlertMessage,
   joinAlertSections,
   partitionRetiredNetworks,
+  redactErrorReason,
   reconcileDecision,
   ttlAlertDelivery,
 } from './reconcile-parked-tasks'
@@ -310,6 +314,52 @@ describe('formatReconcileFailureMessage', () => {
     expect(msg).toContain('zksync')
     expect(msg).toContain('3 task(s)')
     expect(msg).toContain('HTTP request failed')
+  })
+})
+
+describe('redactErrorReason', () => {
+  // Verbatim `error.message` of a viem HttpRequestError (viem@2.33.2) — the shape that
+  // reaches the catch block, carrying the endpoint an RPC URL's API key lives in.
+  const VIEM_HTTP_ERROR = [
+    'HTTP request failed.',
+    '',
+    'URL: https://lb.drpc.org/ogrpc?network=base&dkey=SECRET-KEY-VALUE',
+    'Request body: {"method":"eth_call"}',
+    '',
+    'Details: Was there a typo in the url or port?',
+    'Version: viem@2.33.2',
+  ].join('\n')
+
+  it('strips the endpoint out of a real viem HTTP error', () => {
+    const reason = redactErrorReason(VIEM_HTTP_ERROR)
+    expect(reason).not.toContain('SECRET-KEY-VALUE')
+    expect(reason).not.toContain('drpc.org')
+    expect(reason).toContain('<redacted-url>')
+    expect(reason).toContain('HTTP request failed.')
+  })
+
+  it('strips a mongo connection string, not only http endpoints', () => {
+    const reason = redactErrorReason(
+      'connect ECONNREFUSED mongodb+srv://user:pw@cluster.example.net/db'
+    )
+    expect(reason).not.toContain('pw@')
+    expect(reason).toContain('<redacted-url>')
+  })
+
+  it('collapses the message to one line so the alert layout survives', () => {
+    expect(redactErrorReason(VIEM_HTTP_ERROR)).not.toContain('\n')
+  })
+
+  it('caps an over-long message', () => {
+    const reason = redactErrorReason('x'.repeat(500))
+    expect(reason.length).toBeLessThanOrEqual(181)
+    expect(reason.endsWith('…')).toBe(true)
+  })
+
+  it('leaves a plain message untouched', () => {
+    expect(redactErrorReason('Deployments file not found for arbitrum')).toBe(
+      'Deployments file not found for arbitrum'
+    )
   })
 })
 

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -251,15 +251,17 @@ export function formatOrphanedTaskMessage(
 const MAX_REASON_LENGTH = 180
 
 /**
- * Makes an error message safe to post outside the job log: strips every URL and
- * collapses it to one line.
+ * Makes an error message safe to post outside the job log: strips every
+ * scheme-prefixed URL and collapses the rest to one line.
  *
- * Viem embeds the full endpoint in `error.message` (`URL: https://…/<api-key>`), and
- * Slack is outside the `::add-mask::` redaction that protects the workflow log — so an
- * RPC failure would otherwise publish the key to the channel.
+ * Viem embeds the full endpoint in `error.message` (`URL: https://…/<api-key>`) and the
+ * Mongo driver can echo its connection string, while Slack is outside the `::add-mask::`
+ * redaction that protects the workflow log — so a failure would otherwise publish the
+ * credential to the channel. Only the reason is redacted, never the whole alert: the TTL
+ * section's origin-PR links are what make it actionable.
  *
  * @param message - Raw error message.
- * @returns A single-line, URL-free, length-capped reason.
+ * @returns A single-line, length-capped reason with `scheme://…` tokens replaced.
  */
 export function redactErrorReason(message: string): string {
   const redacted = message

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -185,6 +185,7 @@ export interface IOrphanedParkedTask {
 export interface IReconcileFailure {
   network: string
   environment: EnvironmentEnum
+  /** Alert-safe error text — always via {@link redactErrorReason}, never a raw message. */
   reason: string
   taskCount: number
 }
@@ -244,6 +245,30 @@ export function formatOrphanedTaskMessage(
       `   - [${o.network}:${o.environment}] ${o.facet} (${o.status}) → ${o.prUrl}`
     )
   return lines.join('\n')
+}
+
+/** Longest error text kept in an alert line; viem messages run to several hundred chars. */
+const MAX_REASON_LENGTH = 180
+
+/**
+ * Makes an error message safe to post outside the job log: strips every URL and
+ * collapses it to one line.
+ *
+ * Viem embeds the full endpoint in `error.message` (`URL: https://…/<api-key>`), and
+ * Slack is outside the `::add-mask::` redaction that protects the workflow log — so an
+ * RPC failure would otherwise publish the key to the channel.
+ *
+ * @param message - Raw error message.
+ * @returns A single-line, URL-free, length-capped reason.
+ */
+export function redactErrorReason(message: string): string {
+  const redacted = message
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, '<redacted-url>')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return redacted.length > MAX_REASON_LENGTH
+    ? `${redacted.slice(0, MAX_REASON_LENGTH)}…`
+    : redacted
 }
 
 /**
@@ -419,14 +444,14 @@ async function reconcileAll(
             await revertToQueued(parkedTasks, task.taskKey)
         }
       } catch (error) {
-        const reason = error instanceof Error ? error.message : String(error)
+        const message = error instanceof Error ? error.message : String(error)
         consola.error(
-          `[${network}:${environment}] reconcile failed, continuing with the remaining networks: ${reason}`
+          `[${network}:${environment}] reconcile failed, continuing with the remaining networks: ${message}`
         )
         failures.push({
           network,
           environment,
-          reason,
+          reason: redactErrorReason(message),
           taskCount: tasks.length,
         })
       }

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -16,10 +16,18 @@
  *
  *  2. **TTL alert** — surface open tasks that have aged past the TTL (default 60d)
  *     to the github-ci-notifications Slack channel, so a cold network that never gets
- *     another cut is never silently orphaned (spec §8 backstop).
+ *     another cut is never silently orphaned (spec §8 backstop). The same alert
+ *     carries what the reconcile could not resolve: tasks on a network retired from
+ *     `config/networks.json` (permanent orphans — no RPC, no deploy log, no future
+ *     cut) and network groups that errored this run.
+ *
+ * The sweep is per-network fault-isolated in both directions: a retired network is
+ * partitioned out before any I/O and a group that throws is recorded and skipped.
+ * The alert therefore always runs, and only a group that errored fails the process.
  *
  * The pure decisions ({@link reconcileDecision}, {@link computeTtlAlerts},
- * {@link formatTtlAlertMessage}) are fully unit-tested; only the live CLI wiring
+ * {@link formatTtlAlertMessage}, {@link partitionRetiredNetworks} and the alert
+ * section formatters) are fully unit-tested; only the live CLI wiring
  * (Mongo/loupe/Slack) is unit-test exempt, mirroring `getParkedTasksCollection()`.
  * Dry-run by default (#2047 convention); pass `--yes` to apply transitions and
  * send the alert.
@@ -31,8 +39,10 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { getAddress } from 'viem'
 
+import { type EnvironmentEnum } from '../../common/types'
 import { isUnattendedRun, SlackNotifier } from '../../utils/slack-notifier'
 import { getEnvVar } from '../../utils/utils'
+import { networks } from '../../utils/viemScriptHelpers'
 
 import { fetchOnChainFacets, resolveDiamondAddress } from './diamondRemovalDiff'
 import {
@@ -160,6 +170,106 @@ export function formatTtlAlertMessage(
   return lines.join('\n')
 }
 
+/** An open task whose network `config/networks.json` no longer knows. */
+export interface IOrphanedParkedTask {
+  network: string
+  environment: EnvironmentEnum
+  facet: string
+  status: ParkedTaskStatus
+  prUrl: string
+}
+
+/** A (network, environment) group the reconcile could not evaluate this run. */
+export interface IReconcileFailure {
+  network: string
+  environment: EnvironmentEnum
+  reason: string
+  taskCount: number
+}
+
+/**
+ * Splits open tasks into those whose network is still configured and those whose
+ * network has been retired from `config/networks.json`.
+ *
+ * A retired network has no RPC, no deploy log and will never receive another
+ * diamond cut, so its tasks can neither be reconciled against the loupe nor
+ * drained — they are orphans awaiting a human cancel. Filtering them out
+ * before any I/O is what keeps one retired network from aborting the whole sweep
+ * (and with it the TTL backstop that runs after it).
+ *
+ * @param tasks - Open tasks (any network).
+ * @param isNetworkKnown - Whether `config/networks.json` still has the network.
+ * @returns The reconcilable tasks and the orphans, both in input order.
+ */
+export function partitionRetiredNetworks(
+  tasks: IParkedTask[],
+  isNetworkKnown: (network: string) => boolean
+): { reconcilable: IParkedTask[]; orphaned: IOrphanedParkedTask[] } {
+  const reconcilable: IParkedTask[] = []
+  const orphaned: IOrphanedParkedTask[] = []
+  for (const t of tasks) {
+    if (isNetworkKnown(t.network)) {
+      reconcilable.push(t)
+      continue
+    }
+    orphaned.push({
+      network: t.network,
+      environment: t.environment,
+      facet: t.facetName,
+      status: t.status,
+      prUrl: t.prUrl,
+    })
+  }
+  return { reconcilable, orphaned }
+}
+
+/**
+ * Formats the retired-network section of the alert. Returns `''` when there are no
+ * orphans so the caller can drop the section.
+ *
+ * @param orphaned - Orphans from {@link partitionRetiredNetworks}.
+ * @returns A Slack-ready section, or `''` if `orphaned` is empty.
+ */
+export function formatOrphanedTaskMessage(
+  orphaned: IOrphanedParkedTask[]
+): string {
+  if (orphaned.length === 0) return ''
+  const lines = [
+    `🪦 ${orphaned.length} deferred diamond-cleanup task(s) sit on network(s) no longer in \`config/networks.json\` — they can never be drained; abandon them (\`revertToQueued\` first if \`proposed\`, then \`markCancelled\`) or re-add the network:`,
+  ]
+  for (const o of orphaned)
+    lines.push(
+      `   - [${o.network}:${o.environment}] ${o.facet} (${o.status}) → ${o.prUrl}`
+    )
+  return lines.join('\n')
+}
+
+/**
+ * Formats the per-network failure section of the alert. Returns `''` when the sweep
+ * evaluated every group.
+ *
+ * @param failures - Groups the reconcile skipped after an error.
+ * @returns A Slack-ready section, or `''` if `failures` is empty.
+ */
+export function formatReconcileFailureMessage(
+  failures: IReconcileFailure[]
+): string {
+  if (failures.length === 0) return ''
+  const lines = [
+    `❌ the reconcile could not evaluate ${failures.length} network/environment group(s) this run — their tasks keep their current status:`,
+  ]
+  for (const f of failures)
+    lines.push(
+      `   - [${f.network}:${f.environment}] ${f.taskCount} task(s): ${f.reason}`
+    )
+  return lines.join('\n')
+}
+
+/** Joins the non-empty alert sections; `''` when every section is empty. */
+export function joinAlertSections(...sections: string[]): string {
+  return sections.filter((s) => s !== '').join('\n\n')
+}
+
 export type TtlAlertDelivery = 'dry-run' | 'local' | 'misconfigured' | 'send'
 
 /**
@@ -201,13 +311,25 @@ async function resolveProposalStatus(
   return doc?.status
 }
 
-/** Reconciles every open task, grouped by (network, environment) so the loupe is fetched once each. */
+/** What one reconcile sweep could not resolve, for the alert and the exit code. */
+interface IReconcileOutcome {
+  orphaned: IOrphanedParkedTask[]
+  failures: IReconcileFailure[]
+}
+
+/**
+ * Reconciles every open task, grouped by (network, environment) so the loupe is
+ * fetched once each. Never throws for a single group: a retired network is
+ * partitioned out before any I/O and a group that errors is recorded and skipped,
+ * so one bad network cannot cost the rest of the sweep or the TTL alert that
+ * follows it.
+ */
 async function reconcileAll(
   parkedTasks: Parameters<typeof listParkedTasks>[0],
   networkFilter: string | undefined,
   apply: boolean
-): Promise<void> {
-  const open = [
+): Promise<IReconcileOutcome> {
+  const allOpen = [
     ...(await listParkedTasks(parkedTasks, {
       network: networkFilter,
       status: 'queued',
@@ -217,9 +339,17 @@ async function reconcileAll(
       status: 'proposed',
     })),
   ]
+  const { reconcilable: open, orphaned } = partitionRetiredNetworks(
+    allOpen,
+    (network) => networks[network] !== undefined
+  )
+  for (const o of orphaned)
+    consola.warn(
+      `[${o.network}:${o.environment}] ${o.facet} (${o.status}) → network retired from config/networks.json, cannot reconcile`
+    )
   if (open.length === 0) {
     consola.info('No open parked tasks to reconcile')
-    return
+    return { orphaned, failures: [] }
   }
 
   const byNetworkEnv = new Map<string, typeof open>()
@@ -242,61 +372,94 @@ async function reconcileAll(
     pendingTransactions = col.pendingTransactions
   }
 
+  const failures: IReconcileFailure[] = []
   try {
     for (const tasks of byNetworkEnv.values()) {
       const first = tasks[0]
       if (!first) continue
       const { network, environment } = first
-      const diamondAddress = await resolveDiamondAddress(network, environment)
-      if (!diamondAddress) {
-        consola.warn(
-          `[${network}:${environment}] no LiFiDiamond in deploy log — skipping`
-        )
-        continue
-      }
-      const onChain = await fetchOnChainFacets(diamondAddress, network)
-      const routed = new Set(onChain.map((f) => f.address.toLowerCase()))
+      try {
+        const diamondAddress = await resolveDiamondAddress(network, environment)
+        if (!diamondAddress) {
+          consola.warn(
+            `[${network}:${environment}] no LiFiDiamond in deploy log — skipping`
+          )
+          continue
+        }
+        const onChain = await fetchOnChainFacets(diamondAddress, network)
+        const routed = new Set(onChain.map((f) => f.address.toLowerCase()))
 
-      for (const task of tasks) {
-        const proposalStatus = await resolveProposalStatus(
-          pendingTransactions,
-          task.safeTxHash
+        for (const task of tasks) {
+          const proposalStatus = await resolveProposalStatus(
+            pendingTransactions,
+            task.safeTxHash
+          )
+          const decision = reconcileDecision(task, {
+            facetPresentOnChain: routed.has(
+              getAddress(task.facetAddress).toLowerCase()
+            ),
+            proposalStatus,
+          })
+          consola.info(
+            `[${network}:${environment}] ${task.facetName} (${task.status}) → ${decision}`
+          )
+          if (!apply || decision === 'keep') continue
+          if (decision === 'executed')
+            await markExecuted(parkedTasks, task.taskKey)
+          else if (decision === 'superseded')
+            await markSuperseded(parkedTasks, task.taskKey)
+          else if (decision === 'revert')
+            await revertToQueued(parkedTasks, task.taskKey)
+        }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        consola.error(
+          `[${network}:${environment}] reconcile failed, continuing with the remaining networks: ${reason}`
         )
-        const decision = reconcileDecision(task, {
-          facetPresentOnChain: routed.has(
-            getAddress(task.facetAddress).toLowerCase()
-          ),
-          proposalStatus,
+        failures.push({
+          network,
+          environment,
+          reason,
+          taskCount: tasks.length,
         })
-        consola.info(
-          `[${network}:${environment}] ${task.facetName} (${task.status}) → ${decision}`
-        )
-        if (!apply || decision === 'keep') continue
-        if (decision === 'executed')
-          await markExecuted(parkedTasks, task.taskKey)
-        else if (decision === 'superseded')
-          await markSuperseded(parkedTasks, task.taskKey)
-        else if (decision === 'revert')
-          await revertToQueued(parkedTasks, task.taskKey)
       }
     }
   } finally {
     await safeMongoClient?.close()
   }
+  return { orphaned, failures }
 }
 
-/** Computes and (when applying) sends the cold-network TTL alert. */
-async function runTtlAlert(
+/**
+ * Computes and (when applying) sends the queue alert: aged-past-TTL tasks plus
+ * whatever the reconcile could not resolve, so an orphan on a retired network or a
+ * network that errored is surfaced on the same weekly channel rather than only in
+ * the job log.
+ */
+async function runQueueAlert(
   parkedTasks: Parameters<typeof listParkedTasks>[0],
   networkFilter: string | undefined,
   ttlDays: number,
-  apply: boolean
+  apply: boolean,
+  outcome: IReconcileOutcome
 ): Promise<void> {
   const all = await listParkedTasks(parkedTasks, { network: networkFilter })
-  const stale = computeTtlAlerts(all, new Date(), ttlDays)
-  const message = formatTtlAlertMessage(stale, ttlDays)
+  // A task on a retired network belongs in the orphan section only: the TTL section
+  // tells the reader to drain the network, which is exactly what cannot be done there.
+  const { reconcilable } = partitionRetiredNetworks(
+    all,
+    (network) => networks[network] !== undefined
+  )
+  const stale = computeTtlAlerts(reconcilable, new Date(), ttlDays)
+  const message = joinAlertSections(
+    formatTtlAlertMessage(stale, ttlDays),
+    formatOrphanedTaskMessage(outcome.orphaned),
+    formatReconcileFailureMessage(outcome.failures)
+  )
   if (!message) {
-    consola.info(`No parked tasks older than ${ttlDays}d`)
+    consola.info(
+      `No parked tasks older than ${ttlDays}d, and every network reconciled`
+    )
     return
   }
   consola.warn(message)
@@ -312,7 +475,7 @@ async function runTtlAlert(
   // 'misconfigured' — an unattended run reaching here has no webhook to post to.
   if (!webhookUrl)
     throw new Error(
-      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset, so the TTL alert cannot be delivered. Set the SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS repository secret.'
+      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS is unset, so the queue alert cannot be delivered. Set the SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS repository secret.'
     )
   await new SlackNotifier(webhookUrl).sendNotificationWithRetry({
     text: message,
@@ -350,12 +513,25 @@ const main = defineCommand({
     // getParkedTasksCollection reads the un-gated MONGODB_URI cluster (no tunnel).
     getEnvVar('MONGODB_URI')
     const { client, parkedTasks } = await getParkedTasksCollection()
+    let outcome: IReconcileOutcome
     try {
-      await reconcileAll(parkedTasks, args.network, apply)
-      await runTtlAlert(parkedTasks, args.network, ttlDays, apply)
+      outcome = await reconcileAll(parkedTasks, args.network, apply)
+      await runQueueAlert(parkedTasks, args.network, ttlDays, apply, outcome)
     } finally {
       await client.close()
     }
+    // Fail the run only for groups that errored — those are fixable (RPC, deploy
+    // log, Mongo) and worth a red cron. Orphans on a retired network are a queue
+    // data condition: they are reported in the alert every run until cancelled and
+    // must not keep the job permanently red.
+    if (outcome.failures.length > 0)
+      throw new Error(
+        `${
+          outcome.failures.length
+        } network/environment group(s) failed to reconcile: ${outcome.failures
+          .map((f) => `${f.network}:${f.environment}`)
+          .join(', ')}`
+      )
   },
 })
 

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -22,8 +22,10 @@
  *     cut) and network groups that errored this run.
  *
  * The sweep is per-network fault-isolated in both directions: a retired network is
- * partitioned out before any I/O and a group that throws is recorded and skipped.
- * The alert therefore always runs, and only a group that errored fails the process.
+ * partitioned out before any I/O and a group that throws is recorded and skipped, so
+ * the alert runs for any reachable queue and only a group that errored fails the
+ * process. An unreadable queue still aborts both — the alert reads the same
+ * collection, so there is nothing to degrade to.
  *
  * The pure decisions ({@link reconcileDecision}, {@link computeTtlAlerts},
  * {@link formatTtlAlertMessage}, {@link partitionRetiredNetworks} and the alert
@@ -265,7 +267,12 @@ export function formatReconcileFailureMessage(
   return lines.join('\n')
 }
 
-/** Joins the non-empty alert sections; `''` when every section is empty. */
+/**
+ * Joins the populated alert sections into one message.
+ *
+ * @param sections - Formatted sections, each `''` when it has nothing to report.
+ * @returns The non-empty sections separated by a blank line, or `''` if all are empty.
+ */
 export function joinAlertSections(...sections: string[]): string {
   return sections.filter((s) => s !== '').join('\n\n')
 }
@@ -322,7 +329,7 @@ interface IReconcileOutcome {
  * fetched once each. Never throws for a single group: a retired network is
  * partitioned out before any I/O and a group that errors is recorded and skipped,
  * so one bad network cannot cost the rest of the sweep or the TTL alert that
- * follows it.
+ * follows it. Failing to read the queue at all does still throw.
  */
 async function reconcileAll(
   parkedTasks: Parameters<typeof listParkedTasks>[0],


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-807](https://linear.app/lifi-linear/issue/EXSC-807/reconcileparkedtasks-cron-dies-on-a-retired-network-taking-the-ttl)

# Why did I implement it this way?

`reconcileParkedTasks.yml` has failed on four consecutive weekly runs — 2026-07-27, 08-03, 08-10, 08-17 — always at the `Reconcile parked tasks + TTL alert` step. Two distinct causes:

**2026-07-27** — the CI `MONGODB_URI` role lacked `find` on `deferred-cleanup.parkedTasks`:

```text
[error] not authorized on deferred-cleanup to execute command { find: "parkedTasks", filter: { status: { $eq: "queued" } }, ... }
```

Fixed on the infra side before the next run; no code change here.

**2026-08-03 / 08-10 / 08-17** — a parked task on a retired network killed the sweep:

```text
[error] Chain harmony does not exist. Please check that the network exists in 'config/networks.json'
  at getViemChainForNetworkName (script/utils/viemScriptHelpers.ts:207:11)
  at readFacetsFromChain (script/deploy/safe/diamondRemovalDiff.ts:278:12)
  at reconcileAll (script/deploy/safe/reconcile-parked-tasks.ts:234:29)
```

@0xGoran already diagnosed this class in [the 08-10 alert thread](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1786351865325659?thread_ts=1786351865.325659&cid=C088UJW2DPZ) and unblocked that run by cancelling the stale `evmos` task. What was missing is the code half — this PR — because cancelling the row only moves the abort to the next retired network alphabetically, which is exactly what happened a week later.

PR #2046 enqueued a fleet-wide `GenericSwapFacet` removal that included five networks already retired from `config/networks.json` (`evmos`, `harmony`, `moonbeam`, `okx`, `velas`). `reconcileAll`'s per-network loop had no error isolation, so the first such group threw and the whole sweep aborted mid-loop — the 08-17 run evaluated 27 of 125 open tasks. Worse, `runTtlAlert` (the §8 cold-network backstop) runs **after** the sweep in the same process, so for four weeks no TTL alert was computed, let alone delivered. That is the "stale parked tasks are not surfaced" symptom.

The runs died alphabetically as each blocker was hand-cancelled: `evmos` (08-03, 08-10) → `harmony` (08-17). Since #2202 removed the retired networks' deploy logs (08-18), the same tasks would now throw `Deployments file not found` out of `resolveDiamondAddress` instead — a different message, same fatal outcome. All six retired-network tasks are `cancelled` today, so the next scheduled run would go green by luck until the next network deprecation re-creates the class.

## Fix

- **Partition retired networks out before any I/O.** A network removed from `config/networks.json` has no RPC to read the loupe with, no deploy log to resolve the diamond from, and no future diamond cut to ride along with — its tasks can never reach a terminal state. They are now reported as orphans to cancel instead of being sent to the loupe.
- **Fault-isolate the per-network loop.** A group that throws is recorded and skipped, which is the contract `computeFacetRemovalDiff` already documents for fleet callers ("a caller in a fleet loop should catch, record the network as failed, and continue").
- **Always run the alert** (for any readable queue — if `listParkedTasks` itself fails, as on 07-27, the alert has nothing to read either and the job still fails loudly). It now carries three sections — aged-past-TTL, retired-network orphans, groups that errored — joined only when non-empty. Retired-network tasks are excluded from the TTL section, because that section's advice (`cleanUpProdDiamond --auto --network X`) is exactly what cannot be done on a retired network.
- **Redact error text before it leaves the job log.** Viem embeds the full endpoint in `error.message`, so the new failure section would have posted an RPC API key straight to Slack, which GitHub's `::add-mask::` does not cover. `redactErrorReason()` strips every `scheme://…` token (covering a `mongodb+srv://` connection string too), collapses to one line and caps the length; the raw message still goes to the job log. Caught by CodeRabbit — see the resolved thread.
- **Exit code:** only a group that *errored* fails the run. Those are fixable (RPC, deploy log, Mongo) and worth a red cron. An orphan is a queue data condition that repeats in the alert every run until someone cancels it — keeping the job permanently red for it would bury the next real failure.
- **`errors: true` on the notify step.** The `slackapi/slack-github-action` default (`errors: false`) reports success even when delivery fails, so a rejected or expired webhook would look delivered.
- **`/deprecate-network` cancels the network's open parked tasks first**, before any config or deploy log is removed, and aborts that network's deprecation if a task will not transition — so the orphan class stops being created rather than being created and then reported.

## On the failure notifications — they fired, and were missed

All four alerts posted successfully to **#dev-sc-general** via `SLACK_WEBHOOK_SC_GENERAL` (verified in Slack: [run #1](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1785144642149639), [#2](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1785749406161789), [#3](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1786351865325659), [#4](https://lifi-protocol.slack.com/archives/C088UJW2DPZ/p1786955439849819)). #2208 re-routed this workflow to `SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS` on 08-18, i.e. after the last failure, so future failures land in `#dev-sc-github-ci-notifications` instead. Only one of the four drew a reply. So the gap was never delivery — it was that a red cron in a busy channel reads as noise, which is the argument for the exit-code policy above: reserve red for something a human must act on.

## Verification

Beyond the new unit tests, the guard and the isolation were exercised against the live queue (read-only dry runs, no `--yes`):

1. **The guard fires on the real data that broke CI.** Replayed the queue as it stood at the 08-17 run time (125 open tasks) through `partitionRetiredNetworks`: it holds back exactly `harmony`, `moonbeam`, `okx`, `velas` (the four retired networks open at that moment — `evmos` had been cancelled on 08-11, matching the 08-03/08-10 logs) and leaves 121 reconcilable, with no orphan leaking through. A negative control (`isNetworkKnown` = always true) partitions 0, so the assertion isn't vacuous.
2. **Isolation + alert section, live.** With `ETH_NODE_URI_ZKSYNC` pointed at a dead endpoint, the sweep logs `[zksync:production] reconcile failed, continuing with the remaining networks: …`, still evaluates the other **112 of 118** open tasks, emits `❌ the reconcile could not evaluate 1 network/environment group(s) … [zksync:production] 6 task(s)`, and exits 1.
3. **Redaction, live.** Same run with a canary key in the RPC URL: the alert line reads `URL: <redacted-url>` and the canary appears only on the job-log line, nowhere in the Slack-bound message.
4. **Clean run.** Unmodified dry run against live Mongo + RPCs: all **118** open tasks evaluated across ~65 networks, `No parked tasks older than 60d, and every network reconciled`, exit 0. On `origin/main` the same code path returns early at the first unusable network.

Tests/lints: `bun test script/` → 779 pass / 0 fail (34 in `reconcile-parked-tasks.test.ts`, 17 new). `tsc-files`, `eslint`, `prettier --check`, `markdownlint-cli2` clean on every changed file. No Solidity touched, so no `forge` run.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
