### PR TITLE
fix(scripts): stop logging explorer API keys in verifyContract (EXSC-825)

### DIFF
--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2145,7 +2145,7 @@ function extractFromVerificationOutput() {
 # API-key values must never reach a log: verification runs in CI and in shared
 # transcripts, and a leaked explorer key cannot be un-leaked.
 function redactVerifyCmd() {
-  echo "$*" | sed -E 's/(--(etherscan|verifier)-api-key)[[:space:]]+[^[:space:]]+/\1 ***REDACTED***/g'
+  echo "$@" | sed -E 's/(--(etherscan|verifier)-api-key)[[:space:]]+[^[:space:]]+/\1 ***REDACTED***/g'
 }
 
 function verifyContract() {

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2143,9 +2143,35 @@ function extractFromVerificationOutput() {
 }
 
 # API-key values must never reach a log: verification runs in CI and in shared
-# transcripts, and a leaked explorer key cannot be un-leaked.
+# transcripts, and a leaked explorer key cannot be un-leaked. Redaction runs per
+# argument (never over a joined string) so a key containing whitespace or a
+# newline cannot spill its tail past the substitution, and remaining arguments
+# are quoted with %q so their boundaries stay visible in the log.
 function redactVerifyCmd() {
-  echo "$@" | sed -E 's/(--(etherscan|verifier)-api-key)[[:space:]]+[^[:space:]]+/\1 ***REDACTED***/g'
+  local PLACEHOLDER='***REDACTED***'
+  local OUTPUT=''
+  local ARG
+  local RENDERED
+  local REDACT_NEXT=false
+
+  for ARG in "$@"; do
+    if [[ "$REDACT_NEXT" == true ]]; then
+      # redacted unconditionally, even when it looks like a flag: an unredacted
+      # key is unrecoverable, a redacted flag name only costs log detail
+      RENDERED="$PLACEHOLDER"
+      REDACT_NEXT=false
+    elif [[ "$ARG" == "--etherscan-api-key" || "$ARG" == "--verifier-api-key" ]]; then
+      RENDERED="$ARG"
+      REDACT_NEXT=true
+    elif [[ "$ARG" == "--etherscan-api-key="* || "$ARG" == "--verifier-api-key="* ]]; then
+      RENDERED="${ARG%%=*}=$PLACEHOLDER"
+    else
+      RENDERED=$(printf '%q' "$ARG")
+    fi
+    OUTPUT+="${OUTPUT:+ }$RENDERED"
+  done
+
+  printf '%s\n' "$OUTPUT"
 }
 
 function verifyContract() {

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2142,6 +2142,12 @@ function extractFromVerificationOutput() {
   fi
 }
 
+# API-key values must never reach a log: verification runs in CI and in shared
+# transcripts, and a leaked explorer key cannot be un-leaked.
+function redactVerifyCmd() {
+  echo "$*" | sed -E 's/(--(etherscan|verifier)-api-key)[[:space:]]+[^[:space:]]+/\1 ***REDACTED***/g'
+}
+
 function verifyContract() {
   # read function arguments into variables
   local NETWORK=$1
@@ -2236,7 +2242,7 @@ function verifyContract() {
     )
   fi
 
-  echo "VERIFY_CMD: ${VERIFY_CMD[*]}"
+  echo "VERIFY_CMD: $(redactVerifyCmd "${VERIFY_CMD[@]}")"
 
   # Normalize constructor args: use only the first line to avoid passing multiline values
   # (e.g. from broadcast JSON or jq output), which forge/etherscan can interpret as
@@ -2355,13 +2361,13 @@ function verifyContract() {
   # Always add verifier URL and chain ID so Foundry/verifier use the correct chain (avoids "deployed on mainnet" and 404s)
   VERIFY_CMD+=("--verifier-url" "$VERIFIER_URL" "--chain-id" "$CHAIN_ID")
 
-  echoDebug "VERIFY_CMD: ${VERIFY_CMD[*]}"
+  echoDebug "VERIFY_CMD: $(redactVerifyCmd "${VERIFY_CMD[@]}")"
 
   # Attempt verification with retries (for cases where block explorer isn't synced)
   while [ $RETRY_COUNT -lt "$MAX_RETRIES" ]; do
     echo "[info] Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES: Submitting verification for [$FULL_PATH] $ADDRESS..."
     echo "[info] ...using the following command: "
-    echo "[info] ${VERIFY_CMD[*]}"
+    echo "[info] $(redactVerifyCmd "${VERIFY_CMD[@]}")"
 
     # Execute verification command with --watch flag (will wait for completion)
     local VERIFY_EXIT_CODE=0

--- a/script/redactVerifyCmd.test.ts
+++ b/script/redactVerifyCmd.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for redactVerifyCmd (script/helperFunctions.sh).
+ *
+ * Explorer API keys are passed to `forge verify-contract` as command arguments and the
+ * command is echoed into CI logs. Redaction therefore has to survive keys that contain
+ * whitespace or newlines, which a substitution over the joined command string does not.
+ */
+import { execFileSync } from 'child_process'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..')
+
+/**
+ * Call redactVerifyCmd with the given arguments and return its trimmed output.
+ *
+ * @param args - arguments to pass to redactVerifyCmd
+ */
+function redact(args: string[]): string {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      'source script/helperFunctions.sh >/dev/null 2>&1; redactVerifyCmd "$@"',
+      'harness',
+      ...args,
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  ).trim()
+}
+
+describe('redactVerifyCmd', () => {
+  it('redacts the value of both API-key flags', () => {
+    const output = redact([
+      'forge',
+      'verify-contract',
+      '--etherscan-api-key',
+      'secret-etherscan',
+      '--verifier-api-key',
+      'secret-verifier',
+    ])
+
+    expect(output).not.toContain('secret-etherscan')
+    expect(output).not.toContain('secret-verifier')
+    expect(output).toContain('--etherscan-api-key ***REDACTED***')
+    expect(output).toContain('--verifier-api-key ***REDACTED***')
+  })
+
+  it('redacts the equals form of both API-key flags', () => {
+    const output = redact([
+      '--etherscan-api-key=secret-etherscan',
+      '--verifier-api-key=secret-verifier',
+    ])
+
+    expect(output).not.toContain('secret-etherscan')
+    expect(output).not.toContain('secret-verifier')
+    expect(output).toContain('--etherscan-api-key=***REDACTED***')
+    expect(output).toContain('--verifier-api-key=***REDACTED***')
+  })
+
+  it('redacts a key containing whitespace without leaking its tail', () => {
+    const output = redact([
+      '--etherscan-api-key',
+      'leading tail-of-the-key',
+      '--chain-id',
+      '1',
+    ])
+
+    expect(output).not.toContain('tail-of-the-key')
+    expect(output).toContain('--chain-id 1')
+  })
+
+  it('redacts a key containing a newline without leaking its tail', () => {
+    const output = redact([
+      '--verifier-api-key',
+      'leading\ntail-of-the-key',
+      '--chain-id',
+      '1',
+    ])
+
+    expect(output).not.toContain('tail-of-the-key')
+    expect(output).toContain('--chain-id 1')
+  })
+
+  it('redacts an empty key value without shifting the remaining arguments', () => {
+    const output = redact(['--etherscan-api-key', '', '--chain-id', '1'])
+
+    expect(output).toBe('--etherscan-api-key ***REDACTED*** --chain-id 1')
+  })
+
+  it('keeps arguments separated when a non-key argument contains whitespace', () => {
+    const output = redact(['--constructor-args', 'a b', '--chain-id', '1'])
+
+    expect(output).toContain('--chain-id 1')
+    expect(output).toMatch(/--constructor-args\s+('a b'|a\\ b)/)
+  })
+
+  it('does not fail when the API-key flag has no value at all', () => {
+    expect(redact(['--chain-id', '1', '--etherscan-api-key'])).toBe(
+      '--chain-id 1 --etherscan-api-key'
+    )
+  })
+
+  it('returns nothing when called without arguments', () => {
+    expect(redact([])).toBe('')
+  })
+})


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-825/verifycontract-logs-explorer-api-keys-into-deploy-output

# Why did I implement it this way?

`verifyContract` echoed the fully-expanded `forge verify-contract` command three times. Once `--etherscan-api-key` / `--verifier-api-key` are appended to `VERIFY_CMD`, those echoes print the **live explorer API key in plaintext**.

This is not theoretical: the EXSC-823 ReceiverOIF rollout (one 10-network production deploy) wrote the key into its log **22 times**. Deploy logs get pasted into tickets, shared in CI output and read in transcripts, and a leaked explorer key cannot be un-leaked.

Rather than dropping the log lines — they are genuinely useful when a verification fails and you want to rerun the exact command — this routes every echo of the command through a small `redactVerifyCmd` helper that masks only the value following the two key flags.

All three echo sites are routed through it, **including the one that is key-free today** (it runs before the key is appended). That site is harmless right now, but redacting it too makes the invariant "every echo of `VERIFY_CMD` is redacted" hold independently of the order in which flags get appended, so a future reordering cannot silently reintroduce the leak.

Verified against real data rather than assumed:

- Positive case per flag — `--etherscan-api-key` and `--verifier-api-key` values are both masked.
- Negative control — a command containing no key passes through byte-identical, so the helper cannot quietly mangle unrelated commands.
- Checked the actual rollout log: all 22 occurrences came from these echoes, and none leaked via `VERIFY_OUTPUT` or a request query string. Redacting the echoes therefore closes the complete path.

## Follow-up (not in this PR)

The key exposed by the EXSC-823 deploy reached a transcript and **should be rotated**.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
