### PR TITLE
feat(VaultWrapper): put factory behind TransparentUpgradeableProxy

### DIFF
--- a/.agents/rules/108-vault-wrapper.md
+++ b/.agents/rules/108-vault-wrapper.md
@@ -58,6 +58,24 @@ and counter-intuitive against the repo's Diamond-era conventions.
 - Beacon `upgradeTo` is owner-gated and the owner is the subsystem governance
   (a dedicated 48h timelock). Never add an upgrade path that bypasses it.
 
+## Factory proxy ([CONV:VW-FACTORY-PROXY])
+
+- `LiFiVaultWrapperFactory` is itself upgradeable: it is deployed behind an OZ v5
+  `TransparentUpgradeableProxy`, so it is `Initializable` + `Ownable2StepUpgradeable`,
+  the constructor only calls `_disableInitializers()`, and all constructor-era state
+  (beacon, roles, fee recipient, default split) is set once in `initialize` on the
+  proxy. State (including `beacon`) lives in proxy storage — not `immutable`.
+- The proxy's `ProxyAdmin` (the sole upgrade authority) is owned by the **same 48h
+  timelock** that owns the factory and beacon, so a factory-logic upgrade passes the
+  same delay. Never add a factory upgrade path that bypasses the ProxyAdmin/timelock.
+- The wrapper implementation binds its `FACTORY` immutable to the **proxy** address
+  (predicted via CREATE3 before deploy), so instances read live factory state through
+  a stable address across factory-logic upgrades.
+- Consequence for the fee caps ([CONV:VW-FEES]): the `CAP_*` bytecode constants and
+  the `< 100%` split validation are guarantees of the **current** factory logic only —
+  a timelocked upgrade can change them. Keep docs honest about this; do not describe
+  the caps as immutable guarantees.
+
 ## OpenZeppelin version ([CONV:VW-OZ-VERSION])
 
 - The subsystem builds on **OpenZeppelin v5** — `@openzeppelin/contracts-upgradeable`

--- a/docs/VaultWrapper/LiFiVaultWrapper.md
+++ b/docs/VaultWrapper/LiFiVaultWrapper.md
@@ -184,6 +184,11 @@ proxy storage), and it is the source every instance reads for the factory-level
 global circuit breaker (`globalPaused`), fee bounds, and `lifiFeeRecipient`, as well
 as the `initialize` caller check.
 
