### PR TITLE
refactor(VaultWrapper): remove deposit-side supply floor (EXSC-814)

### DIFF
--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -102,9 +102,9 @@ accepted by design, every bound deriving from the offset alone:
   the grief is self-defeating.
 - Deposits and mints can transact at dust supply (below
   `DUST_SUPPLY_THRESHOLD`). A position held there is either dust (at most
-  ~1e-12 of a share token at par price) or subsidized by a donation of which more than
-  half is forfeited to the virtual-share offset on exit — engineering the
-  state is always loss-making.
+  ~1e-12 of a share token at par price) or subsidized by a donation of
+  which more than half is forfeited to the virtual-share offset on exit —
+  engineering the state is always loss-making.
 - Performance fees on gains earned below `DUST_SUPPLY_THRESHOLD` are forgiven
   (the accrual floats the watermark instead). A bounded fee-revenue leak,
   never a depositor loss; dodging fees this way costs more than the dodged fee.

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -24,8 +24,10 @@ withdrawal.
   time. `distributeFees` is permissionless and pays LI.FI's parts to the factory's
   live `lifiFeeRecipient` and the integrator's parts across its receiver wallets.
 - Inflation-attack protection: a per-instance ERC-4626 virtual-share decimals
-  offset derived at `initialize` (floored at a nonzero minimum) plus a deposit-side
-  supply floor.
+  offset derived at `initialize` (floored at a nonzero minimum of 6), plus a
+  `ZeroSharesMinted` revert on any deposit that would round to zero shares. There
+  is deliberately no enforced minimum share supply — see
+  [Donation griefing](#donation-griefing--accepted-bounds).
 - A single pluggable `IAccessGate` (zero = permissionless) enforced fail-closed on
   entry, share transfers, and exits.
 - Pause is enforced on the deposit/mint path only; withdrawals stay open.
@@ -86,6 +88,27 @@ withdrawal.
   can land a wei past a source's exact liquidity cap — the one tolerated
   artifact. `redeem` has no such boundary and is the guaranteed exit.
 
+## Donation griefing — accepted bounds
+
+There is deliberately no enforced minimum share supply. The virtual-share
+offset (minimum 6) is the sole inflation/donation defense; the following are
+accepted by design, every bound deriving from the offset alone:
+
+- A depositor's rounding loss against a donation-inflated price is bounded by
+  ~`donation / 10^offset` — at the minimum offset, one-millionth of what the
+  attacker burns. A deposit that would round to zero shares reverts
+  `ZeroSharesMinted`; assets are never taken for no shares. Zeroing a given
+  deposit costs ~1e6× that deposit and the donation accrues to the vault, so
+  the grief is self-defeating.
+- Deposits and mints can transact at dust supply (below
+  `DUST_SUPPLY_THRESHOLD`). A position held there is either dust (~1e-12 of a
+  share token at par price) or subsidized by a donation of which more than
+  half is forfeited to the virtual-share offset on exit — engineering the
+  state is always loss-making.
+- Performance fees on gains earned below `DUST_SUPPLY_THRESHOLD` are forgiven
+  (the accrual floats the watermark instead). A bounded fee-revenue leak,
+  never a depositor loss; dodging fees this way costs more than the dodged fee.
+
 ## Admin role
 
 The per-vault admin is OZ's two-step `owner`
@@ -99,11 +122,12 @@ deployed. It sets the identity (`underlying` / `adapter` / `owner` / `factory`),
 the initial fee configuration, receivers, and access gate; resolves the ERC-20
 asset via the adapter; derives the virtual-share offset from the asset decimals;
 and sets a provisional performance watermark at the empty-vault share price. That
-par value is only a placeholder: while total supply is below `MIN_SHARE_SUPPLY`
-(no real holders), each accrual re-floats the watermark to the live price and
-skips the performance fee, so assets donated to the instance's predicted address
-become the first real depositor's baseline instead of being charged to them as
-fabricated gain.
+par value is only a placeholder: while total supply is below
+`DUST_SUPPLY_THRESHOLD` (1e6 shares — where the performance dilution rounds to
+zero shares), each accrual re-floats the watermark to the live price and skips
+the performance fee, so assets donated to the instance's predicted address become
+the next depositor's baseline instead of being charged to them as fabricated
+gain.
 
 ## Upgradeability and the FACTORY binding
 

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -101,8 +101,8 @@ accepted by design, every bound deriving from the offset alone:
   deposit costs ~1e6× that deposit and the donation accrues to the vault, so
   the grief is self-defeating.
 - Deposits and mints can transact at dust supply (below
-  `DUST_SUPPLY_THRESHOLD`). A position held there is either dust (~1e-12 of a
-  share token at par price) or subsidized by a donation of which more than
+  `DUST_SUPPLY_THRESHOLD`). A position held there is either dust (at most
+  ~1e-12 of a share token at par price) or subsidized by a donation of which more than
   half is forfeited to the virtual-share offset on exit — engineering the
   state is always loss-making.
 - Performance fees on gains earned below `DUST_SUPPLY_THRESHOLD` are forgiven

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -51,13 +51,12 @@ import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 ///      `isTransferable(from, to)`, and exits check `isSanctioned` on the share owner and
 ///      asset receiver — all fail-closed, so a misbehaving gate blocks the guarded
 ///      operation (including exits) until the owner swaps the gate. Inflation-attack
-///      protection is layered: the ERC-4626 virtual-share decimals offset is derived
-///      once at `initialize` (`18 - assetDecimals`, floored at a nonzero minimum so even
+///      protection is the ERC-4626 virtual-share decimals offset, derived once at
+///      `initialize` (`18 - assetDecimals`, floored at a nonzero minimum so even
 ///      high-decimal assets stay donation-resistant — strongest exactly where a donated
-///      wei buys the most), and a deposit-side supply floor keeps depositors out of the
-///      dust-denominator regime. EIP-5143 slippage overloads of
-///      the four entrypoints bound the realized amount against in-flight share-price
-///      or fee-rate changes.
+///      wei buys the most), plus the `ZeroSharesMinted` guard on zero-share deposits.
+///      EIP-5143 slippage overloads of the four entrypoints bound the realized amount
+///      against in-flight share-price or fee-rate changes.
 /// @custom:version 1.0.0
 contract LiFiVaultWrapper is
     ERC4626Upgradeable,
@@ -96,25 +95,23 @@ contract LiFiVaultWrapper is
 
     /// @notice Lower bound on the derived virtual-share decimals offset, applied even when
     ///         the asset already has >= `TARGET_SHARE_DECIMALS` decimals (where the derived
