### PR TITLE
docs(VaultWrapper): audit triage — trust-model docs, adapter delegatecall guard, comment fixes

### DIFF
--- a/docs/VaultWrapper/ERC4626Adapter.md
+++ b/docs/VaultWrapper/ERC4626Adapter.md
@@ -11,6 +11,13 @@ The adapter is **stateless** — it holds no storage, so `deposit`/`withdraw` ar
 safe to `delegatecall` from a wrapper (they run in the wrapper's context and act
 only on their arguments). It is not intended to custody funds.
 
+`deposit`/`withdraw` are guarded `onlyDelegateCall`: a direct call to the deployed
+singleton reverts `DirectCallNotAllowed`. Without the guard a direct call would run
+`forceApprove` in the adapter's own context and plant an attacker-chosen ERC-20
+allowance from the shared singleton — harmless only while the adapter holds no
+balance, but armable in advance and permanent. The guard enforces the
+delegatecall-only invariant in code rather than relying on that convention.
+
 ## Assumptions
 
 Assumes a **standard ERC-4626** vault (deposit consumes exactly the requested

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -129,6 +129,30 @@ The per-vault admin is OZ's two-step `owner`
 (`transferOwnership` / `acceptOwnership`). `renounceOwnership` is disabled — a
 custody contract must never be left ownerless.
 
+## Fee rate changes — trust model
+
+`setFeeRate` accrues at the OLD rate first, so management and performance fees
+are never charged retroactively across a change. The asset-side deposit and
+withdrawal rates have no such carry-over: a new rate binds the next transaction
+in the same block. The owner can therefore raise the withdrawal rate to the
+factory bound for exactly the block that carries a victim's already-signed
+`redeem`/`withdraw` and lower it afterwards — a one-block fee sandwich against
+plain ERC-4626 callers.
+
+This is accepted design. The per-vault owner (the integrator) is trusted not to
+act against its own depositors — the same trust the access gate already requires.
+Three things bound it:
+
+- The rate can never exceed the factory's live `feeBounds` for the type, which
+  LI.FI governance sets within the immutable bytecode cap (20% for both deposit
+  and withdrawal). Setting the bound to the smallest workable value shrinks the
+  worst case.
+- The EIP-5143 slippage overloads bound the assets a caller actually pays, so a
+  caller that passes a floor is protected regardless of an in-flight rate change.
+- The owner authority model is pluggable: an integrator that wants to give up the
+  instant-change lever can own its instance through a timelock, making every rate
+  change delayed and publicly visible before it can bind.
+
 ## Initialization
 
 `initialize` is called once by the factory immediately after the proxy is

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -123,6 +123,15 @@ per-vault owner (the integrator) is therefore trusted not to brick its own
 exits. There is no instance-level counter-lever; the only subsystem-wide remedy
 is a beacon upgrade behind the 48h timelock.
 
+The same trust covers LI.FI's own cut. A gate the integrator controls can flag
+the live `lifiFeeRecipient` as sanctioned, so once `distributeFees` mints LI.FI's
+share-side fees (management, performance) to that address they can be neither
+redeemed nor transferred out — confiscating the accrued balance even though the
+recipient is read live from the factory. The integrator is trusted not to
+sanction the LI.FI recipient in its own gate. This reaches only the share-side
+fees; deposit and withdrawal fees settle in the asset token, which the gate does
+not touch.
+
 ## Admin role
 
 The per-vault admin is OZ's two-step `owner`

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -110,6 +110,19 @@ accepted by design, every bound deriving from the offset alone:
   sub-wei flooring of the gain measurement. Bounded, holder-favouring, never
   a depositor loss.
 
+## Access gate — trust model
+
+The pluggable `IAccessGate` is the one per-vault privilege with **no factory
+allowlist** behind it: unlike `adapter` and `underlying`, the owner installs
+arbitrary gate code through `setAccessGate` with no vetting. This is deliberate.
+The gate runs fail-closed on entry, transfers, and exits, so a faulty or hostile
+gate can freeze the integrator's own depositors while the fee engine keeps
+accruing on the frozen AUM — but that blast radius is confined to the
+integrator's own product, and `setAccessGate` reverses it instantly. The
+per-vault owner (the integrator) is therefore trusted not to brick its own
+exits. There is no instance-level counter-lever; the only subsystem-wide remedy
+is a beacon upgrade behind the 48h timelock.
+
 ## Admin role
 
 The per-vault admin is OZ's two-step `owner`

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -910,9 +910,14 @@ contract LiFiVaultWrapper is
 
     /// @notice Sets or clears this instance's access gate.
     /// @dev Owner-only and instant, like every other per-vault setter — the integrator
-    ///      brings their own authority model (EOA/multisig/timelock). The gate is not
-    ///      probed or validated: a misconfigured gate closes the instance fail-closed
-    ///      until this setter repairs it, and only harms the integrator's own product.
+    ///      brings their own authority model (EOA/multisig/timelock). Unlike `adapter`
+    ///      and `underlying`, the gate carries no factory allowlist: the per-vault owner
+    ///      (the integrator) installs arbitrary gate code here with no vetting. This is
+    ///      deliberate — a faulty or hostile gate closes only that integrator's own
+    ///      product fail-closed (freezing its own depositors) and is reversible here at
+    ///      any moment, so the owner is trusted not to brick its own exits. The gate is
+    ///      not probed or validated: a misconfigured gate closes the instance fail-closed
+    ///      until this setter repairs it.
     /// @param _accessGate The new gate; address(0) = fully permissionless.
     function setAccessGate(address _accessGate) external onlyOwner {
         accessGate = _accessGate;

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -756,6 +756,14 @@ contract LiFiVaultWrapper is
     ///      re-anchor is skipped while supply is zero: with no holders there is no
     ///      disabled-period growth to exclude, and the accrual's own up-only ratchet
     ///      anchors the empty-vault price at the next operation.
+    ///      The asset-side deposit/withdrawal rates carry no equivalent old-rate accrual:
+    ///      a new rate binds the next transaction in the same block, so the owner could
+    ///      briefly raise the withdrawal rate around a victim's already-signed exit. This
+    ///      is accepted design — the integrator is trusted not to act against its own
+    ///      depositors (the same trust the access gate requires), the rate is capped by the
+    ///      factory's live `feeBounds`, the EIP-5143 overloads bound what a caller actually
+    ///      pays, and an integrator can own its instance through a timelock to make every
+    ///      rate change delayed and publicly visible before it binds.
     ///      `nonReentrant` because this is the only `_accrueFees` caller outside the entry/
     ///      exit/`distributeFees` guard: without it, a payout hook fired during
     ///      `distributeFees` could reenter here (owner-controlled receiver), book fresh fees,

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -68,9 +68,10 @@ contract LiFiVaultWrapper is
     // OZ v5's ReentrancyGuard keeps its status in a fixed ERC-7201 namespaced slot
     // (it is @custom:stateless), not a sequential one, so it occupies no slot in this
     // layout and is collision-free behind a beacon proxy — which is why OZ ships no
-    // separate Upgradeable variant. The check treats the proxy's uninitialized status
-    // slot as NOT_ENTERED, so the guard is correct from the first call even though the
-    // implementation's constructor never ran in the proxy's storage context.
+    // separate Upgradeable variant. The guard reverts only when that slot reads ENTERED,
+    // so a proxy's zero-valued slot (the implementation's constructor never ran in the
+    // proxy's storage context) reads as not-entered and the guard is correct from the
+    // first call.
     ReentrancyGuard,
     ILiFiVaultWrapper
 {
@@ -1012,9 +1013,13 @@ contract LiFiVaultWrapper is
     ///      floors to zero shares is dropped — at most ~one share's worth of assets per
     ///      accrual, favouring holders. The performance fee is charged AFTER the
     ///      management dilution (perf is net of management). The watermark ratchets up to
-    ///      the live post-crystallization price on EVERY perf-enabled accrual: like
-    ///      elapsed time, a gain is charged or forgiven per accrual, never left pending
-    ///      against a stale mark.
+    ///      the post-crystallization price on EVERY perf-enabled accrual, but that price is
+    ///      measured on the floored `PPS_SCALE` grid: a gain of at least one grid unit is
+    ///      charged now, while a smaller gain moves neither the fee nor the mark and is
+    ///      neither charged nor forgiven — it stays in AUM and is charged once cumulative
+    ///      gains cross a grid unit. The collected fee is therefore independent of how
+    ///      often accrual runs (see `LibVaultWrapperMath.performanceFeeAssets`), unlike the
+    ///      management side above, whose sub-share elapsed time IS dropped per accrual.
     function _accrueFees() private {
         bool mgmtEnabled = _rate(FeeType.Management) != 0;
         bool perfEnabled = _rate(FeeType.Performance) != 0;
@@ -1042,10 +1047,12 @@ contract LiFiVaultWrapper is
             supply += perfShares;
         }
 
-        // Up-only ratchet on every accrual: any gain above the mark is charged or
-        // forgiven now, never left stale, so pre-entry gains (yield or donation) cannot
-        // be charged to a later depositor at any supply. Up-only, never assignment:
-        // floating down after a loss would re-charge the recovery.
+        // Up-only ratchet on every accrual, to the floored grid price: a gain of at least
+        // one PPS grid unit above the mark is charged now (so pre-entry gains — yield or
+        // donation — cannot be charged to a later depositor at any supply); a smaller gain
+        // leaves the floored price, and so the mark, unchanged and stays in AUM until
+        // cumulative gains cross a grid unit. Up-only, never assignment: floating down
+        // after a loss would re-charge the recovery.
         uint192 currentPps = _postDilutionPps(supply, assets);
         if (currentPps > perfHighWaterMarkPps) {
             perfHighWaterMarkPps = currentPps;
@@ -1217,9 +1224,10 @@ contract LiFiVaultWrapper is
     ///      split dust (at most 1 wei per accrual) goes to LI.FI. Accumulation
     ///      SATURATES at the uint128 counter max instead of reverting: this runs
     ///      inside `_accrueFees` on every operation including exits, so an
-    ///      overflowing counter must under-attribute payout entitlements (unreachable
-    ///      for any real asset — it requires a cumulative fee of 2^128 wei) rather
-    ///      than permanently brick withdrawals.
+    ///      overflowing counter must under-attribute payout entitlements rather than
+    ///      permanently brick withdrawals. Unreachable for any real vault — it needs a
+    ///      cumulative accrued 2^128 in the counter's own unit: fee-shares for the
+    ///      share-side counters, asset-wei for the asset-side ones.
     /// @param _feeType The fee type whose share to apply.
     /// @param _feeTotal The total fee amount to split.
     /// @param _lifiAccrued Current LI.FI counter value.

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -27,7 +27,7 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 2.0.0
+/// @custom:version 1.0.0
 contract ERC4626Adapter is IYieldAdapter {
     /// @dev This adapter's own deployed address, captured at construction. Under
     ///      `delegatecall` the running `address(this)` is the calling wrapper, so it

--- a/src/VaultWrapper/adapters/ERC4626Adapter.sol
+++ b/src/VaultWrapper/adapters/ERC4626Adapter.sol
@@ -15,8 +15,10 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      `delegatecall` from a wrapper (they run in the wrapper's context and act only on
 ///      their arguments). `resolveAsset`/`totalAssets` are ordinary view calls.
 ///      This contract is not intended to custody funds; under `delegatecall` the assets
-///      and yield-source shares belong to the calling wrapper, and a direct call holds
-///      nothing.
+///      and yield-source shares belong to the calling wrapper. `deposit`/`withdraw` are
+///      `onlyDelegateCall` — a direct call reverts `DirectCallNotAllowed`, so the adapter
+///      never runs `forceApprove` in its own (fund-less) context and cannot be made to
+///      grant a stray allowance from the shared singleton.
 ///      Assumes a STANDARD ERC-4626 (deposit consumes exactly the requested assets,
 ///      withdraw returns exactly the requested assets) over a non-fee-on-transfer asset.
 ///      `deposit`/`withdraw` return the wrapper's asset balance delta and the wrapper
@@ -25,8 +27,28 @@ import { IYieldAdapter } from "../interfaces/IYieldAdapter.sol";
 ///      credits fewer shares via an internal deposit fee) — measuring that cleanly is
 ///      rounding-sensitive; such non-standard sources are unsupported and require a
 ///      dedicated adapter rather than this reference one.
-/// @custom:version 1.0.0
+/// @custom:version 2.0.0
 contract ERC4626Adapter is IYieldAdapter {
+    /// @dev This adapter's own deployed address, captured at construction. Under
+    ///      `delegatecall` the running `address(this)` is the calling wrapper, so it
+    ///      never equals `SELF`; a direct call to the deployed adapter does — which is
+    ///      how `onlyDelegateCall` tells the two apart.
+    address private immutable SELF = address(this);
+
+    /// @notice Thrown when a `delegatecall`-only method is invoked directly on the
+    ///         deployed adapter.
+    error DirectCallNotAllowed();
+
+    /// @dev Restricts a method to the `delegatecall` path. A direct call runs with
+    ///      `address(this) == SELF` and is rejected; under `delegatecall` the wrapper's
+    ///      address differs from `SELF` and the call proceeds. Guards `deposit`/`withdraw`
+    ///      only: without it a direct call runs `forceApprove` in the adapter's own
+    ///      context, planting an attacker-chosen allowance from the shared singleton.
+    modifier onlyDelegateCall() {
+        if (address(this) == SELF) revert DirectCallNotAllowed();
+        _;
+    }
+
     /// @inheritdoc IYieldAdapter
     function resolveAsset(
         address _underlying
@@ -54,7 +76,7 @@ contract ERC4626Adapter is IYieldAdapter {
         address _asset,
         address _underlying,
         uint256 _assets
-    ) external returns (uint256 deposited) {
+    ) external onlyDelegateCall returns (uint256 deposited) {
         uint256 balanceBefore = IERC20(_asset).balanceOf(address(this));
         SafeERC20.forceApprove(IERC20(_asset), _underlying, _assets);
         IERC4626(_underlying).deposit({
@@ -72,7 +94,7 @@ contract ERC4626Adapter is IYieldAdapter {
         address _asset,
         address _underlying,
         uint256 _assets
-    ) external returns (uint256 withdrawn) {
+    ) external onlyDelegateCall returns (uint256 withdrawn) {
         uint256 balanceBefore = IERC20(_asset).balanceOf(address(this));
         IERC4626(_underlying).withdraw({
             assets: _assets,

--- a/src/VaultWrapper/interfaces/IYieldAdapter.sol
+++ b/src/VaultWrapper/interfaces/IYieldAdapter.sol
@@ -19,7 +19,9 @@ pragma solidity ^0.8.29;
 ///        positions are the wrapper's. They MUST be stateless with respect to adapter
 ///        storage (no reads or writes of adapter state) so a shared adapter cannot
 ///        corrupt or be corrupted by the wrapper's storage layout; they may only act on
-///        their arguments and external calls.
+///        their arguments and external calls. Because a direct call would instead run in
+///        the adapter's own context, adapters MUST reject non-`delegatecall` invocation
+///        of these two methods (see `ERC4626Adapter.onlyDelegateCall`).
 /// @custom:version 1.0.0
 interface IYieldAdapter {
     /// @notice Thrown when the adapter cannot resolve the underlying's asset.

--- a/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
+++ b/test/solidity/VaultWrapper/adapters/ERC4626Adapter.t.sol
@@ -101,4 +101,16 @@ contract ERC4626AdapterTest is Test {
             300e18
         );
     }
+
+    function testRevert_DirectDepositCall() public {
+        vm.expectRevert(ERC4626Adapter.DirectCallNotAllowed.selector);
+
+        adapter.deposit(address(asset), address(vault), 1e18);
+    }
+
+    function testRevert_DirectWithdrawCall() public {
+        vm.expectRevert(ERC4626Adapter.DirectCallNotAllowed.selector);
+
+        adapter.withdraw(address(asset), address(vault), 1e18);
+    }
 }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_Triage of the Pashov audit report (`contracts-pashov-ai-audit-report-20260821-001322.md`) for the LI.FI Earn Vault Wrapper. Add the EXSC ticket ID here._

# Why did I implement it this way?

This PR resolves the accepted-design and stale-comment findings from the audit that need no logic change, plus one small in-scope hardening fix. It does **not** include the sub-share-deposit DoS finding (mint against a zero-share source credit), which needs a `_deposit` guard and is tracked separately.

**Code fix**

- `ERC4626Adapter.deposit`/`withdraw` are now `onlyDelegateCall` (revert `DirectCallNotAllowed`). A direct call to the deployed singleton would run `forceApprove` in the adapter's own context and plant an attacker-chosen ERC-20 allowance from the shared singleton — harmless while the adapter holds no balance, but armable in advance. The guard enforces the delegatecall-only invariant in code. Adapter stays at `1.0.0` — the new revert would normally be a MAJOR bump, but the subsystem is pre-audit and pre-deploy with no shipped version to bump from. The invariant is documented in `IYieldAdapter`.

**Trust-model documentation** (`docs/VaultWrapper/LiFiVaultWrapper.md` + contract NatSpec)

- Access gate can freeze the integrator's own exits; blast radius is confined to that integrator's product and `setAccessGate` reverses it — the owner is trusted not to brick its own exits.
- Instant deposit/withdrawal fee-rate changes are a one-block fee sandwich primitive; accepted design bounded by the factory `feeBounds`, EIP-5143 overloads, and an optional owner-side timelock. The integrator is trusted not to act against its own depositors.
- A gate the integrator controls can sanction the live `lifiFeeRecipient` and strand LI.FI's share-side fees; the integrator is trusted not to sanction the LI.FI recipient.

**Stale-comment corrections** (comment-only, no behavioral change)

- `_accrueFees`: describe the floored `PPS_SCALE`-grid ratchet (sub-grid gains stay in AUM until cumulative gains cross a grid unit), matching `LibVaultWrapperMath.performanceFeeAssets` — replacing the old "charged or forgiven per accrual" wording that predated the frequency-independence change (#2245).
- `_splitFee`: state the uint128 saturation bound in each counter's own unit (fee-shares for the share-side counters, asset-wei for the asset-side ones), not "wei".
- `ReentrancyGuard` header: the guard reverts only when the slot reads `ENTERED`, so a proxy's zero-valued slot reads as not-entered.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