+`FACTORY` points at the factory's `TransparentUpgradeableProxy`, not its logic
+contract, so the factory's own logic can be upgraded (through the proxy's
+timelock-owned `ProxyAdmin`) without changing the address instances read from — see
+[LiFiVaultWrapperFactory.md](./LiFiVaultWrapperFactory.md#upgradeability).
+
 Because that reference lives in implementation bytecode rather than per-instance
 storage, a beacon upgrade to an implementation constructed with a **different**
 factory address silently repoints all live instances' config authority — for

--- a/docs/VaultWrapper/LiFiVaultWrapperFactory.md
+++ b/docs/VaultWrapper/LiFiVaultWrapperFactory.md
@@ -12,13 +12,27 @@ called by the Diamond, and does not follow Diamond patterns. It builds on
 OpenZeppelin v5. It does not custody user funds; it only deploys and configures
 wrapper instances.
 
+## Upgradeability
+
+The factory is deployed behind an OpenZeppelin v5 **TransparentUpgradeableProxy**.
+The proxy's `ProxyAdmin` — the only address that can upgrade the factory logic —
+is owned by the **same 48h TimelockController** that owns the factory, so a
+factory-logic upgrade passes the same 48h delay as every other governance action.
+The logic contract's initializers are locked at construction
+(`_disableInitializers()`); state lives in the proxy and is set once through
+`initialize` at deploy.
+
+The address every wrapper instance is bound to (its `FACTORY`) is the **proxy**,
+so instances keep reading a stable factory address across logic upgrades.
+
 ## Governance
 
 The factory is owned by a dedicated **48h TimelockController** (the subsystem
 governance). Every configuration setter below is `onlyOwner`, so it can only be
 called by scheduling a batch through the timelock and executing it after the 48h
-delay (see `script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol`). Two
-roles sit outside the timelock:
+delay (see `script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol`). The
+timelock also owns the proxy's `ProxyAdmin` (factory-logic upgrades) and the
+beacon (instance-logic upgrades). Two roles sit outside the timelock:
 
 - **emergencyPauser** — trips the global circuit breaker (`globalPause` /
   `globalUnpause`).
@@ -54,7 +68,7 @@ delay.
 
 ## Fee caps
 
-Each fee type is bounded by an **immutable** bytecode cap; governance can only set
+Each fee type is bounded by a bytecode `constant` cap; governance can only set
 adjustable bounds within it:
 
 | Fee type    | Cap    |
@@ -63,6 +77,11 @@ adjustable bounds within it:
 | management  | 10%    |
 | deposit     | 20%    |
 | withdrawal  | 20%    |
+
+Because the factory is upgradeable (see [Upgradeability](#upgradeability)), these
+caps are a guarantee of the **current logic** only — a future factory-logic
+upgrade, itself gated by the 48h timelock, could change them or the split
+validation.
 
 ## Integrator onboarding (onboarding manager)
 

--- a/docs/VaultWrapper/README.md
+++ b/docs/VaultWrapper/README.md
@@ -30,10 +30,11 @@ vendored v4.9.2 core.
 
 ```
                         48h TimelockController                emergencyPauser
-                     (owns factory + beacon)               onboardingManager
+                (owns factory proxy admin + beacon)       onboardingManager
                                 |                                   |
                                 v                                   v
    UpgradeableBeacon  <----  LiFiVaultWrapperFactory  ----  global circuit breaker,
+                             (TransparentUpgradeableProxy)
    (shared impl)             - underlying allowlist          fee bounds, splits,
         |                    - approved adapters             lifiFeeRecipient
         | upgradeTo          - CREATE2 deploy (namespace)
@@ -51,9 +52,12 @@ vendored v4.9.2 core.
                                   (ReferenceAccessGate)  (ERC-4626 vault)
 ```
 
-Every instance reads its factory (an **implementation immutable**, `FACTORY`) live
-for the global pause flag, fee bounds, and `lifiFeeRecipient`. A beacon
-`upgradeTo` repoints every live instance at once.
+Every instance reads its factory (an **implementation immutable**, `FACTORY`,
+bound to the factory **proxy**) live for the global pause flag, fee bounds, and
+`lifiFeeRecipient`. A beacon `upgradeTo` repoints every live instance's logic at
+once; a factory-logic upgrade goes through the proxy's `ProxyAdmin` (also
+timelock-owned) and is invisible to instances because they hold the stable proxy
+address.
 
 ## Contracts
 
@@ -81,7 +85,7 @@ suites, plus `mocks/`); the Foundry deploy scripts live under
 
 | Role | Held by | Can do | Constraints |
 | --- | --- | --- | --- |
-| Factory owner | dedicated 48h `TimelockController` | every factory setter (allowlist, adapter approvals, fee bounds, default split, `lifiFeeRecipient`, role rotation), beacon `upgradeTo` | all changes pass the 48h delay |
+| Factory owner | dedicated 48h `TimelockController` | every factory setter (allowlist, adapter approvals, fee bounds, default split, `lifiFeeRecipient`, role rotation), beacon `upgradeTo`, factory-logic upgrade via the proxy `ProxyAdmin` | all changes pass the 48h delay |
 | Emergency pauser | EOA/Safe set by the owner | `globalPause` / `globalUnpause` (deposit circuit breaker) | no delay; cannot block withdrawals |
 | Onboarding manager | EOA/Safe set by the owner | assign/revoke an integrator's deployer; may deploy any instance | — |
 | Approved integrator deployer | per-namespace, set by onboarding manager | `deploy` under its namespace | integrator share ≤ factory default (can give LI.FI more, never less) |
@@ -95,8 +99,9 @@ close the deposit/mint path.
 Four fee types, each split between LI.FI and the integrator at accrual time and
 paid out by a permissionless `distributeFees`. **Every fee type is optional** — a
 zero rate disables it, so an instance can enable any subset (or none). Each type
-is bounded by an **immutable bytecode cap**; governance sets adjustable bounds
-within it.
+is bounded by a bytecode `constant` cap; governance sets adjustable bounds within
+it. Because the factory is upgradeable, that cap is a guarantee of the current
+factory logic only — a future timelocked factory-logic upgrade could change it.
 
 | Fee type | Cap | Kind |
 | --- | --- | --- |
@@ -114,9 +119,13 @@ only. Full mechanics: [LiFiVaultWrapper.md](./LiFiVaultWrapper.md).
 Consolidated from the per-contract docs; each links to its full treatment.
 
 - **Governance is trusted within the 48h delay.** The timelock owns the factory
-  and the beacon. A beacon upgrade can replace instance logic arbitrarily, so the
-  timelock is the ultimate authority over every live instance. Every impl the
-  beacon points to must be constructed with the same `FACTORY` address — see
+  (through its proxy `ProxyAdmin`) and the beacon. Two upgrade vectors sit behind
+  the delay: a beacon `upgradeTo` replaces instance logic arbitrarily, and a
+  factory-logic upgrade through the proxy can rewrite factory rules — including the
+  fee caps and split validation that are otherwise fixed in bytecode. The timelock
+  is therefore the ultimate authority over every live instance and over the factory
+  rules themselves. Every impl the beacon points to must be constructed with the
+  same `FACTORY` address (the factory proxy) — see
   [upgradeability](./LiFiVaultWrapper.md#upgradeability-and-the-factory-binding).
 - **The per-vault owner (integrator) is trusted not to act against its own
   depositors or against LI.FI's fee recipient.** It installs arbitrary access-gate
@@ -163,7 +172,7 @@ over both an unlimited source and a fuzzed-liquidity source, with
 - **OpenZeppelin v5** — `@openzeppelin/contracts` core and
   `@openzeppelin/contracts-upgradeable` (`ERC4626Upgradeable`,
   `Ownable2StepUpgradeable`, `UpgradeableBeacon`, `BeaconProxy`,
-  `TimelockController`, `Create2`).
+  `TransparentUpgradeableProxy`, `ProxyAdmin`, `TimelockController`, `Create2`).
 - **Solady** — `MetadataReaderLib` (reads underlying token metadata defensively).
 - **Optional, integrator-side** — `ReferenceAccessGate` can back `isSanctioned`
   with an external Chainalysis `SanctionsList` (identical signature); the bundled
@@ -180,7 +189,13 @@ over both an unlimited source and a fuzzed-liquidity source, with
   live instance. Changing the adapter a wrapper routes through is only reachable
   through a beacon `upgradeTo` to new implementation logic, i.e. under the 48h
   timelock.
-- The factory and beacon are deployed and wired by
+- The factory is deployed behind a `TransparentUpgradeableProxy`; its logic is
+  upgradeable through the proxy's `ProxyAdmin`, owned by the 48h timelock (the
+  same authority that owns the factory and beacon). The logic contract's
+  initializers are disabled at construction; factory state is set once through
+  `initialize` on the proxy at deploy. Instances bind to the proxy address, so a
+  factory-logic upgrade is transparent to them.
+- The factory (proxy + logic) and beacon are deployed and wired by
   `script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol` and owned by
   the 48h timelock. Per-network parameters come from `config/vaultWrapper.json`.
 - Factory config is timelock-owned: `UpdateVaultWrapperConfig.s.sol` does not

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -272,10 +272,22 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
         if (_factory.lifiFeeRecipient() != _cfg.lifiFeeRecipient)
             revert WiringMismatch("factory.lifiFeeRecipient");
 
-        // The logic contract must not be usable on its own: its initializers are
-        // locked by the constructor's _disableInitializers().
-        if (_factoryLogic.code.length == 0)
-            revert WiringMismatch("factory.logic");
+        // The proxy must delegate to exactly the logic deployed this run. CREATE3
+        // salts exclude creation code, so a re-run that reuses the proxy salt keeps
+        // the live implementation slot pointing at the old logic while the earlier
+        // through-proxy checks still pass — this catches that stale linkage.
+        address liveImpl = address(
+            uint160(
+                uint256(
+                    vm.load(
+                        address(_factory),
+                        ERC1967Utils.IMPLEMENTATION_SLOT
+                    )
+                )
+            )
+        );
+        if (liveImpl != _factoryLogic)
+            revert WiringMismatch("factory.implementation");
     }
 
     /// @notice Deploys the dedicated 48h timelock (proposer/canceller = multisig,

--- a/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
+++ b/script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol
@@ -5,6 +5,9 @@ import { Script, stdJson } from "forge-std/Script.sol";
 import { DSTest } from "ds-test/test.sol";
 import { TimelockController } from "@openzeppelin/contracts/governance/TimelockController.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ERC1967Utils } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import { ICREATE3Factory } from "create3-factory/ICREATE3Factory.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
@@ -14,24 +17,28 @@ import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 /// @author LI.FI (https://li.fi)
 /// @notice Deploys and wires the vault wrapper system deterministically via the
 ///         shared CREATE3 factory: the dedicated 48h timelock, the vault wrapper
-///         implementation, its upgradeable beacon, the vault wrapper factory, and
-///         the ERC-4626 yield adapter. The timelock owns both the factory and the
-///         beacon, so every factory slow-path call and every beacon upgrade is
-///         gated by the 48h delay.
+///         implementation, its upgradeable beacon, the vault wrapper factory (a
+///         TransparentUpgradeableProxy in front of the factory logic), and the
+///         ERC-4626 yield adapter. The timelock owns the factory, the beacon, and
+///         the proxy's ProxyAdmin, so every factory slow-path call, every beacon
+///         upgrade, and every factory-logic upgrade is gated by the 48h delay.
 /// @dev Standalone forge-std Script (see [CONV:VW-DEPLOY-DIR]) — it does not extend
 ///      DeployScriptBase. Per-network parameters are read from the scoped
 ///      config/vaultWrapper.json under the `NETWORK` key; the only env vars are
 ///      PRIVATE_KEY, NETWORK, and DEPLOYSALT (the salt prefix). Deploy order:
