### PR TITLE
docs(skills): resolve required companion periphery at target resolution (EXSC-826)

### DIFF
--- a/.agents/commands/deploy-contract.md
+++ b/.agents/commands/deploy-contract.md
@@ -68,6 +68,22 @@ jq -e --arg N "<Contract>" '.whitelistPeripheryFunctions | has($N)' config/globa
 
 If it matches, Phase 3b runs an allowlist sync afterwards (a second production proposal). No manual `whitelist.json` editing: the sync derives the address + selectors from `global.json.whitelistPeripheryFunctions` automatically. Facets and non-diamond-called periphery skip Phase 3b.
 
+**Facets with a required companion periphery.** A bridge facet usually covers only the source side; destination calls are completed by a partner contract on the same chain (`LiFiIntentEscrowFacetV2` → `ReceiverOIF`, `StargateFacetV2` → `ReceiverStargateV2`). Deploying the facet alone silently disables inbound transfers there. Detect deterministically:
+
+```bash
+jq -r --arg N "<Contract>" '.facetPeripheryCouplings[$N].requires // empty' config/global.json
+```
+
+If it names a companion, check every target network and **add the ones missing it to this deploy's target list**. An empty string or `MISSING` means it is not registered in that diamond:
+
+```bash
+jq -r --arg C "<Companion>" '.LiFiDiamond.Periphery[$C] // "MISSING"' deployments/<net>.diamond.json
+```
+
+`notRequiredOn` in the same coupling entry names networks where the companion is deliberately absent — respect it rather than deploying over it.
+
+Resolve this here, at target resolution, rather than relying on the existing tooling: the pipeline's `facetCompanionReminder.ts` is a non-fatal nudge that only checks the flat deploy log, so it falls silent once the companion is deployed even if it was never registered, and it is easily lost in an interleaved multi-network log; the enforcing `facet-required-periphery` health-check invariant only catches the gap after the fact. The reminder was already in place when a ten-chain facet rollout shipped without its receiver and disabled inbound traffic on all ten (EXSC-823).
+
 ## Phase 2 — Confirm plan
 
 Present: contract + version (old → new per network), the full network list, environment, and what will be created (per network: one registration; **two** for a diamond-called periphery — registration + allowlist; in production each is a timelock-wrapped Safe proposal). Wait for explicit go-ahead — deployments cost gas and, in production, mint Safe proposals on many chains.

--- a/.agents/commands/multisig-rollout.md
+++ b/.agents/commands/multisig-rollout.md
@@ -63,6 +63,8 @@ Repo version: `grep -m1 "@custom:version" src/Facets/<Contract>.sol` (or `src/Pe
 jq -e --arg N "<Contract>" '.whitelistPeripheryFunctions | has($N)' config/global.json
 ```
 
+Also resolve any **required companion periphery** before confirming the plan — a facet with a `facetPeripheryCouplings` entry in `config/global.json` needs its companion deployed *and* registered on every target chain, or destination calls stay disabled there. `deploy-contract` Phase 1 carries the detection recipes; run them here too, since propose-only and whitelist modes never call that skill.
+
 ### propose-only mode — resolve targets
 
 Triggered by `--propose-only <Contract>` (or natural language: “create the cuts”, “propose already-deployed”, “re-propose after delete”). **Do not deploy.**


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-826/deploy-skills-never-mention-facetperipherycouplings-so-companions

# Why did I implement it this way?

A bridge facet usually covers only the source side; destination calls are completed by a companion contract on the same chain (`LiFiIntentEscrowFacetV2` → `ReceiverOIF`, `StargateFacetV2` → `ReceiverStargateV2`). The couplings are declared in `config/global.json` → `facetPeripheryCouplings`, but **neither deploy skill mentioned them anywhere**, so the companion was never part of target resolution. A ten-chain `LiFiIntentEscrowFacetV2` rollout (#2231) shipped the facet alone and silently disabled inbound LI.FI Intents traffic on all ten chains (EXSC-823).

## Why this is documentation and not more tooling

The obvious reaction is "add a check to the deploy pipeline". There already is one, and it did not help:

`facetCompanionReminder.ts` (EXSC-785, #2211) landed **2026-08-18**, three days *before* #2231 merged on **2026-08-21**. It was in place and the rollout still went out incomplete, because:

1. It only tests the **flat deploy log** (`!deployedContracts[companion]`), so it falls silent the moment the companion is deployed — even if it was never registered in the diamond. It structurally cannot catch "deployed but unregistered", which is half of this failure mode.
2. It is a non-fatal nudge printed mid-deploy; a ten-network run emits thousands of `[network]`-prefixed interleaved lines and one warning is easily lost.
3. The enforcing check — the `facet-required-periphery` health-check invariant — is post-hoc, and its workflow (`healthCheckAllNetworks.yml`) has been `disabled_manually` since 2026-08-07, so nothing reported the gap for weeks.

So the gap is at **planning time**: the companion has to enter the target list before the plan is confirmed and gas is spent. That is a skill-doc concern, which is what this PR fixes.

## Change

Placed as a sibling to the existing "Diamond-called periphery needs a second proposal" block, which has the same shape (a deterministic `jq` detection stated at target-resolution time):

- **`.agents/commands/deploy-contract.md` → Phase 1** — detection recipe, the per-network registration probe, an instruction to add missing networks to the target list, a note to respect `notRequiredOn`, and a short why-not-rely-on-the-reminder rationale.
- **`.agents/commands/multisig-rollout.md` → Phase 1** — one cross-reference, because propose-only and whitelist modes resolve targets without ever calling `deploy-contract`.

Canonical `.agents/` files only — the `.cursor/` and `.claude/` copies are symlinks and were not touched.

Both `jq` recipes were run against real repo data before being written down, including a **negative control** (a facet with no coupling must print nothing) and a registration probe that distinguishes an unregistered empty string from a real address. `notRequiredOn` was verified to be a real field in `script/deploy/shared/facetPeripheryCouplings.ts` rather than only appearing in the health check's hint text.

## Deliberately not in this PR

- Strengthening `facetCompanionReminder` to check diamond registration rather than deploy-log presence.
- Re-enabling `healthCheckAllNetworks.yml` (best done once EXSC-823 and #2233 land, so the first run is near-green).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
