### PR TITLE
fix(VaultWrapper): make the perf fee independent of accrual frequency

### DIFF
--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -164,8 +164,7 @@ contract LiFiVaultWrapper is
     /// @notice Performance-fee high-water mark: the highest post-crystallization price
     ///         per share (scaled by `LibVaultWrapperMath.PPS_SCALE`). Anchored at
     ///         `initialize`, re-anchored upward (never down) when the performance fee
-    ///         is enabled from disabled, and ratcheted whenever a performance accrual
-    ///         mints shares.
+    ///         is enabled from disabled, and ratcheted on every performance accrual.
     uint192 public perfHighWaterMarkPps;
 
     /// @notice Integrator payout wallets (1..50) with their bps split, each packed into one
@@ -259,10 +258,10 @@ contract LiFiVaultWrapper is
         // Provisional anchor at the empty-vault share price, computed pure (supply and
         // position are always 0 on a fresh single-shot-initialized proxy). Deliberately NOT
         // read through the adapter: an underlying whose empty-position query reverts must not
-        // brick deployment. This par value is only a placeholder — `_accrueFees` re-floats the
-        // watermark to the live price on every accrual taken while supply is below the floor,
-        // so a donation to the predicted address is captured into the baseline (not booked as
-        // gain against the first depositor) the moment real supply is minted.
+        // brick deployment. This par value is only a placeholder — `_accrueFees` ratchets the
+        // watermark to the live price on every accrual, so a donation to the predicted address
+        // is captured into the baseline (not booked as gain against the first depositor) the
+        // moment real supply is minted.
         perfHighWaterMarkPps = SafeCast.toUint192(
             LibVaultWrapperMath.pricePerShare(0, 0, _decimalsOffset())
         );
