### PR TITLE
refactor(VaultWrapper): ratchet perf watermark up on every accrual (EXSC-815)

### DIFF
--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -100,14 +100,15 @@ accepted by design, every bound deriving from the offset alone:
   `ZeroSharesMinted`; assets are never taken for no shares. Zeroing a given
   deposit costs ~1e6× that deposit and the donation accrues to the vault, so
   the grief is self-defeating.
-- Deposits and mints can transact at dust supply (below
-  `DUST_SUPPLY_THRESHOLD`). A position held there is either dust (at most
-  ~1e-12 of a share token at par price) or subsidized by a donation of
-  which more than half is forfeited to the virtual-share offset on exit —
-  engineering the state is always loss-making.
-- Performance fees on gains earned below `DUST_SUPPLY_THRESHOLD` are forgiven
-  (the accrual floats the watermark instead). A bounded fee-revenue leak,
-  never a depositor loss; dodging fees this way costs more than the dodged fee.
+- Deposits and mints can transact at any dust supply. A position held there
+  is either dust (at most ~1e-12 of a share token at par price) or subsidized
+  by a donation of which more than half is forfeited to the virtual-share
+  offset on exit — engineering the state is always loss-making.
+- Performance-fee forgiveness is per accrual, sub-step rounding only: each
+  accrual forgives at most ~one share's worth of fee (the dilution rounds to
+  zero below that) — i.e. gain up to ~one share's value / feeRate — plus
+  sub-wei flooring of the gain measurement. Bounded, holder-favouring, never
+  a depositor loss.
 
 ## Admin role
 
@@ -122,12 +123,11 @@ deployed. It sets the identity (`underlying` / `adapter` / `owner` / `factory`),
 the initial fee configuration, receivers, and access gate; resolves the ERC-20
 asset via the adapter; derives the virtual-share offset from the asset decimals;
 and sets a provisional performance watermark at the empty-vault share price. That
-par value is only a placeholder: while total supply is below
-`DUST_SUPPLY_THRESHOLD` (1e6 shares — where the performance dilution rounds to
-zero shares), each accrual re-floats the watermark to the live price and skips
-the performance fee, so assets donated to the instance's predicted address become
-the next depositor's baseline instead of being charged to them as fabricated
-gain.
+par value is only a placeholder: every accrual ratchets the watermark up to the
+live price (charging the gain when the fee dilution mints shares, forgiving it
+when it rounds to zero), so assets donated to the instance's predicted address —
+empty or dust vault alike — become the next depositor's baseline instead of
+being charged to them as fabricated gain.
 
 ## Upgradeability and the FACTORY binding
 

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -105,14 +105,6 @@ contract LiFiVaultWrapper is
     ///         sub-1M-token first deposit into an 18-decimal vault.
     uint8 internal constant MIN_DECIMALS_OFFSET = 6;
 
-    /// @notice Dust-supply threshold for watermark maintenance in `_accrueFees`: below
-    ///         it the perf dilution can round to zero shares while the watermark goes
-    ///         stale. NOT an enforced deposit floor — the virtual-share offset alone
-    ///         bounds degenerate-state losses (see `MIN_DECIMALS_OFFSET`). Sized at
-    ///         10 ** `MIN_DECIMALS_OFFSET`, covering the widest stale window (1e4
-    ///         shares at the 1 bps minimum rate).
-    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
-
     /// Immutables ///
 
     /// @notice The factory bound to this implementation at construction: the only address
@@ -761,9 +753,8 @@ contract LiFiVaultWrapper is
     ///      retroactively; it never moves the watermark down, so toggling the fee off
     ///      and on after a drawdown cannot re-charge the recovery to the old peak. The
     ///      re-anchor is skipped while supply is zero: with no holders there is no
-    ///      disabled-period growth to exclude, and the price per share at zero supply is
-    ///      measured against the virtual offset alone, so a dust donation would otherwise
-    ///      park the watermark permanently out of reach.
+    ///      disabled-period growth to exclude, and the accrual's own up-only ratchet
+    ///      anchors the empty-vault price at the next operation.
     ///      `nonReentrant` because this is the only `_accrueFees` caller outside the entry/
     ///      exit/`distributeFees` guard: without it, a payout hook fired during
     ///      `distributeFees` could reenter here (owner-controlled receiver), book fresh fees,
