### PR TITLE
test(VaultWrapper): close mutation-test coverage gaps (EXSC-810)

### DIFF
--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -251,6 +251,66 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(factory.defaultIntegratorShareBps(), 9999);
     }
 
+    function testRevert_NonOwnerCannotSetFeeBounds() public {
+        vm.prank(pauser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                pauser
+            )
+        );
+
+        factory.setFeeBounds(FeeType.Performance, 100, 4000);
+    }
+
+    function testRevert_NonOwnerCannotSetDefaultSplit() public {
+        vm.prank(pauser);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                pauser
+            )
+        );
+
+        factory.setDefaultSplit(3000);
+    }
+
+    function test_SetFeeBoundsEmitsEvent() public {
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit ILiFiVaultWrapperFactory.FeeBoundsSet(
+            FeeType.Performance,
+            100,
+            4000
+        );
+
+        vm.prank(owner);
+        factory.setFeeBounds(FeeType.Performance, 100, 4000);
+    }
+
+    /// @dev The cap is the only ceiling an integrator cannot renegotiate, so it is pinned
+    ///      one bps either side rather than at a value far above it.
+    function test_OwnerSetsPerformanceFeeBoundsAtExactCap() public {
+        vm.prank(owner);
+        factory.setFeeBounds(FeeType.Performance, 0, 5000);
+
+        (, uint16 maxBps) = factory.feeBounds(FeeType.Performance);
+        assertEq(maxBps, 5000);
+    }
+
+    function testRevert_SetPerformanceFeeBoundsOneBpsAboveCap() public {
+        vm.prank(owner);
+        vm.expectRevert(ILiFiVaultWrapperFactory.InvalidFeeBounds.selector);
+
+        factory.setFeeBounds(FeeType.Performance, 0, 5001);
+    }
+
+    function testRevert_SetDepositFeeBoundsOneBpsAboveCap() public {
+        vm.prank(owner);
+        vm.expectRevert(ILiFiVaultWrapperFactory.InvalidFeeBounds.selector);
+
+        factory.setFeeBounds(FeeType.Deposit, 0, 2001);
+    }
+
     function test_OwnerSetsLifiFeeRecipient() public {
         address newRecipient = makeAddr("newLifiRecipient");
         vm.expectEmit(true, false, false, false, address(factory));
@@ -311,6 +371,58 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.prank(owner);
         vm.expectRevert(ILiFiVaultWrapperFactory.NotEmergencyPauser.selector);
         factory.globalPause();
+    }
+
+    /// @dev Lifting the breaker is as privileged as engaging it: an unguarded unpause
+    ///      would let anyone re-open deposits across every instance mid-incident.
+    function testRevert_NonPauserCannotGlobalUnpause() public {
+        vm.prank(pauser);
+        factory.globalPause();
+
+        vm.prank(owner);
+        vm.expectRevert(ILiFiVaultWrapperFactory.NotEmergencyPauser.selector);
+
+        factory.globalUnpause();
+
+        assertTrue(factory.globalPaused());
+    }
+
+    function test_GlobalPauseTogglesEmitEvents() public {
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit ILiFiVaultWrapperFactory.GlobalPauseSet(true, pauser);
+
+        vm.prank(pauser);
+        factory.globalPause();
+
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit ILiFiVaultWrapperFactory.GlobalPauseSet(false, pauser);
+
+        vm.prank(pauser);
+        factory.globalUnpause();
+    }
+
+    function test_RoleRotationsEmitEvents() public {
+        address newPauser = makeAddr("rotatedPauser");
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit ILiFiVaultWrapperFactory.RoleRotated(
+            keccak256("EMERGENCY_PAUSER"),
+            pauser,
+            newPauser
+        );
+
+        vm.prank(owner);
+        factory.setEmergencyPauser(newPauser);
+
+        address newManager = makeAddr("rotatedManager");
+        vm.expectEmit(true, false, false, true, address(factory));
+        emit ILiFiVaultWrapperFactory.RoleRotated(
+            keccak256("ONBOARDING_MANAGER"),
+            onboarder,
+            newManager
+        );
+
+        vm.prank(owner);
+        factory.setOnboardingManager(newManager);
     }
 
     function test_OwnerRotatesRoles() public {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -248,6 +248,28 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
 
     /// setFeeRate: enable / disable / bounds ///
 
+    /// @dev The re-anchor is gated on enabling the PERFORMANCE fee specifically. Enabling a
+    ///      different fee type must leave the watermark where it is: re-anchoring it to the
+    ///      current price would write off the disabled-period gain that the later
+    ///      performance-fee enablement is supposed to price, so the widened gate is only
+    ///      visible on the watermark itself.
+    function test_SetFeeRateOtherFeeTypeDoesNotReanchorHwm() public {
+        _stackWithFactory(0); // performance disabled, so accrual never moves the watermark
+        vm.prank(owner);
+        factory.setFeeBounds(FeeType.Management, 0, 1000);
+
+        _deposit(alice, DEPOSIT);
+        _simulateYield(200e18);
+
+        uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
+        assertLt(hwmBefore, _pps()); // price has risen above the anchor
+
+        vm.prank(vaultAdmin);
+        wrapper.setFeeRate(FeeType.Management, MGMT_RATE);
+
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
+    }
+
     function test_SetFeeRateEnablePerformanceReanchorsHwm() public {
         _stackWithFactory(0); // performance disabled at deploy
         _deposit(alice, DEPOSIT);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -210,6 +210,18 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         vm.expectRevert(ILiFiVaultWrapper.AssetDecimalsUnavailable.selector);
 
         new BeaconProxy(address(beacon), oversizedInit);
+
+        // A call that succeeds but returns nothing decodes as garbage rather than failing
+        // loudly, so the short-return case is rejected on its own length check.
+        bytes memory emptyReturnInit = _initCallFor(
+            address(
+                new AssetOnlyVault(address(new EmptyReturnDecimalsToken()))
+            )
+        );
+
+        vm.expectRevert(ILiFiVaultWrapper.AssetDecimalsUnavailable.selector);
+
+        new BeaconProxy(address(beacon), emptyReturnInit);
     }
 
     function test_DonationCannotBlockDepositLargerThanItself() public {
@@ -593,6 +605,12 @@ contract OversizedDecimalsToken {
     function decimals() external pure returns (uint256) {
         return 300;
     }
+}
+
+/// @dev Asset stub whose decimals() call succeeds but returns zero-length data, the
+///      non-compliant-token case OZ's probe reads as a successful call.
+contract EmptyReturnDecimalsToken {
+    fallback() external payable {}
 }
 
 /// @dev Minimal ERC-4626-shaped underlying exposing only asset(), so the wrapper resolves

--- a/test/solidity/VaultWrapper/VaultWrapperEntryExitReentrancy.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperEntryExitReentrancy.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFeeTestBase } from "test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol";
+
+/// @notice Minimal 1:1 ERC-4626-shaped yield source that hands control back to the wrapper
+///         from inside `deposit`/`withdraw`. The wrapper delegatecalls its adapter, so the
+///         source is called with the wrapper as `msg.sender` and is the one untrusted
+///         contract every entry and exit necessarily routes through.
+contract ReenteringSourceVault {
+    enum Hook {
+        None,
+        Mint,
+        Withdraw
+    }
+
+    MockERC20 private immutable ASSET;
+    LiFiVaultWrapper private wrapper;
+    Hook private hook;
+    bool private entered;
+
+    mapping(address => uint256) public balanceOf;
+
+    constructor(MockERC20 _asset) {
+        ASSET = _asset;
+    }
+
+    function arm(LiFiVaultWrapper _wrapper, Hook _hook) external {
+        wrapper = _wrapper;
+        hook = _hook;
+        entered = false;
+    }
+
+    function asset() external view returns (address) {
+        return address(ASSET);
+    }
+
+    function convertToAssets(uint256 _shares) external pure returns (uint256) {
+        return _shares;
+    }
+
+    function maxWithdraw(address _holder) external view returns (uint256) {
+        return balanceOf[_holder];
+    }
+
+    function deposit(
+        uint256 _assets,
+        address _receiver
+    ) external returns (uint256) {
+        ASSET.transferFrom(msg.sender, address(this), _assets);
+        balanceOf[_receiver] += _assets;
+        _reenter(Hook.Mint);
+
+        return _assets;
+    }
+
+    function withdraw(
+        uint256 _assets,
+        address _receiver,
+        address _owner
+    ) external returns (uint256) {
+        balanceOf[_owner] -= _assets;
+        ASSET.transfer(_receiver, _assets);
+        _reenter(Hook.Withdraw);
+
+        return _assets;
+    }
+
+    /// @dev Fires once per arming so a guard-less wrapper recurses exactly one level
+    ///      instead of running out of gas, which would mask the missing guard.
+    function _reenter(Hook _hook) private {
+        if (hook != _hook || entered) return;
+        entered = true;
+
+        if (_hook == Hook.Mint) {
+            wrapper.mint(1e6, address(this));
+        } else {
+            wrapper.withdraw(1, address(this), address(this));
+        }
+    }
+}
+
+/// @notice The entry/exit reentrancy guards, driven from the yield source the wrapper hands
+///         control to mid-operation. Each test reenters the SAME entrypoint it is testing:
+///         a shared guard means reentering a different one would revert on the outer
+///         function's guard and pass even with the inner one removed.
+contract VaultWrapperEntryExitReentrancyTest is VaultWrapperFeeTestBase {
+    ReenteringSourceVault internal source;
+
+    function setUp() public override {
+        super.setUp();
+        source = new ReenteringSourceVault(asset);
+
+        uint16[4] memory noFees;
+        wrapper = _newWrapperFor(
+            address(source),
+            FeeConfig({ rateBps: noFees }),
+            [SPLIT, SPLIT, SPLIT, SPLIT]
+        );
+
+        // The source needs its own funded, pre-approved position so the reentrant call
+        // fails on the guard rather than on a missing balance or allowance.
+        asset.mint(address(source), DEPOSIT);
+        vm.prank(address(source));
+        asset.approve(address(wrapper), type(uint256).max);
+    }
+
+    function testRevert_MintCannotBeReenteredFromYieldSource() public {
+        source.arm(wrapper, ReenteringSourceVault.Hook.Mint);
+
+        asset.mint(alice, DEPOSIT);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), DEPOSIT);
+
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+
+        wrapper.mint(DEPOSIT, alice);
+        vm.stopPrank();
+    }
+
+    function testRevert_WithdrawCannotBeReenteredFromYieldSource() public {
+        _deposit(alice, DEPOSIT); // hook still disarmed, so the entry succeeds
+        source.arm(wrapper, ReenteringSourceVault.Hook.Withdraw);
+
+        vm.prank(alice);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+
+        wrapper.withdraw(DEPOSIT / 2, alice, alice);
+    }
+}

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -240,6 +240,12 @@ contract VaultWrapperPauseTest is Test {
 
         vm.prank(vaultAdmin);
         wrapper.pause();
+
+        vm.expectEmit(true, true, true, true, address(wrapper));
+        emit PauseSet(false, vaultAdmin);
+
+        vm.prank(vaultAdmin);
+        wrapper.unpause();
     }
 
     /// EIP-4626 deposit limits report closed while paused ///


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-810](https://linear.app/lifi-linear/issue/EXSC-810/vault-wrapper-close-mutation-test-coverage-gaps-olympix-survivors)

# Why did I implement it this way?

An Olympix mutation-test run over `src/VaultWrapper/` scored **93%** (236 of 254 mutants killed) and left **18 survivors** — lines where the contract can be broken and `test/solidity/VaultWrapper/**` still passes. This PR closes the survivors that were real gaps. It is tests-only; no production code changed.

**No production defect was found.** Every survivor is a test gap, an equivalent mutant, or a mis-score:

- **14 genuine gaps**, closed here.
- **3 equivalent mutants**, left untested because no reachable state distinguishes them:
  - `LiFiVaultWrapper.sol:864` `integratorShares == 0` → `!= 0`. `_splitFee` computes LI.FI's side as the remainder and the per-type split is validated `< BPS_DENOMINATOR`, so a non-zero integrator accrual always leaves a non-zero LI.FI accrual. The retained-fee path cannot produce it either: fee-share payouts move the wrapper's own ERC-20 from `address(this)`, which `_update` deliberately exempts from the access gate, so a share transfer cannot fail.
  - `LiFiVaultWrapperFactory.sol:421` `FeeBounds memory b` → `storage b` — read-only, behaviourally identical.
  - `LiFiVaultWrapper.sol:1298` the `_saturatingAddUint128` overflow guard — reaching it needs the fee accumulator driven to `uint128` saturation, which no realistic accrual reaches.
- **1 mis-scored by Olympix**: `LiFiVaultWrapper.sol:202` (constructor zero-factory check) is already killed by `testRevert_ImplementationConstructorRejectsZeroFactory` — applying the mutant makes `setUp()` itself revert and the whole file fail. Verified by hand.

The one finding worth a reviewer's attention is the **`globalUnpause` asymmetry**: removing `onlyEmergencyPauser` from `globalUnpause` survived, while the same mutation on `globalPause` was killed. Engaging the circuit breaker was tested against an unauthorised caller; lifting it was not.

Each new test was verified the way a mutation test is meant to be read — by re-applying the exact mutation to the contract and confirming the new test **fails**, then reverting. All 14 mutants confirmed killed. Mutations were applied in a throwaway workspace copy, never to the repo source.

Notes on scope and method:

- The mutation run excluded `test/solidity/VaultWrapper/fork/`, which needs RPC URLs from `.env` (passing them to Olympix means uploading `.env`). Survivors in code paths covered only by the Morpho fork scenario would therefore not show up.
- Olympix's CLI could not dispatch from the repo root at all — it walks the full tree, including the 1.2 GB `node_modules` that `foundry.toml` registers in `libs`, and exits without creating a session. The run was dispatched from a trimmed 84 MB workspace instead. Worth knowing before anyone else tries to run Olympix here.
- New tests follow `testRevert_` naming for every case using `vm.expectRevert`. Some pre-existing neighbours in these files (e.g. `test_SetFeeBoundsRevertsAboveCap`) do not; I left them alone to keep the diff reviewable.

**Unrelated pre-existing failure, not addressed here:** `testFuzz_DilutionShares_NoRevert` in `LibVaultWrapperMath.t.sol` panics with arithmetic overflow on near-`uint256.max` inputs under the local unseeded fuzz profile. It reproduces on `dev-vault-wrapper` with this branch's changes stashed. CI pins `seed = '0x1'`, so it may not surface there.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
