### PR TITLE
fix(clear-signing): render destinationChainId as raw again (EXSC-827)

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -18,7 +18,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -85,7 +85,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -174,7 +174,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -241,7 +241,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -314,7 +314,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -381,7 +381,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -448,7 +448,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -521,7 +521,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -594,7 +594,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -667,7 +667,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -740,7 +740,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -807,7 +807,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -880,7 +880,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -953,7 +953,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1020,7 +1020,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1093,7 +1093,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1166,7 +1166,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1239,7 +1239,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1306,7 +1306,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1379,7 +1379,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1446,7 +1446,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1513,7 +1513,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1580,7 +1580,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1647,7 +1647,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1720,7 +1720,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1787,7 +1787,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1854,7 +1854,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1921,7 +1921,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -1988,7 +1988,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2055,7 +2055,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2122,7 +2122,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2198,7 +2198,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2294,7 +2294,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2396,7 +2396,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2492,7 +2492,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2594,7 +2594,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2690,7 +2690,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2786,7 +2786,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2888,7 +2888,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -2990,7 +2990,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3092,7 +3092,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3194,7 +3194,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3290,7 +3290,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3392,7 +3392,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3494,7 +3494,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3590,7 +3590,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3692,7 +3692,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3794,7 +3794,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3896,7 +3896,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -3992,7 +3992,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4094,7 +4094,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4190,7 +4190,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4286,7 +4286,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4382,7 +4382,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4478,7 +4478,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4580,7 +4580,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4676,7 +4676,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4772,7 +4772,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4868,7 +4868,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -4964,7 +4964,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5060,7 +5060,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {
@@ -5156,7 +5156,7 @@
         {
           "path": "_bridgeData.destinationChainId",
           "label": "Destination Chain",
-          "format": "chainId",
+          "format": "raw",
           "visible": "always"
         },
         {

--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -24,14 +24,14 @@ All non-packed variants share the standard `ILiFi.BridgeData` struct:
   "interpolatedIntent": "Bridge {_bridgeData.minAmount} via <Bridge> to chain {_bridgeData.destinationChainId} for {_bridgeData.receiver}",
   "fields": [
     { "path": "_bridgeData.minAmount",          "label": "Amount to Bridge",   "format": "tokenAmount", "params": { "tokenPath": "_bridgeData.sendingAssetId" }, "visible": "always" },
-    { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "chainId",     "visible": "always" },
+    { "path": "_bridgeData.destinationChainId", "label": "Destination Chain", "format": "raw",         "visible": "always" },
     { "path": "_bridgeData.receiver",           "label": "Recipient",         "format": "addressName", "params": { "types": ["eoa","contract"], "sources": ["local","ens"] }, "visible": "always" },
     /* hidden plumbing: transactionId, bridge, integrator, referrer, hasSourceSwaps, hasDestinationCall */
   ]
 }
 ```
 
-Reads on a hardware wallet as one sentence: *"Bridge 100 USDC via Across to chain Polygon for vitalik.eth"*. A destination the wallet cannot name — any non-EVM synthetic id — falls back to the integer.
+Reads on a hardware wallet as one sentence: *"Bridge 100 USDC via Across to chain 137 for vitalik.eth"*.
 
 Note the bridge name (`<Bridge>`) is a literal substituted at descriptor-generation time, not a `{path}` placeholder resolved by the wallet — it's constant per selector and doesn't change between transactions.
 
@@ -92,7 +92,9 @@ The seven existing `display.formats` entries from the current registry descripto
 
 1. **Verb is "Bridge", not "Send"** — clear-signing is a hand-curated security primitive; the verb should match the user's mental model of "moving funds across chains" rather than the developer-facing `start*` naming.
 2. **Bridge name embedded in `interpolatedIntent`** — the bridge identity is the single most important security signal in a bridge tx (Across vs. Mayan vs. StargateV2 have very different trust + finality models). Since wallets prefer `interpolatedIntent` over `intent`, placing the bridge name only in `intent` would effectively hide it from users in the happy path. The cost is ~6-12 extra characters per template, which still fits on a single Ledger Nano X screen for every bridge name in our diamond.
-3. **`destinationChainId` as `chainId`** — the ERC-7730 v2 integer format that renders an EIP-155 chain id as the network's name, so the wallet shows "Polygon" instead of `137`. LI.FI's non-EVM destinations use synthetic ids outside EIP-155 (e.g. Solana); wallets fall back to rendering those numerically.
+3. **`destinationChainId` as `raw`, deliberately not `chainId`** — `chainId` is the format that renders an EIP-155 id as a network name, and it is the obvious choice here, but it cannot be used: it resolves through public EIP-155 chain lists that mislabel LI.FI chains. Chain `999` is HyperEVM to us and resolves to "Wanchain Testnet"; `1337` is HyperCore and resolves to "Geth Testnet" — both mainnet destinations shown to a signer as testnets. Only 7 of 30 ids tested render identically across the two ERC-7730 reference implementations. The spec defines `chainId` over EIP-155 reference values only, with no fallback (unlike `tokenAmount` and `nft`) and no pinned name source, so the rendering of this field is not something the descriptor can bound. A wrong network name is worse than a number here, so it stays raw until that is settled upstream (EXSC-838).
+
+   A LI.FI-authored `format: enum` map was the natural alternative and does not work either: the on-device ENUM_VALUE struct encodes an entry value in a single byte taken from the enum key, so no chain id above 255 is representable and `erc7730 calldata` silently drops the entire descriptor.
 4. **All `BridgeData` plumbing fields hidden** (`transactionId`, `bridge` (free-text), `integrator`, `referrer`, `hasSourceSwaps`, `hasDestinationCall`) — these carry no user-facing decision content.
 5. **Swap-data array tail hidden** — for `swapAndStart*` we hide `_swapData.[].callData`, `callTo`, `approveTo`, `requiresDeposit` since they're opaque to a non-technical signer. The aggregate effect is captured by `_bridgeData.minAmount`.
 

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -284,9 +284,13 @@ const RECEIVER_FIELD: IField = {
 const CHAIN_FIELD: IField = {
   path: '_bridgeData.destinationChainId',
   label: 'Destination Chain',
-  // Non-EVM destinations use synthetic ids outside EIP-155, which wallets fall
-  // back to rendering numerically.
-  format: 'chainId',
+  // Not `chainId`, however much it looks like the right format: this field also
+  // carries LI.FI's synthetic non-EVM ids (LiFiData.sol), and `chainId` resolves
+  // through public EIP-155 chain lists that mislabel our chains — 999 is
+  // HyperEVM to us and "Wanchain Testnet" upstream, 1337 is HyperCore and
+  // "Geth Testnet". A wrong network name on a signing screen is worse than a
+  // number, so this stays raw until ERC-7730 pins a name source and a fallback.
+  format: 'raw',
   visible: 'always',
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-827

# Why did I implement it this way?

Reverts the one-word format change from #2217 (EXSC-793). One line in the generator, 62 lines in the generated artifact.

## Why `chainId` cannot be used for this field

#2217 switched `_bridgeData.destinationChainId` from `raw` to `chainId` so wallets would show a network name instead of a number. That was a reasonable read of the spec, and it turns out not to hold: `chainId` resolves through public EIP-155 chain lists that **mislabel LI.FI chains**.

Measured against both ERC-7730 reference implementations across 30 chain ids. Only **7 of 30** render identically (`100`, `8453`, `42161`, `42170`, `59144`, `534352`, `7777777`). Most of the rest are cosmetic disagreements — but two are not:

| chain id | LI.FI destination | rendered by the chain-list path |
| --- | --- | --- |
| `999` | **HyperEVM** (mainnet) | **"Wanchain Testnet"** |
| `1337` | **HyperCore** (mainnet) | **"Geth Testnet"** |

Two live mainnet destinations displayed to a signer as *testnets*. On a screen whose entire purpose is telling someone where their funds are going, a confidently wrong network name is worse than a bare number — a number is never useful but it is never wrong either. Sampling of the rest, for completeness: `1` → "Ethereum Mainnet" vs "Ethereum", `10` → "OP Mainnet" vs "Optimism", `56` → "BNB Smart Chain Mainnet" vs "BNB Chain", `137` → "Polygon Mainnet" vs "Polygon", `747474` → "katana" (lowercase).

The root cause is in the spec, not in either implementation: `chainId` is defined only over EIP-155 reference values (`erc-7730.md:1411-1416`) and, unlike `tokenAmount` (`:1356`) and `nft` (`:1369`), **defines no fallback** — and nothing pins *which* name source an implementation should use. Both raised upstream. This reverts until that is settled.

## Why not `format: enum` with a LI.FI-authored map

Tried first, and it was the approach I expected to ship — it gives correct names for every destination including the non-EVM ones, and it has registry precedent (`threshold`'s `wormholeChain`, `hyperliquid`'s `cctpDomains`). It had to be abandoned:

The on-device ENUM_VALUE struct encodes an entry's value in a **single byte** — `obj.value.to_bytes(1)` in `erc7730/convert/calldata/v1/tlv.py:255`, two lines below `obj.chain_id.to_bytes(8)`, so the width is deliberate — and `convert_enums` takes that value from the enum **key**, i.e. the chain id. No chain id above 255 fits. Measured on the real descriptor:

| variant | `erc7730 calldata` (on-device) | `testsv2`, both runners |
| --- | --- | --- |
| `raw` (this PR) | 25,382,949 bytes ✅ | green |
| `chainId` (#2217) | 25,385,397 bytes ✅ | fails both |
| `enum` | **`[]` — descriptor dropped entirely** ❌ | green |

So the enum variant is the only one that takes `calldata-LIFIDiamond` from producing an on-device descriptor to producing nothing — no clear signing at all for the diamond on a Ledger. And it fails silently: `erc7730 lint`, `erc7730 format`, `verify-clear-signing` and both `testsv2` runners all pass it, while `erc7730 calldata` exits 0 as it discards everything. The registry precedents convert only because Wormhole chain ids and CCTP domain ids are all ≤ 255.

## Why this needs no registry-side change

The registry sync PR ([#2901](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2901)) is red because its descriptor says `chainId` while the `testsv2` fixture on registry `master` expects raw numbers. With this merged, the sync regenerates a `raw` descriptor that matches that fixture, and #2901 goes green on its own — no human commit on the bot's branch, which matters because the sync rebuilds that branch from `master` and force-pushes.

Verified rather than assumed: ran `tasks/generateLedgerClearSigning.ts` against a real `ethereum/clear-signing-erc7730-registry@master` checkout with this branch's proposal, confirmed all 74 `destinationChainId` entries come out `raw`, then ran both runners at the SHAs the registry pins against **master's untouched fixture**.

| check | result |
| --- | --- |
| `sourcifyeth/clear-signing-test-runner` @ `dae3cda` | **14/14 pass** |
| `llbartekll/clear-signing` @ `10605ba` | **14/14 pass** |
| `bunx tsc-files --noEmit`, `bunx eslint`, `bunx prettier` | clean |
| generator determinism | two consecutive runs byte-identical |

## Follow-ups

- [#2260](https://github.com/lifinance/contracts/pull/2260) (the `enum` attempt) and [#2225](https://github.com/lifinance/contracts/pull/2225) (EXSC-798, pinned `raw` for colliding ids — superseded by all-`raw`, and its collision list missed `999`) are both closed in favour of this.
- Getting a correct network name on screen needs an upstream change — a defined fallback and a pinned name source for `chainId`, or a wider ENUM_VALUE so a project-authored map can reach a device. Tracked in EXSC-838; raised with the EF.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug  <!-- no unit test: the behaviour is how external ERC-7730 implementations render the descriptor. Verified by running both pinned runners against a real registry checkout (see above). -->
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
