### PR TITLE
fix(VaultWrapper): clamp maxDeposit/maxMint to source deposit cap

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -36,6 +36,16 @@ the wrapper never exercises. It equals the full position value on a source with
 no active liquidity limit, and shrinks to what the source can currently honor
 under a limit (an Aave-style utilization cap, a paused source).
 
+## Source cap view
+
+`maxDepositableValue` is the entry-side mirror: the source's `maxDeposit` for the
+holder — the assets it will accept on entry right now, capped by any inflow limit
+(an ERC-4626 supply cap, e.g. MetaMorpho). The wrapper always enters via
+exact-asset `deposit` (bounded by `maxDeposit`), so this reads that axis rather
+than the source's share-side `maxMint`. It returns `type(uint256).max` on a source
+with no active cap — EIP-4626's own unlimited sentinel — which the wrapper passes
+through so an uncapped source keeps reporting unbounded deposit capacity.
+
 ## Functions
 
 ```solidity
@@ -53,6 +63,9 @@ function withdraw(address _asset, address _underlying, uint256 _assets) external
 
 /// The source's `maxWithdraw` for the holder — the exit-liquidity signal (the wrapper exits via `withdraw`, not `redeem`).
 function maxWithdrawableValue(address _underlying, address _holder) external view returns (uint256 assets)
+
+/// The source's `maxDeposit` for the holder — the entry-cap signal; `type(uint256).max` when the source is uncapped.
+function maxDepositableValue(address _underlying, address _holder) external view returns (uint256 assets)
 ```
 
 ## Related contracts

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -29,8 +29,29 @@ withdrawal.
 - A single pluggable `IAccessGate` (zero = permissionless) enforced fail-closed on
   entry, share transfers, and exits.
 - Pause is enforced on the deposit/mint path only; withdrawals stay open.