-///      TimelockController -> LiFiVaultWrapper(predicted factory) ->
-///      UpgradeableBeacon(impl, timelock) -> LiFiVaultWrapperFactory(beacon,
-///      owner=timelock, ...) -> ERC4626Adapter. Each contract is deployed through the
-///      CREATE3 factory under its own salt, so the address depends only on
-///      (deployer, salt) and is independent of constructor args and deploy order —
-///      mainnets sharing the same CREATE3 factory therefore get matching system
-///      addresses, and the factory's address can be predicted and bound into the
-///      implementation before the factory exists. Deploying via the CREATE3 proxy is
-///      safe here because every ownership/role is set from a constructor argument,
-///      never msg.sender. Timelock roles: the LI.FI multisig is proposer AND canceller (OZ
+///      TimelockController -> LiFiVaultWrapper(predicted factory proxy) ->
+///      UpgradeableBeacon(impl, timelock) -> LiFiVaultWrapperFactory logic ->
+///      TransparentUpgradeableProxy(logic, admin owner=timelock, initialize(...)) ->
+///      ERC4626Adapter. Each contract is deployed through the CREATE3 factory under
+///      its own salt, so the address depends only on (deployer, salt) and is
+///      independent of constructor args and deploy order — mainnets sharing the same
+///      CREATE3 factory therefore get matching system addresses, and the factory
+///      PROXY address (salt "LiFiVaultWrapperFactory") can be predicted and bound into
+///      the implementation before the proxy exists. The wrapper implementation binds
+///      to the proxy, not the logic, so instances read live factory state through a
+///      stable address across factory-logic upgrades. Deploying via the CREATE3 proxy
+///      is safe here because every ownership/role is set from a constructor argument
+///      or the proxy initializer, never msg.sender. Timelock roles: the LI.FI multisig is proposer AND canceller (OZ
 ///      grants both to each proposer); the executor role is open (address(0)); the
 ///      optional admin is renounced (address(0)), so the timelock is self-administered.
 ///      Because the factory owner is the 48h timelock, post-deploy configuration —
@@ -144,8 +151,17 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
         beacon = UpgradeableBeacon(
             _deployBeacon(address(impl), address(timelock))
         );
+        address factoryLogic = _deploy(
+            "LiFiVaultWrapperFactoryImpl",
+            type(LiFiVaultWrapperFactory).creationCode
+        );
         factory = LiFiVaultWrapperFactory(
-            _deployFactory(_cfg, address(beacon), address(timelock))
+            _deployFactoryProxy(
+                _cfg,
+                factoryLogic,
+                address(beacon),
+                address(timelock)
+            )
         );
         erc4626Adapter = ERC4626Adapter(
             _deploy("ERC4626Adapter", type(ERC4626Adapter).creationCode)
@@ -153,12 +169,14 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
 
         vm.stopBroadcast();
 
-        _verifyWiring(_cfg, factory, timelock, beacon, impl);
+        _verifyWiring(_cfg, factory, timelock, beacon, impl, factoryLogic);
 
         emit log_named_address("Timelock", address(timelock));
         emit log_named_address("Implementation", address(impl));
         emit log_named_address("Beacon", address(beacon));
+        emit log_named_address("FactoryLogic", factoryLogic);
         emit log_named_address("Factory", address(factory));
+        emit log_named_address("ProxyAdmin", _proxyAdmin(address(factory)));
         emit log_named_address("ERC4626Adapter", address(erc4626Adapter));
     }
 
@@ -210,16 +228,18 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
     ///      turning a silent governance error into a loud failure that tells the
     ///      operator to deploy under a fresh DEPLOYSALT.
     /// @param _cfg The intended deploy config.
-    /// @param _factory The resolved factory.
+    /// @param _factory The resolved factory (proxy).
     /// @param _timelock The resolved timelock.
     /// @param _beacon The resolved beacon.
-    /// @param _impl The resolved implementation.
+    /// @param _impl The resolved wrapper implementation.
+    /// @param _factoryLogic The resolved factory logic behind the proxy.
     function _verifyWiring(
         DeployConfig memory _cfg,
         LiFiVaultWrapperFactory _factory,
         TimelockController _timelock,
         UpgradeableBeacon _beacon,
-        LiFiVaultWrapper _impl
+        LiFiVaultWrapper _impl,
+        address _factoryLogic
     ) internal view {
         if (_timelock.getMinDelay() != MIN_DELAY)
             revert WiringMismatch("timelock.minDelay");
@@ -235,9 +255,15 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
         if (_impl.FACTORY() != address(_factory))
             revert WiringMismatch("impl.expectedFactory");
 
+        address admin = _proxyAdmin(address(_factory));
+        if (admin.code.length == 0)
+            revert WiringMismatch("factory.proxyAdmin");
+        if (ProxyAdmin(admin).owner() != address(_timelock))
+            revert WiringMismatch("factory.proxyAdmin.owner");
+
         if (_factory.owner() != address(_timelock))
             revert WiringMismatch("factory.owner");
-        if (_factory.BEACON() != address(_beacon))
+        if (_factory.beacon() != address(_beacon))
             revert WiringMismatch("factory.beacon");
         if (_factory.emergencyPauser() != _cfg.emergencyPauser)
             revert WiringMismatch("factory.emergencyPauser");
@@ -245,6 +271,11 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
             revert WiringMismatch("factory.onboardingManager");
         if (_factory.lifiFeeRecipient() != _cfg.lifiFeeRecipient)
             revert WiringMismatch("factory.lifiFeeRecipient");
+
+        // The logic contract must not be usable on its own: its initializers are
+        // locked by the constructor's _disableInitializers().
+        if (_factoryLogic.code.length == 0)
+            revert WiringMismatch("factory.logic");
     }
 
     /// @notice Deploys the dedicated 48h timelock (proposer/canceller = multisig,
@@ -285,29 +316,50 @@ contract DeployLiFiVaultWrapperFactory is Script, DSTest {
             );
     }
 
-    /// @notice Deploys the vault wrapper factory owned by the timelock.
+    /// @notice Deploys the factory's TransparentUpgradeableProxy, initialized in the
+    ///         same call. The proxy is the stable "factory" address every wrapper reads
+    ///         from; its ProxyAdmin (auto-deployed by the proxy) and the factory owner
+    ///         are both the timelock.
     /// @param _cfg The validated deploy config (roles + fee recipient).
+    /// @param _logic The factory logic contract the proxy delegates to.
     /// @param _beacon The beacon the factory clones instances from.
