### PR TITLE
feat(healthcheck): group fleet failures by root cause, route alerts to #dev-sc-github-ci-notifications

### DIFF
--- a/.github/workflows/healthCheckAllNetworks.yml
+++ b/.github/workflows/healthCheckAllNetworks.yml
@@ -18,8 +18,11 @@
 #   deploymentAddressConsistency.yml for the static PR tier).
 # - Slack: SIGNAL-ONLY. A message is posted only when a run surfaces something actionable — a failed
 #   network or runner error (:rotating_light: ACTION NEEDED) or a network that passed with warnings
-#   (:warning:). Fully-green runs, and the staging-only no-op push that resolves zero production
-#   networks, stay SILENT so the channel carries only issues, not routine confirmations.
+#   (:warning:). Failures are reported grouped by root cause (one bullet per cause, with the
+#   networks it hit) rather than as a flat network list, so the alert is triageable without opening
+#   the run; the grouping is computed in healthCheckAllNetworks.ts. Fully-green runs, and the
+#   staging-only no-op push that resolves zero production networks, stay SILENT so the channel
+#   carries only issues, not routine confirmations.
 #   Trade-off: no green message means no positive heartbeat, so a silently-broken cron no longer
 #   shows up as a MISSING message — add a separate cron-liveness monitor if that signal is needed.
 # - Known limitations: needs RPCs (MongoDB) + deploy logs; transient RPC errors are absorbed by viem
@@ -156,6 +159,7 @@ jobs:
           WARNED_COUNT: ${{ steps.healthcheck.outputs.warned_count }}
           FAILED_NETWORKS: ${{ steps.healthcheck.outputs.failed_networks }}
           WARNED_NETWORKS: ${{ steps.healthcheck.outputs.warned_networks }}
+          FAILURE_DIGEST: ${{ steps.healthcheck.outputs.failure_digest }}
         run: |
           # Deep-link straight to THIS job so the Slack link lands on the failing step; fall back to
           # the run overview if the jobs API can't be read.
@@ -180,8 +184,17 @@ jobs:
             BODY="<${RUN_URL}|View workflow run>${WARN_LINE}"
           else
             HEADER=":rotating_light: *Diamond health check — ACTION NEEDED*"
-            BODY=$(printf '%s of %s network(s) failed: %s\n<%s|View workflow run>%s' \
-              "${FAILED_COUNT:-?}" "${TOTAL:-?}" "${FAILED_NETWORKS:-unknown (runner error)}" "$RUN_URL" "$WARN_LINE")
+            # Prefer the grouped cause digest: the flat network list says how many chains are red
+            # but not why, which is the part that decides whether anyone has to act. It is absent
+            # when the runner itself died before producing results, so keep the list as fallback.
+            if [[ -n "${FAILURE_DIGEST:-}" ]]; then
+              FAILURE_LINES=$(printf '%s of %s network(s) failed:\n%s' \
+                "${FAILED_COUNT:-?}" "${TOTAL:-?}" "$FAILURE_DIGEST")
+            else
+              FAILURE_LINES=$(printf '%s of %s network(s) failed: %s' \
+                "${FAILED_COUNT:-?}" "${TOTAL:-?}" "${FAILED_NETWORKS:-unknown (runner error)}")
+            fi
+            BODY=$(printf '%s\n<%s|View workflow run>%s' "$FAILURE_LINES" "$RUN_URL" "$WARN_LINE")
           fi
           TEXT=$(printf '%s\n%s' "$HEADER" "$BODY")
           {

--- a/.github/workflows/healthCheckAllNetworks.yml
+++ b/.github/workflows/healthCheckAllNetworks.yml
@@ -18,9 +18,9 @@
 #   deploymentAddressConsistency.yml for the static PR tier).
 # - Slack: SIGNAL-ONLY. A message is posted only when a run surfaces something actionable — a failed
 #   network or runner error (:rotating_light: ACTION NEEDED) or a network that passed with warnings
-#   (:warning:). Failures are reported grouped by root cause (one bullet per cause, with the
-#   networks it hit) rather than as a flat network list, so the alert is triageable without opening
-#   the run; the grouping is computed in healthCheckAllNetworks.ts. Fully-green runs, and the
+#   (:warning:). Failures AND warnings are both reported grouped by root cause (one bullet per
+#   cause, with the networks it hit) rather than as flat network lists, so the alert is triageable
+#   without opening the run; the grouping is computed in healthCheckAllNetworks.ts. Fully-green runs, and the
 #   staging-only no-op push that resolves zero production networks, stay SILENT so the channel
 #   carries only issues, not routine confirmations.
 #   Trade-off: no green message means no positive heartbeat, so a silently-broken cron no longer
@@ -160,6 +160,7 @@ jobs:
           FAILED_NETWORKS: ${{ steps.healthcheck.outputs.failed_networks }}
           WARNED_NETWORKS: ${{ steps.healthcheck.outputs.warned_networks }}
           FAILURE_DIGEST: ${{ steps.healthcheck.outputs.failure_digest }}
+          WARNING_DIGEST: ${{ steps.healthcheck.outputs.warning_digest }}
         run: |
           # Deep-link straight to THIS job so the Slack link lands on the failing step; fall back to
           # the run overview if the jobs API can't be read.
@@ -176,8 +177,16 @@ jobs:
           # in the consolidated report rather than buried in a single network's logs.
           WARN_LINE=""
           if [[ "${WARNED_COUNT:-0}" != "0" ]]; then
-            WARN_LINE=$(printf '\n:warning: %s network(s) passed with warnings: %s' \
-              "${WARNED_COUNT}" "${WARNED_NETWORKS:-?}")
+            # Same reasoning as the failure digest: 40 network names say nothing about what to do,
+            # and a warning nobody can act on is a warning everyone learns to skip. Fall back to
+            # the network list only when no warning text was captured.
+            if [[ -n "${WARNING_DIGEST:-}" ]]; then
+              WARN_LINE=$(printf '\n:warning: %s network(s) passed with warnings:\n%s' \
+                "${WARNED_COUNT}" "$WARNING_DIGEST")
+            else
+              WARN_LINE=$(printf '\n:warning: %s network(s) passed with warnings: %s' \
+                "${WARNED_COUNT}" "${WARNED_NETWORKS:-?}")
+            fi
           fi
           if [[ "$OUTCOME" == "success" && "${FAILED_COUNT:-0}" == "0" ]]; then
             HEADER=":white_check_mark: *Diamond health check — ${PASSED_COUNT:-?}/${TOTAL:-?} networks passed (${SKIPPED_COUNT:-0} skipped)*"

--- a/.github/workflows/healthCheckAllNetworks.yml
+++ b/.github/workflows/healthCheckAllNetworks.yml
@@ -194,7 +194,7 @@ jobs:
         if: ${{ !cancelled() && (steps.healthcheck.outcome == 'failure' || steps.healthcheck.outputs.warned_count != '0') }}
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_SC_GENERAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -321,3 +321,15 @@ describe('formatConsolidatedOutput', () => {
     expect(output).toContain('failed_count=2')
   })
 })
+
+describe('normalizeFailureCause Slack safety', () => {
+  it('uses mask tokens that survive Slack mrkdwn', () => {
+    // Slack parses <...> as a link element, so an angle-bracketed mask would be mangled or
+    // dropped in the message it exists to clarify.
+    const normalized = normalizeFailureCause(
+      'Stale: 0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57 / 0x2646478b, 3 pairs'
+    )
+    expect(normalized).not.toContain('<')
+    expect(normalized).not.toContain('>')
+  })
+})

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -12,8 +12,9 @@ import {
   formatConsolidatedOutput,
   getProductionNetworkNames,
   groupFailuresByCause,
+  groupWarningsByCause,
   normalizeFailureCause,
-  renderFailureDigest,
+  renderCauseDigest,
   summarizeHealthChecks,
 } from './healthCheckAllNetworks'
 