-    ///         offset would otherwise be 0). The offset divides the asset cost of the
-    ///         fresh-vault donation grief: to push a deposit below the `MIN_SHARE_SUPPLY`
-    ///         floor an attacker must donate ~`MIN_SHARE_SUPPLY / 10 ** offset` times that
-    ///         deposit. A minimum of 6 (= log10(`MIN_SHARE_SUPPLY`)) caps that ratio at 1,
-    ///         so a donation can never block a deposit larger than itself — and since the
-    ///         donation accrues to the first real depositor, the grief is self-defeating.
-    ///         With offset 0 a ~1-token donation would block every sub-1M-token first
-    ///         deposit into an 18-decimal vault.
+    ///         offset would otherwise be 0). The offset is the sole inflation/donation
+    ///         defense: zeroing a deposit requires donating ~`10 ** offset` times it, and a
+    ///         depositor's rounding loss is bounded at ~`1 / 10 ** offset` of the donation
+    ///         (a deposit that would round to zero shares reverts `ZeroSharesMinted` in
+    ///         `_deposit`). At the minimum of 6 a donation never zeroes a deposit larger
+    ///         than one-millionth of it — and since the donation accrues to the vault, the
+    ///         grief is self-defeating. With offset 0 a ~1-token donation would zero every
+    ///         sub-1M-token first deposit into an 18-decimal vault.
     uint8 internal constant MIN_DECIMALS_OFFSET = 6;
 
-    /// @notice Deposit-side total-supply floor, in shares: after any deposit or mint
-    ///         the supply must be at least this (exits are exempt — see
-    ///         `_enforceSupplyFloor`). With the offset floored at `MIN_DECIMALS_OFFSET`,
-    ///         any nonzero first deposit already mints at least this many shares, so the
-    ///         floor is a backstop rather than the primary inflation guard: it catches
-    ///         the donation-inflated zero-share deposit and the sub-floor dust an exit can
-    ///         strand. At >= 18 share decimals it is at most ~1e-12 of one token, so no
-    ///         real deposit ever notices it.
-    uint256 internal constant MIN_SHARE_SUPPLY = 1e6;
+    /// @notice Dust-supply threshold for watermark maintenance in `_accrueFees`: below
+    ///         it the perf dilution can round to zero shares while the watermark goes
+    ///         stale. NOT an enforced deposit floor — the virtual-share offset alone
+    ///         bounds degenerate-state losses (see `MIN_DECIMALS_OFFSET`). Sized at
+    ///         10 ** `MIN_DECIMALS_OFFSET`, covering the widest stale window (1e4
+    ///         shares at the 1 bps minimum rate).
+    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
 
     /// Immutables ///
 
@@ -402,9 +399,7 @@ contract LiFiVaultWrapper is
     /// @inheritdoc ERC4626Upgradeable
     /// @dev Reverts `DepositsPaused` while any pause source is engaged, so the named reason
     ///      surfaces to callers rather than OZ's `ERC4626ExceededMaxDeposit` from the
