### PR TITLE
fix(VaultWrapper): mirror sub-floor perf-fee skip in fee-share previews

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1187,9 +1187,17 @@ contract LiFiVaultWrapper is
         uint256 _assets
     ) private view returns (uint256) {
         uint256 mgmtShares = _pendingManagementFee(_supply, _assets);
+        uint256 effectiveSupply = _supply + mgmtShares;
 
-        return
-            mgmtShares + _pendingPerformanceFee(_supply + mgmtShares, _assets);
+        // Mirror the sub-floor branch in `_accrueFees`: below `MIN_SHARE_SUPPLY` no
+        // performance shares are minted (the watermark is re-floated instead), so a
+        // preview that still charged them would price against dilution the accrual
+        // never creates, breaking preview/execution parity.
+        if (effectiveSupply < MIN_SHARE_SUPPLY) {
+            return mgmtShares;
+        }
+
+        return mgmtShares + _pendingPerformanceFee(effectiveSupply, _assets);
     }
 
     /// @dev Reads the configured rate (bps) for a fee type; 0 means disabled.

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -426,7 +426,68 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.lifiFeeShares(), expectedShares - integratorPart);
     }
 
+    /// Sub-floor preview/execution parity ///
+
+    /// @dev Drives the wrapper into a sub-floor supply with a price gain above the
+    ///      watermark, the state where `_accrueFees` skips the performance fee but a
+    ///      preview must not diverge from what the operation actually charges/mints.
+    function _subFloorWithGain() internal {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
+        uint256 leftBehind = MIN_SHARE_SUPPLY / 2;
+        uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
+        vm.prank(alice);
+        wrapper.redeem(toRedeem, alice, alice);
+        assertEq(wrapper.totalSupply(), leftBehind);
+
+        // Credit a position without minting shares so the price rises above the
+        // watermark while the supply stays below the floor.
+        _donateToWrapperPosition(1e15);
+
+        assertGt(_pps(), wrapper.perfHighWaterMarkPps());
+    }
+
+    function test_SubFloorPreviewMintMatchesExecution() public {
+        _subFloorWithGain();
+
+        // `mint` clears the floor post-op (0.5e6 + 1e6), so the operation is allowed.
+        uint256 shares = MIN_SHARE_SUPPLY;
+        uint256 quoted = wrapper.previewMint(shares);
+
+        asset.mint(bob, quoted);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), quoted);
+        uint256 spent = wrapper.mint(shares, bob);
+        vm.stopPrank();
+
+        assertEq(spent, quoted);
+    }
+
+    function test_SubFloorPreviewDepositMatchesExecution() public {
+        _subFloorWithGain();
+
+        uint256 assets = 1e15;
+        uint256 quoted = wrapper.previewDeposit(assets);
+
+        asset.mint(bob, assets);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), assets);
+        uint256 minted = wrapper.deposit(assets, bob);
+        vm.stopPrank();
+
+        assertEq(minted, quoted);
+    }
+
     /// Helpers ///
+
+    /// @dev Credits the wrapper with a source-vault position without minting any wrapper
+    ///      shares — a price gain that is not backed by a share mint.
+    function _donateToWrapperPosition(uint256 _assets) internal {
+        asset.mint(address(this), _assets);
+        asset.approve(address(underlying), _assets);
+        underlying.deposit(_assets, address(wrapper));
+    }
 
     function _newWrapperPerfOnly(
         uint16 _rate


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-813](https://linear.app/lifi-linear/issue/EXSC-813/vault-wrapper-fee-share-previews-omit-the-sub-floor-performance-fee)

# Why did I implement it this way?

`_accrueFees` short-circuits below `MIN_SHARE_SUPPLY`: when the performance fee is enabled and the supply is sub-floor it re-floats the watermark and mints no performance shares. `_pendingFeeShares` — which every preview and conversion override runs through — had no matching branch, so in the sub-floor state previews priced against phantom performance-dilution shares the accrual never mints. That broke the parity invariant documented at `LiFiVaultWrapper.sol:342-344` (a preview returned before an operation equals what the caller gets after accrual): `previewMint` under-quoted assets and `previewDeposit` over-quoted shares (both EIP-4626-violating directions), and `maxRedeem`'s liquidity clamp over-reported. The fix mirrors the accrual's sub-floor branch in `_pendingFeeShares` — return the management shares alone when `supply + mgmtShares < MIN_SHARE_SUPPLY` — so the two paths cannot diverge in that state. I kept the change to the single divergent function rather than extracting a shared fee-share helper across accrual and previews; the larger unification touches the accrual hot path on every operation and is better done as its own reviewed refactor. This is a Low-severity, integration-correctness fix — the state is only reachable on a dust vault (supply pushed below the floor by floor-exempt exits) and there is no fund loss. No version bump, per the pre-deployment convention on this branch (see #2227).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>