### PR TITLE
fix(troncast): cover Tron_pb.cjs in tronweb postinstall patch, report skips (EXSC-836)

### DIFF
--- a/script/troncast/postinstall-tronweb-fix.mjs
+++ b/script/troncast/postinstall-tronweb-fix.mjs
@@ -3,9 +3,8 @@
 /**
  * Postinstall script to fix TronWeb protobuf compatibility issues
  *
- * Purpose: This script patches TronWeb's compiled JavaScript files to resolve
- * conflicts between the 'proto' variable used by TronWeb and global proto
- * definitions that may exist in the execution environment.
+ * Purpose: This script patches TronWeb's compiled JavaScript files so that
+ * the 'proto' variable they rely on is always defined when they load.
  *
  * The issue: TronWeb's bundled protobuf files reference a shared 'proto'
  * variable without declaring it, relying on another module having already
@@ -86,7 +85,6 @@ files.forEach((file) => {
       return
     }
 
-    // Add proto initialization right before its first usage
     const lines = content.split('\n')
     const insertIndex = lines.findIndex((line) =>
       line.includes('goog.object.extend(proto')
@@ -99,7 +97,15 @@ files.forEach((file) => {
         '',
         'var proto = global.proto = global.proto || {};'
       )
-      fs.writeFileSync(file, lines.join('\n'))
+      // Write to a temp file and rename so a failed write cannot truncate the original
+      const tmpFile = `${file}.tmp`
+      try {
+        fs.writeFileSync(tmpFile, lines.join('\n'))
+        fs.renameSync(tmpFile, file)
+      } catch (writeError) {
+        fs.rmSync(tmpFile, { force: true })
+        throw writeError
+      }
       patchedCount++
     } else {
       skippedFiles.push(file)

--- a/script/troncast/postinstall-tronweb-fix.mjs
+++ b/script/troncast/postinstall-tronweb-fix.mjs
@@ -7,12 +7,14 @@
  * conflicts between the 'proto' variable used by TronWeb and global proto
  * definitions that may exist in the execution environment.
  *
- * The issue: TronWeb's bundled code uses a variable named 'proto' which can
- * conflict with other libraries or global variables of the same name, causing
- * runtime errors.
+ * The issue: TronWeb's bundled protobuf files reference a shared 'proto'
+ * variable without declaring it, relying on another module having already
+ * created `global.proto`. Depending on module load order that global may not
+ * exist yet, causing runtime errors.
  *
- * Solution: This script renames all instances of the 'proto' variable in
- * TronWeb's compiled files to 'tronProto' to avoid naming conflicts.
+ * Solution: This script inserts `var proto = global.proto = global.proto || {};`
+ * before the first `goog.object.extend(proto, ...)` usage in each affected
+ * file, so `proto` is defined regardless of module load order.
  *
  * When it runs: Automatically executed after npm/yarn install via postinstall hook
  */
@@ -72,6 +74,7 @@ consola.log(`Found ${files.length} files to patch`)
 
 let patchedCount = 0
 let alreadyPatchedCount = 0
+const skippedFiles = []
 
 files.forEach((file) => {
   try {
@@ -83,22 +86,11 @@ files.forEach((file) => {
       return
     }
 
-    // Add proto initialization after the require statements but before goog.object.extend
+    // Add proto initialization right before its first usage
     const lines = content.split('\n')
-    let insertIndex = -1
-
-    for (let i = 0; i < lines.length; i++) {
-      // Find the last require statement before goog.object.extend
-      if (lines[i].includes('require') && lines[i].includes('_pb.cjs')) {
-        // Check if next few lines have goog.object.extend
-        for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
-          if (lines[j].includes('goog.object.extend(proto')) {
-            insertIndex = i + 1
-            break
-          }
-        }
-      }
-    }
+    const insertIndex = lines.findIndex((line) =>
+      line.includes('goog.object.extend(proto')
+    )
 
     if (insertIndex > -1) {
       lines.splice(
@@ -109,12 +101,20 @@ files.forEach((file) => {
       )
       fs.writeFileSync(file, lines.join('\n'))
       patchedCount++
+    } else {
+      skippedFiles.push(file)
     }
   } catch (e) {
     consola.error(`Error processing ${file}:`, e.message)
+    skippedFiles.push(file)
   }
 })
 
 consola.log(`✓ Patched ${patchedCount} files`)
 consola.log(`✓ ${alreadyPatchedCount} files were already patched`)
-consola.log('TronWeb proto fix applied successfully!')
+if (skippedFiles.length > 0) {
+  consola.warn(`✗ Skipped ${skippedFiles.length} files (not patched):`)
+  skippedFiles.forEach((file) => consola.warn(`  - ${file}`))
+} else {
+  consola.log('TronWeb proto fix applied successfully!')
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-836](https://linear.app/lifi-linear/issue/EXSC-836/fix-tronweb-postinstall-patch-cover-tron-pbcjs-and-report-skipped)

# Why did I implement it this way?

The postinstall patch found 12 tronweb files needing the `global.proto` guard but silently skipped the 3 copies of `protocol/core/Tron_pb.cjs` (lib/commonjs, lib/esm, src): its insert heuristic required a require line containing `_pb.cjs`, while those files require `google-protobuf/google/protobuf/any_pb.js`. They only load today because `any_pb.js` incidentally creates `global.proto` via `goog.exportSymbol` — protection a future tronweb bump or an isolated import of `Tron_pb.cjs` could lose. The new heuristic inserts the guard immediately before the first `goog.object.extend(proto` line — the first use of `proto` and the very pattern that selects a file for patching — so an insert point always exists and the placement provably precedes first use, instead of guessing at require-line shapes that vary between generated files. Files that still can't be patched (e.g. I/O errors) are now counted and listed via `consola.warn`, so found ≠ patched + already-patched can never pass silently again; the script still exits 0 because failing `postinstall` would block every `bun install` while `script/troncast/utils/tronweb.ts` retains a runtime `globalThis.proto` guard as backstop. Verified against the installed tronweb 6.0.4: first run patches exactly the 3 missing files (then 12/12 idempotent), a guard-stripped fresh-install simulation patches 12/12, `require('tronweb')` (node) and `import { TronWeb } from 'tronweb'` (bun + node) load, base58↔hex address round-trip matches, isolated `require` of the patched `Tron_pb.cjs` with `global.proto` deleted works, and a forced read-only file exercises the new skip report. A gate-review round additionally made the patch write atomic (temp file + rename, per CodeRabbit) so a failed write can never truncate a file in node_modules, and tightened the header docblock.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
