### PR TITLE
fix(deploy): abort when the non-zkEVM salt artifact is missing (EXSC-808)

### DIFF
--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -170,7 +170,7 @@ deploySingleContract() {
   if ! isZkEvmNetwork "$NETWORK"; then
     # prepare bytecode
     # getBytecodeFromArtifact reports a missing artifact via error(), which writes to stdout - so
-    # inside this substitution the message lands in BYTECODE and the salt gets derived from it
+    # without this guard, the message would land in BYTECODE and the salt would be derived from it
     if ! BYTECODE=$(getBytecodeFromArtifact "$CONTRACT"); then
       error "could not read bytecode for $CONTRACT from out/$CONTRACT.sol/$CONTRACT.json - the CREATE3 deploy salt cannot be derived without it, please run 'forge build' and try again"
       if [[ -z "$EXIT_ON_ERROR" || $EXIT_ON_ERROR == "false" ]]; then

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -169,8 +169,18 @@ deploySingleContract() {
   # the following is only applicable for networks where we use CREATE3 (= non-zkEVM)
   if ! isZkEvmNetwork "$NETWORK"; then
     # prepare bytecode
-    BYTECODE=$(getBytecodeFromArtifact "$CONTRACT")
-    
+    # getBytecodeFromArtifact reports missing artifacts via error(), which writes to stdout - the
+    # message would be captured into BYTECODE here and the salt derived from it, so check the
+    # return code and report the failure outside the command substitution
+    if ! BYTECODE=$(getBytecodeFromArtifact "$CONTRACT"); then
+      error "could not read bytecode for $CONTRACT from out/$CONTRACT.sol/$CONTRACT.json - the CREATE3 deploy salt cannot be derived without it, please run 'forge build' and try again"
+      if [[ -z "$EXIT_ON_ERROR" || $EXIT_ON_ERROR == "false" ]]; then
+        return 1
+      else
+        exit 1
+      fi
+    fi
+
     # get CREATE3_FACTORY_ADDRESS
     CREATE3_FACTORY_ADDRESS=$(getCreate3FactoryAddress "$NETWORK")
     checkFailure $? "retrieve create3Factory address from networks.json"
@@ -198,7 +208,14 @@ deploySingleContract() {
     local EXECUTOR_DEPLOYSALT=""
     if [[ "$CONTRACT" == "ERC20Proxy" ]]; then
       local EXECUTOR_BYTECODE
-      EXECUTOR_BYTECODE=$(getBytecodeFromArtifact "Executor")
+      if ! EXECUTOR_BYTECODE=$(getBytecodeFromArtifact "Executor"); then
+        error "could not read bytecode for Executor from out/Executor.sol/Executor.json - ERC20Proxy cannot pre-authorize the predicted Executor address without it, please run 'forge build' and try again"
+        if [[ -z "$EXIT_ON_ERROR" || $EXIT_ON_ERROR == "false" ]]; then
+          return 1
+        else
+          exit 1
+        fi
+      fi
       EXECUTOR_DEPLOYSALT=$(cast keccak "${EXECUTOR_BYTECODE}${SALT}")
     fi
 

--- a/script/deploy/deploySingleContract.sh
+++ b/script/deploy/deploySingleContract.sh
@@ -169,9 +169,8 @@ deploySingleContract() {
   # the following is only applicable for networks where we use CREATE3 (= non-zkEVM)
   if ! isZkEvmNetwork "$NETWORK"; then
     # prepare bytecode
-    # getBytecodeFromArtifact reports missing artifacts via error(), which writes to stdout - the
-    # message would be captured into BYTECODE here and the salt derived from it, so check the
-    # return code and report the failure outside the command substitution
+    # getBytecodeFromArtifact reports a missing artifact via error(), which writes to stdout - so
+    # inside this substitution the message lands in BYTECODE and the salt gets derived from it
     if ! BYTECODE=$(getBytecodeFromArtifact "$CONTRACT"); then
       error "could not read bytecode for $CONTRACT from out/$CONTRACT.sol/$CONTRACT.json - the CREATE3 deploy salt cannot be derived without it, please run 'forge build' and try again"
       if [[ -z "$EXIT_ON_ERROR" || $EXIT_ON_ERROR == "false" ]]; then


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-808](https://linear.app/lifi-linear/issue/EXSC-808/non-zkevm-deploy-derives-the-create3-salt-from-an-error-string-when)

# Why did I implement it this way?

## The bug

`deploySingleContract.sh`'s non-zkEVM / CREATE3 branch derived the deploy salt from an unchecked command substitution:

```bash
BYTECODE=$(getBytecodeFromArtifact "$CONTRACT")
```

`getBytecodeFromArtifact` returns 1 on a missing artifact, but reports it via `error()` — which prints to **stdout**. Inside `$(...)` that message is captured into `$BYTECODE` instead of reaching the terminal. With no return-code check, execution continued straight into `SALT_INPUT="$BYTECODE$SALT"` → `cast keccak` → `getContractAddressFromSalt`, so the deploy targeted a CREATE3 address derived from an error message.

Reproduced on `origin/main` in a fresh worktree with no `out/`:

```text
### artifact present? out/FeeForwarder.sol/FeeForwarder.json
  NO
### BYTECODE (first 60 chars): [error] file does not exist: out/FeeForwarder.sol/FeeFo
### BYTECODE length: 133
### derived DEPLOYSALT: 0x6036cd9f80562c8c95ad89463bced9cb4780cf38d340da71d2ceb7218359062c
```

The same unchecked pattern sat a few lines below in the `ERC20Proxy` special case, which derives the *pre-authorized* Executor address. That one is worse than a failed deploy: a missing `Executor` artifact would have produced an `ERC20Proxy` pre-authorizing a garbage address — silently mis-wired rather than aborted. Both call sites are fixed.

## Reachability

Not reachable via `deployContractToNetworks.sh` — each EVM group runs `forge build` before its wave launches, so `out/` is always populated there.

It is reachable via an interactive `scriptMaster.sh` deploy in a fresh checkout: `scriptMaster.sh` only builds when `COMPILE_ON_STARTUP == "true"` (`script/scriptMaster.sh:46`). Also reachable whenever the contract name does not match an artifact (typo, renamed or removed contract), and whenever `out/` is only partially populated.

## Why check-and-abort rather than the self-healing helper

[PR #2234](https://github.com/lifinance/contracts/pull/2234) (EXSC-805) fixed the equivalent problem on the **zkEVM** branch by adding `ensureStandardArtifactForSalt` to `script/helperFunctions.sh`, which runs `forge build --skip test` when the artifact is missing. Reusing that helper here was the obvious first choice, but **#2234 is not merged yet** — it is green and mergeable but `BLOCKED` awaiting review. Vendoring a second copy of that 46-line helper into this PR would mean two open PRs each adding the same function to the same file; git can merge two identical insertions at the same location into a *duplicate* function definition, which in bash is silently last-wins with no error.

So this PR is deliberately self-contained: it touches only `deploySingleContract.sh` and adds no helper. The hunks are at lines ~169 and ~208, well clear of #2234's zk-path hunk at ~248, so the two merge cleanly in either order.

Aborting is also the conservative behaviour on this path. Unlike the zk branch, the non-zkEVM salt is EVM-group dependent — `updateFoundryTomlForGroup` sets solc/EVM version per group before each `forge build`, so bytecode (and therefore salt and address) differs between the london and cancun groups. `scriptMaster.sh` never calls `updateFoundryTomlForGroup`, so auto-building here would build with whatever profile happens to be ambient and could silently deploy to a non-canonical address — the same class of bug, just quieter. Telling the operator to run `forge build` themselves keeps that choice explicit.

**Follow-up:** once #2234 lands, both paths can be unified onto `ensureStandardArtifactForSalt` if we decide self-healing is right for the non-zk path too. Note also that #2234's `|| return 1` at the zk call site ignores `EXIT_ON_ERROR`, unlike the surrounding code — worth reconciling in that same pass.

## What this does *not* fix

Two callers — `deployPeripheryContracts.sh:62` and `deployCoreFacets.sh:51` — invoke `deploySingleContract` inside a loop and **ignore its return code**, then `return 0` at the end. For those, the effect of this fix is that the affected contract is now loudly skipped instead of deployed to a garbage address; the overall script still exits 0. That masking is pre-existing and out of scope here, but nobody should read this PR as "the deploy run now fails" — it fails *that contract's* deployment, visibly.

Verified that no call site invokes `deploySingleContract` inside a command substitution (the example in the function's own header comment, `$(deploySingleContract …)`, is misleading — all 12 real call sites call it directly), so the new `error()` output does reach the terminal. It also survives the one caller that redirects with `2>/dev/null` (`helperFunctions.sh:2776`), because `error()` writes to stdout.

## Note on the repeated `EXIT_ON_ERROR` block

The `if [[ -z "$EXIT_ON_ERROR" || $EXIT_ON_ERROR == "false" ]]; then return 1; else exit 1; fi` pattern is duplicated rather than extracted, matching the four pre-existing occurrences in this same function. Factoring it into a helper would be a wider refactor of the file than this fix warrants.

## Verification

All from a fresh worktree based on `origin/main`, with `out/` absent.

1. **Bug reproduced before the fix** — verbatim extract of the non-zkEVM block derived a salt from the error string (output above).
2. **Harness proven real** — negative control with a stub artifact present derived a salt from actual bytecode (`0x6080604052deadbeef` → `0x26a2e6…`), confirming the harness distinguishes both states rather than always failing.
3. **Return-code propagation confirmed** — verified that both `if ! VAR=$(cmd)` and the pre-declared-`local` variant used at the `Executor` site do propagate the substitution's exit status.
4. **Real function aborts after the fix** — calling the actual `deploySingleContract "FeeForwarder" "arbitrum" "staging" "" "false"` with no `out/`:

   ```text
   [error] could not read bytecode for FeeForwarder from out/FeeForwarder.sol/FeeForwarder.json -
   the CREATE3 deploy salt cannot be derived without it, please run 'forge build' and try again
   === deploySingleContract returned rc=1
   ```

   It stops before the CREATE3 factory lookup and before any network call, and the message reaches the terminal instead of being swallowed.
5. **Four-case matrix on the guarded block**, extracted verbatim from the file with `sed -n '171,220p'` (so the harness runs the real code, not a paraphrase) and driven with no network access. Run after a real `forge build --skip test` populated `out/` with 408 artifacts:

   | Case | State | Expected | Result |
   |---|---|---|---|
   | A | `out/` populated, `FeeForwarder` | proceeds, real salt | `rc=0`, `DEPLOYSALT=0xcc9de6ee…` |
   | B | `out/` populated, `ERC20Proxy` | proceeds, both salts | `rc=0`, `DEPLOYSALT=0x5be46cd5…`, `EXECUTOR_DEPLOYSALT=0x5e135c20…` |
   | C | `out/Executor.sol` hidden, `ERC20Proxy` | new Executor guard fires | `rc=1` + Executor error |
   | D | contract artifact absent | first guard fires | `rc=1` + contract error |

   A and B are the no-regression control; C and D show each guard fires independently.
6. `bash -n script/deploy/deploySingleContract.sh` passes, and the file still sources cleanly under `set -euo pipefail`.

No Solidity changed, so no `forge test` run is relevant to this diff. `.sh` files are not covered by the repo's lint-staged config.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