@@ -1006,11 +997,10 @@ contract LiFiVaultWrapper is
     ///      accrue-at-old-rate-first guarantee). The cost is that elapsed time whose fee
     ///      floors to zero shares is dropped — at most ~one share's worth of assets per
     ///      accrual, favouring holders. The performance fee is charged AFTER the
-    ///      management dilution (perf is net of management). The watermark has two write
-    ///      paths: at dust supply (below `DUST_SUPPLY_THRESHOLD`) it floats to the live
-    ///      price and the perf fee is skipped (see the inline comment); at real supply it
-    ///      ratchets to the post-crystallization price (rounded up) only when shares were
-    ///      actually minted — an uncharged gain stays chargeable, unlike elapsed time.
+    ///      management dilution (perf is net of management). The watermark ratchets up to
+    ///      the live post-crystallization price (rounded up) on EVERY perf-enabled
+    ///      accrual: like elapsed time, a gain is charged or forgiven per accrual, never
+    ///      left pending against a stale mark.
     function _accrueFees() private {
         bool mgmtEnabled = _rate(FeeType.Management) != 0;
         bool perfEnabled = _rate(FeeType.Performance) != 0;
@@ -1029,27 +1019,23 @@ contract LiFiVaultWrapper is
             _bookDilution(FeeType.Management, mgmtShares);
             supply += mgmtShares;
         }
-
-        // Below the threshold the perf dilution can floor to zero shares
-        // (`dilutionShares` ~ rate * supply; widest window 1e4 shares at the 1 bps
-        // minimum) while the watermark goes stale, leaving a donation-driven price rise
-        // chargeable to the next depositor as fabricated gain — so float the watermark
-        // to the live price and skip the fee instead. Holders CAN sit at dust supply
-        // (deposits are not floor-checked), so genuine sub-threshold yield escapes the
-        // perf fee: an accepted, bounded leak (a sub-threshold position at par is at
-        // most ~1e-12 of a share token; inflating it forfeits more than half the donation
-        // to the virtual offset), never a depositor loss.
-        if (perfEnabled && supply < DUST_SUPPLY_THRESHOLD) {
-            perfHighWaterMarkPps = _ceilPps(supply, assets);
-            return;
-        }
+        if (!perfEnabled) return;
 
         uint256 perfShares = _pendingPerformanceFee(supply, assets);
         if (perfShares != 0) {
             _mint(address(this), perfShares);
             _bookDilution(FeeType.Performance, perfShares);
             supply += perfShares;
-            perfHighWaterMarkPps = _ceilPps(supply, assets);
+        }
+
+        // Up-only ratchet on every accrual: any gain above the mark is charged or
+        // forgiven now, never left stale, so pre-entry gains (yield or donation) cannot
+        // be charged to a later depositor at any supply. Per-accrual forgiveness is
+        // bounded by the fee math's flooring — sub-step dust, holder-favouring. Up-only,
+        // never assignment: floating down after a loss would re-charge the recovery.
+        uint192 currentPps = _ceilPps(supply, assets);
+        if (currentPps > perfHighWaterMarkPps) {
+            perfHighWaterMarkPps = currentPps;
         }
     }
 
@@ -1155,9 +1141,7 @@ contract LiFiVaultWrapper is
     /// @dev Fee-shares pending since the last accrual, used by the effective-supply
     ///      conversion overrides. Management first, then performance on the post-
     ///      management effective supply — the exact sequence `_accrueFees` crystallizes
-    ///      in, so previews match execution; that includes mirroring the accrual's
-    ///      dust-supply perf skip (below `DUST_SUPPLY_THRESHOLD` no perf shares are
-    ///      minted, so none may be quoted).
+    ///      in, so previews match execution.
     /// @param _supply The current total supply (pre-accrual).
     /// @param _assets The current total assets.
     /// @return The dilution shares pending.