-    ///      `maxDeposit == 0` view (which stays 0 for EIP-4626 consumers). The shared
-    ///      `_deposit` seam enforces the post-operation supply floor (see
-    ///      `_enforceSupplyFloor`).
+    ///      `maxDeposit == 0` view (which stays 0 for EIP-4626 consumers).
     function deposit(
         uint256 assets,
         address receiver
@@ -419,9 +414,7 @@ contract LiFiVaultWrapper is
     /// @inheritdoc ERC4626Upgradeable
     /// @dev Reverts `DepositsPaused` while any pause source is engaged, so the named reason
     ///      surfaces to callers rather than OZ's `ERC4626ExceededMaxMint` from the
-    ///      `maxMint == 0` view (which stays 0 for EIP-4626 consumers). The shared
-    ///      `_deposit` seam enforces the post-operation supply floor (see
-    ///      `_enforceSupplyFloor`).
+    ///      `maxMint == 0` view (which stays 0 for EIP-4626 consumers).
     function mint(
         uint256 shares,
         address receiver
@@ -434,8 +427,6 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Deliberately NOT floor-checked (see `_enforceSupplyFloor` for why exits
-    ///      are exempt): an exit must always be able to empty the caller's position.
     function withdraw(
         uint256 assets,
         address receiver,
@@ -448,8 +439,6 @@ contract LiFiVaultWrapper is
     }
 
     /// @inheritdoc ERC4626Upgradeable
-    /// @dev Deliberately NOT floor-checked (see `_enforceSupplyFloor` for why exits
-    ///      are exempt): an exit must always be able to empty the caller's position.
     function redeem(
         uint256 shares,
         address receiver,
@@ -663,36 +652,6 @@ contract LiFiVaultWrapper is
 
     /// Internal ///
 
-    /// @dev Deposit-side supply floor: after a non-zero deposit/mint the total supply must
-    ///      be at least `MIN_SHARE_SUPPLY`, so no depositor ever transacts against a
-    ///      dust-sized share denominator (the first-depositor inflation attack's
-    ///      precondition), capping a donation-griefer's damage at ~`1/MIN_SHARE_SUPPLY`
-    ///      of the donation. A post-operation supply of exactly zero is rejected here too:
-    ///      it is reached when a non-zero deposit mints zero shares against a
-    ///      donation-inflated *empty* vault. The complementary case — a non-zero deposit
-    ///      minting zero shares while supply already sits at or above the floor (parked
-    ///      there by prior floor-exempt exits, then donation-inflated) — passes this check
-    ///      and is caught instead by the `shares == 0` guard in `_deposit`: a passing
-    ///      supply check alone does not imply the deposit minted anything.
-    ///      A zero-amount `deposit(0)`/`mint(0)` moves nothing and mints nothing, so the
-    ///      caller skips this check entirely: the no-op stays a no-op even in a sub-floor
-    ///      state. Exits are also deliberately exempt (they never call this): `_accrueFees`
-    ///      mints fee shares to this contract, so an exit-side check could revert the last
-    ///      holder's full exit against sub-floor fee-share residue — and exits must always
-    ///      work. An exit may therefore strand a sub-floor supply, but any non-zero deposit
-    ///      into that state is still protected by this check. Not reflected in the max*
-    ///      limit views (a documented EIP-4626 deviation): with the offset floored at
-    ///      `MIN_DECIMALS_OFFSET`, an ordinary deposit into a clean vault always clears the
-    ///      floor, so the only amounts `<= maxDeposit` that still revert are non-zero
-    ///      deposits that mint zero shares against a donation-inflated vault and deposits
-    ///      into an exit-stranded sub-floor vault — edge states not worth modeling in the
-    ///      limit views.
-    function _enforceSupplyFloor() private view {
-        uint256 supply = totalSupply();
-        if (supply < MIN_SHARE_SUPPLY)
-            revert SupplyBelowMinimum(supply, MIN_SHARE_SUPPLY);
-    }
-
     /// @dev Skims the entry fee and forwards the remaining deposited assets into the yield
     ///      source via the adapter. OZ's `_deposit` has already pulled the asset in and minted
     ///      shares. Reverts if the adapter reports the source accepted less than the net
@@ -703,13 +662,11 @@ contract LiFiVaultWrapper is
     ///      ERC-4626 source reverts on a zero-asset forward, so short-circuiting keeps `deposit`
     ///      non-reverting in exactly the cases where `previewDeposit` returns 0. A deposit
     ///      that would forward a non-zero net amount yet minted zero shares (assets rounded
-    ///      away against a donation-inflated price while supply sits at/above the floor)
-    ///      reverts `ZeroSharesMinted` before the forward, so the caller never loses assets
-    ///      to the pool for no shares. Pause is enforced upstream in `deposit`/`mint`. Both
-    ///      `deposit` and `mint` route through this seam, so the post-operation supply floor
-    ///      is enforced here once for every inflow entrypoint (a zero-amount call mints
-    ///      nothing and skips it); exits go through `_withdraw` and are structurally exempt
-    ///      (see `_enforceSupplyFloor`).
+    ///      away against a donation-inflated price) reverts `ZeroSharesMinted` before the
+    ///      forward, so the caller never loses assets to the pool for no shares — the only
+    ///      revert needed against donation griefs, since the virtual-share offset bounds every
+    ///      non-zero-share outcome's loss at ~`1 / 10 ** offset` of the donation. Pause is
+    ///      enforced upstream in `deposit`/`mint`.
     function _deposit(
         address caller,
         address receiver,
@@ -717,7 +674,6 @@ contract LiFiVaultWrapper is
         uint256 shares
     ) internal override {
         super._deposit(caller, receiver, assets, shares);
-        if (assets != 0) _enforceSupplyFloor();
 
         uint256 depositFee = LibVaultWrapperMath.feeOnTotal({
             _assets: assets,
@@ -1051,11 +1007,10 @@ contract LiFiVaultWrapper is
     ///      floors to zero shares is dropped — at most ~one share's worth of assets per
     ///      accrual, favouring holders. The performance fee is charged AFTER the
     ///      management dilution (perf is net of management). The watermark has two write
-    ///      paths: while supply is below the floor (no real holders), it floats to the live
-    ///      price and the perf fee is skipped, so a donation becomes the first depositor's
-    ///      baseline rather than their loss; at real supply it ratchets to the post-
-    ///      crystallization price (rounded up) only when shares were actually minted — an
-    ///      uncharged gain stays chargeable, unlike elapsed time.
+    ///      paths: at dust supply (below `DUST_SUPPLY_THRESHOLD`) it floats to the live
+    ///      price and the perf fee is skipped (see the inline comment); at real supply it
+    ///      ratchets to the post-crystallization price (rounded up) only when shares were
+    ///      actually minted — an uncharged gain stays chargeable, unlike elapsed time.
     function _accrueFees() private {
         bool mgmtEnabled = _rate(FeeType.Management) != 0;
         bool perfEnabled = _rate(FeeType.Performance) != 0;
@@ -1075,18 +1030,16 @@ contract LiFiVaultWrapper is
             supply += mgmtShares;
         }
 
-        // Below the supply floor there are no real holders: no depositor can transact against
-        // a sub-floor supply (deposits enforce MIN_SHARE_SUPPLY; only floor-exempt exits reach
-        // it), so any price rise is a donation to the (predicted) address, not yield. A plain
-        // `supply == 0` guard is not enough — at dust supply the perf dilution floors to zero
-        // (`dilutionShares` ~ rate * supply, so it rounds to no shares while supply < 1/rate),
-        // leaving the watermark stale and the donation chargeable to the next real depositor.
-        // The floor (1e6) covers every rate: the widest sub-floor window is 1/rate = 1e4 at the
-        // 1 bps minimum. Float the watermark up to the current price so the first real
-        // depositor's entry price becomes the baseline. Trade-off: genuine yield earned while
-        // supply is sub-floor escapes the performance fee, which is bounded (a sub-floor vault
-        // is dust) and consistent with the "no depositor transacts below the floor" invariant.
-        if (perfEnabled && supply < MIN_SHARE_SUPPLY) {
+        // Below the threshold the perf dilution can floor to zero shares
+        // (`dilutionShares` ~ rate * supply; widest window 1e4 shares at the 1 bps
+        // minimum) while the watermark goes stale, leaving a donation-driven price rise
+        // chargeable to the next depositor as fabricated gain — so float the watermark
+        // to the live price and skip the fee instead. Holders CAN sit at dust supply
+        // (deposits are not floor-checked), so genuine sub-threshold yield escapes the
+        // perf fee: an accepted, bounded leak (a sub-threshold position at par is
+        // ~1e-12 of a share token; inflating it forfeits more than half the donation
+        // to the virtual offset), never a depositor loss.
+        if (perfEnabled && supply < DUST_SUPPLY_THRESHOLD) {
             perfHighWaterMarkPps = _ceilPps(supply, assets);
             return;
         }

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1036,8 +1036,8 @@ contract LiFiVaultWrapper is
         // chargeable to the next depositor as fabricated gain — so float the watermark
         // to the live price and skip the fee instead. Holders CAN sit at dust supply
         // (deposits are not floor-checked), so genuine sub-threshold yield escapes the
-        // perf fee: an accepted, bounded leak (a sub-threshold position at par is
-        // ~1e-12 of a share token; inflating it forfeits more than half the donation
+        // perf fee: an accepted, bounded leak (a sub-threshold position at par is at
+        // most ~1e-12 of a share token; inflating it forfeits more than half the donation
         // to the virtual offset), never a depositor loss.
         if (perfEnabled && supply < DUST_SUPPLY_THRESHOLD) {
             perfHighWaterMarkPps = _ceilPps(supply, assets);
@@ -1155,7 +1155,9 @@ contract LiFiVaultWrapper is
     /// @dev Fee-shares pending since the last accrual, used by the effective-supply
     ///      conversion overrides. Management first, then performance on the post-
     ///      management effective supply — the exact sequence `_accrueFees` crystallizes
-    ///      in, so previews match execution.
+    ///      in, so previews match execution; that includes mirroring the accrual's
+    ///      dust-supply perf skip (below `DUST_SUPPLY_THRESHOLD` no perf shares are
+    ///      minted, so none may be quoted).
     /// @param _supply The current total supply (pre-accrual).
     /// @param _assets The current total assets.
     /// @return The dilution shares pending.
@@ -1164,9 +1166,10 @@ contract LiFiVaultWrapper is
         uint256 _assets
     ) private view returns (uint256) {
         uint256 mgmtShares = _pendingManagementFee(_supply, _assets);
+        uint256 supplyAfterMgmt = _supply + mgmtShares;
+        if (supplyAfterMgmt < DUST_SUPPLY_THRESHOLD) return mgmtShares;
 
-        return
-            mgmtShares + _pendingPerformanceFee(_supply + mgmtShares, _assets);
+        return mgmtShares + _pendingPerformanceFee(supplyAfterMgmt, _assets);
     }
 
     /// @dev Reads the configured rate (bps) for a fee type; 0 means disabled.

--- a/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
+++ b/src/VaultWrapper/interfaces/ILiFiVaultWrapper.sol
@@ -141,13 +141,10 @@ interface ILiFiVaultWrapper {
     /// @notice Thrown by the EIP-5143 slippage-guarded entrypoints when the realized
     ///         amount crosses the caller's bound (below a minimum, or above a maximum).
     error SlippageExceeded(uint256 actual, uint256 bound);
-    /// @notice Thrown when a deposit or mint would leave the total share supply below the
-    ///         minimum supply floor (a post-operation supply of exactly zero included).
-    error SupplyBelowMinimum(uint256 supply, uint256 minSupply);
     /// @notice Thrown when a deposit would forward a non-zero net amount into the yield
     ///         source yet mint zero shares (its assets rounded away against a
-    ///         donation-inflated price per share while supply sits at or above the
-    ///         floor) — otherwise the caller's assets are lost to the pool for no shares.
+    ///         donation-inflated price per share) — otherwise the caller's assets are
+    ///         lost to the pool for no shares.
     error ZeroSharesMinted(uint256 assets);
     /// @notice Thrown at initialization when the asset's ERC-20 decimals() cannot be read
     ///         as a well-formed uint8, so the virtual-share offset cannot be sized safely.

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -468,10 +468,9 @@ contract LiFiVaultWrapperTest is Test {
     }
 
     function test_VirtualSharesGiveSecondDepositorFairShares() public {
-        // The smallest floor-clearing first deposit (1e6 shares = MIN_SHARE_SUPPLY;
-        // anything smaller reverts SupplyBelowMinimum) must not let virtual-share
-        // accounting zero out a normal-sized second deposit (the empty-vault edge
-        // the inflation attack targets).
+        // A minimal first deposit (1e6 asset-wei -> 1e12 shares at the minimum offset)
+        // must not let virtual-share accounting zero out a normal-sized second deposit
+        // (the empty-vault edge the inflation attack targets).
         _deposit(alice, 1e6);
         _deposit(bob, DEPOSIT);
 

--- a/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapper.t.sol
@@ -468,7 +468,7 @@ contract LiFiVaultWrapperTest is Test {
     }
 
     function test_VirtualSharesGiveSecondDepositorFairShares() public {
-        // A minimal first deposit (1e6 asset-wei -> 1e12 shares at the minimum offset)
+        // A small first deposit (1e6 asset-wei -> 1e12 shares at the minimum offset)
         // must not let virtual-share accounting zero out a normal-sized second deposit
         // (the empty-vault edge the inflation attack targets).
         _deposit(alice, 1e6);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFees.t.sol
@@ -101,8 +101,7 @@ contract LiFiVaultWrapperFeesTest is VaultWrapperFeeTestBase {
 
         // No prior deposits: totalSupply()/totalAssets() are zero, so the accrual at the
         // top of the first operation finds nothing to dilute. The 1-wei crystallizing
-        // deposit is the vault's first and mints 1e6 shares (18-dec asset, offset 6),
-        // so it clears the supply floor on its own.
+        // deposit is the vault's first and mints 1e6 shares (18-dec asset, offset 6).
         vm.warp(block.timestamp + YEAR);
         _crystallize();
 
@@ -111,9 +110,8 @@ contract LiFiVaultWrapperFeesTest is VaultWrapperFeeTestBase {
 
     function test_ZeroShareAccrualStillAdvancesBaseline() public {
         wrapper = _newWrapperMgmtOnly(MGMT_RATE);
-        // A tiny AUM (the smallest floor-clearing deposit) makes the per-second
-        // management fee floor to zero shares, so the accrual at the top of an
-        // operation mints nothing.
+        // A tiny AUM (1e6 asset-wei) makes the per-second management fee floor to
+        // zero shares, so the accrual at the top of an operation mints nothing.
         _deposit(alice, 1e6);
 
         vm.warp(block.timestamp + 1);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -426,7 +426,68 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.lifiFeeShares(), expectedShares - integratorPart);
     }
 
+    /// Dust-supply preview/execution parity ///
+
+    /// @dev Drives the wrapper into dust supply with a price gain above the watermark,
+    ///      the state where `_accrueFees` skips the performance fee but a preview must
+    ///      not diverge from what the operation actually charges/mints.
+    function _dustSupplyWithGain() internal {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
+        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
+        uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
+        vm.prank(alice);
+        wrapper.redeem(toRedeem, alice, alice);
+
+        assertEq(wrapper.totalSupply(), leftBehind);
+
+        // Credit a position without minting shares so the price rises above the
+        // watermark while the supply stays below the threshold.
+        _donateToWrapperPosition(1e15);
+
+        assertGt(_pps(), wrapper.perfHighWaterMarkPps());
+    }
+
+    function test_DustSupplyPreviewMintMatchesExecution() public {
+        _dustSupplyWithGain();
+
+        uint256 shares = DUST_SUPPLY_THRESHOLD;
+        uint256 quoted = wrapper.previewMint(shares);
+
+        asset.mint(bob, quoted);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), quoted);
+        uint256 spent = wrapper.mint(shares, bob);
+        vm.stopPrank();
+
+        assertEq(spent, quoted);
+    }
+
+    function test_DustSupplyPreviewDepositMatchesExecution() public {
+        _dustSupplyWithGain();
+
+        uint256 assets = 1e15;
+        uint256 quoted = wrapper.previewDeposit(assets);
+
+        asset.mint(bob, assets);
+        vm.startPrank(bob);
+        asset.approve(address(wrapper), assets);
+        uint256 minted = wrapper.deposit(assets, bob);
+        vm.stopPrank();
+
+        assertEq(minted, quoted);
+    }
+
     /// Helpers ///
+
+    /// @dev Credits the wrapper with a source-vault position without minting any wrapper
+    ///      shares — a price gain that is not backed by a share mint.
+    function _donateToWrapperPosition(uint256 _assets) internal {
+        asset.mint(address(this), _assets);
+        asset.approve(address(underlying), _assets);
+        underlying.deposit(_assets, address(wrapper));
+    }
 
     function _newWrapperPerfOnly(
         uint16 _rate

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -423,7 +423,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
     }
 
     function test_SmallFirstMintSucceeds() public {
-        // Sub-1e6-share first mints used to revert on the removed supply floor.
+        // A first mint below the dust threshold is a valid entry.
         uint256 shares = DUST_SUPPLY_THRESHOLD / 2;
         uint256 cost = wrapper.previewMint(shares);
         asset.mint(alice, cost);
@@ -441,12 +441,13 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         // from dust share counts.
         _deposit(alice, 1);
 
-        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertEq(wrapper.totalSupply(), 10 ** wrapper.shareDecimalsOffset());
     }
 
     function test_DustSupplyIsDepositableAfterExit() public {
-        // Exits can leave a dust supply; entries into that state now succeed. The
-        // sub-threshold top-up is an explicit mint that used to revert.
+        // Exits can leave a dust supply; deposits and mints into that state must
+        // succeed. A plain deposit over-clears the threshold (offset-scaled), so the
+        // sub-threshold top-up is shown via an explicit mint.
         _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
         uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -10,8 +10,9 @@ import { FeeConfig, FeeType } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol"
 import { VaultWrapperFeeTestBase } from "test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol";
 
 /// @notice The wrapper's protection layer (EXSC-414): EIP-5143 slippage-guarded
-///         entrypoints, the asset-derived virtual-share decimals offset, and the
-///         minimum share-supply floor (first-depositor inflation mitigation).
+///         entrypoints, the asset-derived virtual-share decimals offset
+///         (first-depositor inflation mitigation), and the donation-degenerate
+///         entry states the offset bounds.
 contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
     address internal attacker = makeAddr("attacker");
     address internal victim = makeAddr("victim");
@@ -225,10 +226,9 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
     }
 
     function test_DonationCannotBlockDepositLargerThanItself() public {
-        // Regression for the dust-donation launch DoS: with the minimum offset the
-        // asset barrier a donation imposes is at most 1x the donation, so a deposit
-        // larger than the donation always clears the floor. At offset 0 this same
-        // 1-token donation would have blocked every sub-1M-token first deposit.
+        // Offset-derived bound: zeroing a deposit requires donating ~10 ** offset
+        // times it, so a deposit larger than the donation always mints shares. At
+        // offset 0 this 1-token donation would zero every sub-1M-token first deposit.
         MockERC4626 source = MockERC4626(address(underlying));
         uint256 donated = 1e18; // 1 token
         asset.mint(attacker, donated);
@@ -247,8 +247,8 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         uint256 shares = wrapper.deposit(firstDeposit, victim);
         vm.stopPrank();
 
-        assertGe(shares, MIN_SHARE_SUPPLY);
-        assertGe(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertGt(shares, 0);
+        assertEq(wrapper.totalSupply(), shares);
     }
 
     function test_InflationAttackIsUnprofitableOnLowDecimalAsset() public {
@@ -344,12 +344,12 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         assertLt(attackerOut, seeded + donated);
     }
 
-    /// Minimum share-supply floor ///
+    /// Donation-degenerate entry states ///
 
     function testRevert_ZeroShareDepositIntoDonatedEmptyVault() public {
         // Attacker donates source shares straight to the wrapper: totalAssets() > 0
-        // while totalSupply() stays 0. The minimum offset (6) means the victim's deposit
-        // only rounds to zero shares once the donation exceeds it by ~MIN_SHARE_SUPPLY,
+        // while totalSupply() stays 0. The minimum offset (6) means the victim's
+        // deposit only rounds to zero shares once the donation exceeds it ~1e6-fold,
         // so the donation dwarfs the deposit here (the grief is deeply unprofitable).
         MockERC4626 source = MockERC4626(address(underlying));
         uint256 donated = 2_000_000e18;
@@ -363,9 +363,9 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.totalSupply(), 0);
         assertGt(wrapper.totalAssets(), 0);
 
-        // The victim's deposit rounds to zero shares against the inflated price. Without
-        // the zero-supply guard this would forward the assets for no shares (100% loss);
-        // the floor must reject it (post-operation supply stays 0).
+        // The victim's deposit rounds to zero shares against the inflated price; the
+        // shares == 0 guard must reject it, else the assets are forwarded for no
+        // shares (100% loss).
         uint256 victimDeposit = 1e18;
         asset.mint(victim, victimDeposit);
         vm.startPrank(victim);
@@ -374,9 +374,8 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                ILiFiVaultWrapper.SupplyBelowMinimum.selector,
-                0,
-                MIN_SHARE_SUPPLY
+                ILiFiVaultWrapper.ZeroSharesMinted.selector,
+                victimDeposit
             )
         );
 
@@ -384,15 +383,15 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         vm.stopPrank();
     }
 
-    function testRevert_ZeroShareDepositAtParkedSupplyFloor() public {
-        // The supply floor alone does not catch a zero-share deposit: an attacker parks
-        // the supply at exactly MIN_SHARE_SUPPLY with a dust deposit (exits are
-        // floor-exempt, so any supply >= the floor is reachable and holdable), then
-        // donates source shares to inflate the price. A later non-zero deposit rounds to
-        // zero shares while supply stays at the floor, so `_enforceSupplyFloor` passes —
-        // the `shares == 0` guard must reject it, else the assets are forwarded for free.
+    function testRevert_ZeroShareDepositAtInflatedPriceWithExistingSupply()
+        public
+    {
+        // Same zero-share grief with non-zero existing supply: a dust deposit seeds
+        // the vault, then a donation inflates the price until a later non-zero
+        // deposit rounds to zero shares. The `shares == 0` guard must reject it,
+        // else the assets are forwarded for free.
         _deposit(attacker, 1);
-        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
 
         MockERC4626 source = MockERC4626(address(underlying));
         uint256 donated = 3_000_000e18;
@@ -403,7 +402,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         source.transfer(address(wrapper), donatedShares);
         vm.stopPrank();
 
-        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
         assertGt(wrapper.totalAssets(), 0);
 
         uint256 victimDeposit = 1e18;
@@ -423,42 +422,33 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         vm.stopPrank();
     }
 
-    function testRevert_MintBelowSupplyFloor() public {
-        // Any nonzero deposit into a clean vault over-clears the floor (the offset
-        // scales shares up by 10 ** offset), so the floor is reached from below only by
-        // minting an explicit sub-floor share count.
-        uint256 shares = MIN_SHARE_SUPPLY / 2;
-        asset.mint(alice, 1);
+    function test_SmallFirstMintSucceeds() public {
+        // Sub-1e6-share first mints used to revert on the removed supply floor.
+        uint256 shares = DUST_SUPPLY_THRESHOLD / 2;
+        uint256 cost = wrapper.previewMint(shares);
+        asset.mint(alice, cost);
         vm.startPrank(alice);
-        asset.approve(address(wrapper), 1);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILiFiVaultWrapper.SupplyBelowMinimum.selector,
-                shares,
-                MIN_SHARE_SUPPLY
-            )
-        );
-
+        asset.approve(address(wrapper), cost);
         wrapper.mint(shares, alice);
         vm.stopPrank();
+
+        assertEq(wrapper.totalSupply(), shares);
+        assertEq(wrapper.balanceOf(alice), shares);
     }
 
-    function test_FirstDepositAtSupplyFloorPasses() public {
-        // The smallest possible deposit (1 asset-wei) already mints exactly the floor,
-        // since the offset scales 1 wei into MIN_SHARE_SUPPLY shares.
+    function test_SmallestDepositMintsOffsetScaledShares() public {
+        // 1 asset-wei mints 10 ** offset shares — the offset scales every entry away
+        // from dust share counts.
         _deposit(alice, 1);
 
-        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
     }
 
-    function test_ExitMayStrandDustSupplyButNextDepositMustClearFloor()
-        public
-    {
-        // Exits are exempt from the floor (they must always work), so a sub-floor
-        // supply can be stranded...
-        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
-        uint256 leftBehind = MIN_SHARE_SUPPLY / 2;
+    function test_DustSupplyIsDepositableAfterExit() public {
+        // Exits can leave a dust supply; entries into that state now succeed. The
+        // sub-threshold top-up is an explicit mint that used to revert.
+        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
+        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
 
         vm.prank(alice);
@@ -466,36 +456,55 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         assertEq(wrapper.totalSupply(), leftBehind);
 
-        // ...but anyone entering that state is still protected: an operation leaving the
-        // supply below the floor reverts. A plain deposit over-clears the floor (the
-        // offset scales shares up), so the sub-floor top-up is shown via an explicit
-        // mint of fewer shares than the floor needs.
-        uint256 shortMint = MIN_SHARE_SUPPLY / 4;
-        asset.mint(bob, 1);
+        uint256 topUp = DUST_SUPPLY_THRESHOLD / 4;
+        uint256 cost = wrapper.previewMint(topUp);
+        asset.mint(bob, cost);
         vm.startPrank(bob);
-        asset.approve(address(wrapper), 1);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ILiFiVaultWrapper.SupplyBelowMinimum.selector,
-                leftBehind + shortMint,
-                MIN_SHARE_SUPPLY
-            )
-        );
-
-        wrapper.mint(shortMint, bob);
+        asset.approve(address(wrapper), cost);
+        wrapper.mint(topUp, bob);
         vm.stopPrank();
 
-        _deposit(bob, MIN_SHARE_SUPPLY);
+        assertEq(wrapper.totalSupply(), leftBehind + topUp);
+        assertEq(wrapper.balanceOf(bob), topUp);
 
-        assertGe(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        _deposit(bob, DUST_SUPPLY_THRESHOLD);
+
+        assertGt(wrapper.totalSupply(), leftBehind + topUp);
+    }
+
+    function test_SubThresholdDepositorLossBoundedByOffsetShare() public {
+        // A deposit against a donation-inflated empty vault can mint sub-threshold
+        // shares; the rounding loss is bounded by ~donation / 10**offset.
+        MockERC4626 source = MockERC4626(address(underlying));
+        uint256 donated = 2_000_000e18;
+        asset.mint(attacker, donated);
+        vm.startPrank(attacker);
+        asset.approve(address(source), donated);
+        uint256 donatedShares = source.deposit(donated, attacker);
+        source.transfer(address(wrapper), donatedShares);
+        vm.stopPrank();
+
+        uint256 victimDeposit = 4e18;
+        asset.mint(victim, victimDeposit);
+        vm.startPrank(victim);
+        asset.approve(address(wrapper), victimDeposit);
+        uint256 shares = wrapper.deposit(victimDeposit, victim);
+        vm.stopPrank();
+
+        assertGt(shares, 0);
+        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+
+        uint256 oneShareBound = donated /
+            (10 ** wrapper.shareDecimalsOffset());
+        vm.prank(victim);
+        uint256 redeemed = wrapper.redeem(shares, victim, victim);
+
+        assertGe(redeemed + oneShareBound + 1, victimDeposit);
     }
 
     function test_ZeroDepositAndMintAreNoopsRegardlessOfSupply() public {
-        // A zero-amount deposit/mint moves nothing and mints nothing, so it must never
-        // revert on the supply floor — not on a fresh empty vault, nor in a sub-floor
-        // state an exit can strand. The floor guards real deposits, not zero-amount
-        // accrual pokes.
+        // A zero-amount deposit/mint moves nothing and must never revert — fresh
+        // vault or dust-supply state alike.
         vm.startPrank(bob);
 
         assertEq(wrapper.deposit(0, bob), 0);
@@ -504,8 +513,8 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         assertEq(wrapper.totalSupply(), 0);
 
-        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
-        uint256 leftBehind = MIN_SHARE_SUPPLY / 2;
+        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
+        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
 
         vm.prank(alice);
@@ -525,13 +534,12 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
     function test_FullExitSucceedsWithFeeShareResidue() public {
         // Regression: fee accrual mints shares to the wrapper itself, so the last
-        // holder's full exit leaves those fee shares as the only supply. The exit must
-        // still succeed — exits never consult the floor. (Sub-floor exit-exemption is
-        // covered by test_ExitMayStrand... and test_FullExitToZeroSupplyPasses.)
+        // holder's full exit leaves those fee shares as the only supply. The exit
+        // must still succeed.
         FeeConfig memory fees;
         fees.rateBps[uint8(FeeType.Management)] = MGMT_RATE;
         wrapper = _newWrapper(fees);
-        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
+        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
 
         vm.warp(block.timestamp + 30 days);
         uint256 aliceShares = wrapper.balanceOf(alice);
@@ -545,18 +553,8 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.balanceOf(address(wrapper)), residue);
     }
 
-    function test_ExitLeavingFloorSupplyPasses() public {
-        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
-        uint256 toRedeem = wrapper.balanceOf(alice) - MIN_SHARE_SUPPLY;
-
-        vm.prank(alice);
-        wrapper.redeem(toRedeem, alice, alice);
-
-        assertEq(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
-    }
-
     function test_FullExitToZeroSupplyPasses() public {
-        _deposit(alice, 2 * MIN_SHARE_SUPPLY);
+        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
         uint256 allShares = wrapper.balanceOf(alice);
 
         vm.prank(alice);

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -33,9 +33,10 @@ abstract contract VaultWrapperFeeTestBase is Test {
     uint16 internal constant MGMT_RATE = 200; // 2% / year
     uint16 internal constant SPLIT = 8000; // integrator share used for every fee type here
     uint256 internal constant YEAR = 365 days;
-    // Mirror of the wrapper's internal MIN_SHARE_SUPPLY (deposit-side supply floor); the
-    // production constant is internal, so the suites read this single shared copy.
-    uint256 internal constant MIN_SHARE_SUPPLY = 1e6;
+    // Mirror of the wrapper's internal DUST_SUPPLY_THRESHOLD (watermark-maintenance
+    // threshold in _accrueFees; equals 10 ** MIN_DECIMALS_OFFSET, the share count a
+    // 1-wei deposit mints); the production constant is internal.
+    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
 
     /// @dev Dust `_crystallize` deposits. 1 wei suffices while the underlying's own PPS
     ///      is 1:1; suites that inflate the underlying raise it (solmate's MockERC4626

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -102,6 +102,31 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         assertGe(aliceAssets, (DEPOSIT * 9999) / 10_000);
     }
 
+    function test_SubThresholdSupplyYieldEscapesPerfFee() public {
+        // Accepted leak: yield earned while supply is below DUST_SUPPLY_THRESHOLD
+        // escapes the performance fee — the accrual floats the watermark over it.
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        _deposit(bob, DEPOSIT);
+        uint256 bobShares = wrapper.balanceOf(bob);
+        vm.prank(bob);
+        wrapper.redeem(bobShares - 10, bob, bob);
+
+        assertGt(wrapper.totalSupply(), 0);
+        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+
+        // Genuine source-side yield at sub-threshold supply.
+        _simulateYield(1e18);
+
+        assertGe(wrapper.totalAssets(), 1e18);
+
+        // The entry accrual floats the watermark over the gain; no fee shares minted.
+        _deposit(alice, DEPOSIT);
+
+        assertEq(_accruedFeeShares(), 0);
+        assertGt(wrapper.perfHighWaterMarkPps(), _parPps());
+    }
+
     function test_PreviewDepositMatchesExecutionAtDustSupply() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -77,16 +77,15 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
     function test_DustSupplyDonationNotChargedToNextDepositor() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
-        // Bob seeds then exits down to dust supply: exits are exempt from MIN_SHARE_SUPPLY,
-        // so an attacker can leave the vault holding a few shares of real supply — a regime
-        // where the perf dilution floors to zero and the watermark never ratchets.
+        // Bob seeds then exits down to dust supply (below DUST_SUPPLY_THRESHOLD) — a
+        // regime where the perf dilution floors to zero and the watermark never ratchets.
         _deposit(bob, DEPOSIT);
         uint256 bobShares = wrapper.balanceOf(bob);
         vm.prank(bob);
         wrapper.redeem(bobShares - 1, bob, bob);
 
         assertGt(wrapper.totalSupply(), 0);
-        assertLt(wrapper.totalSupply(), MIN_SHARE_SUPPLY);
+        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
 
         _donateToWrapperPosition(1e15);
 

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -102,6 +102,33 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         assertGe(aliceAssets, (DEPOSIT * 9999) / 10_000);
     }
 
+    function test_PreviewDepositMatchesExecutionAtDustSupply() public {
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        // Dust supply with pps pushed above the watermark: the accrual skips the perf
+        // mint, so the preview must not quote pending perf shares either (EIP-4626:
+        // previewDeposit must not overstate what the deposit mints). Enough real
+        // shares are left that the pending perf dilution itself is non-zero.
+        _deposit(bob, DEPOSIT);
+        uint256 toRedeem = wrapper.balanceOf(bob) - DUST_SUPPLY_THRESHOLD / 2;
+        vm.prank(bob);
+        wrapper.redeem(toRedeem, bob, bob);
+
+        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+
+        _donateToWrapperPosition(1e15);
+
+        uint256 quote = wrapper.previewDeposit(DEPOSIT);
+        asset.mint(alice, DEPOSIT);
+        vm.startPrank(alice);
+        asset.approve(address(wrapper), DEPOSIT);
+        uint256 shares = wrapper.deposit(DEPOSIT, alice);
+        vm.stopPrank();
+
+        assertGt(shares, 0);
+        assertEq(shares, quote);
+    }
+
     function test_PricePerShareCeilRoundsUpAndDefaultFloors() public pure {
         uint256 floored = LibVaultWrapperMath.pricePerShare(
             2,

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -22,6 +22,10 @@ import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/Moc
 contract VaultWrapperInvariantHandler is Test {
     uint256 internal constant NUM_ACTORS = 3;
 
+    // Mirror of the wrapper's internal DUST_SUPPLY_THRESHOLD: below it `_accrueFees`
+    // floats the watermark instead of ratcheting it.
+    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
+
     // Deposits/mints are floored well above any price-per-share the bounded yield can push
     // the underlying to, so an underlying `deposit` never rounds to zero shares.
     uint256 internal constant MIN_ENTER = 1e18;
@@ -43,7 +47,8 @@ contract VaultWrapperInvariantHandler is Test {
     uint256 public ghostAssetsOut;
     /// @notice Assets ever injected into the underlying as external yield.
     uint256 public ghostYield;
-    /// @notice Highest high-water mark observed; the ratchet asserts it never regresses.
+    /// @notice Last observed high-water mark; asserted monotonic only for operations
+    ///         whose accrual ran at/above `DUST_SUPPLY_THRESHOLD` (see `_ratchetHwm`).
     uint256 public hwmFloor;
 
     constructor(
@@ -69,6 +74,7 @@ contract VaultWrapperInvariantHandler is Test {
         if (WRAPPER.depositsPaused()) return;
 
         address actor = _actor(_actorSeed);
+        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 assets = bound(_assets, MIN_ENTER, MAX_ENTER);
         ASSET.mint(actor, assets);
 
@@ -79,13 +85,14 @@ contract VaultWrapperInvariantHandler is Test {
         vm.stopPrank();
 
         ghostAssetsIn += assets;
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function mint(uint256 _actorSeed, uint256 _shares) external {
         if (WRAPPER.depositsPaused()) return;
 
         address actor = _actor(_actorSeed);
+        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 shares = bound(_shares, MIN_ENTER, MAX_ENTER);
         uint256 assets = WRAPPER.previewMint(shares);
         ASSET.mint(actor, assets);
@@ -97,7 +104,7 @@ contract VaultWrapperInvariantHandler is Test {
         vm.stopPrank();
 
         ghostAssetsIn += assets;
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function withdraw(uint256 _actorSeed, uint256 _assets) external {
@@ -108,13 +115,14 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 ceiling = WRAPPER.maxWithdraw(actor);
         if (ceiling == 0) return;
 
+        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 assets = bound(_assets, 1, ceiling);
 
         vm.prank(actor);
         WRAPPER.withdraw(assets, actor, actor);
 
         ghostAssetsOut += assets;
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {
@@ -126,19 +134,21 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 ceiling = WRAPPER.maxRedeem(actor);
         if (ceiling == 0) return;
 
+        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 shares = bound(_shares, 1, ceiling);
 
         vm.prank(actor);
         uint256 received = WRAPPER.redeem(shares, actor, actor);
 
         ghostAssetsOut += received;
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function distributeFees() external {
+        uint256 preOpSupply = WRAPPER.totalSupply();
         WRAPPER.distributeFees();
 
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function injectYield(uint256 _amount) external {
@@ -162,13 +172,14 @@ contract VaultWrapperInvariantHandler is Test {
 
     function setFee(uint256 _typeSeed, uint256 _rateSeed) external {
         FeeType feeType = FeeType(bound(_typeSeed, 0, 3));
+        uint256 preOpSupply = WRAPPER.totalSupply();
         (, uint16 maxBps) = FACTORY.feeBounds(feeType);
         uint16 rate = uint16(bound(_rateSeed, 0, maxBps));
 
         vm.prank(VAULT_ADMIN);
         WRAPPER.setFeeRate(feeType, rate);
 
-        _ratchetHwm();
+        _ratchetHwm(preOpSupply);
     }
 
     function togglePause() external {
@@ -186,12 +197,18 @@ contract VaultWrapperInvariantHandler is Test {
         return actors[bound(_seed, 0, NUM_ACTORS - 1)];
     }
 
-    /// @dev Asserts the performance high-water mark never regresses across any operation that
-    ///      crystallizes fees, then advances the floor. The mark is re-anchored up-only on a
-    ///      fee re-enable and ratcheted up on a performance accrual, so it must be monotonic.
-    function _ratchetHwm() private {
+    /// @dev Asserts the performance high-water mark never regresses across an operation
+    ///      that crystallizes fees, then advances the floor. Monotonic only when the
+    ///      operation's accrual ran at/above `DUST_SUPPLY_THRESHOLD`: below it,
+    ///      `_accrueFees` floats the mark to the live price — which exits at dust supply
+    ///      collapse (virtual shares dominate) — so those operations only re-anchor.
+    ///      Gated on the PRE-operation supply because the accrual runs before the
+    ///      operation's own mint/burn.
+    function _ratchetHwm(uint256 _preOpSupply) private {
         uint256 current = WRAPPER.perfHighWaterMarkPps();
-        assertGe(current, hwmFloor, "high-water mark regressed");
+        if (_preOpSupply >= DUST_SUPPLY_THRESHOLD) {
+            assertGe(current, hwmFloor, "high-water mark regressed");
+        }
         hwmFloor = current;
     }
 }

--- a/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
+++ b/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
@@ -446,11 +446,18 @@ contract LibVaultWrapperMathTest is Test {
         uint8 _decimalsOffset
     ) public view {
         _decimalsOffset = uint8(bound(_decimalsOffset, 0, 18));
-        _feeAssets = bound(_feeAssets, 0, type(uint128).max);
         _totalSupply = bound(_totalSupply, 0, type(uint128).max);
         _totalAssets = bound(_totalAssets, 0, type(uint128).max);
+        _feeAssets = bound(
+            _feeAssets,
+            0,
+            _totalAssets == 0 ? 0 : _totalAssets - 1
+        );
 
-        // Must not revert (div-by-zero / underflow / overflow) for any bounded input.
+        // Must not revert (div-by-zero / underflow / overflow) anywhere in the
+        // documented input domain: the caller is expected to clamp
+        // `_feeAssets < _totalAssets` (at equality the denominator collapses to 1 and
+        // the mulDiv product can exceed uint256).
         lib.dilutionShares(
             _feeAssets,
             _totalSupply,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-814](https://linear.app/lifi-linear/issue/EXSC-814/vault-wrapper-remove-deposit-side-supply-floor-offset-is-the-sole)

Fixes EXSC-813 (absorbs PR #2240 — same `_pendingFeeShares` fix, its parity tests ported here; #2240 is closed as superseded).

# Why did I implement it this way?

The deposit-side supply floor (`MIN_SHARE_SUPPLY` + `_enforceSupplyFloor`) was redundant with the virtual-share offset for every depositor-loss bound: with the offset floored at 6, zeroing a deposit requires donating ~10^offset times it, a depositor's rounding loss is capped at ~`donation / 10^offset`, and the `shares == 0` guard (`ZeroSharesMinted`) rejects zero-share deposits outright. Removing the floor deletes a revert path, the `SupplyBelowMinimum` error, and the documented EIP-4626 `maxDeposit`/`maxMint` deviation.

The constant survives only as `DUST_SUPPLY_THRESHOLD`: below it, perf-fee dilution rounds to zero shares while the watermark would go stale, so `_accrueFees` floats the watermark to the live price and skips the fee. Because deposits can now transact at dust supply, `_pendingFeeShares` mirrors that skip so previews match execution exactly (this is the EXSC-813 fix; previously previews priced against perf shares the accrual never mints).

Accepted trade-offs, documented in `docs/VaultWrapper/LiFiVaultWrapper.md` ("Donation griefing — accepted bounds") and pinned by tests:

- Deposits/mints can transact at dust supply; rounding loss stays bounded by the offset (`test_SubThresholdDepositorLossBoundedByOffsetShare`).
- Performance fees on gains earned below the dust threshold are forgiven — a bounded fee-revenue leak, never a depositor loss (`test_SubThresholdSupplyYieldEscapesPerfFee`).

Also repairs two pre-existing test defects that reproduce on the base branch: the `testFuzz_DilutionShares_NoRevert` fuzz domain fed `_feeAssets == _totalAssets` (outside the library's documented caller contract, overflowing at extreme inputs), and the invariant handler asserted watermark monotonicity, which the dust-supply float legitimately violates (the assert is now gated on pre-operation supply).

Pre-audit: `@custom:version` stays 1.0.0 in both touched contracts. No storage-layout or selector changes (a private function, an internal constant, and an unused error removed). Full suite: 1948/1948 passing; mutation sanity check confirms the `ZeroSharesMinted` guard is covered (3 tests kill the mutant).

A follow-up stacked PR proposes an up-only watermark ratchet that would delete `DUST_SUPPLY_THRESHOLD` entirely.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