@@ -776,7 +775,10 @@ contract LiFiVaultWrapper is
             if (_feeType == FeeType.Performance && _rate(_feeType) == 0) {
                 uint256 supply = totalSupply();
                 if (supply != 0) {
-                    uint192 currentPps = _ceilPps(supply, totalAssets());
+                    uint192 currentPps = _postDilutionPps(
+                        supply,
+                        totalAssets()
+                    );
                     // Up-only: anchoring below the stored watermark would let the owner
                     // toggle the fee off/on at a trough and charge the recovery back to
                     // the old peak — the double-charge the watermark exists to prevent.
@@ -997,9 +999,9 @@ contract LiFiVaultWrapper is
     ///      floors to zero shares is dropped — at most ~one share's worth of assets per
     ///      accrual, favouring holders. The performance fee is charged AFTER the
     ///      management dilution (perf is net of management). The watermark ratchets up to
-    ///      the live post-crystallization price (rounded up) on EVERY perf-enabled
-    ///      accrual: like elapsed time, a gain is charged or forgiven per accrual, never
-    ///      left pending against a stale mark.
+    ///      the live post-crystallization price on EVERY perf-enabled accrual: like
+    ///      elapsed time, a gain is charged or forgiven per accrual, never left pending
+    ///      against a stale mark.
     function _accrueFees() private {
         bool mgmtEnabled = _rate(FeeType.Management) != 0;
         bool perfEnabled = _rate(FeeType.Performance) != 0;
@@ -1029,29 +1031,28 @@ contract LiFiVaultWrapper is
 
         // Up-only ratchet on every accrual: any gain above the mark is charged or
         // forgiven now, never left stale, so pre-entry gains (yield or donation) cannot
-        // be charged to a later depositor at any supply. Per-accrual forgiveness is
-        // bounded by the fee math's flooring — sub-step dust, holder-favouring. Up-only,
-        // never assignment: floating down after a loss would re-charge the recovery.
-        uint192 currentPps = _ceilPps(supply, assets);
+        // be charged to a later depositor at any supply. Up-only, never assignment:
+        // floating down after a loss would re-charge the recovery.
+        uint192 currentPps = _postDilutionPps(supply, assets);
         if (currentPps > perfHighWaterMarkPps) {
             perfHighWaterMarkPps = currentPps;
         }
     }
 
     /// @dev The price per share the performance-fee watermark is anchored at, narrowed to
-    ///      the watermark's storage width. Ceil, not floor: a floored post-dilution price
-    ///      can fall a full pps step below the price the fee was just charged at, re-opening
-    ///      that step to be charged again on the next crossing (severe for low-decimal
-    ///      assets, where a step is a coarse slice of AUM). Rounding up keeps the watermark
-    ///      at/above the crystallization price, at most under-charging by one sub-step — the
-    ///      holder-favouring direction the rest of the fee math already rounds in. Prices
-    ///      through `_decimalsOffset()`, so it is only valid once `initialize` has written
-    ///      `shareDecimalsOffset` (the provisional anchor there uses the pure floored
-    ///      overload instead).
-    /// @param _supply The share supply to price against.
+    ///      the watermark's storage width. Call with the supply that already includes any
+    ///      fee-shares minted this accrual: the mark must land on the price holders are
+    ///      left holding AFTER the dilution, so the next gain is measured from there. An
+    ///      anchor above that price forgives the difference and one below re-charges it,
+    ///      and either way the error repeats per accrual — a caller-controlled variable,
+    ///      since `distributeFees` is permissionless. Floored, the same direction gain
+    ///      measurement rounds, so the mark cannot land off the measured price by rounding
+    ///      alone. Prices through `_decimalsOffset()`, so it is only valid once
+    ///      `initialize` has written `shareDecimalsOffset`.
+    /// @param _supply The share supply to price against, including fee-shares just minted.
     /// @param _assets The gross assets to price against.
-    /// @return The ceil-rounded price per share, scaled by `LibVaultWrapperMath.PPS_SCALE`.
-    function _ceilPps(
+    /// @return The price per share, scaled by `LibVaultWrapperMath.PPS_SCALE`.
+    function _postDilutionPps(
         uint256 _supply,
         uint256 _assets
     ) private view returns (uint192) {
@@ -1060,8 +1061,7 @@ contract LiFiVaultWrapper is
                 LibVaultWrapperMath.pricePerShare(
                     _supply,
                     _assets,
-                    _decimalsOffset(),
-                    Math.Rounding.Ceil
+                    _decimalsOffset()
                 )
             );
     }

--- a/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
+++ b/src/VaultWrapper/libraries/LibVaultWrapperMath.sol
@@ -23,7 +23,19 @@ library LibVaultWrapperMath {
 
     /// @notice Fixed-point scale of the price-per-share values (`pricePerShare` results
     ///         and the performance-fee high-water mark).
-    uint256 internal constant PPS_SCALE = 1e18;
+    /// @dev The performance fee measures gains on this grid AND anchors its watermark on
+    ///      it, so one unit of the grid is the smallest gain the fee can see: a coarse grid
+    ///      turns per-accrual rounding into a real slice of AUM, and accrual frequency is
+    ///      caller-controlled (`distributeFees` is permissionless). One unit is
+    ///      `10 ** offset / PPS_SCALE` of AUM, so `10 ** -(assetDecimals + 6)` while the
+    ///      offset tracks `18 - assetDecimals`, and finer once it bottoms out at
+    ///      `MIN_DECIMALS_OFFSET`: 1e-10 of AUM for a 4-decimal asset (the coarsest
+    ///      onboarded), 1e-12 at 6 decimals, which even one block of yield clears. At 1e18
+    ///      it was `10 ** -assetDecimals`: a whole USDC on a 1M USDC vault, which ordinary
+    ///      traffic crosses every few minutes. Headroom: par pps is
+    ///      `PPS_SCALE / 10 ** offset` (1e6..1e18 across the supported offsets) against the
+    ///      watermark's `uint192` ceiling of ~6.3e57.
+    uint256 internal constant PPS_SCALE = 1e24;
 
     /// @notice Fee taken on top of a net amount (gross = net + fee).
     /// @dev Used where `_assets` is the net amount the user wants moved (previewMint,
@@ -81,50 +93,27 @@ library LibVaultWrapperMath {
         if (feeAssets >= _totalAssets) feeAssets = _totalAssets - 1;
     }
 
-    /// @notice Price per share as a `PPS_SCALE`-scaled fixed-point value.
+    /// @notice Price per share as a `PPS_SCALE`-scaled fixed-point value, rounded down.
     /// @dev `convertToAssets(PPS_SCALE)` under OZ's virtual-offset convention:
     ///      `pps = (totalAssets + 1) * PPS_SCALE / (totalSupply + 10**offset)`. The same
-    ///      convention as the share/asset conversions so the performance watermark is measured
-    ///      on exactly the price depositors transact at. Rounding is caller-chosen: gain
-    ///      measurement floors (under-measures, favouring holders); the high-water-mark ratchet
-    ///      ceils so a floored post-dilution price cannot fall a full step below the price the
-    ///      fee was crystallized at and re-charge that step on the next crossing.
+    ///      convention as the share/asset conversions so the performance watermark is
+    ///      measured on exactly the price depositors transact at. Floored throughout:
+    ///      gain measurement and the watermark ratchet must share one rounding direction,
+    ///      or the mark lands off the price the fee was measured at and the gap is either
+    ///      re-charged or forgiven on the next accrual.
     /// @param _totalSupply Current share supply.
     /// @param _totalAssets Gross assets under management.
     /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
-    /// @param _rounding Rounding direction for the division.
     /// @return The current price per share, scaled by `PPS_SCALE`.
-    function pricePerShare(
-        uint256 _totalSupply,
-        uint256 _totalAssets,
-        uint8 _decimalsOffset,
-        Math.Rounding _rounding
-    ) internal pure returns (uint256) {
-        return
-            (_totalAssets + 1).mulDiv(
-                PPS_SCALE,
-                _totalSupply + 10 ** _decimalsOffset,
-                _rounding
-            );
-    }
-
-    /// @notice `pricePerShare` with the floored measurement convention.
-    /// @dev The default used by gain measurement and the empty-vault anchor; the watermark
-    ///      ratchet calls the rounding-aware overload with `Math.Rounding.Ceil` instead.
-    /// @param _totalSupply Current share supply.
-    /// @param _totalAssets Gross assets under management.
-    /// @param _decimalsOffset The ERC-4626 virtual-share decimals offset.
-    /// @return The current price per share, scaled by `PPS_SCALE`, rounded down.
     function pricePerShare(
         uint256 _totalSupply,
         uint256 _totalAssets,
         uint8 _decimalsOffset
     ) internal pure returns (uint256) {
         return
-            pricePerShare(
-                _totalSupply,
-                _totalAssets,
-                _decimalsOffset,
+            (_totalAssets + 1).mulDiv(
+                PPS_SCALE,
+                _totalSupply + 10 ** _decimalsOffset,
                 Math.Rounding.Floor
             );
     }
@@ -136,13 +125,12 @@ library LibVaultWrapperMath {
     ///      per share is at or below the watermark, so a net loss is never charged.
     ///      Clamped strictly below `_totalAssets` so the dilution-share denominator stays
     ///      positive even at extreme watermark/rate inputs.
-    ///      Precision: the price per share is a floored `PPS_SCALE`-scaled integer whose
-    ///      step is ~`10 ** -assetDecimals` of value (par PPS = `10 ** assetDecimals` for
-    ///      assets up to 12 decimals). A gain smaller than one step leaves the floored PPS
-    ///      unchanged and accrues nothing that round; the gain stays in AUM and is charged
-    ///      once cumulative gains cross a step. Negligible for mainstream assets (>= 6
-    ///      decimals, step <= 1e-6) but coarse for very-low-decimal assets (<= 3), which
-    ///      onboarding excludes rather than modeling here.
+    ///      Precision: the price per share is a floored `PPS_SCALE`-scaled integer, so a
+    ///      gain smaller than one unit of that grid leaves it unchanged and accrues nothing
+    ///      that round; the gain stays in AUM and is charged once cumulative gains cross a
+    ///      unit. `PPS_SCALE` is sized so that unit is far below one block of yield for
+    ///      every onboardable asset (see its doc), so the fee an accrual sequence collects
+    ///      does not depend on how often it is taken.
     /// @param _totalAssets Gross assets under management at accrual time.
     /// @param _totalSupply Current share supply.
     /// @param _hwmPps The high-water mark, a `PPS_SCALE`-scaled price per share.

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperPerformanceFee.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
 import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";
@@ -122,16 +121,14 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         uint256 expectedHwm = LibVaultWrapperMath.pricePerShare(
             supply + expectedShares,
             assets,
-            wrapper.shareDecimalsOffset(),
-            Math.Rounding.Ceil
+            wrapper.shareDecimalsOffset()
         );
 
         _crystallize();
 
-        // The watermark equals the diluted (post-fee-mint) PPS rounded up, sitting below the
-        // pre-charge peak: holders' realized value is the new baseline. Rounding up keeps a
-        // floored price from dropping a full step below the crystallization price and being
-        // re-charged on the next crossing.
+        // The watermark equals the diluted (post-fee-mint) PPS, sitting below the pre-charge
+        // peak: holders' realized value is the new baseline, so the next gain is measured
+        // from what they actually hold rather than from the pre-dilution peak.
         uint256 hwm = wrapper.perfHighWaterMarkPps();
         assertEq(hwm, expectedHwm);
         assertLt(hwm, ppsBeforeCharge);
@@ -143,22 +140,23 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         assertEq(_accruedFeeShares(), sharesAfterCharge);
     }
 
-    function test_SubStepGainMintsNothingAndIsForgiven() public {
+    function test_SubUnitGainMintsNothingAndStaysChargeable() public {
         wrapper = _newWrapperPerfOnly(PERF_RATE);
         _deposit(alice, DEPOSIT);
 
-        // A gain below one PPS unit (supply / PPS_SCALE = 1000 wei here) floors to a
-        // zero-share fee: nothing is minted and, like the management baseline, the
-        // watermark ratchets over the gain — charged or forgiven per accrual, never
-        // left pending (forgiveness bounded by one PPS step of AUM per accrual).
+        // A gain below one PPS unit (supply / PPS_SCALE = 1000 wei here) leaves the
+        // measured price unchanged: nothing is minted and the watermark does not move.
+        // It must NOT move — advancing over an un-charged gain would forgive it, and
+        // accrual frequency is caller-controlled through the permissionless
+        // `distributeFees`, so a caller accruing once per unit could forgive every gain.
         _simulateYield(500);
         uint256 hwmBefore = wrapper.perfHighWaterMarkPps();
         _crystallize();
 
         assertEq(_accruedFeeShares(), 0);
-        assertGt(wrapper.perfHighWaterMarkPps(), hwmBefore);
+        assertEq(wrapper.perfHighWaterMarkPps(), hwmBefore);
 
-        // A later material gain is charged from the advanced watermark.
+        // The gain stayed in AUM and is charged once cumulative gains cross a unit.
         _simulateYield(200e18);
         _crystallize();
 
@@ -280,14 +278,13 @@ contract LiFiVaultWrapperPerformanceFeeTest is VaultWrapperFeeTestBase {
         vm.prank(vaultAdmin);
         wrapper.setFeeRate(FeeType.Performance, PERF_RATE);
 
-        // The watermark re-anchored at the current (post-yield) PPS, rounded up...
+        // The watermark re-anchored at the current (post-yield) PPS...
         assertEq(
             wrapper.perfHighWaterMarkPps(),
             LibVaultWrapperMath.pricePerShare(
                 wrapper.totalSupply(),
                 wrapper.totalAssets(),
-                wrapper.shareDecimalsOffset(),
-                Math.Rounding.Ceil
+                wrapper.shareDecimalsOffset()
             )
         );
         assertEq(_accruedFeeShares(), 0);

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
-import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
@@ -142,9 +141,9 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         uint96 _gainRaw,
         uint96 _depositRaw
     ) public {
-        // After any perf-enabled accrual the mark must sit at/above the live price or
-        // fee shares were minted for the full gap — a stale mark lets pre-entry gains
-        // be charged to a later depositor as fabricated gain.
+        // After any perf-enabled accrual the mark must sit at/above the live measured
+        // price or fee shares were minted for the full gap — a stale mark lets pre-entry
+        // gains be charged to a later depositor as fabricated gain.
         wrapper = _newWrapperPerfOnly(PERF_RATE);
         uint256 dep = bound(uint256(_depositRaw), 1, 1_000e18);
         uint256 gain = bound(uint256(_gainRaw), 1, 1_000e18);
@@ -156,11 +155,15 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         uint256 livePps = LibVaultWrapperMath.pricePerShare(
             wrapper.totalSupply(),
             wrapper.totalAssets(),
-            wrapper.shareDecimalsOffset(),
-            Math.Rounding.Ceil
+            wrapper.shareDecimalsOffset()
         );
 
         assertGe(wrapper.perfHighWaterMarkPps(), livePps);
+
+        // The same property from the fee side: nothing is left chargeable.
+        uint256 feesAfterAccrual = _accruedFeeShares();
+        _accrueOnly();
+        assertEq(_accruedFeeShares(), feesAfterAccrual);
     }
 
     function test_LossRecoveryNotChargedAgain() public {
@@ -244,36 +247,30 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         assertEq(shares, quote);
     }
 
-    function test_PricePerShareCeilRoundsUpAndDefaultFloors() public pure {
-        uint256 floored = LibVaultWrapperMath.pricePerShare(
-            2,
-            6,
-            0,
-            Math.Rounding.Floor
+    function test_PricePerShareFloorsTheDivision() public pure {
+        // 7 * PPS_SCALE / 3 is not exact: the remainder is dropped, never rounded up, so
+        // the watermark anchor and the gain measurement share one price.
+        assertEq(
+            LibVaultWrapperMath.pricePerShare(2, 6, 0),
+            (7 * LibVaultWrapperMath.PPS_SCALE) / 3
         );
-        uint256 ceiled = LibVaultWrapperMath.pricePerShare(
-            2,
-            6,
-            0,
-            Math.Rounding.Ceil
-        );
-
-        // 7e18 / 3 is not exact: ceil is exactly one unit above floor.
-        assertEq(floored, 2333333333333333333);
-        assertEq(ceiled, 2333333333333333334);
-
-        // The parameterless overload keeps the floored measurement convention.
-        assertEq(LibVaultWrapperMath.pricePerShare(2, 6, 0), floored);
     }
 }
 
-/// @notice Second defect in isolation: a 6-decimal asset (one price-per-share step is a
-///         whole unit of a 1M vault) taking frequent sub-step yield. Deployed through the
-///         real factory stack so `distributeFees` (a principal-free, permissionless accrual
-///         trigger) is available. The pre-fix floored watermark re-charged a full step each
-///         crossing, confiscating ~76% of the yield; the fix caps it at the configured 20%.
-contract PerfFeeLowDecimalOverchargeTest is VaultWrapperFeeTestBase {
+/// @notice The price-per-share grid on a 6-decimal asset, where one unit of the grid used
+///         to be a whole token of a 1M vault. Both watermark defects this file guards lived
+///         here: anchoring below the measured price re-charged a full unit each crossing
+///         (~76% of the yield confiscated), and anchoring above it forgave a unit per
+///         crossing, which suppressed the fee entirely once accruals came more often than
+///         one unit of yield. Deployed through the real factory stack so `distributeFees`
+///         (a principal-free, permissionless accrual trigger) is available.
+contract PerfFeeLowDecimalGridTest is VaultWrapperFeeTestBase {
     uint16 internal constant PERF_RATE = 2000; // 20% of gains
+    uint256 internal constant PRINCIPAL = 1_000_000e6;
+    uint256 internal constant TOTAL_YIELD = 84e6;
+    /// @dev The fee is quantized to the price grid and each round's charge rounds up, so
+    ///      the collected total sits within a hair of the rate rather than exactly on it.
+    uint256 internal constant FEE_TOLERANCE = 0.001e18; // 0.1%
 
     function setUp() public override {
         asset = new MockERC20("USD Coin", "USDC", 6);
@@ -282,30 +279,41 @@ contract PerfFeeLowDecimalOverchargeTest is VaultWrapperFeeTestBase {
         _stackWithFactory(FeeType.Performance, PERF_RATE, 5000);
     }
 
-    function test_LowDecimalPerfFeeDoesNotOverchargeAcrossManyAccruals()
-        public
-    {
-        uint256 principal = 1_000_000e6;
-        _deposit(alice, principal);
-
-        uint256 drip = 210_000; // 0.21 USDC, below the 1 USDC price-per-share step
-        uint256 rounds = 400;
-        for (uint256 i = 0; i < rounds; i++) {
-            _simulateYield(drip);
-            wrapper.distributeFees();
-        }
-        wrapper.distributeFees();
-
-        uint256 totalYield = drip * rounds;
-
+    /// @dev Fee collected on `alice`'s position: what the holder does not get back.
+    function _feeCollected() internal returns (uint256) {
         uint256 aliceShares = wrapper.balanceOf(alice);
         vm.prank(alice);
         uint256 aliceOut = wrapper.redeem(aliceShares, alice, alice);
 
-        // Holder keeps the large majority of the yield: the cap is 20% and the floored
-        // measurement only ever under-charges. The pre-fix re-flooring left the holder
-        // <25%; here they retain well over half.
-        assertGe(aliceOut, principal + (totalYield * 60) / 100);
-        assertLe(aliceOut, principal + totalYield);
+        return PRINCIPAL + TOTAL_YIELD - aliceOut;
+    }
+
+    function _expectedFee() internal pure returns (uint256) {
+        return (TOTAL_YIELD * PERF_RATE) / 10_000;
+    }
+
+    function test_PerfFeeMatchesRateInOneAccrual() public {
+        _deposit(alice, PRINCIPAL);
+        _simulateYield(TOTAL_YIELD);
+        wrapper.distributeFees();
+
+        assertApproxEqRel(_feeCollected(), _expectedFee(), FEE_TOLERANCE);
+    }
+
+    /// @dev The same yield sliced into rounds each smaller than one unit of the price grid,
+    ///      with an accrual after every one. Accrual frequency is caller-controlled through
+    ///      the permissionless `distributeFees`, so the fee must not depend on it: two-sided
+    ///      bounds, since a leak in either direction is exploitable by whoever benefits.
+    function test_PerfFeeMatchesRateAcrossManyAccruals() public {
+        _deposit(alice, PRINCIPAL);
+
+        uint256 rounds = 400;
+        uint256 drip = TOTAL_YIELD / rounds; // 0.21 USDC per round
+        for (uint256 i = 0; i < rounds; i++) {
+            _simulateYield(drip);
+            wrapper.distributeFees();
+        }
+
+        assertApproxEqRel(_feeCollected(), _expectedFee(), FEE_TOLERANCE);
     }
 }

--- a/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPerfFeeWatermark.t.sol
@@ -187,10 +187,10 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         assertEq(_accruedFeeShares(), feesAtPeak);
     }
 
-    function test_FrequentAccrualsForgiveOnlyBoundedFee() public {
+    function test_FrequentAccrualsCollectTheSameFeeAsOneAccrual() public {
         // Ten sub-gain accruals vs one lump accrual of the same total gain: per-accrual
-        // forgiveness is only flooring slack, so frequent accruals cannot dodge a
-        // meaningful part of the fee.
+        // rounding is flooring slack only, so the fee cannot be moved by accrual
+        // frequency in either direction.
         wrapper = _newWrapperPerfOnly(PERF_RATE);
         _deposit(bob, DEPOSIT);
 
@@ -213,9 +213,7 @@ contract PerfFeeDonationWatermarkTest is VaultWrapperFeeTestBase {
         // The split path may slightly EXCEED the lump in share terms (~0.04% measured):
         // earlier fee mints participate in later chunks' gains. Bounded both ways —
         // no dodging low side, no runaway compounding high side.
-        assertLe(feeSplit, (feeSingle * 101) / 100);
-        // Slack: one flooring event per accrual (10) + 1.
-        assertGe(feeSplit + 10 + 1, (feeSingle * 9) / 10);
+        assertApproxEqRel(feeSplit, feeSingle, 0.001e18); // 0.1%
     }
 
     function test_PreviewDepositMatchesExecutionAtDustSupply() public {

--- a/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
+++ b/test/solidity/VaultWrapper/libraries/LibVaultWrapperMath.t.sol
@@ -552,9 +552,12 @@ contract LibVaultWrapperMathTest is Test {
     /* ---------------------- pricePerShare / performanceFeeAssets ------------- */
 
     function test_PricePerShare_EmptyVaultIsOneToOne() public view {
-        // (0 + 1) * 1e18 / (0 + 10**offset)
-        assertEq(lib.pricePerShare(0, 0, 0), 1e18);
-        assertEq(lib.pricePerShare(0, 0, 3), 1e15);
+        // (0 + 1) * PPS_SCALE / (0 + 10**offset)
+        assertEq(lib.pricePerShare(0, 0, 0), LibVaultWrapperMath.PPS_SCALE);
+        assertEq(
+            lib.pricePerShare(0, 0, 3),
+            LibVaultWrapperMath.PPS_SCALE / 1e3
+        );
     }
 
     function testFuzz_PricePerShare_MatchesConvertToAssets(
@@ -571,7 +574,7 @@ contract LibVaultWrapperMathTest is Test {
         assertEq(
             lib.pricePerShare(_totalSupply, _totalAssets, _decimalsOffset),
             lib.convertToAssets({
-                _shares: 1e18,
+                _shares: LibVaultWrapperMath.PPS_SCALE,
                 _totalSupply: _totalSupply,
                 _pendingFeeShares: 0,
                 _totalAssets: _totalAssets,
@@ -597,13 +600,13 @@ contract LibVaultWrapperMathTest is Test {
     }
 
     function test_PerformanceFee_KnownValue() public view {
-        // supply 1000e18, assets 1200e18, hwm 1e18 => gain ~200e18; 20% => ~40e18.
+        // supply 1000e18, assets 1200e18, hwm at par => gain ~200e18; 20% => ~40e18.
         // The flooring of the PPS quantizes the gain to steps of supply/PPS_SCALE
-        // (1000 wei here), always in the holders' favour.
+        // (sub-wei here), always in the holders' favour.
         uint256 fee = lib.performanceFeeAssets(
             1200e18,
             1000e18,
-            1e18,
+            LibVaultWrapperMath.PPS_SCALE,
             2000,
             0
         );


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-822](https://linear.app/lifi-linear/issue/EXSC-822/vault-wrapper-perf-fee-suppressed-by-accrual-frequency-ceil-watermark)

Follow-up to [EXSC-802](https://linear.app/lifi-linear/issue/EXSC-802/vault-wrapper-fix-performance-fee-high-water-mark-watermark-defects) / [EXSC-815](https://linear.app/lifi-linear/issue/EXSC-815/vault-wrapper-ratchet-perf-watermark-up-on-every-accrual-delete-dust) (#2227, #2242). Found by the pashov-ai audit pass and reproduced with Foundry before fixing.

# Why did I implement it this way?

`_accrueFees` anchored `perfHighWaterMarkPps` at the ceil-rounded post-dilution price, while `performanceFeeAssets` measures the gain against the floored price and returns 0 on the non-strict `pps <= hwm`. For any non-integral price `ceil(pps) > pps > floor(pps)`, so after every accrual the mark sat strictly above the live price and the charge condition could only fire after a full price-grid unit of growth. One accrual per unit of growth left `floor(pps) <= hwm` forever and the performance fee became exactly zero, permanently. At `PPS_SCALE = 1e18` one unit is `10 ** -assetDecimals` of AUM — a whole USDC on a 1M USDC vault — which ordinary traffic on a 6-decimal vault crosses every few minutes at normal APY. No attacker is needed; `distributeFees` being permissionless just makes it cheap to force.

Measured on the pre-fix code, 1M USDC vault at 2000 bps:

| scenario | fee collected | at the configured rate |
| --- | --- | --- |
| 84 USDC of yield, one accrual | 16.600001 USDC | 16.8 |
| the same 84 USDC in 400 accruals | 1 wei | 16.8 |
| $50M vault, 2 days at 5% APY, one 1-USDC deposit every 300 s | 0.078759 USDC | 2,739.7 |

The fix anchors on the floored **post-dilution** price — the same price the gain is measured against — so the mark lands on what holders are left holding after the dilution and the next gain is measured from there, with no gap for a later accrual to re-charge or forgive. Flooring alone would re-open defect 2 of EXSC-802 (a unit re-charged per crossing, measured at 64 of 84 USDC), so `PPS_SCALE` widens from 1e18 to 1e24: one unit of the grid drops from `10 ** -assetDecimals` of AUM to `10 ** -(assetDecimals + 6)`, far below one block of yield for every onboardable asset, which bounds both rounding directions to dust. `PPS_SCALE` feeds the stored watermark on deployed instances, so this is layout-safe only pre-deploy — no instance is deployed yet. The ratchet stays unconditional and up-only.

Two alternatives were implemented and measured before settling on this one. **Gating the ratchet on crystallization** (the pre-#2242 shape) regresses defect 1 of EXSC-802: a gain whose dilution floors to zero shares goes stale and is charged to a later depositor as fabricated gain — `test_DustSupplyDonationNotChargedToNextDepositor`, `test_DustSupplyYieldEscapesPerfFee` and `testFuzz_WatermarkNeverStaleAfterAccrual` all fail on it, and the organic scenario still collects only 56%. **Anchoring on the floored pre-dilution price** keeps the mark non-stale but bakes in a permanent shortfall: the fee's own price drop has to be re-earned before the next fee, so `charged = gross / (1 + rate)` and the effective rate is 16.67% instead of 20% (measured at 83% of correct, and scale-independent, so widening `PPS_SCALE` does not rescue it).

On the test side, the two 6-decimal scenarios now assert the fee two-sided against the configured rate. The previous version of the sliced-accrual test ran this exact scenario but bounded the fee only from above, which zero passes — that is why the defect shipped. `test_SubStepGainMintsNothingAndIsForgiven` asserted the defect as intended behaviour and is replaced by `test_SubUnitGainMintsNothingAndStaysChargeable`, which asserts the mark does **not** advance over an un-charged gain. The 18-decimal frequency test had a 10% lower bound against a measured 0.04% divergence; it is now bounded at 0.1% both ways. Each new assertion was confirmed to fail against the pre-fix source. The rounding-aware `pricePerShare` overload has no callers left and is removed rather than kept for tests.

Full suite green: 2027 tests, 0 failures.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