@@ -69,10 +70,15 @@ describe('deploymentPathsToNetworks', () => {
 describe('summarizeHealthChecks', () => {
   it('splits passed / failed / skipped / warned and counts the total', () => {
     const summary = summarizeHealthChecks([
-      { network: 'polygon', status: 'passed', warnings: 0, detail: '' },
-      { network: 'optimism', status: 'failed', warnings: 0, detail: 'boom' },
-      { network: 'arbitrum', status: 'passed', warnings: 2, detail: '' },
-      { network: 'tron', status: 'skipped', warnings: 0, detail: 'skipHc' },
+      { network: 'polygon', status: 'passed', warnings: [], detail: '' },
+      { network: 'optimism', status: 'failed', warnings: [], detail: 'boom' },
+      {
+        network: 'arbitrum',
+        status: 'passed',
+        warnings: ['reduced coverage', 'stale pair'],
+        detail: '',
+      },
+      { network: 'tron', status: 'skipped', warnings: [], detail: 'skipHc' },
     ])
     expect(summary.total).toBe(4)
     expect(summary.passed).toEqual(['arbitrum', 'polygon'])
@@ -84,7 +90,7 @@ describe('summarizeHealthChecks', () => {
 
   it('handles the all-passed case', () => {
     const summary = summarizeHealthChecks([
-      { network: 'polygon', status: 'passed', warnings: 0, detail: '' },
+      { network: 'polygon', status: 'passed', warnings: [], detail: '' },
     ])
     expect(summary.failed).toEqual([])
     expect(summary.passed).toEqual(['polygon'])
@@ -163,19 +169,19 @@ describe('groupFailuresByCause', () => {
       {
         network: 'avalanche',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: RECEIVER_OIF_DETAIL,
       },
       {
         network: 'celo',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: RECEIVER_OIF_DETAIL,
       },
       {
         network: 'gnosis',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: RECEIVER_OIF_DETAIL,
       },
     ])
@@ -189,19 +195,19 @@ describe('groupFailuresByCause', () => {
       {
         network: 'bob',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: STALE_PAIR_DETAIL('0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57'),
       },
       {
         network: 'avalanche',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: RECEIVER_OIF_DETAIL,
       },
       {
         network: 'celo',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: RECEIVER_OIF_DETAIL,
       },
     ])
@@ -212,11 +218,16 @@ describe('groupFailuresByCause', () => {
   it('ignores passed and skipped networks', () => {
     expect(
       groupFailuresByCause([
-        { network: 'polygon', status: 'passed', warnings: 3, detail: '' },
+        {
+          network: 'polygon',
+          status: 'passed',
+          warnings: ['a', 'b', 'c'],
+          detail: '',
+        },
         {
           network: 'arc',
           status: 'skipped',
-          warnings: 0,
+          warnings: [],
           detail: 'skipHealthcheck',
         },
       ])
@@ -225,16 +236,16 @@ describe('groupFailuresByCause', () => {
 
   it('groups a network with no detail under an explicit unknown-cause bucket', () => {
     const groups = groupFailuresByCause([
-      { network: 'polygon', status: 'failed', warnings: 0, detail: '' },
+      { network: 'polygon', status: 'failed', warnings: [], detail: '' },
     ])
     expect(groups).toHaveLength(1)
     expect(groups[0]?.cause).toBe('no detail captured (see workflow run)')
   })
 })
 
-describe('renderFailureDigest', () => {
+describe('renderCauseDigest', () => {
   it('renders one bullet per cause with its network count and list', () => {
-    const digest = renderFailureDigest([
+    const digest = renderCauseDigest([
       { cause: 'ReceiverOIF not registered', networks: ['avalanche', 'celo'] },
     ])
     expect(digest).toBe('• ReceiverOIF not registered (2): avalanche, celo')
@@ -242,7 +253,7 @@ describe('renderFailureDigest', () => {
 
   it('truncates an over-long network list rather than flooding the message', () => {
     const networks = Array.from({ length: 15 }, (_, i) => `net${i}`)
-    const digest = renderFailureDigest([{ cause: 'boom', networks }], {
+    const digest = renderCauseDigest([{ cause: 'boom', networks }], {
       maxNetworksPerGroup: 12,
     })
     expect(digest).toContain('+3 more')
@@ -254,13 +265,13 @@ describe('renderFailureDigest', () => {
       cause: `cause ${i}`,
       networks: [`net${i}`],
     }))
-    const digest = renderFailureDigest(groups, { maxGroups: 6 })
+    const digest = renderCauseDigest(groups, { maxGroups: 6 })
     expect(digest.split('\n')).toHaveLength(7)
     expect(digest).toContain('3 further cause(s) not shown')
   })
 
   it('collapses a multi-line cause onto one bullet', () => {
-    const digest = renderFailureDigest([
+    const digest = renderCauseDigest([
       {
         cause:
           'Pair Array has <n> stale pairs not in config:\n  Stale: <address> / 0x2646478b',
@@ -272,7 +283,7 @@ describe('renderFailureDigest', () => {
   })
 
   it('returns an empty string when there is nothing to report', () => {
-    expect(renderFailureDigest([])).toBe('')
+    expect(renderCauseDigest([])).toBe('')
   })
 })
 
@@ -284,6 +295,7 @@ describe('formatConsolidatedOutput', () => {
     skipped: [],
     warned: ['polygon'],
     failureDigest: '',
+    warningDigest: '',
   }
 
   it('emits the scalar counts the Slack composer reads', () => {
@@ -307,7 +319,20 @@ describe('formatConsolidatedOutput', () => {
   it('emits an empty digest as a plain empty scalar', () => {
     const output = formatConsolidatedOutput(summary)
     expect(output).toContain('failure_digest=')
+    expect(output).toContain('warning_digest=')
     expect(output).not.toContain('HEALTHCHECK_DIGEST_EOF')
+  })
+
+  it('emits the warning digest independently of the failure digest', () => {
+    // A fully-green fleet can still warn, so the warning digest must not depend on failures.
+    const output = formatConsolidatedOutput({
+      ...summary,
+      failed: [],
+      warningDigest: '• FraxFacet routed but unlogged (17): mainnet, base',
+    })
+    expect(output).toContain('failure_digest=')
+    expect(output).toContain('warning_digest<<HEALTHCHECK_DIGEST_EOF')
+    expect(output).toContain('• FraxFacet routed but unlogged (17)')
   })
 
   it('strips a delimiter collision so on-chain text cannot forge extra outputs', () => {
@@ -372,17 +397,193 @@ describe('normalizeFailureCause redaction', () => {
       {
         network: 'base',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: 'HTTP request failed. URL: https://a.example.org/?k=AAA',
       },
       {
         network: 'polygon',
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: 'HTTP request failed. URL: https://b.example.org/?k=BBB',
       },
     ])
     expect(groups).toHaveLength(1)
     expect(groups[0]?.networks).toEqual(['base', 'polygon'])
+  })
+})
+
+/**
+ * Verbatim warning from run 32680003424 — FraxFacet was cut into 17 diamonds while the deploy-log
+ * entries recording it were still sitting in an unmerged PR. The network name is embedded in the
+ * text, which is what makes network-masking load-bearing for grouping.
+ */
+const fraxWarning = (network: string, address: string) =>
+  `Facet ${address} is registered on-chain but absent from the deploy log; its selectors match FraxFacet - confirm whether this is the current build before recording it in deployments/${network}.json, since a superseded deployment can still match`
+
+describe('normalizeFailureCause network masking', () => {
+  it('masks the network name so one cause does not split per network', () => {
+    expect(
+      normalizeFailureCause(
+        fraxWarning('mainnet', '0x8452788daad6af88fe88bc5dfc892974c11c32ad'),
+        'mainnet'
+      )
+    ).toBe(
+      normalizeFailureCause(
+        fraxWarning('zksync', '0x7cd2c2341d598be51938eaba921537bef718e6bf'),
+        'zksync'
+      )
+    )
+  })
+
+  it('masks the name only as a whole word, never inside another word', () => {
+    // 'ink' is a network id and also a substring of 'thinking'.
+    expect(
+      normalizeFailureCause('thinking about deployments/ink.json', 'ink')
+    ).toBe('thinking about deployments/[network].json')
+  })
+
+  it('leaves the text alone when no network is supplied', () => {
+    expect(normalizeFailureCause('deployments/ink.json')).toBe(
+      'deployments/ink.json'
+    )
+  })
+})
+
+describe('groupWarningsByCause', () => {
+  it('collapses the FraxFacet rollout warning across every affected network', () => {
+    const networks = [
+      ['mainnet', '0x8452788daad6af88fe88bc5dfc892974c11c32ad'],
+      ['arbitrum', '0x8452788daad6af88fe88bc5dfc892974c11c32ad'],
+      ['zksync', '0x7cd2c2341d598be51938eaba921537bef718e6bf'],
+      ['katana', '0x649e769250a69c1b6af003a104a5f3e5a9bc5ee7'],
+    ]
+    const groups = groupWarningsByCause(
+      networks.map(([network, address]) => ({
+        network: network as string,
+        status: 'passed' as const,
+        warnings: [fraxWarning(network as string, address as string)],
+        detail: '',
+      }))
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual([
+      'arbitrum',
+      'katana',
+      'mainnet',
+      'zksync',
+    ])
+    expect(groups[0]?.cause).toContain('FraxFacet')
+  })
+
+  it('puts a network with two distinct warnings in both groups', () => {
+    const groups = groupWarningsByCause([
+      {
+        network: 'polygon',
+        status: 'passed',
+        warnings: ['rate limit reached', 'stale pair in config'],
+        detail: '',
+      },
+      {
+        network: 'base',
+        status: 'passed',
+        warnings: ['rate limit reached'],
+        detail: '',
+      },
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups[0]?.cause).toBe('rate limit reached')
+    expect(groups[0]?.networks).toEqual(['base', 'polygon'])
+    expect(groups[1]?.networks).toEqual(['polygon'])
+  })
+
+  it('lists a network once even if it emits the same warning twice', () => {
+    const groups = groupWarningsByCause([
+      {
+        network: 'tron',
+        status: 'passed',
+        warnings: ['rate limit reached', 'rate limit reached'],
+        detail: '',
+      },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual(['tron'])
+  })
+
+  it('includes warnings from failed and skipped networks, not just passing ones', () => {
+    // A network can fail one invariant and warn on another; dropping the warning would hide it.
+    const groups = groupWarningsByCause([
+      {
+        network: 'tron',
+        status: 'failed',
+        warnings: ['reduced coverage'],
+        detail: 'boom',
+      },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual(['tron'])
+  })
+
+  it('returns nothing when no network warned', () => {
+    expect(
+      groupWarningsByCause([
+        { network: 'polygon', status: 'passed', warnings: [], detail: '' },
+      ])
+    ).toEqual([])
+  })
+})
+
+describe('renderCauseDigest truncation', () => {
+  it('truncates a long cause at a word boundary, not mid-word', () => {
+    const cause =
+      'Facet is registered on-chain but absent from the deploy log, and no compiled selector set identifies it (unexpected or rogue facet, or a retired contract whose source is gone)'
+    const digest = renderCauseDigest([{ cause, networks: ['base'] }], {
+      maxCauseChars: 120,
+    })
+    expect(digest).toContain('…')
+    // The break lands after a whole word, so no partial token is shown.
+    const shown = digest.slice(2, digest.indexOf('…'))
+    expect(cause.startsWith(shown)).toBe(true)
+    expect(shown.endsWith(' ')).toBe(false)
+    expect(cause[shown.length]).toBe(' ')
+  })
+
+  it('does not truncate a cause that already fits', () => {
+    const digest = renderCauseDigest([
+      { cause: 'rate limit reached', networks: ['tron'] },
+    ])
+    expect(digest).toBe('• rate limit reached (1): tron')
+  })
+
+  it('falls back to a hard cut when the cause has no word break in range', () => {
+    const digest = renderCauseDigest(
+      [{ cause: 'x'.repeat(200), networks: ['base'] }],
+      { maxCauseChars: 20 }
+    )
+    expect(digest).toContain('…')
+    expect(digest.length).toBeLessThan(60)
+  })
+})
+
+describe('groupFailuresByCause never drops a failed network', () => {
+  it('buckets a whitespace-only detail as unknown rather than dropping it', () => {
+    // A failed network missing from the digest is worse than an unhelpful line: the count says
+    // 3 failed and the operator can only find 2.
+    const groups = groupFailuresByCause([
+      { network: 'polygon', status: 'failed', warnings: [], detail: '   \n  ' },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual(['polygon'])
+    expect(groups[0]?.cause).toBe('no detail captured (see workflow run)')
+  })
+
+  it('accounts for every failed network across mixed details', () => {
+    const results = [
+      { network: 'a', status: 'failed' as const, warnings: [], detail: 'boom' },
+      { network: 'b', status: 'failed' as const, warnings: [], detail: '' },
+      { network: 'c', status: 'failed' as const, warnings: [], detail: ' \t ' },
+      { network: 'd', status: 'passed' as const, warnings: [], detail: '' },
+    ]
+    const grouped = groupFailuresByCause(results).flatMap((g) => g.networks)
+    expect(grouped.sort()).toEqual(['a', 'b', 'c'])
   })
 })

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -9,7 +9,11 @@ import type { INetwork } from '../common/types'
 
 import {
   deploymentPathsToNetworks,
+  formatConsolidatedOutput,
   getProductionNetworkNames,
+  groupFailuresByCause,
+  normalizeFailureCause,
+  renderFailureDigest,
   summarizeHealthChecks,
 } from './healthCheckAllNetworks'
 
@@ -96,5 +100,224 @@ describe('summarizeHealthChecks', () => {
       skipped: [],
       warned: [],
     })
+  })
+})
+
+/** Real detail strings from run 32680003424, verbatim apart from the network they came from. */
+const RECEIVER_OIF_DETAIL =
+  'LiFiIntentEscrowFacetV2 live but companion ReceiverOIF not registered in Diamond - destination calls for this integration are disabled on this network'
+const STALE_PAIR_DETAIL = (address: string) =>
+  `Pair Array has 1 stale pairs not in config:\n  Stale: ${address} / 0x2646478b`
+
+describe('normalizeFailureCause', () => {
+  it('masks EVM addresses so the same cause on different networks collapses', () => {
+    expect(
+      normalizeFailureCause(
+        STALE_PAIR_DETAIL('0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57')
+      )
+    ).toBe(
+      normalizeFailureCause(
+        STALE_PAIR_DETAIL('0x642eeb39b287bb7809043aae89bcfac2f409737d')
+      )
+    )
+  })
+
+  it('masks Tron base58 addresses too', () => {
+    expect(
+      normalizeFailureCause(
+        'Stale: ta7qd9kpebh7qasaxxupjwvfe3gitwpd7q / 0xe0cbc5f2'
+      )
+    ).toBe(
+      normalizeFailureCause(
+        'Stale: TQpv2Zc9dCzvxRxTfgHVXpnCvvfFmGxUnB / 0xe0cbc5f2'
+      )
+    )
+  })
+
+  it('keeps 4-byte selectors, which identify the cause', () => {
+    const normalized = normalizeFailureCause(
+      STALE_PAIR_DETAIL('0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57')
+    )
+    expect(normalized).toContain('0x2646478b')
+    // A different selector is a different cause, not the same one.
+    expect(normalized).not.toBe(
+      normalizeFailureCause(
+        'Pair Array has 1 stale pairs not in config:\n  Stale: 0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57 / 0xe0cbc5f2'
+      )
+    )
+  })
+
+  it('masks standalone counts but never digits inside a contract name', () => {
+    expect(normalizeFailureCause('has 1 stale pairs')).toBe(
+      normalizeFailureCause('has 2 stale pairs')
+    )
+    expect(normalizeFailureCause(RECEIVER_OIF_DETAIL)).toContain(
+      'LiFiIntentEscrowFacetV2'
+    )
+  })
+})
+
+describe('groupFailuresByCause', () => {
+  it('collapses one shared cause across networks into a single group', () => {
+    const groups = groupFailuresByCause([
+      {
+        network: 'avalanche',
+        status: 'failed',
+        warnings: 0,
+        detail: RECEIVER_OIF_DETAIL,
+      },
+      {
+        network: 'celo',
+        status: 'failed',
+        warnings: 0,
+        detail: RECEIVER_OIF_DETAIL,
+      },
+      {
+        network: 'gnosis',
+        status: 'failed',
+        warnings: 0,
+        detail: RECEIVER_OIF_DETAIL,
+      },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual(['avalanche', 'celo', 'gnosis'])
+    expect(groups[0]?.cause).toContain('ReceiverOIF not registered')
+  })
+
+  it('orders groups by blast radius, widest first', () => {
+    const groups = groupFailuresByCause([
+      {
+        network: 'bob',
+        status: 'failed',
+        warnings: 0,
+        detail: STALE_PAIR_DETAIL('0x3fc68470a35072c3a49ac28187c2cc0d4ad1bc57'),
+      },
+      {
+        network: 'avalanche',
+        status: 'failed',
+        warnings: 0,
+        detail: RECEIVER_OIF_DETAIL,
+      },
+      {
+        network: 'celo',
+        status: 'failed',
+        warnings: 0,
+        detail: RECEIVER_OIF_DETAIL,
+      },
+    ])
+    expect(groups.map((g) => g.networks.length)).toEqual([2, 1])
+    expect(groups[0]?.cause).toContain('ReceiverOIF')
+  })
+
+  it('ignores passed and skipped networks', () => {
+    expect(
+      groupFailuresByCause([
+        { network: 'polygon', status: 'passed', warnings: 3, detail: '' },
+        {
+          network: 'arc',
+          status: 'skipped',
+          warnings: 0,
+          detail: 'skipHealthcheck',
+        },
+      ])
+    ).toEqual([])
+  })
+
+  it('groups a network with no detail under an explicit unknown-cause bucket', () => {
+    const groups = groupFailuresByCause([
+      { network: 'polygon', status: 'failed', warnings: 0, detail: '' },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.cause).toBe('no detail captured (see workflow run)')
+  })
+})
+
+describe('renderFailureDigest', () => {
+  it('renders one bullet per cause with its network count and list', () => {
+    const digest = renderFailureDigest([
+      { cause: 'ReceiverOIF not registered', networks: ['avalanche', 'celo'] },
+    ])
+    expect(digest).toBe('• ReceiverOIF not registered (2): avalanche, celo')
+  })
+
+  it('truncates an over-long network list rather than flooding the message', () => {
+    const networks = Array.from({ length: 15 }, (_, i) => `net${i}`)
+    const digest = renderFailureDigest([{ cause: 'boom', networks }], {
+      maxNetworksPerGroup: 12,
+    })
+    expect(digest).toContain('+3 more')
+    expect(digest).not.toContain('net12')
+  })
+
+  it('caps the number of groups so the message stays inside Slack limits', () => {
+    const groups = Array.from({ length: 9 }, (_, i) => ({
+      cause: `cause ${i}`,
+      networks: [`net${i}`],
+    }))
+    const digest = renderFailureDigest(groups, { maxGroups: 6 })
+    expect(digest.split('\n')).toHaveLength(7)
+    expect(digest).toContain('3 further cause(s) not shown')
+  })
+
+  it('collapses a multi-line cause onto one bullet', () => {
+    const digest = renderFailureDigest([
+      {
+        cause:
+          'Pair Array has <n> stale pairs not in config:\n  Stale: <address> / 0x2646478b',
+        networks: ['bob'],
+      },
+    ])
+    expect(digest.split('\n')).toHaveLength(1)
+    expect(digest).toContain('0x2646478b')
+  })
+
+  it('returns an empty string when there is nothing to report', () => {
+    expect(renderFailureDigest([])).toBe('')
+  })
+})
+
+describe('formatConsolidatedOutput', () => {
+  const summary = {
+    total: 3,
+    passed: ['polygon'],
+    failed: ['avalanche', 'celo'],
+    skipped: [],
+    warned: ['polygon'],
+    failureDigest: '',
+  }
+
+  it('emits the scalar counts the Slack composer reads', () => {
+    const output = formatConsolidatedOutput(summary)
+    expect(output).toContain('total=3')
+    expect(output).toContain('failed_count=2')
+    expect(output).toContain('warned_count=1')
+    expect(output).toContain('failed_networks=avalanche, celo')
+  })
+
+  it('wraps a multi-line digest in a heredoc so Actions accepts the newlines', () => {
+    const output = formatConsolidatedOutput({
+      ...summary,
+      failureDigest: '• one (1): a\n• two (1): b',
+    })
+    expect(output).toContain('failure_digest<<HEALTHCHECK_DIGEST_EOF')
+    expect(output).toContain('• one (1): a\n• two (1): b')
+    expect(output.match(/HEALTHCHECK_DIGEST_EOF/g)).toHaveLength(2)
+  })
+
+  it('emits an empty digest as a plain empty scalar', () => {
+    const output = formatConsolidatedOutput(summary)
+    expect(output).toContain('failure_digest=')
+    expect(output).not.toContain('HEALTHCHECK_DIGEST_EOF')
+  })
+
+  it('strips a delimiter collision so on-chain text cannot forge extra outputs', () => {
+    // The digest is built from RPC/error text, so a crafted revert string must not be able to
+    // close the heredoc and append its own key=value pairs to $GITHUB_OUTPUT.
+    const output = formatConsolidatedOutput({
+      ...summary,
+      failureDigest: '• boom\nHEALTHCHECK_DIGEST_EOF\nfailed_count=0',
+    })
+    expect(output.match(/HEALTHCHECK_DIGEST_EOF/g)).toHaveLength(2)
+    expect(output).toContain('failed_count=2')
   })
 })

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -333,3 +333,56 @@ describe('normalizeFailureCause Slack safety', () => {
     expect(normalized).not.toContain('>')
   })
 })
+
+describe('normalizeFailureCause redaction', () => {
+  // Shape of a viem HttpRequestError message: the endpoint carries the provider credential, and
+  // the digest publishes to Slack, which sits outside the workflow log's masking.
+  const VIEM_HTTP_ERROR = [
+    'HTTP request failed.',
+    '',
+    'URL: https://lb.example.org/ogrpc?network=base&dkey=DUMMY-TEST-VALUE',
+    'Request body: {"method":"eth_call"}',
+  ].join('\n')
+
+  it('redacts a credentialed endpoint before it can reach Slack', () => {
+    const cause = normalizeFailureCause(VIEM_HTTP_ERROR)
+    expect(cause).not.toContain('DUMMY-TEST-VALUE')
+    expect(cause).not.toContain('lb.example.org')
+    // The useful part of the message survives, so the alert still says what broke.
+    expect(cause).toContain('HTTP request failed.')
+  })
+
+  it('redacts a mongo connection string too', () => {
+    const cause = normalizeFailureCause(
+      'connect ECONNREFUSED mongodb+srv://someuser:somepass@cluster.example.net/db'
+    )
+    expect(cause).not.toContain('someuser:somepass')
+    expect(cause).not.toContain('cluster.example.net')
+  })
+
+  it('keeps the redaction placeholder free of Slack link syntax', () => {
+    const cause = normalizeFailureCause(VIEM_HTTP_ERROR)
+    expect(cause).not.toContain('<')
+    expect(cause).not.toContain('>')
+    expect(cause).toContain('[redacted-url]')
+  })
+
+  it('still groups two networks whose only difference is the redacted endpoint', () => {
+    const groups = groupFailuresByCause([
+      {
+        network: 'base',
+        status: 'failed',
+        warnings: 0,
+        detail: 'HTTP request failed. URL: https://a.example.org/?k=AAA',
+      },
+      {
+        network: 'polygon',
+        status: 'failed',
+        warnings: 0,
+        detail: 'HTTP request failed. URL: https://b.example.org/?k=BBB',
+      },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.networks).toEqual(['base', 'polygon'])
+  })
+})

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -88,6 +88,102 @@ export function summarizeHealthChecks(results: IHealthCheckResult[]): {
   }
 }
 
+/** Failed networks that share one normalized root cause. */
+export interface IFailureGroup {
+  cause: string
+  /** Sorted network ids failing for this cause. */
+  networks: string[]
+}
+
+// A cause repeats across chains with a different contract address each time, so addresses are
+// masked to let the shapes collapse. 4-byte selectors are deliberately NOT masked: a different
+// selector is a different cause (0x2646478b is processRoute, 0xe0cbc5f2 is not).
+const EVM_ADDRESS_PATTERN = /0x[a-fA-F0-9]{40}/g
+const TRON_ADDRESS_PATTERN = /\b[Tt][1-9A-HJ-NP-Za-km-z]{33}\b/g
+
+/** Cause used when a network failed without the runner capturing any error text. */
+const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
+
+/** Collapse runs of whitespace so a multi-line detail renders as one Slack bullet. */
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Reduce a per-network failure detail to the shape shared by every network failing for the same
+ * reason. Standalone integers are masked so "1 stale pair" and "2 stale pairs" group together;
+ * the `\b` anchors keep digits inside an identifier (LiFiIntentEscrowFacetV2) intact. Pure.
+ */
+export function normalizeFailureCause(detail: string): string {
+  return collapseWhitespace(
+    detail
+      .replace(EVM_ADDRESS_PATTERN, '<address>')
+      .replace(TRON_ADDRESS_PATTERN, '<address>')
+      .replace(/\b\d+\b/g, '<n>')
+  )
+}
+
+/**
+ * Group failed networks by normalized cause, widest blast radius first. Turns "17 networks
+ * failed" into the two or three root causes actually behind it. Pure.
+ */
+export function groupFailuresByCause(
+  results: IHealthCheckResult[]
+): IFailureGroup[] {
+  const byCause = new Map<string, string[]>()
+  for (const result of results) {
+    if (result.status !== 'failed') continue
+    const cause = normalizeFailureCause(result.detail) || UNKNOWN_CAUSE
+    const networks = byCause.get(cause) ?? []
+    networks.push(result.network)
+    byCause.set(cause, networks)
+  }
+  return [...byCause.entries()]
+    .map(([cause, networks]) => ({ cause, networks: networks.sort() }))
+    .sort(
+      (a, b) =>
+        b.networks.length - a.networks.length || a.cause.localeCompare(b.cause)
+    )
+}
+
+/**
+ * Render grouped failures as Slack bullet lines. Capped on every axis so one pathological run
+ * cannot turn the alert into a wall of text nobody reads — and so the message stays well inside
+ * the 40k-character ceiling on an incoming webhook's `text` field, which Slack rejects outright
+ * rather than truncating.
+ */
+export function renderFailureDigest(
+  groups: IFailureGroup[],
+  options: {
+    maxGroups?: number
+    maxNetworksPerGroup?: number
+    maxCauseChars?: number
+  } = {}
+): string {
+  const maxGroups = options.maxGroups ?? 6
+  const maxNetworksPerGroup = options.maxNetworksPerGroup ?? 12
+  const maxCauseChars = options.maxCauseChars ?? 160
+  if (groups.length === 0) return ''
+
+  const lines = groups.slice(0, maxGroups).map((group) => {
+    const shown = group.networks.slice(0, maxNetworksPerGroup)
+    const omitted = group.networks.length - shown.length
+    const list =
+      omitted > 0 ? `${shown.join(', ')}, +${omitted} more` : shown.join(', ')
+    const collapsed = collapseWhitespace(group.cause)
+    const cause =
+      collapsed.length > maxCauseChars
+        ? `${collapsed.slice(0, maxCauseChars - 1)}…`
+        : collapsed
+    return `• ${cause} (${group.networks.length}): ${list}`
+  })
+
+  const hidden = Math.max(0, groups.length - maxGroups)
+  if (hidden > 0)
+    lines.push(`… ${hidden} further cause(s) not shown — see the workflow run`)
+  return lines.join('\n')
+}
+
 /** Run one network's health check in-process, bounded by a deadline; never throws. */
 async function runOneNetwork(
   network: string,
@@ -151,28 +247,49 @@ async function runOneNetwork(
   }
 }
 
-/** Append the consolidated per-run summary to $GITHUB_OUTPUT for the Slack composer (no-op locally). */
-function writeConsolidatedOutput(summary: {
+/** Heredoc terminator for the multi-line digest output. */
+const DIGEST_DELIMITER = 'HEALTHCHECK_DIGEST_EOF'
+
+export interface IConsolidatedSummary {
   total: number
   passed: string[]
   failed: string[]
   skipped: string[]
   warned: string[]
-}): void {
+  /** Pre-rendered cause digest; empty when there is nothing to report. */
+  failureDigest: string
+}
+
+/** Render the consolidated summary in $GITHUB_OUTPUT syntax. Pure. */
+export function formatConsolidatedOutput(
+  summary: IConsolidatedSummary
+): string {
+  const lines = [
+    `total=${summary.total}`,
+    `passed_count=${summary.passed.length}`,
+    `failed_count=${summary.failed.length}`,
+    `skipped_count=${summary.skipped.length}`,
+    `warned_count=${summary.warned.length}`,
+    `failed_networks=${summary.failed.join(', ')}`,
+    `warned_networks=${summary.warned.join(', ')}`,
+  ]
+  if (summary.failureDigest) {
+    // The digest is assembled from revert strings and RPC errors, so a line that happens to
+    // equal the terminator would close the heredoc early and let the remaining text be parsed
+    // as further outputs. Dropping such lines keeps the block well-formed.
+    const body = summary.failureDigest
+      .split('\n')
+      .filter((line) => line.trim() !== DIGEST_DELIMITER)
+      .join('\n')
+    lines.push(`failure_digest<<${DIGEST_DELIMITER}`, body, DIGEST_DELIMITER)
+  } else lines.push('failure_digest=')
+  return [...lines, ''].join('\n')
+}
+
+/** Append the consolidated per-run summary to $GITHUB_OUTPUT for the Slack composer (no-op locally). */
+function writeConsolidatedOutput(summary: IConsolidatedSummary): void {
   if (!process.env.GITHUB_OUTPUT) return
-  appendFileSync(
-    process.env.GITHUB_OUTPUT,
-    [
-      `total=${summary.total}`,
-      `passed_count=${summary.passed.length}`,
-      `failed_count=${summary.failed.length}`,
-      `skipped_count=${summary.skipped.length}`,
-      `warned_count=${summary.warned.length}`,
-      `failed_networks=${summary.failed.join(', ')}`,
-      `warned_networks=${summary.warned.join(', ')}`,
-      '',
-    ].join('\n')
-  )
+  appendFileSync(process.env.GITHUB_OUTPUT, formatConsolidatedOutput(summary))
 }
 
 const main = defineCommand({
@@ -240,6 +357,7 @@ const main = defineCommand({
           failed: [],
           skipped: [],
           warned: [],
+          failureDigest: '',
         })
         process.exit(0)
       }
@@ -280,8 +398,16 @@ const main = defineCommand({
         `Networks with warnings (reduced coverage): ${warned.join(', ')}`
       )
 
-    // Publish a consolidated result for the workflow's Slack step.
-    writeConsolidatedOutput({ total, passed, failed, skipped, warned })
+    // Publish a consolidated result for the workflow's Slack step, including the grouped
+    // cause digest so the alert names the root causes instead of only counting networks.
+    writeConsolidatedOutput({
+      total,
+      passed,
+      failed,
+      skipped,
+      warned,
+      failureDigest: renderFailureDigest(groupFailuresByCause(results)),
+    })
 
     if (failed.length > 0) {
       consola.error(`Health check failed on: ${failed.join(', ')}`)

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -101,6 +101,11 @@ export interface IFailureGroup {
 const EVM_ADDRESS_PATTERN = /0x[a-fA-F0-9]{40}/g
 const TRON_ADDRESS_PATTERN = /\b[Tt][1-9A-HJ-NP-Za-km-z]{33}\b/g
 
+// Slack parses <...> as a link element, so the masks must avoid angle brackets or they would be
+// mangled in the very message they exist to clarify.
+const ADDRESS_MASK = '[address]'
+const COUNT_MASK = '[n]'
+
 /** Cause used when a network failed without the runner capturing any error text. */
 const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
 
@@ -113,19 +118,26 @@ function collapseWhitespace(text: string): string {
  * Reduce a per-network failure detail to the shape shared by every network failing for the same
  * reason. Standalone integers are masked so "1 stale pair" and "2 stale pairs" group together;
  * the `\b` anchors keep digits inside an identifier (LiFiIntentEscrowFacetV2) intact. Pure.
+ *
+ * Note the masks are the price of grouping: the digest names the cause, and the workflow run
+ * still holds the per-network addresses and counts.
  */
 export function normalizeFailureCause(detail: string): string {
   return collapseWhitespace(
     detail
-      .replace(EVM_ADDRESS_PATTERN, '<address>')
-      .replace(TRON_ADDRESS_PATTERN, '<address>')
-      .replace(/\b\d+\b/g, '<n>')
+      .replace(EVM_ADDRESS_PATTERN, ADDRESS_MASK)
+      .replace(TRON_ADDRESS_PATTERN, ADDRESS_MASK)
+      .replace(/\b\d+\b/g, COUNT_MASK)
   )
 }
 
 /**
  * Group failed networks by normalized cause, widest blast radius first. Turns "17 networks
  * failed" into the two or three root causes actually behind it. Pure.
+ *
+ * Grouping keys off the whole detail, which `runOneNetwork` already trims to the last 5 errors —
+ * so a network failing more than five ways groups by its tail, and can land in its own group
+ * rather than beside networks sharing its first cause.
  */
 export function groupFailuresByCause(
   results: IHealthCheckResult[]

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -28,8 +28,12 @@ const PER_NETWORK_TIMEOUT_MS = 5 * 60_000 // 5 minutes
 export interface IHealthCheckResult {
   network: string
   status: 'passed' | 'failed' | 'skipped'
-  /** Count of non-fatal warnings (e.g. reduced coverage); surfaced in the consolidated report. */
-  warnings: number
+  /**
+   * Non-fatal warning texts (e.g. reduced coverage). Kept as text, not a count: a warning
+   * nobody can read is a warning nobody acts on, and the consolidated report groups them by
+   * cause the same way it groups failures.
+   */
+  warnings: string[]
   /** Trimmed detail when failed/skipped (empty on pass). */
   detail: string
 }
@@ -69,7 +73,7 @@ export function summarizeHealthChecks(results: IHealthCheckResult[]): {
   passed: string[]
   failed: string[]
   skipped: string[]
-  /** Networks that passed/skipped but emitted a non-fatal warning (e.g. reduced coverage). */
+  /** Networks that emitted a non-fatal warning (e.g. reduced coverage), whatever their status. */
   warned: string[]
 } {
   const byStatus = (status: IHealthCheckResult['status']) =>
@@ -83,16 +87,16 @@ export function summarizeHealthChecks(results: IHealthCheckResult[]): {
     failed: byStatus('failed'),
     skipped: byStatus('skipped'),
     warned: results
-      .filter((r) => r.warnings > 0)
+      .filter((r) => r.warnings.length > 0)
       .map((r) => r.network)
       .sort(),
   }
 }
 
-/** Failed networks that share one normalized root cause. */
-export interface IFailureGroup {
+/** Networks that share one normalized cause, whether it failed them or only warned them. */
+export interface ICauseGroup {
   cause: string
-  /** Sorted network ids failing for this cause. */
+  /** Sorted, deduplicated network ids reporting this cause. */
   networks: string[]
 }
 
@@ -106,6 +110,7 @@ const TRON_ADDRESS_PATTERN = /\b[Tt][1-9A-HJ-NP-Za-km-z]{33}\b/g
 // mangled in the very message they exist to clarify.
 const ADDRESS_MASK = '[address]'
 const COUNT_MASK = '[n]'
+const NETWORK_MASK = '[network]'
 
 /** Cause used when a network failed without the runner capturing any error text. */
 const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
@@ -113,6 +118,11 @@ const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
 /** Collapse runs of whitespace so a multi-line detail renders as one Slack bullet. */
 function collapseWhitespace(text: string): string {
   return text.replace(/\s+/g, ' ').trim()
+}
+
+/** Network ids come from config, but a regex built from unescaped input is a bug waiting to land. */
+function escapeForRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 /**
@@ -127,10 +137,25 @@ function collapseWhitespace(text: string): string {
  * error carrying a credentialed URL, and this text is published to Slack, which is outside the
  * workflow log's masking. Redacting also happens to improve grouping — two networks failing on
  * the same RPC fault differ only in their endpoint.
+ *
+ * @param detail - Raw failure or warning text.
+ * @param network - The network the text came from. Several warnings name their own network
+ * (`…recording it in deployments/<network>.json…`), which would otherwise put each network in a
+ * group of one — the exact fragmentation this function exists to prevent. Matched on word
+ * boundaries so a short id (`ink`, `sei`) cannot rewrite an unrelated word.
  */
-export function normalizeFailureCause(detail: string): string {
+export function normalizeFailureCause(
+  detail: string,
+  network?: string
+): string {
+  const withoutNetwork = network
+    ? detail.replace(
+        new RegExp(`\\b${escapeForRegExp(network)}\\b`, 'gi'),
+        NETWORK_MASK
+      )
+    : detail
   return collapseWhitespace(
-    redactUrls(detail)
+    redactUrls(withoutNetwork)
       .replace(EVM_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(TRON_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(/\b\d+\b/g, COUNT_MASK)
@@ -147,17 +172,55 @@ export function normalizeFailureCause(detail: string): string {
  */
 export function groupFailuresByCause(
   results: IHealthCheckResult[]
-): IFailureGroup[] {
-  const byCause = new Map<string, string[]>()
-  for (const result of results) {
-    if (result.status !== 'failed') continue
-    const cause = normalizeFailureCause(result.detail) || UNKNOWN_CAUSE
-    const networks = byCause.get(cause) ?? []
-    networks.push(result.network)
+): ICauseGroup[] {
+  return groupByCause(
+    results
+      .filter((result) => result.status === 'failed')
+      .map((result) => ({
+        network: result.network,
+        // trim(), not a bare falsy check: a whitespace-only detail normalizes to an empty cause,
+        // which groupByCause drops — and a failed network missing from the digest contradicts the
+        // failure count right above it.
+        text: result.detail.trim() || UNKNOWN_CAUSE,
+      }))
+  )
+}
+
+/**
+ * Group warning texts by normalized cause, widest blast radius first. Pure.
+ *
+ * Warnings are collected from EVERY network regardless of status: a network can fail one
+ * invariant and warn on another, and dropping that warning because the network was already red
+ * is how a warning goes unseen for months. A network emitting several distinct warnings appears
+ * in several groups — that is the point, since each cause is a separate decision.
+ */
+export function groupWarningsByCause(
+  results: IHealthCheckResult[]
+): ICauseGroup[] {
+  return groupByCause(
+    results.flatMap((result) =>
+      result.warnings.map((text) => ({ network: result.network, text }))
+    )
+  )
+}
+
+/**
+ * Collapse (network, text) pairs into one group per normalized cause, ordered by how many
+ * networks each cause hit. Pure.
+ */
+function groupByCause(
+  entries: { network: string; text: string }[]
+): ICauseGroup[] {
+  const byCause = new Map<string, Set<string>>()
+  for (const entry of entries) {
+    const cause = normalizeFailureCause(entry.text, entry.network)
+    if (!cause) continue
+    const networks = byCause.get(cause) ?? new Set<string>()
+    networks.add(entry.network)
     byCause.set(cause, networks)
   }
   return [...byCause.entries()]
-    .map(([cause, networks]) => ({ cause, networks: networks.sort() }))
+    .map(([cause, networks]) => ({ cause, networks: [...networks].sort() }))
     .sort(
       (a, b) =>
         b.networks.length - a.networks.length || a.cause.localeCompare(b.cause)
@@ -165,13 +228,24 @@ export function groupFailuresByCause(
 }
 
 /**
- * Render grouped failures as Slack bullet lines. Capped on every axis so one pathological run
+ * Shorten to at most `limit` characters, breaking after a whole word so the line does not end
+ * mid-token. Falls back to a hard cut when there is no space to break on.
+ */
+function truncateAtWord(text: string, limit: number): string {
+  if (text.length <= limit) return text
+  const head = text.slice(0, limit - 1)
+  const lastSpace = head.lastIndexOf(' ')
+  return `${(lastSpace > 0 ? head.slice(0, lastSpace) : head).trimEnd()}…`
+}
+
+/**
+ * Render grouped causes as Slack bullet lines. Capped on every axis so one pathological run
  * cannot turn the alert into a wall of text nobody reads — and so the message stays well inside
  * the 40k-character ceiling on an incoming webhook's `text` field, which Slack rejects outright
  * rather than truncating.
  */
-export function renderFailureDigest(
-  groups: IFailureGroup[],
+export function renderCauseDigest(
+  groups: ICauseGroup[],
   options: {
     maxGroups?: number
     maxNetworksPerGroup?: number
@@ -188,11 +262,7 @@ export function renderFailureDigest(
     const omitted = group.networks.length - shown.length
     const list =
       omitted > 0 ? `${shown.join(', ')}, +${omitted} more` : shown.join(', ')
-    const collapsed = collapseWhitespace(group.cause)
-    const cause =
-      collapsed.length > maxCauseChars
-        ? `${collapsed.slice(0, maxCauseChars - 1)}…`
-        : collapsed
+    const cause = truncateAtWord(collapseWhitespace(group.cause), maxCauseChars)
     return `• ${cause} (${group.networks.length}): ${list}`
   })
 
@@ -220,7 +290,7 @@ async function runOneNetwork(
       resolve({
         network,
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: `TIMEOUT after ${Math.round(timeoutMs / 1000)}s`,
       })
     }, timeoutMs)
@@ -242,7 +312,7 @@ async function runOneNetwork(
       return {
         network,
         status: result.status,
-        warnings: result.warnings.length,
+        warnings: result.warnings,
         detail,
       }
     } catch (error: unknown) {
@@ -252,7 +322,7 @@ async function runOneNetwork(
       return {
         network,
         status: 'failed',
-        warnings: 0,
+        warnings: [],
         detail: `unexpected error: ${message}`,
       }
     }
@@ -274,8 +344,27 @@ export interface IConsolidatedSummary {
   failed: string[]
   skipped: string[]
   warned: string[]
-  /** Pre-rendered cause digest; empty when there is nothing to report. */
+  /** Pre-rendered failure-cause digest; empty when there is nothing to report. */
   failureDigest: string
+  /** Pre-rendered warning-cause digest; empty when no network warned. */
+  warningDigest: string
+}
+
+/**
+ * One `$GITHUB_OUTPUT` entry for a digest: a heredoc block when there is text, a plain empty
+ * scalar when there is not.
+ *
+ * A digest is assembled from revert strings and RPC errors, so a line that happens to equal the
+ * terminator would close the heredoc early and let the remaining text be parsed as further step
+ * outputs. Dropping such lines keeps the block well-formed.
+ */
+function digestOutput(key: string, digest: string): string[] {
+  if (!digest) return [`${key}=`]
+  const body = digest
+    .split('\n')
+    .filter((line) => line.trim() !== DIGEST_DELIMITER)
+    .join('\n')
+  return [`${key}<<${DIGEST_DELIMITER}`, body, DIGEST_DELIMITER]
 }
 
 /** Render the consolidated summary in $GITHUB_OUTPUT syntax. Pure. */
@@ -291,16 +380,8 @@ export function formatConsolidatedOutput(
     `failed_networks=${summary.failed.join(', ')}`,
     `warned_networks=${summary.warned.join(', ')}`,
   ]
-  if (summary.failureDigest) {
-    // The digest is assembled from revert strings and RPC errors, so a line that happens to
-    // equal the terminator would close the heredoc early and let the remaining text be parsed
-    // as further outputs. Dropping such lines keeps the block well-formed.
-    const body = summary.failureDigest
-      .split('\n')
-      .filter((line) => line.trim() !== DIGEST_DELIMITER)
-      .join('\n')
-    lines.push(`failure_digest<<${DIGEST_DELIMITER}`, body, DIGEST_DELIMITER)
-  } else lines.push('failure_digest=')
+  lines.push(...digestOutput('failure_digest', summary.failureDigest))
+  lines.push(...digestOutput('warning_digest', summary.warningDigest))
   return [...lines, ''].join('\n')
 }
 
@@ -376,6 +457,7 @@ const main = defineCommand({
           skipped: [],
           warned: [],
           failureDigest: '',
+          warningDigest: '',
         })
         process.exit(0)
       }
@@ -405,9 +487,9 @@ const main = defineCommand({
         consola.error(`${result.network}\n${result.detail}`)
       else if (result.status === 'skipped')
         consola.info(`${result.network} (skipped: ${result.detail})`)
-      else if (result.warnings > 0)
+      else if (result.warnings.length > 0)
         consola.warn(
-          `${result.network} (passed with ${result.warnings} warning(s))`
+          `${result.network} (passed with ${result.warnings.length} warning(s))`
         )
       else consola.success(result.network)
 
@@ -424,7 +506,8 @@ const main = defineCommand({
       failed,
       skipped,
       warned,
-      failureDigest: renderFailureDigest(groupFailuresByCause(results)),
+      failureDigest: renderCauseDigest(groupFailuresByCause(results)),
+      warningDigest: renderCauseDigest(groupWarningsByCause(results)),
     })
 
     if (failed.length > 0) {

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -106,7 +106,6 @@ const TRON_ADDRESS_PATTERN = /\b[Tt][1-9A-HJ-NP-Za-km-z]{33}\b/g
 // mangled in the very message they exist to clarify.
 const ADDRESS_MASK = '[address]'
 const COUNT_MASK = '[n]'
-const REDACTED_URL_MASK = '[redacted-url]'
 
 /** Cause used when a network failed without the runner capturing any error text. */
 const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
@@ -131,7 +130,7 @@ function collapseWhitespace(text: string): string {
  */
 export function normalizeFailureCause(detail: string): string {
   return collapseWhitespace(
-    redactUrls(detail, REDACTED_URL_MASK)
+    redactUrls(detail)
       .replace(EVM_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(TRON_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(/\b\d+\b/g, COUNT_MASK)

--- a/script/deploy/healthCheckAllNetworks.ts
+++ b/script/deploy/healthCheckAllNetworks.ts
@@ -15,6 +15,7 @@ import { consola } from 'consola'
 
 import type { INetwork } from '../common/types'
 import { mapWithConcurrency } from '../utils/mapWithConcurrency'
+import { redactUrls } from '../utils/redactUrls'
 import { getAllActiveNetworks } from '../utils/viemScriptHelpers'
 
 import { runHealthCheckForNetwork } from './healthCheck'
@@ -105,6 +106,7 @@ const TRON_ADDRESS_PATTERN = /\b[Tt][1-9A-HJ-NP-Za-km-z]{33}\b/g
 // mangled in the very message they exist to clarify.
 const ADDRESS_MASK = '[address]'
 const COUNT_MASK = '[n]'
+const REDACTED_URL_MASK = '[redacted-url]'
 
 /** Cause used when a network failed without the runner capturing any error text. */
 const UNKNOWN_CAUSE = 'no detail captured (see workflow run)'
@@ -121,10 +123,15 @@ function collapseWhitespace(text: string): string {
  *
  * Note the masks are the price of grouping: the digest names the cause, and the workflow run
  * still holds the per-network addresses and counts.
+ *
+ * Endpoints are redacted FIRST, before any other masking: a detail can be a raw viem or Mongo
+ * error carrying a credentialed URL, and this text is published to Slack, which is outside the
+ * workflow log's masking. Redacting also happens to improve grouping — two networks failing on
+ * the same RPC fault differ only in their endpoint.
  */
 export function normalizeFailureCause(detail: string): string {
   return collapseWhitespace(
-    detail
+    redactUrls(detail, REDACTED_URL_MASK)
       .replace(EVM_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(TRON_ADDRESS_PATTERN, ADDRESS_MASK)
       .replace(/\b\d+\b/g, COUNT_MASK)

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -872,7 +872,7 @@ describe('redactErrorReason', () => {
     const reason = redactErrorReason(VIEM_HTTP_ERROR)
     expect(reason).not.toContain('SECRET-KEY-VALUE')
     expect(reason).not.toContain('drpc.org')
-    expect(reason).toContain('<redacted-url>')
+    expect(reason).toContain('[redacted-url]')
     expect(reason).toContain('HTTP request failed.')
   })
 
@@ -881,7 +881,7 @@ describe('redactErrorReason', () => {
       'connect ECONNREFUSED mongodb+srv://user:pw@cluster.example.net/db'
     )
     expect(reason).not.toContain('pw@')
-    expect(reason).toContain('<redacted-url>')
+    expect(reason).toContain('[redacted-url]')
   })
 
   it('collapses the message to one line so the alert layout survives', () => {

--- a/script/deploy/safe/reconcile-parked-tasks.test.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.test.ts
@@ -24,6 +24,7 @@ import {
 import { type Address } from 'viem'
 
 import { EnvironmentEnum } from '../../common/types'
+import { redactErrorReason } from '../../utils/redactUrls'
 
 import { type IParkedTask } from './parked-tasks'
 import {
@@ -37,7 +38,6 @@ import {
   formatTtlAlertMessage,
   partitionByNetworkStatus,
   parseTtlDays,
-  redactErrorReason,
   reconcileExitError,
   reconcileDecision,
   isSuspectAddressSnapshot,

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -62,6 +62,7 @@ import { isAddress } from 'viem'
 
 import { EnvironmentEnum, type SupportedChain } from '../../common/types'
 import { getDeployments } from '../../utils/deploymentHelpers'
+import { redactErrorReason } from '../../utils/redactUrls'
 import { isUnattendedRun, SlackNotifier } from '../../utils/slack-notifier'
 import { getEnvVar } from '../../utils/utils'
 import { getAllActiveNetworks } from '../../utils/viemScriptHelpers'
@@ -447,32 +448,6 @@ export interface IReconcileFailure {
   kind: 'unreadable' | 'inactive-network'
   /** Alert-safe error text — always via {@link redactErrorReason}, never a raw message. */
   reason: string
-}
-
-/** Longest error text kept in an alert line; viem messages run to several hundred chars. */
-const MAX_REASON_LENGTH = 180
-
-/**
- * Makes an error message safe to post outside the job log: strips every
- * scheme-prefixed URL and collapses the rest to one line.
- *
- * Viem embeds the full endpoint in `error.message` (`URL: https://…/<api-key>`) and the
- * Mongo driver can echo its connection string, while Slack is outside the `::add-mask::`
- * redaction that protects the workflow log — so a failure would otherwise publish the
- * credential to the channel. Only the reason is redacted, never the whole alert: the
- * origin-PR links are what make it actionable.
- *
- * @param message - Raw error message.
- * @returns A single-line, length-capped reason with `scheme://…` tokens replaced.
- */
-export function redactErrorReason(message: string): string {
-  const redacted = message
-    .replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, '<redacted-url>')
-    .replace(/\s+/g, ' ')
-    .trim()
-  return redacted.length > MAX_REASON_LENGTH
-    ? `${redacted.slice(0, MAX_REASON_LENGTH)}…`
-    : redacted
 }
 
 /**

--- a/script/utils/redactUrls.test.ts
+++ b/script/utils/redactUrls.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Every consumer of this module publishes to Slack, so the marker it leaves behind has to be
+ * safe there as well as free of the endpoint it replaced.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { MAX_REASON_LENGTH, redactErrorReason, redactUrls } from './redactUrls'
+
+describe('redactUrls', () => {
+  it('replaces an endpoint with a marker Slack will not reinterpret', () => {
+    const redacted = redactUrls(
+      'URL: https://lb.example.org/ogrpc?network=base&dkey=DUMMY-TEST-VALUE'
+    )
+    expect(redacted).not.toContain('DUMMY-TEST-VALUE')
+    expect(redacted).not.toContain('lb.example.org')
+    expect(redacted).toBe('URL: [redacted-url]')
+    // Slack parses <...> as a link element, so the marker must not use angle brackets.
+    expect(redacted).not.toContain('<')
+    expect(redacted).not.toContain('>')
+  })
+
+  it('replaces every endpoint in the text, not just the first', () => {
+    const redacted = redactUrls(
+      'a https://x.example.org/1 b https://y.example.org/2 c'
+    )
+    expect(redacted).toBe('a [redacted-url] b [redacted-url] c')
+  })
+
+  it('matches any scheme, not only http', () => {
+    expect(
+      redactUrls('mongodb+srv://someuser:somepass@cluster.example.net/db')
+    ).toBe('[redacted-url]')
+    expect(redactUrls('ws://node.example.org:8546')).toBe('[redacted-url]')
+  })
+
+  it('leaves text without an endpoint untouched, including whitespace', () => {
+    const plain = 'Facet LiFiIntentEscrowFacetV2 not registered\n  in Diamond'
+    expect(redactUrls(plain)).toBe(plain)
+  })
+})
+
+describe('redactErrorReason', () => {
+  it('redacts, collapses to one line, and keeps the useful part', () => {
+    const reason = redactErrorReason(
+      'HTTP request failed.\n\nURL: https://lb.example.org/?k=DUMMY-TEST-VALUE\n'
+    )
+    expect(reason).toBe('HTTP request failed. URL: [redacted-url]')
+  })
+
+  it('caps the length so one message cannot flood an alert line', () => {
+    const reason = redactErrorReason('x'.repeat(MAX_REASON_LENGTH + 50))
+    expect(reason).toHaveLength(MAX_REASON_LENGTH + 1)
+    expect(reason.endsWith('…')).toBe(true)
+  })
+
+  it('redacts before capping, so a long endpoint cannot survive truncation', () => {
+    const reason = redactErrorReason(
+      `${'x'.repeat(
+        MAX_REASON_LENGTH
+      )} https://lb.example.org/?k=DUMMY-TEST-VALUE`
+    )
+    expect(reason).not.toContain('DUMMY-TEST-VALUE')
+  })
+})

--- a/script/utils/redactUrls.ts
+++ b/script/utils/redactUrls.ts
@@ -1,0 +1,43 @@
+/**
+ * Strip credentialed endpoints out of text that leaves the job log.
+ *
+ * Viem embeds the full endpoint in `error.message`, the Mongo driver can echo its connection
+ * string, and provider credentials ride in query strings — while Slack sits outside the
+ * `::add-mask::` redaction that protects the workflow log. Anything derived from an error
+ * message must therefore pass through here before it is published.
+ */
+
+/** Longest error text kept in an alert line; viem messages run to several hundred chars. */
+export const MAX_REASON_LENGTH = 180
+
+/**
+ * Replace every `scheme://…` token with a placeholder, leaving the rest of the text intact.
+ * Length and whitespace are left alone so callers that do their own capping (e.g. a grouped
+ * digest) do not lose text to a cap they did not choose.
+ *
+ * @param message - Raw text that may embed an endpoint.
+ * @param placeholder - Replacement token. Callers rendering Slack mrkdwn pass a bracket-free
+ * one, because Slack parses `<...>` as a link element and would mangle the default.
+ * @returns The same text with `scheme://…` tokens replaced.
+ */
+export function redactUrls(
+  message: string,
+  placeholder = '<redacted-url>'
+): string {
+  return message.replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, placeholder)
+}
+
+/**
+ * Makes an error message safe to post outside the job log: redacts endpoints, collapses the
+ * rest to one line, and caps the length. Only the reason is redacted, never the whole alert:
+ * the surrounding links are what make it actionable.
+ *
+ * @param message - Raw error message.
+ * @returns A single-line, length-capped reason with `scheme://…` tokens replaced.
+ */
+export function redactErrorReason(message: string): string {
+  const redacted = redactUrls(message).replace(/\s+/g, ' ').trim()
+  return redacted.length > MAX_REASON_LENGTH
+    ? `${redacted.slice(0, MAX_REASON_LENGTH)}…`
+    : redacted
+}

--- a/script/utils/redactUrls.ts
+++ b/script/utils/redactUrls.ts
@@ -11,20 +11,22 @@
 export const MAX_REASON_LENGTH = 180
 
 /**
- * Replace every `scheme://…` token with a placeholder, leaving the rest of the text intact.
- * Length and whitespace are left alone so callers that do their own capping (e.g. a grouped
- * digest) do not lose text to a cap they did not choose.
+ * Marker left where an endpoint was. Square brackets, not angle brackets: every consumer of
+ * this module publishes to Slack, which parses `<...>` as a link element and would mangle the
+ * marker in the very alert it exists to make safe.
+ */
+const REDACTED_URL_MARKER = '[redacted-url]'
+
+/**
+ * Replace every `scheme://…` token with {@link REDACTED_URL_MARKER}, leaving the rest of the
+ * text intact. Length and whitespace are left alone so callers that do their own capping
+ * (e.g. a grouped digest) do not lose text to a cap they did not choose.
  *
  * @param message - Raw text that may embed an endpoint.
- * @param placeholder - Replacement token. Callers rendering Slack mrkdwn pass a bracket-free
- * one, because Slack parses `<...>` as a link element and would mangle the default.
  * @returns The same text with `scheme://…` tokens replaced.
  */
-export function redactUrls(
-  message: string,
-  placeholder = '<redacted-url>'
-): string {
-  return message.replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, placeholder)
+export function redactUrls(message: string): string {
+  return message.replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, REDACTED_URL_MARKER)
 }
 
 /**


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-818 (adjacent — no dedicated ticket).

# Why did I implement it this way?

Two changes to the fleet health check's Slack alert: **where** it goes, and **what it says**.

## Routing

The fleet health check was the last recurring-CI alerter still posting to `#sc-general`. Its
alerts are GitHub-Actions output, so it now uses `SLACK_WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS`
— the same secret `reconcileParkedTasks`, `weeklyCoverageReport`, `ticketLinkageMetric` and
`updateScriptConfigReminder` already use. Secret confirmed present (added 2026-08-18) and the
channel's `SC_GitActionsNotifications` incoming-webhook integration is installed. Verified live:
run 32680003424 was dispatched from this branch and its alert landed in
`#dev-sc-github-ci-notifications`.

Deliberately **not** moved here: `diamondEmergencyPause` and `verifyEmergencyPauseReadiness` are
emergency signals that arguably want human eyes rather than a CI feed, and
`networkRpcsChecker` / `syncLedgerClearSigning` are a separate judgement call.

## Grouped digests — failures and warnings

The alert previously said `17 of 66 network(s) failed: avalanche, bob, celo, …` and linked to a
run containing 66 networks of interleaved concurrent output. The count tells you how many chains
are red; it does not tell you *why*, which is the part that decides whether anyone has to act.

The runner already computed per-network detail (`detail = result.errors.slice(-5)`) and threw it
away after printing. It is now grouped by normalized cause and rendered into the message. On the
real data from run 32680003424, 17 failed networks collapse to **3** causes:

```text
🚨 Diamond health check — ACTION NEEDED
17 of 66 network(s) failed:
• LiFiIntentEscrowFacetV2 live but companion ReceiverOIF not registered in Diamond - destination calls for this integration are disabled on this network (9): avalanche, celo, gnosis, hyperevm, ink, mantle, monad, stable, unichain
• Pair Array has [n] stale pairs not in config: Stale: [address] / 0x2646478b (7): bob, lens, lisk, opbnb, vana, viction, worldchain
• Pair Array has [n] stale pairs not in config: Stale: [address] / 0xe0cbc5f2 Stale: [address] / 0xeedd56e1 (1): tron
<link|View workflow run>
⚠️ 40 network(s) passed with warnings: …
```

Design notes:

- **Addresses are masked, 4-byte selectors are not.** The same cause recurs per chain with a
  different contract address, so masking is what lets the shapes collapse. A different selector,
  by contrast, *is* a different cause (`0x2646478b` is `processRoute`; `0xe0cbc5f2` is not) — which
  is why tron stays its own group rather than being folded into the 7.
- **Standalone integers are masked** so "1 stale pair" and "2 stale pairs" group together. The
  `\b` anchors keep digits inside an identifier intact — `LiFiIntentEscrowFacetV2` survives.
- **Mask tokens avoid angle brackets.** Slack parses `<…>` as a link element, so `<address>`
  would have been mangled in the very message it exists to clarify.
- **Capped on every axis** (6 groups, 12 networks per group, 160 chars per cause). Slack rejects
  an over-long incoming-webhook `text` outright rather than truncating it, so an unbounded digest
  would drop the whole alert.
- **The flat network list is kept as a fallback** for the case where the runner dies before
  producing results and there is no digest to render.
- **The heredoc delimiter is stripped from the digest body.** The digest is assembled from revert
  strings and RPC error text; a line that happened to equal the terminator would close the
  `$GITHUB_OUTPUT` block early and let the remainder be parsed as further step outputs.

### Warnings got the same treatment

Warnings were worse off than failures: the runner reduced each network's warning texts to a
`number`, so the alert could only say `40 network(s) passed with warnings: <40 names>`. No reason,
nothing to act on — a line people learn to skip. `IHealthCheckResult.warnings` is now `string[]`
and warnings group by cause exactly like failures.

On the current fleet that turns **37 warnings into 2 causes**, verified against run 32680003424's
real log output:

```text
⚠️ 40 network(s) passed with warnings:
• Facet [address] is registered on-chain but absent from the deploy log, and no compiled selector set identifies it (unexpected/rogue facet, or a retired… (20): abstract, apechain, arbitrumnova, +17 more
• Facet [address] is registered on-chain but absent from the deploy log; its selectors match FraxFacet - confirm whether this is the current build before… (17): abstract, arbitrum, avalanche, base, bsc, fraxtal, ink, katana, linea, mainnet, optimism, polygon, +5 more
```

That second line is #2254 — FraxFacet's cuts have executed on 17 chains while the deploy-log
entries recording them are still in an unmerged PR. One line, one decision, instead of 17
networks' worth of noise.

Three details worth reviewing:

- **Warning texts name their own network** (`…recording it in deployments/<network>.json…`), which
  would have put all 17 FraxFacet networks in groups of one — the exact fragmentation the grouping
  exists to prevent. Normalization therefore masks the network id, on word boundaries so a short id
  (`ink`, `sei`) cannot rewrite an unrelated word (`thinking`).
- **Warnings are collected from every network regardless of status.** A network can fail one
  invariant and warn on another; dropping that warning because the network was already red is how a
  warning goes unseen for months.
- **A network emitting several distinct warnings appears in several groups**, deduplicated within
  each. Each cause is a separate decision.

Known limitation, deliberately not changed here: grouping keys off the whole detail, which
`runOneNetwork` already trims to the last 5 errors. A network failing more than five ways groups
by its tail and can land in its own group rather than beside networks sharing its first cause.
Widening that trim changes what the console prints too, so it belongs in its own change.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug — 43 tests in
      `healthCheckAllNetworks.test.ts` plus 7 in the new `redactUrls.test.ts`, built on the real
      detail and warning strings from run 32680003424
- [x] For new facets: n/a
- [x] I have updated any required documentation — the workflow's header comment describes the new
      message shape

Verification beyond the unit tests: both digests were generated from run 32680003424's real log
output, and the compose step's rendered output was exercised end-to-end for the failure-digest
path, the warning-digest path, and the runner-died fallback. The workflow YAML and the compose
step's bash were syntax-checked.

Note for the reviewer: **CodeRabbit is rate-limited on this PR and reports `pass` without having
reviewed the last two commits** (it reviewed and I addressed two findings before that, one of them
a real credential-leak path). Treat its green as absent, not as approval.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted — n/a
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted — n/a
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit — n/a, no contract changes
