### PR TITLE
feat(safe): cross-check whitelist pair contracts against the deploy log (EXSC-811)

### DIFF
--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -20,12 +20,24 @@ import {
 import { consola } from 'consola'
 import { toFunctionSelector } from 'viem'
 
+import composerWhitelistJson from '../../../config/composerWhitelist.json'
+import whitelistJson from '../../../config/whitelist.json'
+import mainnetDeployments from '../../../deployments/mainnet.json'
+import tronDeployments from '../../../deployments/tron.json'
+import { normalizeAddressForNetwork } from '../../utils/normalizeAddressStringForViem'
+
 import {
   getRoleName,
   formatRoleChange,
   formatBatchSetContractSelectorWhitelist,
   formatWhitelistDeployLogCheck,
 } from './safe-decode-utils'
+
+/** Fails the test loudly rather than silently skipping when repo data moves. */
+const required = <T>(value: T | undefined, what: string): T => {
+  if (value === undefined) throw new Error(`test fixture missing: ${what}`)
+  return value
+}
 
 const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
 // OpenZeppelin AccessControl role hashes (public, keccak256 of role names) —
@@ -265,17 +277,19 @@ describe('formatBatchSetContractSelectorWhitelist', () => {
 })
 
 describe('formatWhitelistDeployLogCheck', () => {
+  // The decision table is exercised through explicit inputs, so these are
+  // deliberately role-neutral: which address is live and which is superseded is
+  // whatever the arguments of a given case say it is.
   const NETWORK = 'mainnet'
-  const LIVE = '0xC748171a028401BfD0c0F0a757ab4A1F93b00576'
-  const SUPERSEDED = '0x5Bf8351f8C349634911965Bd000fE9c625C1A0d9'
-  const THIRD_PARTY = '0xeCCc2Ce02907c1C86B286FB50d1355384F55A298'
+  const ADDRESS_A = '0xC748171a028401BfD0c0F0a757ab4A1F93b00576'
+  const ADDRESS_B = '0x5Bf8351f8C349634911965Bd000fE9c625C1A0d9'
 
   const check = (
     overrides: Partial<Parameters<typeof formatWhitelistDeployLogCheck>[0]>
   ): string =>
     formatWhitelistDeployLogCheck({
       network: NETWORK,
-      contractAddress: LIVE,
+      contractAddress: ADDRESS_A,
       whitelisted: true,
       ...overrides,
     })
@@ -283,7 +297,7 @@ describe('formatWhitelistDeployLogCheck', () => {
   it('confirms an added pair whose address is the current deployment', () => {
     const output = check({
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE,
+      registeredAddress: ADDRESS_A,
       deployLogName: 'FeeForwarder',
     })
     expect(output).toContain('✅ matches deployments')
@@ -291,11 +305,11 @@ describe('formatWhitelistDeployLogCheck', () => {
 
   it('flags an added pair the deploy log disagrees with', () => {
     const output = check({
-      contractAddress: SUPERSEDED,
+      contractAddress: ADDRESS_B,
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE,
+      registeredAddress: ADDRESS_A,
     })
-    expect(output).toContain('❌ mismatch')
+    expect(output).toContain('whitelist.json and deployments disagree')
     expect(output).toContain('FeeForwarder')
   })
 
@@ -306,9 +320,9 @@ describe('formatWhitelistDeployLogCheck', () => {
 
   it('accepts removing a superseded address without raising an alarm', () => {
     const output = check({
-      contractAddress: SUPERSEDED,
+      contractAddress: ADDRESS_B,
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE,
+      registeredAddress: ADDRESS_A,
       whitelisted: false,
     })
     expect(output).toContain('superseded')
@@ -318,7 +332,7 @@ describe('formatWhitelistDeployLogCheck', () => {
   it('warns when a removal targets the current deployment', () => {
     const output = check({
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE,
+      registeredAddress: ADDRESS_A,
       deployLogName: 'FeeForwarder',
       whitelisted: false,
     })
@@ -334,9 +348,9 @@ describe('formatWhitelistDeployLogCheck', () => {
 
   it('warns on a removal of an address the deploy log still points at under another name', () => {
     const output = check({
-      contractAddress: SUPERSEDED,
+      contractAddress: ADDRESS_B,
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE,
+      registeredAddress: ADDRESS_A,
       deployLogName: 'FeeForwarderLegacy',
       whitelisted: false,
     })
@@ -344,17 +358,138 @@ describe('formatWhitelistDeployLogCheck', () => {
     expect(output).toContain('FeeForwarderLegacy')
     expect(output).not.toContain('superseded')
   })
-  it('leaves third-party contracts unannotated in both directions', () => {
-    expect(check({ contractAddress: THIRD_PARTY })).toBe('')
-    expect(check({ contractAddress: THIRD_PARTY, whitelisted: false })).toBe('')
+  it('says nothing when neither source knows the address', () => {
+    expect(check({ contractAddress: ADDRESS_B })).toBe('')
+    expect(check({ contractAddress: ADDRESS_B, whitelisted: false })).toBe('')
   })
 
+  it('annotates an address the deploy log knows but whitelist.json does not label', () => {
+    const output = check({ deployLogName: 'Executor' })
+    expect(output).toContain('deployments: Executor')
+  })
   it('compares addresses case-insensitively', () => {
     const output = check({
-      contractAddress: LIVE.toLowerCase(),
+      contractAddress: ADDRESS_A.toLowerCase(),
       peripheryName: 'FeeForwarder',
-      registeredAddress: LIVE.toUpperCase().replace('0X', '0x'),
+      registeredAddress: ADDRESS_A.toUpperCase().replace('0X', '0x'),
     })
     expect(output).toContain('✅ matches deployments')
+  })
+})
+
+describe('whitelist pair rendering on Tron', () => {
+  // viem's decodeFunctionData yields hex for a Tron proposal while both
+  // config/whitelist.json and the deploy log store base58, so the periphery
+  // match has to be network-aware rather than a case fold.
+  it('resolves a periphery contract passed in the decoded hex form', async () => {
+    const name = 'FeeCollector'
+    const base58 = required(
+      (tronDeployments as Record<string, string>)[name],
+      `deployments/tron.json ->  `
+    )
+    const labelled = (
+      (whitelistJson as { PERIPHERY: Record<string, { name: string }[]> })
+        .PERIPHERY.tron ?? []
+    ).some((entry) => entry.name === name)
+    expect(labelled).toBe(true)
+
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatBatchSetContractSelectorWhitelist(
+      [[normalizeAddressForNetwork('tron', base58)], ['0xe0cbc5f2'], true],
+      'tron'
+    )
+    const output = infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(output).toContain(`PERIPHERY/${name}`)
+    expect(output).toContain('✅ matches deployments')
+  })
+})
+
+describe('whitelist deploy-log check against the repo config', () => {
+  const render = async (
+    network: string,
+    address: string,
+    selector: string,
+    whitelisted: boolean
+  ): Promise<string> => {
+    const infoSpy = spyOn(consola, 'info').mockImplementation(
+      (() => {}) as never
+    )
+    await formatBatchSetContractSelectorWhitelist(
+      [[address], [selector], whitelisted],
+      network
+    )
+    const output = infoSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    infoSpy.mockRestore()
+    return output
+  }
+
+  // Composer's whitelist entries are merged from config/composerWhitelist.json
+  // by updateWhitelistPeriphery.ts and never reach a deploy log, so checking
+  // them against deployments would flag every correct pair on every network.
+  it('checks a Composer pair against composerWhitelist.json, not the deploy log', async () => {
+    const composerEntries =
+      (
+        composerWhitelistJson as Record<
+          string,
+          { address: string; functionSelectors: { selector: string }[] }[]
+        >
+      ).mainnet ?? []
+    const entry = required(
+      composerEntries[0],
+      'composerWhitelist.json -> mainnet[0]'
+    )
+    const composerSelector = required(
+      entry.functionSelectors[0],
+      'composerWhitelist.json -> mainnet[0].functionSelectors[0]'
+    ).selector
+    const added = await render('mainnet', entry.address, composerSelector, true)
+    expect(added).toContain('matches composerWhitelist.json')
+    expect(added).not.toContain('no deployments entry')
+
+    const removed = await render(
+      'mainnet',
+      entry.address,
+      composerSelector,
+      false
+    )
+    expect(removed).toContain('composerWhitelist.json still lists')
+  })
+
+  it('says nothing about a third-party DEX contract in either direction', async () => {
+    const owned = new Set(
+      Object.values(
+        mainnetDeployments as unknown as Record<string, string>
+      ).map((address) => address.toLowerCase())
+    )
+    const dex = (
+      whitelistJson as unknown as {
+        DEXS: {
+          contracts?: Record<
+            string,
+            { address: string; functions?: Record<string, string> }[]
+          >
+        }[]
+      }
+    ).DEXS.flatMap((item) => item.contracts?.mainnet ?? []).find(
+      (contract) =>
+        !owned.has(contract.address.toLowerCase()) &&
+        Object.keys(contract.functions ?? {}).length > 0
+    )
+    expect(dex).toBeDefined()
+    if (!dex) return
+    const selector = required(
+      Object.keys(dex.functions ?? {})[0],
+      'a DEXS mainnet contract with at least one selector'
+    )
+
+    for (const whitelisted of [true, false]) {
+      const output = await render('mainnet', dex.address, selector, whitelisted)
+      expect(output).not.toContain('✅')
+      expect(output).not.toContain('❌')
+      expect(output).not.toContain('⚠️')
+      expect(output).not.toContain('deployments')
+    }
   })
 })

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -24,6 +24,7 @@ import {
   getRoleName,
   formatRoleChange,
   formatBatchSetContractSelectorWhitelist,
+  formatWhitelistDeployLogCheck,
 } from './safe-decode-utils'
 
 const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
@@ -260,5 +261,100 @@ describe('formatBatchSetContractSelectorWhitelist', () => {
     const output = await capture([FALLBACK_ONLY])
     expect(output).toContain('signature unknown')
     expect(output).not.toContain('transfer(address,uint256)')
+  })
+})
+
+describe('formatWhitelistDeployLogCheck', () => {
+  const NETWORK = 'mainnet'
+  const LIVE = '0xC748171a028401BfD0c0F0a757ab4A1F93b00576'
+  const SUPERSEDED = '0x5Bf8351f8C349634911965Bd000fE9c625C1A0d9'
+  const THIRD_PARTY = '0xeCCc2Ce02907c1C86B286FB50d1355384F55A298'
+
+  const check = (
+    overrides: Partial<Parameters<typeof formatWhitelistDeployLogCheck>[0]>
+  ): string =>
+    formatWhitelistDeployLogCheck({
+      network: NETWORK,
+      contractAddress: LIVE,
+      whitelisted: true,
+      ...overrides,
+    })
+
+  it('confirms an added pair whose address is the current deployment', () => {
+    const output = check({
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE,
+      deployLogName: 'FeeForwarder',
+    })
+    expect(output).toContain('✅ matches deployments')
+  })
+
+  it('flags an added pair the deploy log disagrees with', () => {
+    const output = check({
+      contractAddress: SUPERSEDED,
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE,
+    })
+    expect(output).toContain('❌ mismatch')
+    expect(output).toContain('FeeForwarder')
+  })
+
+  it('flags an added pair for a periphery the deploy log does not know', () => {
+    const output = check({ peripheryName: 'FeeForwarder' })
+    expect(output).toContain("❌ no deployments entry for 'FeeForwarder'")
+  })
+
+  it('accepts removing a superseded address without raising an alarm', () => {
+    const output = check({
+      contractAddress: SUPERSEDED,
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE,
+      whitelisted: false,
+    })
+    expect(output).toContain('superseded')
+    expect(output).not.toContain('❌')
+  })
+
+  it('warns when a removal targets the current deployment', () => {
+    const output = check({
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE,
+      deployLogName: 'FeeForwarder',
+      whitelisted: false,
+    })
+    expect(output).toContain('⚠️')
+    expect(output).toContain('FeeForwarder')
+  })
+
+  it('warns on a removal of a deploy-log address whitelist.json does not label', () => {
+    const output = check({ deployLogName: 'Executor', whitelisted: false })
+    expect(output).toContain('⚠️')
+    expect(output).toContain('Executor')
+  })
+
+  it('warns on a removal of an address the deploy log still points at under another name', () => {
+    const output = check({
+      contractAddress: SUPERSEDED,
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE,
+      deployLogName: 'FeeForwarderLegacy',
+      whitelisted: false,
+    })
+    expect(output).toContain('⚠️')
+    expect(output).toContain('FeeForwarderLegacy')
+    expect(output).not.toContain('superseded')
+  })
+  it('leaves third-party contracts unannotated in both directions', () => {
+    expect(check({ contractAddress: THIRD_PARTY })).toBe('')
+    expect(check({ contractAddress: THIRD_PARTY, whitelisted: false })).toBe('')
+  })
+
+  it('compares addresses case-insensitively', () => {
+    const output = check({
+      contractAddress: LIVE.toLowerCase(),
+      peripheryName: 'FeeForwarder',
+      registeredAddress: LIVE.toUpperCase().replace('0X', '0x'),
+    })
+    expect(output).toContain('✅ matches deployments')
   })
 })

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -15,13 +15,13 @@ import type { Abi, Address, Hex } from 'viem'
 import {
   bytesToHex,
   decodeFunctionData,
-  getAddress,
   keccak256,
   parseAbi,
   stringToHex,
   toFunctionSelector,
 } from 'viem'
 
+import composerWhitelist from '../../../config/composerWhitelist.json'
 import networksData from '../../../config/networks.json'
 import { EnvironmentEnum, type SupportedChain } from '../../common/types'
 import { getDeployments } from '../../utils/deploymentHelpers'
@@ -62,14 +62,6 @@ function getWhitelistJson(): unknown {
   return whitelistCache
 }
 
-function safeNormalizeAddress(address: string): string {
-  try {
-    return getAddress(address as Address).toLowerCase()
-  } catch {
-    return address.toLowerCase()
-  }
-}
-
 function computeSelectorFromSignature(signature: string): string {
   const hash = keccak256(stringToHex(signature))
   return `0x${hash.slice(2, 10)}`
@@ -84,7 +76,8 @@ function lookupWhitelistMetaForContractSelector(
   if (!isRecord(whitelist)) return {}
 
   const networkKey = network.toLowerCase()
-  const addr = safeNormalizeAddress(contractAddress)
+  const matchesQueriedAddress = (candidate: string): boolean =>
+    !!candidate && isSameAddress(network, candidate, contractAddress)
   const sel = selector.toLowerCase()
 
   const peripheryRoot = whitelist['PERIPHERY']
@@ -94,7 +87,7 @@ function lookupWhitelistMetaForContractSelector(
       const entry = peripheryNetwork.find((e) => {
         if (!isRecord(e)) return false
         const address = typeof e.address === 'string' ? e.address : ''
-        return safeNormalizeAddress(address) === addr
+        return matchesQueriedAddress(address)
       })
       if (isRecord(entry)) {
         const entryName =
@@ -132,7 +125,7 @@ function lookupWhitelistMetaForContractSelector(
       const contractEntry = contractsByNetwork.find((c) => {
         if (!isRecord(c)) return false
         const address = typeof c.address === 'string' ? c.address : ''
-        return safeNormalizeAddress(address) === addr
+        return matchesQueriedAddress(address)
       })
       if (!isRecord(contractEntry)) continue
       let signature: string | undefined
@@ -301,6 +294,12 @@ export interface IWhitelistDeployLogCheckInput {
   deployLogName?: string
   /** The call's third argument: adding pairs when true, removing them when false. */
   whitelisted: boolean
+  /**
+   * Set for a periphery whose whitelist entry comes from a config file rather
+   * than the deploy log, in which case that file is what the pair must agree
+   * with.
+   */
+  configSource?: { file: string; listsAddress: boolean }
 }
 
 /**
@@ -314,9 +313,13 @@ export interface IWhitelistDeployLogCheckInput {
  * The verdict depends on the direction: on a removal, absence from the deploy
  * log is expected (the superseded address is gone from it) and presence is the
  * alarm, because removing the selectors of an address the deploy log still
- * points at un-whitelists the contract in use. Third-party contracts can never
- * appear in the deploy log, so they stay unannotated rather than collecting a
- * permanent ❌ that would teach signers to ignore the marker.
+ * points at un-whitelists the contract in use. An address absent from the
+ * deploy log entirely stays unannotated — that is every third-party DEX, and a
+ * permanent ❌ there would teach signers to ignore the marker.
+ *
+ * Both sources read are the production ones, so a staging whitelist proposal
+ * gets no verdict — as it gets no `(PERIPHERY/…)` label today, for the same
+ * reason.
  */
 export function formatWhitelistDeployLogCheck(
   input: IWhitelistDeployLogCheckInput
@@ -328,7 +331,21 @@ export function formatWhitelistDeployLogCheck(
     registeredAddress,
     deployLogName,
     whitelisted,
+    configSource,
   } = input
+
+  // A config-backed periphery is absent from the deploy log by design, so that
+  // file — not the deploy log — is what its pairs must agree with.
+  if (configSource) {
+    const { file, listsAddress } = configSource
+    if (whitelisted)
+      return listsAddress
+        ? ` \u001b[32m(✅ matches ${file})\u001b[0m`
+        : ` \u001b[31m(❌ not listed in ${file})\u001b[0m`
+    return listsAddress
+      ? ` \u001b[33m(⚠️ un-whitelists an address ${file} still lists)\u001b[0m`
+      : ` \u001b[90m(no longer in ${file})\u001b[0m`
+  }
 
   // A removal's verdict hangs on `deployLogName` alone: any address the deploy
   // log still points at is live, whether or not whitelist.json labels it under
@@ -354,18 +371,58 @@ export function formatWhitelistDeployLogCheck(
       network,
       registeredAddress
     )
-    return ` \u001b[31m(❌ mismatch: deployments has ${expectedDisplay} for '${peripheryName}')\u001b[0m`
+    return ` \u001b[31m(❌ whitelist.json and deployments disagree: deployments has ${expectedDisplay} for '${peripheryName}')\u001b[0m`
   }
 
   return ` \u001b[31m(❌ no deployments entry for '${peripheryName}')\u001b[0m`
 }
 
-async function getWhitelistDeployLogCheckSuffix(
+/**
+ * `script/tasks/updateWhitelistPeriphery.ts` merges this periphery's whitelist
+ * entries from `config/composerWhitelist.json`; nothing ever writes it to a
+ * deploy log.
+ */
+const CONFIG_BACKED_PERIPHERY: Record<string, string> = {
+  Composer: 'composerWhitelist.json',
+}
+
+function getComposerListsAddress(
+  network: string,
+  contractAddress: string
+): boolean {
+  const perNetwork = (composerWhitelist as Record<string, unknown>)[
+    network.toLowerCase()
+  ]
+  if (!Array.isArray(perNetwork)) return false
+  return perNetwork.some(
+    (entry) =>
+      isRecord(entry) &&
+      typeof entry.address === 'string' &&
+      isSameAddress(network, entry.address, contractAddress)
+  )
+}
+
+export async function getWhitelistDeployLogCheckSuffix(
   network: string,
   contractAddress: string,
   peripheryName: string | undefined,
   whitelisted: boolean
 ): Promise<string> {
+  const configFile = peripheryName
+    ? CONFIG_BACKED_PERIPHERY[peripheryName]
+    : undefined
+  if (configFile)
+    return formatWhitelistDeployLogCheck({
+      network,
+      contractAddress,
+      peripheryName,
+      whitelisted,
+      configSource: {
+        file: configFile,
+        listsAddress: getComposerListsAddress(network, contractAddress),
+      },
+    })
+
   const deployments = await getDeploymentsRecord(network)
   if (!deployments)
     return peripheryName ? ` \u001b[90m(deployments unavailable)\u001b[0m` : ''
@@ -400,7 +457,8 @@ async function getWhitelistDeployLogCheckSuffix(
  * so the only one that earns the ✓ — then from the shared selector registry,
  * then from the batched 4byte lookup. Without the latter two, a pair missing
  * from this network's whitelist entry leaves the signer eyeballing a raw
- * selector.
+ * selector. Each contract line additionally carries the deploy-log verdict from
+ * `formatWhitelistDeployLogCheck`.
  */
 export async function formatBatchSetContractSelectorWhitelist(
   args: readonly unknown[],
@@ -464,7 +522,8 @@ export async function formatBatchSetContractSelectorWhitelist(
       )
     : new Map<string, string>()
 
-  // Resolved up front so the rendering loop below stays synchronous.
+  // Sequential, but only the first call reaches the filesystem: getDeployments
+  // memoizes per network for the process lifetime.
   const deployLogSuffixes = new Map<string, string>()
   if (network)
     for (const { contract, selectorList } of rows)

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -45,6 +45,8 @@ export interface IFormatDecodedTxContext {
 export interface IWhitelistContractSelectorMeta {
   contractLabel?: string
   signature?: string
+  /** Set only for our own periphery, whose name can be cross-checked against the deploy log. */
+  peripheryName?: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -113,6 +115,7 @@ function lookupWhitelistMetaForContractSelector(
         return {
           contractLabel: entryName ? `PERIPHERY/${entryName}` : 'PERIPHERY',
           signature: signature ? String(signature) : undefined,
+          peripheryName: entryName,
         }
       }
     }
@@ -276,6 +279,120 @@ async function getPeripheryDeploymentCheckSuffix(
   return ` \u001b[31m(❌ mismatch: expected ${expectedDisplay})\u001b[0m`
 }
 
+function isSameAddress(network: string, a: string, b: string): boolean {
+  try {
+    return (
+      normalizeAddressForNetwork(network, a.trim()).toLowerCase() ===
+      normalizeAddressForNetwork(network, b.trim()).toLowerCase()
+    )
+  } catch {
+    return a.trim().toLowerCase() === b.trim().toLowerCase()
+  }
+}
+
+export interface IWhitelistDeployLogCheckInput {
+  network: string
+  contractAddress: string
+  /** Name under which `config/whitelist.json` claims this address is our periphery. */
+  peripheryName?: string
+  /** Deploy-log address for `peripheryName`. */
+  registeredAddress?: string
+  /** Deploy-log name whose current address is `contractAddress`. */
+  deployLogName?: string
+  /** The call's third argument: adding pairs when true, removing them when false. */
+  whitelisted: boolean
+}
+
+/**
+ * Cross-checks a whitelist pair's contract against the deploy log.
+ *
+ * `config/whitelist.json`'s PERIPHERY section is generated from the deploy log
+ * by `script/tasks/updateWhitelistPeriphery.ts`, so a disagreement between the
+ * two means the proposal was built from a stale whitelist — today that renders
+ * as a confident `(PERIPHERY/<name>)` label on the wrong address.
+ *
+ * The verdict depends on the direction: on a removal, absence from the deploy
+ * log is expected (the superseded address is gone from it) and presence is the
+ * alarm, because removing the selectors of an address the deploy log still
+ * points at un-whitelists the contract in use. Third-party contracts can never
+ * appear in the deploy log, so they stay unannotated rather than collecting a
+ * permanent ❌ that would teach signers to ignore the marker.
+ */
+export function formatWhitelistDeployLogCheck(
+  input: IWhitelistDeployLogCheckInput
+): string {
+  const {
+    network,
+    contractAddress,
+    peripheryName,
+    registeredAddress,
+    deployLogName,
+    whitelisted,
+  } = input
+
+  // A removal's verdict hangs on `deployLogName` alone: any address the deploy
+  // log still points at is live, whether or not whitelist.json labels it under
+  // that same name.
+  if (!whitelisted) {
+    if (deployLogName)
+      return ` \u001b[33m(⚠️ un-whitelists current '${deployLogName}')\u001b[0m`
+    if (!peripheryName) return ''
+    return registeredAddress
+      ? ` \u001b[90m(superseded '${peripheryName}')\u001b[0m`
+      : ` \u001b[90m(not in deployments)\u001b[0m`
+  }
+
+  if (!peripheryName)
+    return deployLogName
+      ? ` \u001b[90m(deployments: ${deployLogName})\u001b[0m`
+      : ''
+
+  if (registeredAddress) {
+    if (isSameAddress(network, registeredAddress, contractAddress))
+      return ` \u001b[32m(✅ matches deployments)\u001b[0m`
+    const expectedDisplay = formatAddressForNetworkCliDisplay(
+      network,
+      registeredAddress
+    )
+    return ` \u001b[31m(❌ mismatch: deployments has ${expectedDisplay} for '${peripheryName}')\u001b[0m`
+  }
+
+  return ` \u001b[31m(❌ no deployments entry for '${peripheryName}')\u001b[0m`
+}
+
+async function getWhitelistDeployLogCheckSuffix(
+  network: string,
+  contractAddress: string,
+  peripheryName: string | undefined,
+  whitelisted: boolean
+): Promise<string> {
+  const deployments = await getDeploymentsRecord(network)
+  if (!deployments)
+    return peripheryName ? ` \u001b[90m(deployments unavailable)\u001b[0m` : ''
+
+  const registeredRaw = peripheryName ? deployments[peripheryName] : undefined
+  const registeredAddress =
+    typeof registeredRaw === 'string' && registeredRaw
+      ? registeredRaw
+      : undefined
+
+  const deployLogName = Object.entries(deployments).find(
+    ([, value]) =>
+      typeof value === 'string' &&
+      value &&
+      isSameAddress(network, value, contractAddress)
+  )?.[0]
+
+  return formatWhitelistDeployLogCheck({
+    network,
+    contractAddress,
+    peripheryName,
+    registeredAddress,
+    deployLogName,
+    whitelisted,
+  })
+}
+
 /**
  * Renders the contract/selector pairs of a `batchSetContractSelectorWhitelist`
  * call. Signatures are resolved per pair from `config/whitelist.json` first —
@@ -347,6 +464,24 @@ export async function formatBatchSetContractSelectorWhitelist(
       )
     : new Map<string, string>()
 
+  // Resolved up front so the rendering loop below stays synchronous.
+  const deployLogSuffixes = new Map<string, string>()
+  if (network)
+    for (const { contract, selectorList } of rows)
+      deployLogSuffixes.set(
+        contract,
+        await getWhitelistDeployLogCheckSuffix(
+          network,
+          contract,
+          lookupWhitelistMetaForContractSelector(
+            network,
+            contract,
+            selectorList[0] ?? ''
+          ).peripheryName,
+          whitelisted
+        )
+      )
+
   const actionText = whitelisted ? 'Adding pairs' : 'Removing pairs'
   const actionColor = whitelisted ? '\u001b[32m' : '\u001b[33m'
   consola.info(`${pre}Action: ${actionColor}${actionText}\u001b[0m`)
@@ -370,6 +505,7 @@ export async function formatBatchSetContractSelectorWhitelist(
     if (network) {
       const explorerUrl = buildExplorerContractPageUrl(network, displayContract)
       if (explorerUrl) contractLine += ` \u001b[36m${explorerUrl}\u001b[0m`
+      contractLine += deployLogSuffixes.get(originalContract) ?? ''
     }
     consola.info(`${pre}${contractLine}`)
     consola.info(`${pre}    Selectors:`)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-811/safe-signing-display-cross-check-whitelist-pair-contracts-against-the

Follow-up to EXSC-804 / #2232.

# Why did I implement it this way?

`registerPeripheryContract` proposals already render a deploy-log verdict next to the address (`✅ matches deployments` / `❌ mismatch: expected …`) — it can, because the call carries the periphery **name** in its calldata.

`batchSetContractSelectorWhitelist` carries **only addresses**, so it had no such verdict. Its magenta `(PERIPHERY/<name>)` label comes from `config/whitelist.json`, which is *generated* by `script/tasks/updateWhitelistPeriphery.ts`. When a rollout proposes a whitelist sync built from a stale `whitelist.json`, the signer therefore sees a confident, correct-looking label on a superseded address and has nothing to catch it with. This PR turns that single-source label into a two-source agreement check.

With no name in the calldata, the check is a *reverse* lookup over the deploy log rather than a copy of the registration check, and the verdict has to be direction-aware:

| whitelist.json label | in deploy log | Adding | Removing |
| -- | -- | -- | -- |
| `PERIPHERY/N` | as `N` | `✅ matches deployments` | `⚠️ un-whitelists current 'N'` |
| `PERIPHERY/N` | `N` = other address | `❌ whitelist.json and deployments disagree` | `(superseded 'N')` |
| `PERIPHERY/N` | absent | `❌ no deployments entry for 'N'` | `(not in deployments)` |
| none | present as `N` | `(deployments: N)` | `⚠️ un-whitelists current 'N'` |
| none | absent | *silent* | *silent* |

Three constraints drove that shape:

- **Removals invert the meaning.** Absence from the deploy log is the *expected* state for a removal (the superseded address is gone from it); presence is the alarm, because removing the selectors of an address the deploy log still points at un-whitelists the contract in use. Reusing the registration check verbatim would have painted every correct removal red. The removal verdict keys off the reverse lookup alone, so it still fires when the deploy log holds the address under a name other than the one `whitelist.json` labels it with.
- **Most pairs are third-party.** DEX/aggregator contracts can never appear in the deploy log, so they stay unannotated — a permanent ❌ there would train signers to ignore the marker.
- **Not every periphery is deploy-log-backed.** `Composer`'s whitelist entries are merged from `config/composerWhitelist.json` and never reach a deploy log, so its pairs are checked against *that* file (`✅ matches composerWhitelist.json` / `⚠️ un-whitelists an address composerWhitelist.json still lists`). Checking Composer against the deploy log would have emitted a false ❌ on every correct Composer pair on all 70 networks it is configured for — see the review notes below; this was caught pre-merge, not shipped.

Because Safe calldata is decoded with viem, a Tron pair arrives as `0x` hex while both `whitelist.json` and the deploy log store base58. The pre-existing periphery match folded case instead of normalising per network, so `peripheryName` was always undefined on Tron — meaning the magenta label never appeared there and the new ✅/❌ verdicts could never fire. The match now goes through the same network-aware comparison as the rest of this file, which also restores the missing Tron periphery label.

The decision table lives in a pure exported function (`formatWhitelistDeployLogCheck`); the source-selection wrapper (`getWhitelistDeployLogCheckSuffix`) is exported too, so the whitelist/deploy-log/config resolution that picks the row is covered by tests reading the repo's real `config/` and `deployments/` files rather than synthetic fixtures.

### Verification beyond the unit tests

Rendered against the repo's own unmodified `config/whitelist.json`, `config/composerWhitelist.json` and `deployments/*.json`:

- every whitelist pair of `mainnet` (125), `arbitrum` (123), `tron` (8) and `nibiru` (11), in both directions: **0 red rows**; the only ⚠️ rows are the removal half for our own live periphery, which is the intended alarm.
- adding a live periphery → `✅ matches deployments`; removing the same address → `⚠️ un-whitelists current '<name>'` (negative control: the alarm does fire on real data).
- a real third-party DEX address (mainnet DODO) → silent in both directions.
- a Tron periphery passed in the hex form viem actually decodes → label plus `✅`; reverting the network-aware match makes that test fail, and reverting the Composer entry makes the Composer test fail, so both new guards are proven to be load-bearing.

### Known limits

- An address in **neither** source is indistinguishable from a third-party contract and stays silent. Nothing claims it is ours, so there is nothing to cross-check.
- Both sources read are the **production** ones, so a staging whitelist proposal gets no verdict — as it gets no `(PERIPHERY/…)` label today, for the same reason. Threading the environment through the decode path is a larger change than this PR; flagging rather than silently widening scope.
- The deploy-log reverse lookup takes the **first** matching name. No deployments file currently registers one address under two names, so this cannot fire today, but co-registering two versions under different names is a known pattern in this repo.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