-    /// @param _timelock The factory owner (subsystem governance).
-    /// @return The deployed factory address.
-    function _deployFactory(
+    /// @param _timelock The factory owner and the ProxyAdmin owner (subsystem governance).
+    /// @return The deployed factory proxy address.
+    function _deployFactoryProxy(
         DeployConfig memory _cfg,
+        address _logic,
         address _beacon,
         address _timelock
     ) internal returns (address) {
+        bytes memory initData = abi.encodeCall(
+            LiFiVaultWrapperFactory.initialize,
+            (
+                _beacon,
+                _timelock,
+                _cfg.emergencyPauser,
+                _cfg.onboardingManager,
+                _cfg.lifiFeeRecipient
+            )
+        );
+
         return
             _deploy(
                 "LiFiVaultWrapperFactory",
                 abi.encodePacked(
-                    type(LiFiVaultWrapperFactory).creationCode,
-                    abi.encode(
-                        _beacon,
-                        _timelock,
-                        _cfg.emergencyPauser,
-                        _cfg.onboardingManager,
-                        _cfg.lifiFeeRecipient
-                    )
+                    type(TransparentUpgradeableProxy).creationCode,
+                    abi.encode(_logic, _timelock, initData)
                 )
+            );
+    }
+
+    /// @notice Reads the ProxyAdmin address from a TransparentUpgradeableProxy's
+    ///         ERC-1967 admin slot.
+    /// @param _proxy The proxy to inspect.
+    /// @return The proxy's ProxyAdmin address.
+    function _proxyAdmin(address _proxy) internal view returns (address) {
+        return
+            address(
+                uint160(uint256(vm.load(_proxy, ERC1967Utils.ADMIN_SLOT)))
             );
     }
 

--- a/src/VaultWrapper/LiFiVaultWrapperFactory.sol
+++ b/src/VaultWrapper/LiFiVaultWrapperFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
@@ -17,8 +17,17 @@ import { ILiFiVaultWrapperFactory } from "./interfaces/ILiFiVaultWrapperFactory.
 ///         deploy authorization, and a factory-level global circuit breaker.
 ///         This contract does not custody user funds; it only deploys and
 ///         configures wrapper instances.
+/// @dev Deployed behind a TransparentUpgradeableProxy; its logic is upgradeable by
+///      the proxy's ProxyAdmin, owned by the same 48h subsystem timelock that owns
+///      this factory. Because the logic is upgradeable, the `CAP_*` fee-cap constants
+///      below and the split validation are guarantees of the CURRENT bytecode only —
+///      a future timelocked upgrade could change them.
 /// @custom:version 1.0.0
-contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
+contract LiFiVaultWrapperFactory is
+    Initializable,
+    Ownable2StepUpgradeable,
+    ILiFiVaultWrapperFactory
+{
     /// Constants ///
 
     /// @notice Immutable upper cap for the performance fee (bps); 50%.
@@ -43,13 +52,12 @@ contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
     bytes32 internal constant ROLE_ONBOARDING_MANAGER =
         keccak256("ONBOARDING_MANAGER");
 
-    /// Immutables ///
-
-    /// @notice The UpgradeableBeacon holding the shared implementation every vault wrapper delegatecalls to.
-    address public immutable BEACON;
-
     /// Storage ///
 
+    /// @notice The UpgradeableBeacon holding the shared implementation every vault
+    ///         wrapper delegatecalls to. Set once in `initialize`; storage rather than
+    ///         an immutable because the logic sits behind a proxy.
+    address public beacon;
     /// @notice Address authorized to toggle the global circuit breaker.
     address public emergencyPauser;
     /// @notice Address authorized to approve and revoke integrators.
@@ -91,19 +99,30 @@ contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
 
     /// Constructor ///
 
+    /// @notice Locks the logic contract so it can never be initialized directly; the
+    ///         factory is only ever used through its TransparentUpgradeableProxy.
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// Initializer ///
+
     /// @notice Initializes the factory with a beacon and role addresses.
+    /// @dev Called once through the proxy at deploy (guarded by `initializer`). `_owner`
+    ///      becomes the factory's Ownable2Step owner; the proxy's separate ProxyAdmin,
+    ///      which controls upgrades, is owned by the same address (the subsystem timelock).
     /// @param _beacon        Address of the UpgradeableBeacon holding the wrapper implementation.
     /// @param _owner         Address that will own the factory.
     /// @param _emergencyPauser Address authorized to trigger global pause.
     /// @param _onboardingManager Address authorized to assign/revoke the deployer for each integrator namespace.
     /// @param _lifiFeeRecipient Recipient of LI.FI's fee share.
-    constructor(
+    function initialize(
         address _beacon,
         address _owner,
         address _emergencyPauser,
         address _onboardingManager,
         address _lifiFeeRecipient
-    ) Ownable(_owner) {
+    ) external initializer {
         if (
             _beacon == address(0) ||
             _emergencyPauser == address(0) ||
@@ -112,7 +131,9 @@ contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
         ) revert ZeroAddress();
         if (_beacon.code.length == 0) revert InvalidContract();
 
-        BEACON = _beacon;
+        __Ownable_init(_owner);
+
+        beacon = _beacon;
         emergencyPauser = _emergencyPauser;
         onboardingManager = _onboardingManager;
         lifiFeeRecipient = _lifiFeeRecipient;
@@ -390,7 +411,7 @@ contract LiFiVaultWrapperFactory is Ownable2Step, ILiFiVaultWrapperFactory {
         return
             abi.encodePacked(
                 type(BeaconProxy).creationCode,
-                abi.encode(BEACON, bytes(""))
+                abi.encode(beacon, bytes(""))
             );
     }
 

--- a/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
+++ b/test/solidity/VaultWrapper/BeaconUpgrade.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
@@ -40,22 +41,28 @@ contract BeaconUpgradeTest is Test {
     bytes32 internal constant NS = bytes32("Coinbase");
 
     function setUp() public virtual {
-        // The factory is the fourth CREATE in this setUp (implV1, implV2, beacon,
-        // factory); both implementations bind that factory at construction.
-        address predictedFactory = vm.computeCreateAddress(
+        // Both implementations bind the factory PROXY at construction. CREATE order after
+        // the factory logic: implV1 (n), implV2 (n+1), beacon (n+2), proxy (n+3).
+        LiFiVaultWrapperFactory logic = new LiFiVaultWrapperFactory();
+        address predictedProxy = vm.computeCreateAddress(
             address(this),
             vm.getNonce(address(this)) + 3
         );
-        implV1 = new LiFiVaultWrapper(predictedFactory);
-        implV2 = new MockVaultWrapperV2(predictedFactory);
-        beacon = new UpgradeableBeacon(address(implV1), address(this));
-        beacon.transferOwnership(owner);
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
-            owner,
-            pauser,
-            onboarder,
-            lifiRecipient
+        implV1 = new LiFiVaultWrapper(predictedProxy);
+        implV2 = new MockVaultWrapperV2(predictedProxy);
+        beacon = new UpgradeableBeacon(address(implV1), owner);
+        bytes memory initData = abi.encodeCall(
+            LiFiVaultWrapperFactory.initialize,
+            (address(beacon), owner, pauser, onboarder, lifiRecipient)
+        );
+        factory = LiFiVaultWrapperFactory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(logic),
+                    owner,
+                    initData
+                )
+            )
         );
         adapter = new ERC4626Adapter();
         underlying = new MockERC4626Underlying(assetToken);

--- a/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
+++ b/test/solidity/VaultWrapper/LiFiVaultWrapperFactory.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.29;
 
 import { Test } from "forge-std/Test.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ILiFiVaultWrapperFactory } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapperFactory.sol";
 import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrapper.sol";
@@ -12,13 +13,15 @@ import { IYieldAdapter } from "lifi/VaultWrapper/interfaces/IYieldAdapter.sol";
 import { Errors } from "@openzeppelin/contracts/utils/Errors.sol";
 import { FeeType, DeployParams, FeeConfig } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { defaultReceivers } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { MockERC4626Underlying } from "./mocks/MockERC4626Underlying.sol";
 import { MockZeroAdapter } from "./mocks/MockZeroAdapter.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 
 contract LiFiVaultWrapperFactoryTest is Test {
     LiFiVaultWrapperFactory internal factory;
+    LiFiVaultWrapperFactory internal logic;
     UpgradeableBeacon internal beacon;
     LiFiVaultWrapper internal impl;
     ERC4626Adapter internal adapter;
@@ -34,28 +37,53 @@ contract LiFiVaultWrapperFactoryTest is Test {
     address internal assetToken = address(new MockERC20("Asset", "AST", 18));
 
     function setUp() public virtual {
-        // The implementation binds the factory allowed to call initialize; the factory
-        // is the second CREATE after the implementation (beacon in between).
-        address predictedFactory = vm.computeCreateAddress(
+        // The factory sits behind a TransparentUpgradeableProxy; the wrapper impl binds
+        // to the PROXY address. CREATE order after the factory logic: impl (n), beacon
+        // (n+1), proxy (n+2).
+        logic = new LiFiVaultWrapperFactory();
+        address predictedProxy = vm.computeCreateAddress(
             address(this),
             vm.getNonce(address(this)) + 2
         );
-        impl = new LiFiVaultWrapper(predictedFactory);
+        impl = new LiFiVaultWrapper(predictedProxy);
         beacon = new UpgradeableBeacon(address(impl), address(this));
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
-            owner,
-            pauser,
-            onboarder,
-            lifiRecipient
+        factory = LiFiVaultWrapperFactory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(logic),
+                    owner,
+                    _initData(
+                        address(beacon),
+                        owner,
+                        pauser,
+                        onboarder,
+                        lifiRecipient
+                    )
+                )
+            )
         );
         adapter = new ERC4626Adapter();
         vm.prank(owner);
         factory.setAdapterApproved(address(adapter), true);
     }
 
-    function test_ConstructorSetsRolesBeaconAndDefaultSplit() public view {
-        assertEq(factory.BEACON(), address(beacon));
+    /// @dev Encodes an initialize(...) call for a factory proxy under test.
+    function _initData(
+        address beacon_,
+        address owner_,
+        address pauser_,
+        address onboarder_,
+        address recipient_
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodeCall(
+                LiFiVaultWrapperFactory.initialize,
+                (beacon_, owner_, pauser_, onboarder_, recipient_)
+            );
+    }
+
+    function test_InitializeSetsRolesBeaconAndDefaultSplit() public view {
+        assertEq(factory.beacon(), address(beacon));
         assertEq(factory.owner(), owner);
         assertEq(factory.emergencyPauser(), pauser);
         assertEq(factory.onboardingManager(), onboarder);
@@ -68,79 +96,113 @@ contract LiFiVaultWrapperFactoryTest is Test {
         assertEq(impl.FACTORY(), address(factory));
     }
 
+    function testRevert_LogicInitializerIsDisabled() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        logic.initialize(
+            address(beacon),
+            owner,
+            pauser,
+            onboarder,
+            lifiRecipient
+        );
+    }
+
+    function testRevert_ProxyCannotBeInitializedTwice() public {
+        vm.expectRevert(Initializable.InvalidInitialization.selector);
+        factory.initialize(
+            address(beacon),
+            owner,
+            pauser,
+            onboarder,
+            lifiRecipient
+        );
+    }
+
     function testRevert_ImplementationConstructorRejectsZeroFactory() public {
         vm.expectRevert(ILiFiVaultWrapper.ZeroAddress.selector);
         new LiFiVaultWrapper(address(0));
     }
 
-    function test_ConstructorRevertsOnZeroBeacon() public {
+    function testRevert_InitializeRevertsOnZeroBeacon() public {
         vm.expectRevert(ILiFiVaultWrapperFactory.ZeroAddress.selector);
-        new LiFiVaultWrapperFactory(
-            address(0),
+        new TransparentUpgradeableProxy(
+            address(logic),
             owner,
-            pauser,
-            onboarder,
-            lifiRecipient
+            _initData(address(0), owner, pauser, onboarder, lifiRecipient)
         );
     }
 
-    function test_ConstructorRevertsOnZeroOwner() public {
+    function testRevert_InitializeRevertsOnZeroOwner() public {
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableInvalidOwner.selector,
+                OwnableUpgradeable.OwnableInvalidOwner.selector,
                 address(0)
             )
         );
-        new LiFiVaultWrapperFactory(
-            address(beacon),
-            address(0),
-            pauser,
-            onboarder,
-            lifiRecipient
-        );
-    }
-
-    function test_ConstructorRevertsOnZeroPauser() public {
-        vm.expectRevert(ILiFiVaultWrapperFactory.ZeroAddress.selector);
-        new LiFiVaultWrapperFactory(
-            address(beacon),
+        new TransparentUpgradeableProxy(
+            address(logic),
             owner,
-            address(0),
-            onboarder,
-            lifiRecipient
+            _initData(
+                address(beacon),
+                address(0),
+                pauser,
+                onboarder,
+                lifiRecipient
+            )
         );
     }
 
-    function test_ConstructorRevertsOnZeroOnboardingManager() public {
+    function testRevert_InitializeRevertsOnZeroPauser() public {
         vm.expectRevert(ILiFiVaultWrapperFactory.ZeroAddress.selector);
-        new LiFiVaultWrapperFactory(
-            address(beacon),
+        new TransparentUpgradeableProxy(
+            address(logic),
             owner,
-            pauser,
-            address(0),
-            lifiRecipient
+            _initData(
+                address(beacon),
+                owner,
+                address(0),
+                onboarder,
+                lifiRecipient
+            )
         );
     }
 
-    function test_ConstructorRevertsOnZeroLifiFeeRecipient() public {
+    function testRevert_InitializeRevertsOnZeroOnboardingManager() public {
         vm.expectRevert(ILiFiVaultWrapperFactory.ZeroAddress.selector);
-        new LiFiVaultWrapperFactory(
-            address(beacon),
+        new TransparentUpgradeableProxy(
+            address(logic),
             owner,
-            pauser,
-            onboarder,
-            address(0)
+            _initData(
+                address(beacon),
+                owner,
+                pauser,
+                address(0),
+                lifiRecipient
+            )
         );
     }
 
-    function test_ConstructorRevertsOnNonContractBeacon() public {
+    function testRevert_InitializeRevertsOnZeroLifiFeeRecipient() public {
+        vm.expectRevert(ILiFiVaultWrapperFactory.ZeroAddress.selector);
+        new TransparentUpgradeableProxy(
+            address(logic),
+            owner,
+            _initData(address(beacon), owner, pauser, onboarder, address(0))
+        );
+    }
+
+    function testRevert_InitializeRevertsOnNonContractBeacon() public {
         vm.expectRevert(ILiFiVaultWrapperFactory.InvalidContract.selector);
-        new LiFiVaultWrapperFactory(
-            makeAddr("notBeacon"),
+        new TransparentUpgradeableProxy(
+            address(logic),
             owner,
-            pauser,
-            onboarder,
-            lifiRecipient
+            _initData(
+                makeAddr("notBeacon"),
+                owner,
+                pauser,
+                onboarder,
+                lifiRecipient
+            )
         );
     }
 
@@ -156,7 +218,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     function test_NonOwnerCannotSetUnderlyingAllowed() public {
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableUnauthorizedAccount.selector,
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
                 address(this)
             )
         );
@@ -255,7 +317,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.prank(pauser);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableUnauthorizedAccount.selector,
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
                 pauser
             )
         );
@@ -267,7 +329,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
         vm.prank(pauser);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableUnauthorizedAccount.selector,
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
                 pauser
             )
         );
@@ -329,7 +391,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     function test_NonOwnerCannotSetLifiFeeRecipient() public {
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableUnauthorizedAccount.selector,
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
                 address(this)
             )
         );
@@ -822,7 +884,7 @@ contract LiFiVaultWrapperFactoryTest is Test {
     function test_NonOwnerCannotSetAdapterApproved() public {
         vm.expectRevert(
             abi.encodeWithSelector(
-                Ownable.OwnableUnauthorizedAccount.selector,
+                OwnableUpgradeable.OwnableUnauthorizedAccount.selector,
                 address(this)
             )
         );

--- a/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDeployScripts.t.sol
@@ -12,6 +12,8 @@ import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeType, FEE_TYPE_COUNT } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 import { DeployLiFiVaultWrapperFactory } from "../../../script/deploy/vaultWrapper/DeployLiFiVaultWrapperFactory.s.sol";
 import { UpdateVaultWrapperConfig } from "../../../script/deploy/vaultWrapper/UpdateVaultWrapperConfig.s.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 
 /// @title VaultWrapperDeployScriptsTest
 /// @author LI.FI (https://li.fi)
@@ -55,9 +57,14 @@ contract VaultWrapperDeployScriptsTest is Test {
     function test_DeploySystem_WiresGovernance() public view {
         assertEq(beacon.owner(), address(timelock));
         assertEq(factory.owner(), address(timelock));
-        assertEq(factory.BEACON(), address(beacon));
+        assertEq(factory.beacon(), address(beacon));
         assertEq(beacon.implementation(), address(impl));
         assertEq(impl.FACTORY(), address(factory));
+
+        ProxyAdmin admin = ProxyAdmin(
+            VaultWrapperFactoryDeployer.proxyAdmin(address(factory))
+        );
+        assertEq(admin.owner(), address(timelock));
 
         assertEq(factory.emergencyPauser(), pauser);
         assertEq(factory.onboardingManager(), onboarder);

--- a/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperDistribution.t.sol
@@ -11,6 +11,7 @@ import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrappe
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { LibVaultWrapperMath } from "lifi/VaultWrapper/libraries/LibVaultWrapperMath.sol";
+import { VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 import { FeeType, FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 
 /// @notice A blacklisting ERC20: `transfer` reverts to any blocked address (mirrors USDC).
@@ -84,18 +85,8 @@ contract VaultWrapperDistributionTest is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
-        // The implementation binds the factory allowed to call initialize; the factory
-        // is the second CREATE after the implementation (beacon in between).
-        address predictedFactory = vm.computeCreateAddress(
+        (beacon, factory) = VaultWrapperFactoryDeployer.deploy(
             address(this),
-            vm.getNonce(address(this)) + 2
-        );
-        beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper(predictedFactory)),
-            address(this)
-        );
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
             owner,
             makeAddr("pauser"),
             onboarder,

--- a/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFactoryStackBase.sol
@@ -7,6 +7,7 @@ import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeType, DeployParams } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 
 /// @notice Shared factory-stack bring-up for the vault-wrapper fork and invariant suites:
 ///         deploys the adapter, beacon, and factory, approves the adapter and the underlying,
@@ -29,19 +30,8 @@ abstract contract VaultWrapperFactoryStackBase is Test {
         uint16[4] memory _bounds
     ) internal {
         adapter = new ERC4626Adapter();
-        // The implementation binds the factory allowed to call initialize at
-        // construction; the factory is the second CREATE after the implementation
-        // (beacon in between), so its address is predictable here.
-        address predictedFactory = vm.computeCreateAddress(
-            address(this),
-            vm.getNonce(address(this)) + 2
-        );
-        beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper(predictedFactory)),
-            makeAddr("beaconOwner")
-        );
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
+        (beacon, factory) = VaultWrapperFactoryDeployer.deploy(
+            makeAddr("beaconOwner"),
             makeAddr("owner"),
             makeAddr("pauser"),
             makeAddr("onboarder"),

--- a/test/solidity/VaultWrapper/VaultWrapperFeeReentrancy.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeReentrancy.t.sol
@@ -9,6 +9,7 @@ import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeType, FeeConfig, DeployParams, FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 
 interface IReenterHook {
     function onTokensReceived() external;
@@ -91,18 +92,8 @@ contract VaultWrapperFeeReentrancyTest is Test {
         adapter = new ERC4626Adapter();
         ownerHook = new ReenteringFeeOwner();
 
-        // The implementation binds the factory allowed to call initialize; the factory is
-        // the second CREATE after the implementation (beacon in between).
-        address predictedFactory = vm.computeCreateAddress(
+        (beacon, factory) = VaultWrapperFactoryDeployer.deploy(
             address(this),
-            vm.getNonce(address(this)) + 2
-        );
-        beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper(predictedFactory)),
-            address(this)
-        );
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
             owner,
             makeAddr("pauser"),
             onboarder,

--- a/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperFeeTestBase.sol
@@ -10,7 +10,7 @@ import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeType, FeeConfig, DeployParams } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
-import { defaultReceivers } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
+import { defaultReceivers, VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 
 /// @notice Shared scaffolding for the vault-wrapper fee-engine suites: the direct
 ///         beacon-proxy setup (real inflatable `MockERC4626`), the factory stack for
@@ -135,18 +135,9 @@ abstract contract VaultWrapperFeeTestBase is Test {
         uint16 _maxBps
     ) internal {
         // The setUp implementation is bound to this test contract, so the factory
-        // stack needs its own implementation+beacon bound to the factory — the
-        // second CREATE after the implementation (beacon in between).
-        address predictedFactory = vm.computeCreateAddress(
+        // stack needs its own implementation+beacon+proxy bound to the factory proxy.
+        (, factory) = VaultWrapperFactoryDeployer.deploy(
             address(this),
-            vm.getNonce(address(this)) + 2
-        );
-        UpgradeableBeacon stackBeacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper(predictedFactory)),
-            address(this)
-        );
-        factory = new LiFiVaultWrapperFactory(
-            address(stackBeacon),
             owner,
             makeAddr("pauser"),
             makeAddr("onboarder"),

--- a/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperPause.t.sol
@@ -12,7 +12,7 @@ import { ILiFiVaultWrapper } from "lifi/VaultWrapper/interfaces/ILiFiVaultWrappe
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
 import { FeeConfig, DeployParams } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
-import { defaultReceivers } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
+import { defaultReceivers, VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
 
 /// @notice Minimal stand-in for the factory: deploys the instance (so it is the
 ///         `factory`/initializer the wrapper reads back) and exposes a toggleable global
@@ -338,18 +338,8 @@ contract VaultWrapperGlobalPauseE2ETest is Test {
         asset = new MockERC20("Token", "TKN", 18);
         underlying = new MockERC4626(asset, "Yield Token", "yTKN");
         adapter = new ERC4626Adapter();
-        // The implementation binds the factory allowed to call initialize; the factory
-        // is the second CREATE after the implementation (beacon in between).
-        address predictedFactory = vm.computeCreateAddress(
+        (beacon, factory) = VaultWrapperFactoryDeployer.deploy(
             address(this),
-            vm.getNonce(address(this)) + 2
-        );
-        beacon = new UpgradeableBeacon(
-            address(new LiFiVaultWrapper(predictedFactory)),
-            address(this)
-        );
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
             owner,
             pauser,
             onboarder,

--- a/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.29;
 
+import { Vm } from "forge-std/Vm.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ERC1967Utils } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import { FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
+import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
+import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 
 /// @notice Minimal valid integrator receiver set: a single wallet holding 100% of the
 ///         fan-out. Shared by the VaultWrapper test suites that don't exercise distribution,
@@ -10,4 +16,82 @@ import { FeeReceiver } from "lifi/VaultWrapper/LiFiVaultWrapperTypes.sol";
 function defaultReceivers() pure returns (FeeReceiver[] memory r) {
     r = new FeeReceiver[](1);
     r[0] = FeeReceiver({ wallet: address(0xFEE1), bps: 10_000 });
+}
+
+/// @notice Brings up the full factory topology for tests the way the production deploy
+///         script does: a wrapper implementation bound to the factory PROXY address, a
+///         beacon over it, and the factory logic behind a TransparentUpgradeableProxy
+///         initialized in the same call. Centralizes the CREATE-nonce prediction of the
+///         proxy so individual suites don't re-derive it.
+library VaultWrapperFactoryDeployer {
+    // Lowercase `vm` is the forge-std cheatcode idiom; keep it so call sites read
+    // like the rest of the suite.
+    // solhint-disable-next-line const-name-snakecase
+    Vm private constant vm =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @notice Deploys logic + impl + beacon + proxy, wiring the wrapper impl to the proxy.
+    /// @dev Internal library functions are inlined, so every `new` and nonce read resolves
+    ///      against the calling test contract. Order after the logic CREATE: impl (nonce n),
+    ///      beacon (n+1), proxy (n+2); the impl is bound to the predicted proxy at n+2. The
+    ///      ProxyAdmin the proxy spawns is a CREATE from the proxy, not the caller, so it
+    ///      does not shift the caller nonce.
+    /// @param _beaconOwner The beacon owner (governs beacon upgrades).
+    /// @param _factoryOwner The factory Ownable2Step owner and the ProxyAdmin owner.
+    /// @param _emergencyPauser The factory emergency pauser role.
+    /// @param _onboardingManager The factory onboarding manager role.
+    /// @param _lifiFeeRecipient The LI.FI fee recipient.
+    /// @return beacon The deployed beacon.
+    /// @return factory The factory, typed at its proxy address.
+    function deploy(
+        address _beaconOwner,
+        address _factoryOwner,
+        address _emergencyPauser,
+        address _onboardingManager,
+        address _lifiFeeRecipient
+    )
+        internal
+        returns (UpgradeableBeacon beacon, LiFiVaultWrapperFactory factory)
+    {
+        LiFiVaultWrapperFactory logic = new LiFiVaultWrapperFactory();
+
+        address predictedProxy = vm.computeCreateAddress(
+            address(this),
+            vm.getNonce(address(this)) + 2
+        );
+        beacon = new UpgradeableBeacon(
+            address(new LiFiVaultWrapper(predictedProxy)),
+            _beaconOwner
+        );
+
+        bytes memory initData = abi.encodeCall(
+            LiFiVaultWrapperFactory.initialize,
+            (
+                address(beacon),
+                _factoryOwner,
+                _emergencyPauser,
+                _onboardingManager,
+                _lifiFeeRecipient
+            )
+        );
+        factory = LiFiVaultWrapperFactory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(logic),
+                    _factoryOwner,
+                    initData
+                )
+            )
+        );
+    }
+
+    /// @notice The ProxyAdmin address behind a TransparentUpgradeableProxy.
+    /// @param _proxy The proxy to inspect.
+    /// @return The proxy's ProxyAdmin (reads the ERC-1967 admin slot).
+    function proxyAdmin(address _proxy) internal view returns (address) {
+        return
+            address(
+                uint160(uint256(vm.load(_proxy, ERC1967Utils.ADMIN_SLOT)))
+            );
+    }
 }

--- a/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
+++ b/test/solidity/VaultWrapper/VaultWrapperTimelock.t.sol
@@ -8,17 +8,28 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { LiFiVaultWrapperFactory } from "lifi/VaultWrapper/LiFiVaultWrapperFactory.sol";
 import { LiFiVaultWrapper } from "lifi/VaultWrapper/LiFiVaultWrapper.sol";
 import { ERC4626Adapter } from "lifi/VaultWrapper/adapters/ERC4626Adapter.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { VaultWrapperFactoryDeployer } from "test/solidity/VaultWrapper/VaultWrapperTestHelpers.sol";
+
+/// @notice Upgrade target proving a factory-logic upgrade takes effect: extends the
+///         factory (identical storage layout) and adds a version() selector absent
+///         from V1.
+contract MockFactoryV2 is LiFiVaultWrapperFactory {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}
 
 /// @title VaultWrapperTimelockTest
 /// @notice Integration tests for the dedicated 48h timelock that governs the vault
-///         wrapper factory slow-path and beacon upgrades (S10).
+///         wrapper factory slow-path, beacon upgrades, and factory-logic upgrades (S10).
 contract VaultWrapperTimelockTest is Test {
     uint256 internal constant MIN_DELAY = 48 hours;
 
     TimelockController internal timelock;
     LiFiVaultWrapperFactory internal factory;
     UpgradeableBeacon internal beacon;
-    LiFiVaultWrapper internal impl;
     ERC4626Adapter internal adapter;
 
     address internal multisig = makeAddr("multisig");
@@ -28,15 +39,6 @@ contract VaultWrapperTimelockTest is Test {
     address internal stranger = makeAddr("stranger");
 
     function setUp() public {
-        // The factory is the fourth CREATE in this setUp (impl, beacon, timelock,
-        // factory); the implementation binds the factory address at construction.
-        address predictedFactory = vm.computeCreateAddress(
-            address(this),
-            vm.getNonce(address(this)) + 3
-        );
-        impl = new LiFiVaultWrapper(predictedFactory);
-        beacon = new UpgradeableBeacon(address(impl), address(this));
-
         address[] memory proposers = new address[](1);
         proposers[0] = multisig;
 
@@ -50,14 +52,16 @@ contract VaultWrapperTimelockTest is Test {
             address(0)
         );
 
-        factory = new LiFiVaultWrapperFactory(
-            address(beacon),
+        // The timelock owns the beacon, the factory, and the factory proxy's ProxyAdmin,
+        // so every beacon upgrade, factory slow-path call, and factory-logic upgrade is
+        // gated by the 48h delay.
+        (beacon, factory) = VaultWrapperFactoryDeployer.deploy(
+            address(timelock),
             address(timelock),
             pauser,
             onboarder,
             lifiRecipient
         );
-        beacon.transferOwnership(address(timelock));
 
         adapter = new ERC4626Adapter();
     }
@@ -67,6 +71,11 @@ contract VaultWrapperTimelockTest is Test {
     function test_TimelockOwnsFactoryAndBeacon() public view {
         assertEq(factory.owner(), address(timelock));
         assertEq(beacon.owner(), address(timelock));
+
+        ProxyAdmin admin = ProxyAdmin(
+            VaultWrapperFactoryDeployer.proxyAdmin(address(factory))
+        );
+        assertEq(admin.owner(), address(timelock));
     }
 
     function test_TimelockRolesAndDelay() public view {
@@ -241,6 +250,71 @@ contract VaultWrapperTimelockTest is Test {
         );
 
         beacon.upgradeTo(address(newImpl));
+    }
+
+    /// Factory-logic upgrade gating ///
+
+    function test_FactoryLogicUpgradeViaTimelock() public {
+        ProxyAdmin admin = ProxyAdmin(
+            VaultWrapperFactoryDeployer.proxyAdmin(address(factory))
+        );
+        address newLogic = address(new LiFiVaultWrapperFactory());
+        bytes memory data = abi.encodeCall(
+            ProxyAdmin.upgradeAndCall,
+            (ITransparentUpgradeableProxy(address(factory)), newLogic, "")
+        );
+
+        _schedule(address(admin), data);
+        vm.warp(block.timestamp + MIN_DELAY);
+        _execute(stranger, address(admin), data);
+
+        assertEq(factory.beacon(), address(beacon));
+        assertEq(factory.owner(), address(timelock));
+    }
+
+    function test_FactoryLogicUpgradePreservesStateAndAddsBehavior() public {
+        // A pre-upgrade state change that must survive the upgrade.
+        vm.prank(onboarder);
+        factory.setApprovedIntegratorDeployer(bytes32("NS"), stranger);
+
+        ProxyAdmin admin = ProxyAdmin(
+            VaultWrapperFactoryDeployer.proxyAdmin(address(factory))
+        );
+        address newLogic = address(new MockFactoryV2());
+        bytes memory data = abi.encodeCall(
+            ProxyAdmin.upgradeAndCall,
+            (ITransparentUpgradeableProxy(address(factory)), newLogic, "")
+        );
+
+        _schedule(address(admin), data);
+        vm.warp(block.timestamp + MIN_DELAY);
+        _execute(stranger, address(admin), data);
+
+        assertEq(MockFactoryV2(address(factory)).version(), 2);
+        assertEq(factory.approvedIntegratorDeployer(bytes32("NS")), stranger);
+        assertEq(factory.beacon(), address(beacon));
+        assertEq(factory.owner(), address(timelock));
+    }
+
+    function testRevert_FactoryLogicUpgradeDirectByMultisig() public {
+        ProxyAdmin admin = ProxyAdmin(
+            VaultWrapperFactoryDeployer.proxyAdmin(address(factory))
+        );
+        address newLogic = address(new LiFiVaultWrapperFactory());
+
+        vm.prank(multisig);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                multisig
+            )
+        );
+
+        admin.upgradeAndCall(
+            ITransparentUpgradeableProxy(address(factory)),
+            newLogic,
+            ""
+        );
     }
 
     /// Emergency pause stays outside the timelock ///


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_TODO: link the EXSC ticket for the factory-upgradeability change before requesting review._

# Why did I implement it this way?

The `LiFiVaultWrapperFactory` was a plain non-proxied contract, so its logic was
fixed for the life of a deployment — the only way to change factory behaviour was
to deploy a new factory (new address), which breaks the CREATE2 instance-address
parity the subsystem is built around.

This puts the factory behind an OpenZeppelin v5 **TransparentUpgradeableProxy**:

- Constructor → `initialize` (`Initializable` + `Ownable2StepUpgradeable`); the
  logic contract calls `_disableInitializers()` so it is never usable directly.
- `BEACON` immutable → `beacon` storage set in `initialize` (an impl behind a proxy
  can't carry a per-deployment constructor immutable). Getter renamed `BEACON()` →
  `beacon()`; nothing is deployed yet, so there is no ABI to preserve.
- The proxy's `ProxyAdmin` — the sole upgrade authority — is owned by the **same 48h
  timelock** that owns the factory and beacon, so a factory-logic upgrade passes the
  same delay (per request). Upgrades go through `ProxyAdmin.upgradeAndCall`.
- The deploy script now deploys the factory logic under salt
  `LiFiVaultWrapperFactoryImpl` and the proxy under the existing
  `LiFiVaultWrapperFactory` salt; the wrapper implementation binds `FACTORY` to the
  **proxy**, so instances read live factory state through a stable address across
  upgrades. `_verifyWiring` additionally asserts the ProxyAdmin is timelock-owned.

**Trust-model change (called out for audit):** the `CAP_*` fee-cap constants and the
`< 100%` split validation are no longer immutable guarantees — a future timelocked
factory-logic upgrade can change them. Docs (`docs/VaultWrapper/*`) and the subsystem
rule (`[CONV:VW-FACTORY-PROXY]` in `108-vault-wrapper.md`) are updated to state this
explicitly.

Versions are intentionally **not** bumped: the subsystem is pre-audit and pre-deploy.

Tests: shared proxy bring-up centralized in `VaultWrapperFactoryDeployer`; the
constructor-revert tests became initializer-revert tests; added coverage for
disabled-initializer, double-init, ProxyAdmin ownership, timelock-gated
factory-logic upgrade (incl. state preservation + new behaviour), and non-admin
upgrade reverts. Full VaultWrapper suite: 377 passing.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