+- The entry `max*` views are source-cap-aware — see
+  [Entry semantics](#entry-semantics).
 - The exit `max*` views are source-liquidity-aware — see
   [Exit semantics](#exit-semantics).
+
+## Entry semantics
+
+- `maxDeposit`/`maxMint` clamp to what the source will currently accept (via the
+  adapter's `maxDepositableValue`), so a `deposit`/`mint` within the reported max
+  never reverts under a source inflow cap (an ERC-4626 supply cap, e.g.
+  MetaMorpho). An uncapped source reports `type(uint256).max`, passed through
+  unchanged (`maxMint` skips the share conversion to avoid overflow) so the views
+  stay unbounded exactly when the source is. This is the entry-side mirror of the
+  exit-liquidity clamp below.
+- Both views report `0` while any pause source is engaged or the access gate
+  rejects the receiver, so EIP-4626 consumers see the vault as closed rather than
+  building a deposit that would revert `DepositsPaused`.
+- Because they consult the source's `maxDeposit`, they revert if that view
+  reverts (a bricked source) — fail-closed by design, the same deliberate
+  deviation from EIP-4626's never-revert expectation noted for the exit views.
+- `previewDeposit`/`previewMint` remain **cap-agnostic**: EIP-4626 requires
+  previews to ignore deposit limits, so they value the requested amount and never
+  consult `maxDepositableValue`.
 
 ## Exit semantics
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -58,7 +58,7 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      dust-denominator regime. EIP-5143 slippage overloads of
 ///      the four entrypoints bound the realized amount against in-flight share-price
 ///      or fee-rate changes.
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
     // OZ v5's Ownable/Ownable2Step keep `_owner`/`_pendingOwner` in fixed ERC-7201
@@ -574,24 +574,48 @@ contract LiFiVaultWrapper is
     /// @dev Reports 0 while any pause source is engaged, or while the access gate rejects
     ///      the receiver, so EIP-4626 consumers see the vault as closed to deposits and do
     ///      not build deposits that would revert. Mirrors `deposit`'s guards; a reverting
-    ///      gate reverts this view too (fail-closed, like the entrypoint).
+    ///      gate reverts this view too (fail-closed, like the entrypoint). Otherwise clamps
+    ///      to the assets the source will currently accept (`adapter.maxDepositableValue`),
+    ///      keeping the EIP-4626 guarantee that a `deposit` within `maxDeposit` never reverts
+    ///      under a source inflow cap — the entry-side mirror of `maxRedeem`'s liquidity
+    ///      clamp. Reverts if the source's view reverts (fail-closed).
     function maxDeposit(
         address receiver
     ) public view override returns (uint256) {
         if (depositsPaused() || !_depositAllowed(receiver)) return 0;
 
-        return super.maxDeposit(receiver);
+        uint256 sourceCap = IYieldAdapter(adapter).maxDepositableValue(
+            underlying,
+            address(this)
+        );
+        uint256 selfMax = super.maxDeposit(receiver);
+
+        return sourceCap < selfMax ? sourceCap : selfMax;
     }
 
     /// @inheritdoc ERC4626Upgradeable
     /// @dev Reports 0 while any pause source is engaged, or while the access gate rejects
     ///      the receiver, so EIP-4626 consumers see the vault as closed to mints and do
     ///      not build mints that would revert. Mirrors `mint`'s guards; a reverting gate
-    ///      reverts this view too (fail-closed, like the entrypoint).
+    ///      reverts this view too (fail-closed, like the entrypoint). Otherwise clamps to
+    ///      the source's inflow cap (`adapter.maxDepositableValue`, floor-converted to
+    ///      shares), so a `mint` within `maxMint` never reverts under a source cap. An
+    ///      uncapped source returns `type(uint256).max`, passed through unconverted to avoid
+    ///      overflowing the share conversion. Reverts if the source's view reverts
+    ///      (fail-closed).
     function maxMint(address receiver) public view override returns (uint256) {
         if (depositsPaused() || !_depositAllowed(receiver)) return 0;
 
-        return super.maxMint(receiver);
+        uint256 sourceCap = IYieldAdapter(adapter).maxDepositableValue(
+            underlying,
+            address(this)
+        );
+        if (sourceCap == type(uint256).max) return super.maxMint(receiver);
+
+        uint256 mintCap = _convertToShares(sourceCap, Math.Rounding.Floor);
+        uint256 selfMax = super.maxMint(receiver);
+
+        return mintCap < selfMax ? mintCap : selfMax;
     }
 
     /// @inheritdoc ERC4626Upgradeable

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -58,7 +58,7 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      dust-denominator regime. EIP-5143 slippage overloads of
 ///      the four entrypoints bound the realized amount against in-flight share-price
 ///      or fee-rate changes.
-/// @custom:version 1.1.0
+/// @custom:version 1.0.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
     // OZ v5's Ownable/Ownable2Step keep `_owner`/`_pendingOwner` in fixed ERC-7201

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -25,7 +25,7 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 contract ERC4626Adapter is IYieldAdapter {
     /// @inheritdoc IYieldAdapter
     function resolveAsset(
@@ -97,5 +97,19 @@ contract ERC4626Adapter is IYieldAdapter {
         address _holder
     ) external view returns (uint256 assets) {
         assets = IERC4626(_underlying).maxWithdraw(_holder);
+    }
+
+    /// @inheritdoc IYieldAdapter
+    /// @dev The source's `maxDeposit` for the holder — the assets it will accept on entry
+    ///      right now, capped by any supply/inflow limit. Returns `type(uint256).max` when
+    ///      the source imposes no cap (EIP-4626's own sentinel), which the wrapper passes
+    ///      through so an uncapped source keeps reporting unlimited deposit capacity. The
+    ///      wrapper always enters via exact-asset `IERC4626.deposit`, so `maxDeposit` — not
+    ///      the source's share-side `maxMint` — is the axis that governs an entry revert.
+    function maxDepositableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets) {
+        assets = IERC4626(_underlying).maxDeposit(_holder);
     }
 }

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -25,7 +25,7 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 1.1.0
+/// @custom:version 1.0.0
 contract ERC4626Adapter is IYieldAdapter {
     /// @inheritdoc IYieldAdapter
     function resolveAsset(

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -10,16 +10,17 @@ pragma solidity ^0.8.29;
 ///         than changing the factory or the wrapper implementation.
 /// @dev Methods split by how the wrapper invokes them, and this split is a security
 ///      invariant adapters MUST honour:
-///      - `resolveAsset`, `totalAssets`, and `maxWithdrawableValue` are invoked as
-///        ordinary (static) calls and run in the adapter's own context; they take an
-///        explicit `_holder`/`_underlying` and MUST be free of side effects.
+///      - `resolveAsset`, `totalAssets`, `maxWithdrawableValue`, and
+///        `maxDepositableValue` are invoked as ordinary (static) calls and run in the
+///        adapter's own context; they take an explicit `_holder`/`_underlying` and MUST
+///        be free of side effects.
 ///      - `deposit` and `withdraw` are invoked via `delegatecall` and therefore run in
 ///        the wrapper's context: `address(this)`, token balances, and yield-source
 ///        positions are the wrapper's. They MUST be stateless with respect to adapter
 ///        storage (no reads or writes of adapter state) so a shared adapter cannot
 ///        corrupt or be corrupted by the wrapper's storage layout; they may only act on
 ///        their arguments and external calls.
-/// @custom:version 1.0.0
+/// @custom:version 1.1.0
 interface IYieldAdapter {
     /// @notice Thrown when the adapter cannot resolve the underlying's asset.
     error AssetResolutionFailed();
@@ -87,6 +88,23 @@ interface IYieldAdapter {
     /// @param _holder The account whose position is valued (the wrapper).
     /// @return assets The gross, source-liquidity-capped position value.
     function maxWithdrawableValue(
+        address _underlying,
+        address _holder
+    ) external view returns (uint256 assets);
+
+    /// @notice Assets `_holder` can currently deposit into `_underlying`, capped by the
+    ///         source's own inflow limit (e.g. an ERC-4626 supply cap).
+    /// @dev Ordinary static call. Returns the source's `maxDeposit` for the holder — the
+    ///      assets it will accept on entry right now. A `type(uint256).max` return signals
+    ///      no active cap, which the wrapper passes through so an uncapped source keeps
+    ///      reporting unlimited deposit capacity. The wrapper folds this into its own
+    ///      `maxDeposit`/`maxMint` so an EIP-4626 consumer never sizes a deposit the source
+    ///      would reject — the entry-side mirror of `maxWithdrawableValue`. MAY revert if
+    ///      the source's view reverts; the wrapper treats that as fail-closed.
+    /// @param _underlying The yield source identifier.
+    /// @param _holder The account the deposit is credited to (the wrapper).
+    /// @return assets The source-cap-limited depositable amount.
+    function maxDepositableValue(
         address _underlying,
         address _holder
     ) external view returns (uint256 assets);

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.29;
 ///        storage (no reads or writes of adapter state) so a shared adapter cannot
 ///        corrupt or be corrupted by the wrapper's storage layout; they may only act on
 ///        their arguments and external calls.
-/// @custom:version 1.1.0
+/// @custom:version 1.0.0
 interface IYieldAdapter {
     /// @notice Thrown when the adapter cannot resolve the underlying's asset.
     error AssetResolutionFailed();

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -113,6 +113,13 @@ contract LossyVault {
     function maxWithdraw(address _owner) external view returns (uint256) {
         return balanceOf[_owner];
     }
+
+    /// @dev Unlimited deposit capacity: `ERC4626Adapter.maxDepositableValue` reads
+    ///      `maxDeposit`, so the wrapper's inflow clamp is a no-op and the shortfall path
+    ///      under test is still reached.
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
 }
 
 contract LiFiVaultWrapperTest is Test {

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperDepositCap.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperDepositCap.t.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC4626Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryStackBase } from "test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol";
+import { MockDepositCappedERC4626 } from "test/solidity/VaultWrapper/mocks/MockDepositCappedERC4626.sol";
+
+/// @notice Entry-side mirror of LiFiVaultWrapperLiquidityTest: proves `maxDeposit`/`maxMint`
+///         fold the yield source's inflow cap so a caller that respects the reported max
+///         never reverts, and that a deposit past it reverts with the EIP-4626 limit error
+///         rather than deep inside the source.
+contract LiFiVaultWrapperDepositCapTest is VaultWrapperFactoryStackBase {
+    MockERC20 internal asset;
+    MockDepositCappedERC4626 internal source;
+
+    address internal vaultAdmin = makeAddr("vaultAdmin");
+    address internal integrator = makeAddr("integrator");
+    address internal alice = makeAddr("alice");
+
+    uint256 internal constant SEED = 1_000e18;
+
+    function setUp() public {
+        asset = new MockERC20("Token", "TKN", 18);
+        source = new MockDepositCappedERC4626(asset, "Yield", "yTKN");
+
+        _bringUpFactory(address(source), [uint16(5000), 1000, 2000, 2000]);
+        _deployWrapper(_params());
+
+        asset.mint(alice, 10_000e18);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), 10_000e18);
+        wrapper.deposit(SEED, alice);
+
+        vm.stopPrank();
+    }
+
+    function _params() private view returns (DeployParams memory) {
+        FeeReceiver[] memory receivers = new FeeReceiver[](1);
+        receivers[0] = FeeReceiver({ wallet: integrator, bps: 10000 });
+
+        return
+            DeployParams({
+                namespace: bytes32("LI.FI-Earn"),
+                vaultWrapperAdmin: vaultAdmin,
+                adapter: address(adapter),
+                underlying: address(source),
+                nonce: 0,
+                fees: FeeConfig({ rateBps: [uint16(0), 0, 0, 0] }),
+                integratorShareBps: [uint16(8000), 8000, 8000, 8000],
+                accessGate: address(0),
+                receivers: receivers
+            });
+    }
+
+    function test_MaxDepositUnlimitedWhenSourceUncapped() public view {
+        assertEq(wrapper.maxDeposit(alice), type(uint256).max);
+        assertEq(wrapper.maxMint(alice), type(uint256).max);
+    }
+
+    function test_MaxDepositReflectsSourceHeadroom() public {
+        source.setDepositCap(SEED + 500e18);
+
+        assertEq(wrapper.maxDeposit(alice), 500e18);
+    }
+
+    function test_MaxMintReflectsSourceHeadroom() public {
+        source.setDepositCap(SEED + 500e18);
+
+        assertEq(wrapper.maxMint(alice), wrapper.previewDeposit(500e18));
+    }
+
+    function test_MaxDepositIsZeroWhenCapReached() public {
+        source.setDepositCap(SEED);
+
+        assertEq(wrapper.maxDeposit(alice), 0);
+        assertEq(wrapper.maxMint(alice), 0);
+    }
+
+    function test_DepositAtCappedMaxSucceeds() public {
+        source.setDepositCap(SEED + 500e18);
+        uint256 maxAssets = wrapper.maxDeposit(alice);
+
+        vm.prank(alice);
+        uint256 shares = wrapper.deposit(maxAssets, alice);
+
+        assertGt(shares, 0);
+        assertEq(wrapper.maxDeposit(alice), 0);
+    }
+
+    function testRevert_DepositAboveCappedMax() public {
+        source.setDepositCap(SEED + 500e18);
+        uint256 maxAssets = wrapper.maxDeposit(alice);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxDeposit.selector,
+                alice,
+                maxAssets + 1,
+                maxAssets
+            )
+        );
+
+        vm.prank(alice);
+        wrapper.deposit(maxAssets + 1, alice);
+    }
+
+    function test_MintAtCappedMaxSucceeds() public {
+        source.setDepositCap(SEED + 500e18);
+        uint256 maxShares = wrapper.maxMint(alice);
+
+        vm.prank(alice);
+        uint256 assets = wrapper.mint(maxShares, alice);
+
+        assertGt(assets, 0);
+    }
+
+    function testRevert_MintAboveCappedMax() public {
+        source.setDepositCap(SEED + 500e18);
+        uint256 maxShares = wrapper.maxMint(alice);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxMint.selector,
+                alice,
+                maxShares + 1,
+                maxShares
+            )
+        );
+
+        vm.prank(alice);
+        wrapper.mint(maxShares + 1, alice);
+    }
+
+    // The partial-headroom case from the finding: with the cap partway above the seeded
+    // position, an integrator can size a deposit off the reported max, fill it exactly, and
+    // sees the max drop to zero rather than guessing into a source revert.
+    function test_PartialHeadroomIsSizableThenClosed() public {
+        source.setDepositCap(SEED + 100e18);
+        assertEq(wrapper.maxDeposit(alice), 100e18);
+
+        vm.prank(alice);
+        wrapper.deposit(100e18, alice);
+
+        assertEq(wrapper.maxDeposit(alice), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Upgradeable.ERC4626ExceededMaxDeposit.selector,
+                alice,
+                1,
+                0
+            )
+        );
+
+        vm.prank(alice);
+        wrapper.deposit(1, alice);
+    }
+
+    function test_MaxDepositAndMaxMintZeroWhenPausedDespiteHeadroom() public {
+        source.setDepositCap(SEED + 500e18);
+
+        vm.prank(vaultAdmin);
+        wrapper.pause();
+
+        assertEq(wrapper.maxDeposit(alice), 0);
+        assertEq(wrapper.maxMint(alice), 0);
+    }
+}

--- a/test/solidity/VaultWrapper/VaultWrapperEntryExitReentrancy.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperEntryExitReentrancy.t.sol
@@ -47,6 +47,10 @@ contract ReenteringSourceVault {
         return balanceOf[_holder];
     }
 
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
     function deposit(
         uint256 _assets,
         address _receiver

--- a/test/solidity/VaultWrapper/mocks/MockDepositCappedERC4626.sol
+++ b/test/solidity/VaultWrapper/mocks/MockDepositCappedERC4626.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.29;
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+
+/// @notice ERC-4626 modelling a MetaMorpho-style supply cap on the entry axis: an
+///         asset-denominated `depositCap` bounds the total assets the source will hold, so
+///         `maxDeposit` reports the remaining headroom and `deposit`/`mint` revert past it,
+///         while the exit axis stays unrestricted. The entry-side mirror of
+///         MockWithdrawCappedERC4626; used to prove the wrapper folds the source's inflow cap
+///         into `maxDeposit`/`maxMint` so a caller that respects the reported max never
+///         reverts. `setDepositCap` moves the cap to fuzz shifting capacity; a cap of
+///         `type(uint256).max` models an uncapped source.
+contract MockDepositCappedERC4626 is MockERC4626 {
+    error DepositExceedsCap();
+
+    uint256 public depositCap = type(uint256).max;
+
+    constructor(
+        ERC20 _asset,
+        string memory _name,
+        string memory _symbol
+    ) MockERC4626(_asset, _name, _symbol) {}
+
+    function setDepositCap(uint256 _assets) external {
+        depositCap = _assets;
+    }
+
+    function maxDeposit(address) public view override returns (uint256) {
+        if (depositCap == type(uint256).max) return type(uint256).max;
+
+        uint256 held = totalAssets();
+        return held < depositCap ? depositCap - held : 0;
+    }
+
+    function maxMint(address receiver) public view override returns (uint256) {
+        uint256 assetCap = maxDeposit(receiver);
+        if (assetCap == type(uint256).max) return type(uint256).max;
+
+        return convertToShares(assetCap);
+    }
+
+    function deposit(
+        uint256 assets,
+        address receiver
+    ) public override returns (uint256) {
+        if (assets > maxDeposit(receiver)) revert DepositExceedsCap();
+
+        return super.deposit(assets, receiver);
+    }
+
+    function mint(
+        uint256 shares,
+        address receiver
+    ) public override returns (uint256) {
+        if (shares > maxMint(receiver)) revert DepositExceedsCap();
+
+        return super.mint(shares, receiver);
+    }
+}

--- a/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
+++ b/test/solidity/VaultWrapper/mocks/MockZeroAdapter.sol
@@ -38,4 +38,11 @@ contract MockZeroAdapter is IYieldAdapter {
     ) external pure returns (uint256) {
         return 0;
     }
+
+    function maxDepositableValue(
+        address,
+        address
+    ) external pure returns (uint256) {
+        return 0;
+    }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-812](https://linear.app/lifi-linear/issue/EXSC-812/vault-wrapper-maxdepositmaxmint-ignore-the-source-deposit-cap)

# Why did I implement it this way?

Comparative-review finding 5.1 (Medium): `LiFiVaultWrapper.maxDeposit`/`maxMint` returned OZ's hardcoded `type(uint256).max` regardless of the yield source's own deposit cap (e.g. a MetaMorpho supply cap), so a `deposit`/`mint` sized off the reported max could revert inside the source — breaking the EIP-4626 guarantee that an operation within `max*` never reverts. This is the entry-side mirror of the exit-axis clamp already shipped in EXSC-803, so I implemented it the same way for symmetry: a first-class adapter read (`maxDepositableValue`, an ordinary static call taking the holder explicitly, exactly like `maxWithdrawableValue`) that `ERC4626Adapter` fulfils as `IERC4626.maxDeposit`, with the two views clamping to it. `maxMint` floor-converts the asset cap to shares and short-circuits the `type(uint256).max` sentinel to avoid overflowing the share conversion, so an uncapped source keeps reporting unbounded capacity. The pause/gate guards stay ahead of the clamp, and `previewDeposit`/`previewMint` remain cap-agnostic per EIP-4626. No fund-loss path — the source revert is atomic — so this is an integration-correctness fix, not a security patch. The two hand-rolled source mocks (`LossyVault`, `ReenteringSourceVault`) gained a `maxDeposit` stub, the same retrofit they already made for `maxWithdraw` when the exit clamp landed, since the wrapper now reads that axis through them.

Note: `IYieldAdapter`, `ERC4626Adapter`, and `LiFiVaultWrapper` all bump to 1.1.0 (new adapter method + behavioural change on the two views).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>