@@ -1166,10 +1150,9 @@ contract LiFiVaultWrapper is
         uint256 _assets
     ) private view returns (uint256) {
         uint256 mgmtShares = _pendingManagementFee(_supply, _assets);
-        uint256 supplyAfterMgmt = _supply + mgmtShares;
-        if (supplyAfterMgmt < DUST_SUPPLY_THRESHOLD) return mgmtShares;
 
-        return mgmtShares + _pendingPerformanceFee(supplyAfterMgmt, _assets);
+        return
+            mgmtShares + _pendingPerformanceFee(_supply + mgmtShares, _assets);
     }
 
     /// @dev Reads the configured rate (bps) for a fee type; 0 means disabled.

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -143,22 +143,22 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertEq(_accruedFeeShares(), sharesAfterCharge);
     }
 
-    function test_SubThresholdGainMintsNothingAndStaysChargeable() public {
+    function test_SubStepGainMintsNothingAndIsForgiven() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
         _deposit(alice, DEPOSIT);
 
         // A gain below one PPS unit (supply / PPS_SCALE = 1000 wei here) floors to a
-        // zero-share fee: nothing is minted and, unlike the management baseline, the
-        // watermark does NOT advance — the gain stays chargeable.
+        // zero-share fee: nothing is minted and, like the management baseline, the
+        // watermark ratchets over the gain — charged or forgiven per accrual, never
+        // left pending (forgiveness bounded by one PPS step of AUM per accrual).
         _simulateYield(500);
         uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
         _crystallize();
 
         assertEq(_accruedFeeShares(), 0);
-        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
+        assertGt(wrapper.perfHighWaterMarkPps(), hwmBefore);
 
-        // Once the cumulative gain is material it is charged in full from the original
-        // watermark, not from the sub-threshold peak.
+        // A later material gain is charged from the advanced watermark.
         _simulateYield(200e18);
         _crystallize();
 
@@ -428,14 +428,16 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
 
     /// Dust-supply preview/execution parity ///
 
-    /// @dev Drives the wrapper into dust supply with a price gain above the watermark,
-    ///      the state where `_accrueFees` skips the performance fee but a preview must
-    ///      not diverge from what the operation actually charges/mints.
+    /// @dev Drives the wrapper into dust supply (below the shares a 1-wei deposit
+    ///      mints) with a price gain above the watermark — a once-special accrual
+    ///      regime where previews must agree with execution on the perf dilution like
+    ///      everywhere else.
     function _dustSupplyWithGain() internal {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
-        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
-        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
+        uint256 dustScale = 10 ** wrapper.shareDecimalsOffset();
+        _deposit(alice, 2 * dustScale);
+        uint256 leftBehind = dustScale / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
         vm.prank(alice);
         wrapper.redeem(toRedeem, alice, alice);
@@ -443,7 +445,7 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.totalSupply(), leftBehind);
 
         // Credit a position without minting shares so the price rises above the
-        // watermark while the supply stays below the threshold.
+        // watermark while the supply stays in the dust regime.
         _donateToWrapperPosition(1e15);
 
         assertGt(_pps(), wrapper.perfHighWaterMarkPps());
@@ -452,7 +454,7 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
     function test_DustSupplyPreviewMintMatchesExecution() public {
         _dustSupplyWithGain();
 
-        uint256 shares = DUST_SUPPLY_THRESHOLD;
+        uint256 shares = 10 ** wrapper.shareDecimalsOffset();
         uint256 quoted = wrapper.previewMint(shares);
 
         asset.mint(bob, quoted);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperProtections.t.sol
@@ -391,7 +391,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         // deposit rounds to zero shares. The `shares == 0` guard must reject it,
         // else the assets are forwarded for free.
         _deposit(attacker, 1);
-        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertEq(wrapper.totalSupply(), 10 ** wrapper.shareDecimalsOffset());
 
         MockERC4626 source = MockERC4626(address(underlying));
         uint256 donated = 3_000_000e18;
@@ -402,7 +402,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         source.transfer(address(wrapper), donatedShares);
         vm.stopPrank();
 
-        assertEq(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertEq(wrapper.totalSupply(), 10 ** wrapper.shareDecimalsOffset());
         assertGt(wrapper.totalAssets(), 0);
 
         uint256 victimDeposit = 1e18;
@@ -423,8 +423,8 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
     }
 
     function test_SmallFirstMintSucceeds() public {
-        // A first mint below the dust threshold is a valid entry.
-        uint256 shares = DUST_SUPPLY_THRESHOLD / 2;
+        // A first mint below the shares a 1-wei deposit mints is a valid entry.
+        uint256 shares = (10 ** wrapper.shareDecimalsOffset()) / 2;
         uint256 cost = wrapper.previewMint(shares);
         asset.mint(alice, cost);
         vm.startPrank(alice);
@@ -446,10 +446,11 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
     function test_DustSupplyIsDepositableAfterExit() public {
         // Exits can leave a dust supply; deposits and mints into that state must
-        // succeed. A plain deposit over-clears the threshold (offset-scaled), so the
-        // sub-threshold top-up is shown via an explicit mint.
-        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
-        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
+        // succeed. A plain deposit mints offset-scaled shares, so the dust-scale
+        // top-up is shown via an explicit mint.
+        uint256 dustScale = 10 ** wrapper.shareDecimalsOffset();
+        _deposit(alice, 2 * dustScale);
+        uint256 leftBehind = dustScale / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
 
         vm.prank(alice);
@@ -457,7 +458,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         assertEq(wrapper.totalSupply(), leftBehind);
 
-        uint256 topUp = DUST_SUPPLY_THRESHOLD / 4;
+        uint256 topUp = dustScale / 4;
         uint256 cost = wrapper.previewMint(topUp);
         asset.mint(bob, cost);
         vm.startPrank(bob);
@@ -468,14 +469,14 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         assertEq(wrapper.totalSupply(), leftBehind + topUp);
         assertEq(wrapper.balanceOf(bob), topUp);
 
-        _deposit(bob, DUST_SUPPLY_THRESHOLD);
+        _deposit(bob, dustScale);
 
         assertGt(wrapper.totalSupply(), leftBehind + topUp);
     }
 
-    function test_SubThresholdDepositorLossBoundedByOffsetShare() public {
-        // A deposit against a donation-inflated empty vault can mint sub-threshold
-        // shares; the rounding loss is bounded by ~donation / 10**offset.
+    function test_DustSupplyDepositorLossBoundedByOffsetShare() public {
+        // A deposit against a donation-inflated empty vault can mint fewer shares
+        // than a 1-wei par deposit; the loss is bounded by ~donation / 10**offset.
         MockERC4626 source = MockERC4626(address(underlying));
         uint256 donated = 2_000_000e18;
         asset.mint(attacker, donated);
@@ -493,7 +494,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         vm.stopPrank();
 
         assertGt(shares, 0);
-        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertLt(wrapper.totalSupply(), 10 ** wrapper.shareDecimalsOffset());
 
         uint256 oneShareBound = donated /
             (10 ** wrapper.shareDecimalsOffset());
@@ -514,8 +515,9 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
 
         assertEq(wrapper.totalSupply(), 0);
 
-        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
-        uint256 leftBehind = DUST_SUPPLY_THRESHOLD / 2;
+        uint256 dustScale = 10 ** wrapper.shareDecimalsOffset();
+        _deposit(alice, 2 * dustScale);
+        uint256 leftBehind = dustScale / 2;
         uint256 toRedeem = wrapper.balanceOf(alice) - leftBehind;
 
         vm.prank(alice);
@@ -540,7 +542,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
         FeeConfig memory fees;
         fees.rateBps[uint8(FeeType.Management)] = MGMT_RATE;
         wrapper = _newWrapper(fees);
-        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
+        _deposit(alice, 2 * (10 ** wrapper.shareDecimalsOffset()));
 
         vm.warp(block.timestamp + 30 days);
         uint256 aliceShares = wrapper.balanceOf(alice);
@@ -555,7 +557,7 @@ contract LiFiVaultWrapperProtectionsTest is VaultWrapperFeeTestBase {
     }
 
     function test_FullExitToZeroSupplyPasses() public {
-        _deposit(alice, 2 * DUST_SUPPLY_THRESHOLD);
+        _deposit(alice, 2 * (10 ** wrapper.shareDecimalsOffset()));
         uint256 allShares = wrapper.balanceOf(alice);
 
         vm.prank(alice);

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -33,10 +33,6 @@ abstract contract VaultWrapperFeeTestBase is Test {
     uint16 internal constant MGMT_RATE = 200; // 2% / year
     uint16 internal constant SPLIT = 8000; // integrator share used for every fee type here
     uint256 internal constant YEAR = 365 days;
-    // Mirror of the wrapper's internal DUST_SUPPLY_THRESHOLD (watermark-maintenance
-    // threshold in _accrueFees; equals 10 ** MIN_DECIMALS_OFFSET, the share count a
-    // 1-wei deposit mints); the production constant is internal.
-    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
 
     /// @dev Dust `_crystallize` deposits. 1 wei suffices while the underlying's own PPS
     ///      is 1:1; suites that inflate the underlying raise it (solmate's MockERC4626

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -30,6 +30,15 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
             );
     }
 
+    /// @dev Principal-free accrual trigger that keeps the fee counters intact:
+    ///      `distributeFees` pays them out, and a dust deposit trips solmate's
+    ///      ZERO_SHARES forward guard once the source pps exceeds 1. Re-setting the
+    ///      already-zero management rate accrues first and changes nothing.
+    function _accrueOnly() internal {
+        vm.prank(vaultAdmin);
+        wrapper.setFeeRate(FeeType.Management, 0);
+    }
+
     /// @dev Credits the empty wrapper with a source-vault position without minting any
     ///      wrapper shares — the "donation to the predicted address" of the first defect.
     function _donateToWrapperPosition(uint256 _assets) internal {
@@ -77,15 +86,16 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
     function test_DustSupplyDonationNotChargedToNextDepositor() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
-        // Bob seeds then exits down to dust supply (below DUST_SUPPLY_THRESHOLD) — a
-        // regime where the perf dilution floors to zero and the watermark never ratchets.
+        // Bob seeds then exits down to a supply so small the perf dilution floors to
+        // zero shares (dilutionShares ~ rate * supply, zero below 1/rate shares), so
+        // no fee mint can ratchet the watermark over the donation.
         _deposit(bob, DEPOSIT);
         uint256 bobShares = wrapper.balanceOf(bob);
         vm.prank(bob);
         wrapper.redeem(bobShares - 1, bob, bob);
 
         assertGt(wrapper.totalSupply(), 0);
-        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertLt(wrapper.totalSupply(), 10_000 / PERF_RATE);
 
         _donateToWrapperPosition(1e15);
 
@@ -102,44 +112,124 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         assertGe(aliceAssets, (DEPOSIT * 9999) / 10_000);
     }
 
-    function test_SubThresholdSupplyYieldEscapesPerfFee() public {
-        // Accepted leak: yield earned while supply is below DUST_SUPPLY_THRESHOLD
-        // escapes the performance fee — the accrual floats the watermark over it.
+    function test_DustSupplyYieldEscapesPerfFee() public {
+        // Accepted per-accrual leak: a gain whose perf dilution floors to zero shares
+        // (dilutionShares ~ rate * supply, zero below 1/rate shares) is forgiven — the
+        // accrual ratchets the watermark over it instead of minting.
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
         _deposit(bob, DEPOSIT);
         uint256 bobShares = wrapper.balanceOf(bob);
         vm.prank(bob);
-        wrapper.redeem(bobShares - 10, bob, bob);
+        wrapper.redeem(bobShares - 1, bob, bob);
 
         assertGt(wrapper.totalSupply(), 0);
-        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertLt(wrapper.totalSupply(), 10_000 / PERF_RATE);
 
-        // Genuine source-side yield at sub-threshold supply.
+        // Genuine source-side yield at dust supply.
         _simulateYield(1e18);
 
         assertGe(wrapper.totalAssets(), 1e18);
 
-        // The entry accrual floats the watermark over the gain; no fee shares minted.
+        // The entry accrual ratchets the watermark over the gain; no fee shares minted.
         _deposit(alice, DEPOSIT);
 
         assertEq(_accruedFeeShares(), 0);
         assertGt(wrapper.perfHighWaterMarkPps(), _parPps());
     }
 
+    function testFuzz_WatermarkNeverStaleAfterAccrual(
+        uint96 _gainRaw,
+        uint96 _depositRaw
+    ) public {
+        // After any perf-enabled accrual the mark must sit at/above the live price or
+        // fee shares were minted for the full gap — a stale mark lets pre-entry gains
+        // be charged to a later depositor as fabricated gain.
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        uint256 dep = bound(uint256(_depositRaw), 1, 1_000e18);
+        uint256 gain = bound(uint256(_gainRaw), 1, 1_000e18);
+
+        _deposit(bob, dep);
+        _simulateYield(gain);
+        _accrueOnly();
+
+        uint256 livePps = LibVaultWrapperMath.pricePerShare(
+            wrapper.totalSupply(),
+            wrapper.totalAssets(),
+            wrapper.shareDecimalsOffset(),
+            Math.Rounding.Ceil
+        );
+
+        assertGe(wrapper.perfHighWaterMarkPps(), livePps);
+    }
+
+    function test_LossRecoveryNotChargedAgain() public {
+        // Up-only requirement: an accrual after a loss must not float the mark down,
+        // or recovering back to the old peak would be re-charged as new gain.
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+
+        _deposit(bob, DEPOSIT);
+        _simulateYield(100e18);
+        _accrueOnly();
+
+        uint256 feesAtPeak = _accruedFeeShares();
+        assertGt(feesAtPeak, 0);
+
+        _simulateLoss(100e18);
+        _accrueOnly();
+
+        _simulateYield(100e18);
+        _accrueOnly();
+
+        assertEq(_accruedFeeShares(), feesAtPeak);
+    }
+
+    function test_FrequentAccrualsForgiveOnlyBoundedFee() public {
+        // Ten sub-gain accruals vs one lump accrual of the same total gain: per-accrual
+        // forgiveness is only flooring slack, so frequent accruals cannot dodge a
+        // meaningful part of the fee.
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(bob, DEPOSIT);
+
+        uint256 totalGain = 1e18;
+        for (uint256 i = 0; i < 10; i++) {
+            _simulateYield(totalGain / 10);
+            _accrueOnly();
+        }
+        uint256 feeSplit = _accruedFeeShares();
+
+        // Fresh source too: yield minted to a shared source is split pro-rata with the
+        // first wrapper's position, which would halve the lump-path gain.
+        underlying = new MockERC4626(asset, "Yield Token", "yTOK");
+        wrapper = _newWrapperPerfOnly(PERF_RATE);
+        _deposit(bob, DEPOSIT);
+        _simulateYield(totalGain);
+        _accrueOnly();
+        uint256 feeSingle = _accruedFeeShares();
+
+        // The split path may slightly EXCEED the lump in share terms (~0.04% measured):
+        // earlier fee mints participate in later chunks' gains. Bounded both ways —
+        // no dodging low side, no runaway compounding high side.
+        assertLe(feeSplit, (feeSingle * 101) / 100);
+        // Slack: one flooring event per accrual (10) + 1.
+        assertGe(feeSplit + 10 + 1, (feeSingle * 9) / 10);
+    }
+
     function test_PreviewDepositMatchesExecutionAtDustSupply() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
 
-        // Dust supply with pps pushed above the watermark: the accrual skips the perf
-        // mint, so the preview must not quote pending perf shares either (EIP-4626:
-        // previewDeposit must not overstate what the deposit mints). Enough real
-        // shares are left that the pending perf dilution itself is non-zero.
+        // Dust supply (below the shares a 1-wei deposit mints) with pps pushed above
+        // the watermark — the regime that used to take a special accrual path. Preview
+        // and execution must agree on the perf dilution here like everywhere else
+        // (EIP-4626: previewDeposit must not overstate what the deposit mints). Enough
+        // real shares are left that the pending perf dilution itself is non-zero.
         _deposit(bob, DEPOSIT);
-        uint256 toRedeem = wrapper.balanceOf(bob) - DUST_SUPPLY_THRESHOLD / 2;
+        uint256 dustScale = 10 ** wrapper.shareDecimalsOffset();
+        uint256 toRedeem = wrapper.balanceOf(bob) - dustScale / 2;
         vm.prank(bob);
         wrapper.redeem(toRedeem, bob, bob);
 
-        assertLt(wrapper.totalSupply(), DUST_SUPPLY_THRESHOLD);
+        assertLt(wrapper.totalSupply(), dustScale);
 
         _donateToWrapperPosition(1e15);
 

--- a/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
+++ b/test/solidity/VaultWrapper/invariant/VaultWrapperInvariantHandler.sol
@@ -22,10 +22,6 @@ import { MockLiquidityCappedERC4626 } from "test/solidity/VaultWrapper/mocks/Moc
 contract VaultWrapperInvariantHandler is Test {
     uint256 internal constant NUM_ACTORS = 3;
 
-    // Mirror of the wrapper's internal DUST_SUPPLY_THRESHOLD: below it `_accrueFees`
-    // floats the watermark instead of ratcheting it.
-    uint256 internal constant DUST_SUPPLY_THRESHOLD = 1e6;
-
     // Deposits/mints are floored well above any price-per-share the bounded yield can push
     // the underlying to, so an underlying `deposit` never rounds to zero shares.
     uint256 internal constant MIN_ENTER = 1e18;
@@ -47,8 +43,7 @@ contract VaultWrapperInvariantHandler is Test {
     uint256 public ghostAssetsOut;
     /// @notice Assets ever injected into the underlying as external yield.
     uint256 public ghostYield;
-    /// @notice Last observed high-water mark; asserted monotonic only for operations
-    ///         whose accrual ran at/above `DUST_SUPPLY_THRESHOLD` (see `_ratchetHwm`).
+    /// @notice Highest high-water mark observed; the ratchet asserts it never regresses.
     uint256 public hwmFloor;
 
     constructor(
@@ -74,7 +69,6 @@ contract VaultWrapperInvariantHandler is Test {
         if (WRAPPER.depositsPaused()) return;
 
         address actor = _actor(_actorSeed);
-        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 assets = bound(_assets, MIN_ENTER, MAX_ENTER);
         ASSET.mint(actor, assets);
 
@@ -85,14 +79,13 @@ contract VaultWrapperInvariantHandler is Test {
         vm.stopPrank();
 
         ghostAssetsIn += assets;
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function mint(uint256 _actorSeed, uint256 _shares) external {
         if (WRAPPER.depositsPaused()) return;
 
         address actor = _actor(_actorSeed);
-        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 shares = bound(_shares, MIN_ENTER, MAX_ENTER);
         uint256 assets = WRAPPER.previewMint(shares);
         ASSET.mint(actor, assets);
@@ -104,7 +97,7 @@ contract VaultWrapperInvariantHandler is Test {
         vm.stopPrank();
 
         ghostAssetsIn += assets;
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function withdraw(uint256 _actorSeed, uint256 _assets) external {
@@ -115,14 +108,13 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 ceiling = WRAPPER.maxWithdraw(actor);
         if (ceiling == 0) return;
 
-        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 assets = bound(_assets, 1, ceiling);
 
         vm.prank(actor);
         WRAPPER.withdraw(assets, actor, actor);
 
         ghostAssetsOut += assets;
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function redeem(uint256 _actorSeed, uint256 _shares) external {
@@ -134,21 +126,19 @@ contract VaultWrapperInvariantHandler is Test {
         uint256 ceiling = WRAPPER.maxRedeem(actor);
         if (ceiling == 0) return;
 
-        uint256 preOpSupply = WRAPPER.totalSupply();
         uint256 shares = bound(_shares, 1, ceiling);
 
         vm.prank(actor);
         uint256 received = WRAPPER.redeem(shares, actor, actor);
 
         ghostAssetsOut += received;
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function distributeFees() external {
-        uint256 preOpSupply = WRAPPER.totalSupply();
         WRAPPER.distributeFees();
 
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function injectYield(uint256 _amount) external {
@@ -172,14 +162,13 @@ contract VaultWrapperInvariantHandler is Test {
 
     function setFee(uint256 _typeSeed, uint256 _rateSeed) external {
         FeeType feeType = FeeType(bound(_typeSeed, 0, 3));
-        uint256 preOpSupply = WRAPPER.totalSupply();
         (, uint16 maxBps) = FACTORY.feeBounds(feeType);
         uint16 rate = uint16(bound(_rateSeed, 0, maxBps));
 
         vm.prank(VAULT_ADMIN);
         WRAPPER.setFeeRate(feeType, rate);
 
-        _ratchetHwm(preOpSupply);
+        _ratchetHwm();
     }
 
     function togglePause() external {
@@ -197,18 +186,12 @@ contract VaultWrapperInvariantHandler is Test {
         return actors[bound(_seed, 0, NUM_ACTORS - 1)];
     }
 
-    /// @dev Asserts the performance high-water mark never regresses across an operation
-    ///      that crystallizes fees, then advances the floor. Monotonic only when the
-    ///      operation's accrual ran at/above `DUST_SUPPLY_THRESHOLD`: below it,
-    ///      `_accrueFees` floats the mark to the live price — which exits at dust supply
-    ///      collapse (virtual shares dominate) — so those operations only re-anchor.
-    ///      Gated on the PRE-operation supply because the accrual runs before the
-    ///      operation's own mint/burn.
-    function _ratchetHwm(uint256 _preOpSupply) private {
+    /// @dev Asserts the performance high-water mark never regresses across any operation
+    ///      that crystallizes fees, then advances the floor. Monotonic by construction:
+    ///      the accrual's ratchet and `setFeeRate`'s re-enable anchor are both up-only.
+    function _ratchetHwm() private {
         uint256 current = WRAPPER.perfHighWaterMarkPps();
-        if (_preOpSupply >= DUST_SUPPLY_THRESHOLD) {
-            assertGe(current, hwmFloor, "high-water mark regressed");
-        }
+        assertGe(current, hwmFloor, "high-water mark regressed");
         hwmFloor = current;
     }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-815](https://linear.app/lifi-linear/issue/EXSC-815/vault-wrapper-ratchet-perf-watermark-up-on-every-accrual-delete-dust)

Was stacked on #2241 (EXSC-814, now merged); rebased onto `dev-vault-wrapper` — the diff is only the ratchet change.

# Why did I implement it this way?

**This PR gates a fee-semantics decision — the review is the accept/reject gate.** Today an uncharged gain (perf dilution rounding to zero shares) stays chargeable at a later accrual, at the cost of a stale-watermark defect class: a gain that rounds to zero at accrual time leaves the watermark below the live price, so the next depositor can be charged for pre-entry gains. With #2241 allowing deposits at dust supply, the dust-branch float only papers over that class at one supply regime.

The change: `_accrueFees` ratchets the watermark **up-only** (`current > hwm`) to the live post-crystallization ceil price on every perf-enabled accrual. A gain above the mark is either charged (fee shares minted) or forgiven (mark ratchets over it) — never left stale. Up-only is load-bearing: floating down after a loss would re-charge the recovery back to the previous peak (`test_LossRecoveryNotChargedAgain` guards this, and it passes on both old and new code).

**What is given up:** sub-step gains whose fee floors to zero shares are forgiven per accrual instead of accumulating. Bound (documented in the docs page, pinned by `test_FrequentAccrualsForgiveOnlyBoundedFee`): at most ~one share's worth of fee per accrual — gain up to ~one share's value / feeRate — plus sub-wei flooring of the gain measurement, always holder-favouring. Measured: splitting a 1e18 gain across 10 accruals yields 100.04% of the single-accrual fee (slight fee-on-fee overshoot, no undershoot).

**What it buys:**

- The stale-watermark class is gone at every supply level — `testFuzz_WatermarkNeverStaleAfterAccrual` fails on the pre-change code (counterexample: the mark sits one pps unit below the live price after a sub-fee gain) and passes here.
- `DUST_SUPPLY_THRESHOLD`, the dust-supply accrual branch, the `_pendingFeeShares` preview mirror, and the invariant handler's supply gating are all deleted; preview/execution parity holds trivially (both sides unconditional) and the handler's watermark-monotonicity assert is now true by construction.

Forgiveness at dust supply narrows from "supply < 1e6 shares" to the exact dilution-floor window "supply < 10^4 / rate shares"; the EXSC-802 donation regressions are unchanged and green.

Pre-audit: `@custom:version` stays 1.0.0. No storage-layout or selector changes. Full VaultWrapper sweep: 369/369; fuzz on 4 seeds including the dust regime; mutation checks kill both the stale-mark and float-down mutants.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
