### PR TITLE
fix(timelock): pre-check the fleet over one MongoDB connection, stop silently skipping networks (EXSC-841)

### DIFF
--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -47,7 +47,6 @@ import { formatTimelockScheduleBatch } from './safe-decode-utils'
 import {
   classifyPrefetchResults,
   fetchPendingForNetworks,
-  type IPendingFetchResult,
 } from './timelock-prefetch'
 import {
   byOperationId,
@@ -235,9 +234,8 @@ const cmd = defineCommand({
     if (executeAll || rejectAll) {
       consola.info('🚀 Checking all networks for pending operations...')
 
-      const networksWithPending = await prefetchNetworksWithPendingOps(
-        networksToProcess
-      )
+      const { networks: networksWithPending, failedCount: prefetchFailures } =
+        await prefetchNetworksWithPendingOps(networksToProcess)
       if (networksWithPending.length === 0) return
 
       consola.info(
@@ -245,9 +243,9 @@ const cmd = defineCommand({
       )
 
       const results = await Promise.all(
-        networksWithPending.map((fetched) =>
+        networksWithPending.map((network) =>
           processNetwork(
-            fetched.network,
+            network,
             isDryRun,
             specificOperationId,
             executeAll,
@@ -302,17 +300,26 @@ const cmd = defineCommand({
           consola.warn('Failed to send batch summary notification:', error)
         }
 
-      // Exit with error code if there were failures
-      if (failedNetworks > 0 || totalOperationsFailed > 0) {
+      // Exit with error code if there were failures. A network the prefetch
+      // could not check counts: it was never looked at, and having found work
+      // elsewhere does not make that safe to pass over silently.
+      if (
+        failedNetworks > 0 ||
+        totalOperationsFailed > 0 ||
+        prefetchFailures > 0
+      ) {
+        if (prefetchFailures > 0)
+          consola.error(
+            `   ❌ Networks never checked (prefetch failed): ${prefetchFailures}`
+          )
         consola.error('\n❌ Script completed with errors')
         process.exit(1)
       }
     } else {
       consola.info('🔄 Checking all networks for pending operations...')
 
-      const networksWithPending = await prefetchNetworksWithPendingOps(
-        networksToProcess
-      )
+      const { networks: networksWithPending, failedCount: prefetchFailures } =
+        await prefetchNetworksWithPendingOps(networksToProcess)
       if (networksWithPending.length === 0) return
 
       consola.info(
@@ -322,10 +329,10 @@ const cmd = defineCommand({
       let totalFailed = 0
       let totalSucceeded = 0
 
-      for (const fetched of networksWithPending)
+      for (const network of networksWithPending)
         try {
           const result = await processNetwork(
-            fetched.network,
+            network,
             isDryRun,
             specificOperationId,
             executeAll,
@@ -342,16 +349,19 @@ const cmd = defineCommand({
               `[${result.network}] ❌ ${result.operationsFailed} operation(s) failed`
             )
         } catch (error) {
-          consola.error(
-            `Error processing network ${fetched.network.name}:`,
-            error
-          )
+          consola.error(`Error processing network ${network.name}:`, error)
           totalFailed++
         }
 
-      if (totalFailed > 0) {
+      // A network the prefetch could not check was never looked at; finding work
+      // elsewhere does not make passing over it safe, so it fails the run too.
+      if (totalFailed > 0 || prefetchFailures > 0) {
         consola.error(
-          `\n❌ Script completed with ${totalFailed} network(s) having failures`
+          `\n❌ Script completed with ${totalFailed} network(s) having failures${
+            prefetchFailures > 0
+              ? ` and ${prefetchFailures} network(s) never checked (prefetch failed)`
+              : ''
+          }`
         )
         process.exit(1)
       } else
@@ -454,19 +464,32 @@ async function fetchQueuedTimelockOps(
   }
 }
 
+/** Outcome of the fleet pre-check, as the run needs it. */
+interface IPrefetchedWork {
+  /** Networks with at least one queued op. */
+  networks: INetworksObject[string][]
+  /**
+   * Networks the prefetch could not check. Non-zero must fail the run even when
+   * other networks had work: those networks were not looked at either way.
+   */
+  failedCount: number
+}
+
 /**
  * Pre-checks the fleet, reports the outcome, and returns only the networks that
  * have queued ops.
  *
- * Exits non-zero when nothing is pending but some networks could not be checked:
- * "0 pending" is only trustworthy if every network was actually reached.
+ * Exits non-zero immediately when nothing is pending but some networks could not
+ * be checked: "0 pending" is only trustworthy if every network was actually
+ * reached. When there *is* work, the run proceeds so the reachable networks are
+ * executed, and the caller fails the run afterwards via `failedCount`.
  *
  * @param networksToProcess - Networks to pre-check.
- * @returns Networks with at least one queued op; empty when there is no work.
+ * @returns The networks to process and how many could not be checked.
  */
 async function prefetchNetworksWithPendingOps(
   networksToProcess: INetworksObject[string][]
-): Promise<IPendingFetchResult[]> {
+): Promise<IPrefetchedWork> {
   const { withPending, skipped, failed, mustExitWithError } =
     classifyPrefetchResults(await fetchPendingForNetworks(networksToProcess))
 
@@ -505,7 +528,10 @@ async function prefetchNetworksWithPendingOps(
   if (withPending.length === 0)
     consola.success('No networks with pending timelock transactions.')
 
-  return withPending
+  return {
+    networks: withPending.map((r) => r.network),
+    failedCount: failed.length,
+  }
 }
 
 async function processNetwork(

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -229,7 +229,9 @@ const cmd = defineCommand({
     if (isDryRun)
       consola.info('Running in DRY RUN mode - no transactions will be sent')
 
-    // Process networks: scan once (one RPC per network), then process only networks with ready ops. We do not reuse prefetch RPC clients so execution always uses a fresh connection.
+    // The prefetch is queue-only over a single MongoDB connection; processNetwork
+    // then opens a fresh RPC per network so execution never reuses a connection
+    // that idled through a long interactive pause.
     if (executeAll || rejectAll) {
       consola.info('🚀 Checking all networks for pending operations...')
 

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -45,21 +45,17 @@ import {
 } from './parked-tasks'
 import { formatTimelockScheduleBatch } from './safe-decode-utils'
 import {
+  classifyPrefetchResults,
+  fetchPendingForNetworks,
+  type IPendingFetchResult,
+} from './timelock-prefetch'
+import {
   byOperationId,
   computeOperationIdBatch,
   deserializeScheduleParams,
   getTimelockQueueCollection,
   type ITimelockQueueDoc,
 } from './timelock-queue'
-
-/** Result of pre-checking a network (queue only, no RPC). Used to decide which networks to process; processNetwork always opens a fresh RPC and re-fetches queued ops to verify on-chain readiness. */
-interface IPendingFetchResult {
-  network: INetworksObject[string]
-  /** Number of queued timelock ops for this network (on-chain ready count unknown until processNetwork runs). */
-  pendingInMongoCount: number
-  /** Set when prefetch failed; callers must not treat as "no pending" without checking. */
-  fetchError?: unknown
-}
 
 // TimelockController ABI for the functions we need
 const TIMELOCK_ABI = parseAbi([
@@ -237,44 +233,10 @@ const cmd = defineCommand({
     if (executeAll || rejectAll) {
       consola.info('🚀 Checking all networks for pending operations...')
 
-      const fetchResults = await Promise.all(
-        networksToProcess.map((network) => fetchPendingForNetwork(network))
+      const networksWithPending = await prefetchNetworksWithPendingOps(
+        networksToProcess
       )
-
-      const networksWithPending = fetchResults.filter(
-        (r) => r.pendingInMongoCount > 0
-      )
-      const networksWithFetchError = fetchResults.filter((r) => r.fetchError)
-
-      consola.info(
-        `Checked ${networksToProcess.length} network(s) (MongoDB only); ${
-          networksWithPending.length
-        } have pending timelock tx(s)${
-          networksWithPending.length > 0
-            ? `: ${networksWithPending.map((r) => r.network.name).join(', ')}`
-            : ''
-        }`
-      )
-      if (networksWithFetchError.length > 0) {
-        consola.warn(
-          `Prefetch failed for ${
-            networksWithFetchError.length
-          } network(s): ${networksWithFetchError
-            .map((r) => r.network.name)
-            .join(', ')}`
-        )
-      }
-
-      if (networksWithPending.length === 0) {
-        if (networksWithFetchError.length > 0) {
-          consola.error(
-            'No networks with pending timelock txs; some networks failed to fetch. Exiting with error to avoid silently skipping work.'
-          )
-          process.exit(1)
-        }
-        consola.success('No networks with pending timelock transactions.')
-        return
-      }
+      if (networksWithPending.length === 0) return
 
       consola.info(
         'Processing networks with pending txs (fresh RPC per network).'
@@ -346,45 +308,10 @@ const cmd = defineCommand({
     } else {
       consola.info('🔄 Checking all networks for pending operations...')
 
-      // Pre-check all networks in parallel; only process those with ready operations
-      const fetchResults = await Promise.all(
-        networksToProcess.map((network) => fetchPendingForNetwork(network))
+      const networksWithPending = await prefetchNetworksWithPendingOps(
+        networksToProcess
       )
-
-      const networksWithPending = fetchResults.filter(
-        (r) => r.pendingInMongoCount > 0
-      )
-      const networksWithFetchError = fetchResults.filter((r) => r.fetchError)
-
-      consola.info(
-        `Checked ${networksToProcess.length} network(s) (MongoDB only); ${
-          networksWithPending.length
-        } have pending timelock tx(s)${
-          networksWithPending.length > 0
-            ? `: ${networksWithPending.map((r) => r.network.name).join(', ')}`
-            : ''
-        }`
-      )
-      if (networksWithFetchError.length > 0) {
-        consola.warn(
-          `Prefetch failed for ${
-            networksWithFetchError.length
-          } network(s): ${networksWithFetchError
-            .map((r) => r.network.name)
-            .join(', ')}`
-        )
-      }
-
-      if (networksWithPending.length === 0) {
-        if (networksWithFetchError.length > 0) {
-          consola.error(
-            'No networks with pending timelock txs; some networks failed to fetch. Exiting with error to avoid silently skipping work.'
-          )
-          process.exit(1)
-        }
-        consola.success('No networks with pending timelock transactions.')
-        return
-      }
+      if (networksWithPending.length === 0) return
 
       consola.info(
         'Processing networks with pending txs sequentially (fresh RPC per network).'
@@ -526,37 +453,57 @@ async function fetchQueuedTimelockOps(
 }
 
 /**
- * Pre-checks a single network using the queue only (no RPC). Returns how
- * many queued timelock ops exist for the network. processNetwork always
- * opens a fresh RPC and re-fetches queued rows for on-chain ready check.
+ * Pre-checks the fleet, reports the outcome, and returns only the networks that
+ * have queued ops.
+ *
+ * Exits non-zero when nothing is pending but some networks could not be checked:
+ * "0 pending" is only trustworthy if every network was actually reached.
+ *
+ * @param networksToProcess - Networks to pre-check.
+ * @returns Networks with at least one queued op; empty when there is no work.
  */
-async function fetchPendingForNetwork(
-  network: INetworksObject[string]
-): Promise<IPendingFetchResult> {
-  const empty: IPendingFetchResult = {
-    network,
-    pendingInMongoCount: 0,
-  }
-  try {
-    const deploymentData = (await getDeployments(
-      network.name as SupportedChain,
-      EnvironmentEnum.production
-    )) as { LiFiTimelockController?: string }
+async function prefetchNetworksWithPendingOps(
+  networksToProcess: INetworksObject[string][]
+): Promise<IPendingFetchResult[]> {
+  const { withPending, skipped, failed, mustExitWithError } =
+    classifyPrefetchResults(await fetchPendingForNetworks(networksToProcess))
 
-    if (!deploymentData.LiFiTimelockController) return empty
-
-    const rows = await fetchQueuedTimelockOps(network.name)
-    return {
-      network,
-      pendingInMongoCount: rows.length,
-    }
-  } catch (err) {
-    consola.error(
-      `[${network.name}] Prefetch failed (pending count may have been skipped):`,
-      err
+  consola.info(
+    `Checked ${networksToProcess.length - skipped.length} of ${
+      networksToProcess.length
+    } network(s) (MongoDB only); ${
+      withPending.length
+    } have pending timelock tx(s)${
+      withPending.length > 0
+        ? `: ${withPending.map((r) => r.network.name).join(', ')}`
+        : ''
+    }`
+  )
+  if (skipped.length > 0)
+    consola.info(
+      `Skipped ${
+        skipped.length
+      } network(s) without a production timelock: ${skipped
+        .map((r) => `${r.network.name} (${r.skipReason})`)
+        .join(', ')}`
     )
-    return { ...empty, fetchError: err }
+  if (failed.length > 0)
+    consola.warn(
+      `Prefetch failed for ${failed.length} network(s): ${failed
+        .map((r) => r.network.name)
+        .join(', ')}`
+    )
+
+  if (mustExitWithError) {
+    consola.error(
+      'No networks with pending timelock txs; some networks failed to fetch. Exiting with error to avoid silently skipping work.'
+    )
+    process.exit(1)
   }
+  if (withPending.length === 0)
+    consola.success('No networks with pending timelock transactions.')
+
+  return withPending
 }
 
 async function processNetwork(

--- a/script/deploy/safe/execute-pending-timelock-tx.ts
+++ b/script/deploy/safe/execute-pending-timelock-tx.ts
@@ -471,7 +471,7 @@ async function prefetchNetworksWithPendingOps(
     classifyPrefetchResults(await fetchPendingForNetworks(networksToProcess))
 
   consola.info(
-    `Checked ${networksToProcess.length - skipped.length} of ${
+    `Checked ${networksToProcess.length - skipped.length - failed.length} of ${
       networksToProcess.length
     } network(s) (MongoDB only); ${
       withPending.length

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -290,4 +290,18 @@ describe('formatDecodedArg', () => {
   it('still renders a top-level bigint bare, without JSON quoting', () => {
     expect(formatDecodedArg(10800n)).toBe('10800')
   })
+
+  it('renders a nested address in the network format, like a top-level one', () => {
+    const address = '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE'
+    const nested = formatDecodedArg({ target: address }, 'tron')
+
+    expect(nested).toContain(formatDecodedArg(address, 'tron'))
+    expect(nested).not.toContain(`"${address}"`)
+  })
+
+  it('leaves a nested non-address string untouched', () => {
+    expect(formatDecodedArg({ name: 'FraxFacet' }, 'tron')).toBe(
+      '{"name":"FraxFacet"}'
+    )
+  })
 })

--- a/script/deploy/safe/safe-decode-utils.test.ts
+++ b/script/deploy/safe/safe-decode-utils.test.ts
@@ -24,6 +24,7 @@ import {
   getRoleName,
   formatRoleChange,
   formatBatchSetContractSelectorWhitelist,
+  formatDecodedArg,
 } from './safe-decode-utils'
 
 const DEFAULT_ADMIN_ROLE = `0x${'00'.repeat(32)}`
@@ -260,5 +261,33 @@ describe('formatBatchSetContractSelectorWhitelist', () => {
     const output = await capture([FALLBACK_ONLY])
     expect(output).toContain('signature unknown')
     expect(output).not.toContain('transfer(address,uint256)')
+  })
+})
+
+describe('formatDecodedArg', () => {
+  it('renders a tuple array carrying bigints instead of failing the decode', () => {
+    // initFrax((uint256 chainId, uint32 eid)[]) shape: viem decodes the numeric
+    // fields as bigints, which a plain JSON.stringify throws on — taking the
+    // whole decode down and leaving the operator approving an unshown payload.
+    const arg = [
+      { chainId: 1n, eid: 30101 },
+      { chainId: 480n, eid: 30319 },
+    ]
+
+    const output = formatDecodedArg(arg)
+
+    expect(output).toContain('"chainId":"1"')
+    expect(output).toContain('"chainId":"480"')
+    expect(output).toContain('30319')
+  })
+
+  it('renders nested bigints at any depth', () => {
+    const output = formatDecodedArg({ outer: [{ inner: [7n] }] })
+
+    expect(output).toBe('{"outer":[{"inner":["7"]}]}')
+  })
+
+  it('still renders a top-level bigint bare, without JSON quoting', () => {
+    expect(formatDecodedArg(10800n)).toBe('10800')
   })
 })

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -462,11 +462,15 @@ export function formatDecodedArg(arg: unknown, network?: string): string {
   if (typeof arg === 'bigint') return arg.toString()
   // Tuple and array args (e.g. initFrax's (chainId, eid) pairs) carry nested
   // bigints, which plain JSON.stringify throws on — losing the whole decode and
-  // leaving the operator approving a payload they were never shown.
+  // leaving the operator approving a payload they were never shown. Nested
+  // strings recurse so an address inside a tuple gets the same per-network
+  // rendering as a top-level one instead of staying raw hex.
   if (typeof arg === 'object')
-    return JSON.stringify(arg, (_key, value) =>
-      typeof value === 'bigint' ? value.toString() : value
-    )
+    return JSON.stringify(arg, (_key, value: unknown) => {
+      if (typeof value === 'bigint') return value.toString()
+      if (typeof value === 'string') return formatDecodedArg(value, network)
+      return value
+    })
   const s = String(arg)
   if (
     network !== undefined &&

--- a/script/deploy/safe/safe-decode-utils.ts
+++ b/script/deploy/safe/safe-decode-utils.ts
@@ -450,10 +450,23 @@ function getDiamondAbiItemForSelector(selector: string): Abi[number] | null {
   return null
 }
 
-function formatDecodedArg(arg: unknown, network?: string): string {
+/**
+ * Renders one decoded ABI argument for display.
+ *
+ * @param arg - Decoded argument value (may be a bigint, tuple, or array).
+ * @param network - When set, addresses are rendered in the network's format.
+ * @returns Display string for the argument.
+ */
+export function formatDecodedArg(arg: unknown, network?: string): string {
   if (arg === undefined || arg === null) return String(arg)
   if (typeof arg === 'bigint') return arg.toString()
-  if (typeof arg === 'object') return JSON.stringify(arg)
+  // Tuple and array args (e.g. initFrax's (chainId, eid) pairs) carry nested
+  // bigints, which plain JSON.stringify throws on — losing the whole decode and
+  // leaving the operator approving a payload they were never shown.
+  if (typeof arg === 'object')
+    return JSON.stringify(arg, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
   const s = String(arg)
   if (
     network !== undefined &&

--- a/script/deploy/safe/timelock-prefetch.test.ts
+++ b/script/deploy/safe/timelock-prefetch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the timelock executor's fleet pre-check: the queue tally, the
+ * skip/failure classification that decides whether "0 pending" may be trusted,
+ * and the real-deployments skip resolution.
+ */
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import networks from '../../../config/networks.json'
+import type { INetworksObject } from '../../common/types'
+
+import {
+  assemblePrefetchResults,
+  classifyPrefetchResults,
+  resolveTimelockSkipReason,
+  tallyQueuedOpsByNetwork,
+  type IPendingFetchResult,
+  type TTimelockSkipReason,
+} from './timelock-prefetch'
+
+const networksConfig = networks as INetworksObject
+
+const network = (name: string): INetworksObject[string] => {
+  const entry = networksConfig[name]
+  if (!entry)
+    throw new Error(`Test fixture references unknown network: ${name}`)
+  return entry
+}
+
+describe('tallyQueuedOpsByNetwork', () => {
+  it('counts rows per network, case-insensitively', () => {
+    const counts = tallyQueuedOpsByNetwork([
+      { network: 'worldchain' },
+      { network: 'tron' },
+      { network: 'WorldChain' },
+    ])
+
+    expect(counts.get('worldchain')).toBe(2)
+    expect(counts.get('tron')).toBe(1)
+  })
+
+  it('omits networks with no queued rows rather than storing zero', () => {
+    const counts = tallyQueuedOpsByNetwork([{ network: 'tron' }])
+
+    expect(counts.has('worldchain')).toBe(false)
+    expect(counts.get('worldchain') ?? 0).toBe(0)
+  })
+})
+
+describe('assemblePrefetchResults', () => {
+  const inputs = [network('mainnet'), network('base'), network('tronshasta')]
+  const skips = new Map<string, TTimelockSkipReason>([
+    ['tronshasta', 'no-deployment-log'],
+  ])
+
+  it('returns one result per input network, in input order', () => {
+    const results = assemblePrefetchResults(
+      inputs,
+      skips,
+      new Map([['base', 2]])
+    )
+
+    expect(results.map((r) => r.network.name)).toEqual([
+      'mainnet',
+      'base',
+      'tronshasta',
+    ])
+    expect(results[1]?.pendingInMongoCount).toBe(2)
+    expect(results[0]?.pendingInMongoCount).toBe(0)
+  })
+
+  it('marks skipped networks as skipped, never as failed', () => {
+    const results = assemblePrefetchResults(inputs, skips, new Map())
+    const shasta = results.find((r) => r.network.name === 'tronshasta')
+
+    expect(shasta?.skipReason).toBe('no-deployment-log')
+    expect(shasta?.fetchError).toBeUndefined()
+  })
+
+  it('marks every non-skipped network as failed when the queue read failed', () => {
+    const err = new Error('querySrv ETIMEOUT')
+    const results = assemblePrefetchResults(inputs, skips, new Map(), err)
+
+    expect(
+      results.filter((r) => r.fetchError === err).map((r) => r.network.name)
+    ).toEqual(['mainnet', 'base'])
+    // A skipped network has nothing to fail at, so the error must not reach it.
+    expect(
+      results.find((r) => r.network.name === 'tronshasta')?.fetchError
+    ).toBeUndefined()
+  })
+
+  it('reports zero pending for a network absent from the tally', () => {
+    const results = assemblePrefetchResults(inputs, new Map(), new Map())
+
+    expect(results.every((r) => r.pendingInMongoCount === 0)).toBe(true)
+  })
+})
+
+describe('classifyPrefetchResults', () => {
+  const result = (
+    name: string,
+    overrides: Partial<IPendingFetchResult> = {}
+  ): IPendingFetchResult => ({
+    network: network(name),
+    pendingInMongoCount: 0,
+    ...overrides,
+  })
+
+  it('refuses to trust "0 pending" when a network could not be checked', () => {
+    const outcome = classifyPrefetchResults([
+      result('mainnet', { fetchError: new Error('boom') }),
+      result('base'),
+    ])
+
+    expect(outcome.withPending).toHaveLength(0)
+    expect(outcome.failed.map((r) => r.network.name)).toEqual(['mainnet'])
+    expect(outcome.mustExitWithError).toBe(true)
+  })
+
+  it('trusts "0 pending" when every network was reached', () => {
+    const outcome = classifyPrefetchResults([result('mainnet'), result('base')])
+
+    expect(outcome.mustExitWithError).toBe(false)
+  })
+
+  it('does not treat an expected skip as a reason to fail the run', () => {
+    const outcome = classifyPrefetchResults([
+      result('tronshasta', { skipReason: 'no-deployment-log' }),
+      result('base'),
+    ])
+
+    expect(outcome.skipped.map((r) => r.network.name)).toEqual(['tronshasta'])
+    expect(outcome.failed).toHaveLength(0)
+    expect(outcome.mustExitWithError).toBe(false)
+  })
+
+  it('surfaces networks with queued ops', () => {
+    const outcome = classifyPrefetchResults([
+      result('mainnet', { pendingInMongoCount: 2 }),
+      result('base'),
+    ])
+
+    expect(outcome.withPending.map((r) => r.network.name)).toEqual(['mainnet'])
+    expect(outcome.mustExitWithError).toBe(false)
+  })
+})
+
+describe('resolveTimelockSkipReason (real deployments/)', () => {
+  it('skips an active network that has no production deployments file', async () => {
+    // tronshasta is `status: active` in networks.json but was never brought up
+    // in production, so it has no deployments/tronshasta.json. Before this was
+    // a skip it surfaced as a prefetch error with a full stack trace.
+    expect(await resolveTimelockSkipReason(network('tronshasta'))).toBe(
+      'no-deployment-log'
+    )
+  })
+
+  it('does not skip a network whose deployments file has a timelock', async () => {
+    expect(await resolveTimelockSkipReason(network('mainnet'))).toBeUndefined()
+  })
+})

--- a/script/deploy/safe/timelock-prefetch.test.ts
+++ b/script/deploy/safe/timelock-prefetch.test.ts
@@ -3,6 +3,8 @@
  * skip/failure classification that decides whether "0 pending" may be trusted,
  * and the real-deployments skip resolution.
  */
+import { rmSync, writeFileSync } from 'fs'
+
 import {
   describe,
   expect,
@@ -11,7 +13,8 @@ import {
 } from 'bun:test'
 
 import networks from '../../../config/networks.json'
-import type { INetworksObject } from '../../common/types'
+import { EnvironmentEnum, type INetworksObject } from '../../common/types'
+import { getDeploymentsFilePath } from '../../utils/deploymentHelpers'
 
 import {
   assemblePrefetchResults,
@@ -83,7 +86,11 @@ describe('assemblePrefetchResults', () => {
 
   it('marks every non-skipped network as failed when the queue read failed', () => {
     const err = new Error('querySrv ETIMEOUT')
-    const results = assemblePrefetchResults(inputs, skips, new Map(), err)
+    const errors = new Map<string, unknown>([
+      ['mainnet', err],
+      ['base', err],
+    ])
+    const results = assemblePrefetchResults(inputs, skips, new Map(), errors)
 
     expect(
       results.filter((r) => r.fetchError === err).map((r) => r.network.name)
@@ -92,6 +99,26 @@ describe('assemblePrefetchResults', () => {
     expect(
       results.find((r) => r.network.name === 'tronshasta')?.fetchError
     ).toBeUndefined()
+  })
+
+  it('fails only the networks that actually errored', () => {
+    const err = new Error('unreadable deployments file')
+    const results = assemblePrefetchResults(
+      inputs,
+      new Map(),
+      new Map([['base', 3]]),
+      new Map<string, unknown>([['mainnet', err]])
+    )
+
+    expect(results.find((r) => r.network.name === 'mainnet')?.fetchError).toBe(
+      err
+    )
+    expect(
+      results.find((r) => r.network.name === 'base')?.fetchError
+    ).toBeUndefined()
+    expect(
+      results.find((r) => r.network.name === 'base')?.pendingInMongoCount
+    ).toBe(3)
   })
 
   it('reports zero pending for a network absent from the tally', () => {
@@ -162,5 +189,27 @@ describe('resolveTimelockSkipReason (real deployments/)', () => {
 
   it('does not skip a network whose deployments file has a timelock', async () => {
     expect(await resolveTimelockSkipReason(network('mainnet'))).toBeUndefined()
+  })
+
+  it('refuses to skip a network whose deployments file exists but will not load', async () => {
+    // getDeployments reports an unreadable file as not-found, so classifying
+    // every throw as a skip would hide a network that does have a timelock.
+    // tronshasta has no deployments file, so we can create one and remove it
+    // again without disturbing a tracked file.
+    const filePath = getDeploymentsFilePath(
+      'tronshasta',
+      EnvironmentEnum.production
+    )
+    writeFileSync(filePath, '{ this is not valid json')
+    let thrown: unknown
+    try {
+      await resolveTimelockSkipReason(network('tronshasta'))
+    } catch (err) {
+      thrown = err
+    } finally {
+      rmSync(filePath, { force: true })
+    }
+
+    expect(thrown).toBeInstanceOf(Error)
   })
 })

--- a/script/deploy/safe/timelock-prefetch.test.ts
+++ b/script/deploy/safe/timelock-prefetch.test.ts
@@ -149,6 +149,18 @@ describe('classifyPrefetchResults', () => {
     expect(outcome.mustExitWithError).toBe(true)
   })
 
+  it('counts a falsy thrown value as a failure, not as a checked network', () => {
+    // assemblePrefetchResults records a failure with `!== undefined`, so a
+    // truthiness test here would let `throw ''` read as checked-with-0-pending.
+    const outcome = classifyPrefetchResults([
+      result('mainnet', { fetchError: '' }),
+      result('base'),
+    ])
+
+    expect(outcome.failed.map((r) => r.network.name)).toEqual(['mainnet'])
+    expect(outcome.mustExitWithError).toBe(true)
+  })
+
   it('trusts "0 pending" when every network was reached', () => {
     const outcome = classifyPrefetchResults([result('mainnet'), result('base')])
 

--- a/script/deploy/safe/timelock-prefetch.test.ts
+++ b/script/deploy/safe/timelock-prefetch.test.ts
@@ -19,9 +19,11 @@ import { getDeploymentsFilePath } from '../../utils/deploymentHelpers'
 import {
   assemblePrefetchResults,
   classifyPrefetchResults,
+  countQueuedOpsByNetwork,
   resolveTimelockSkipReason,
   tallyQueuedOpsByNetwork,
   type IPendingFetchResult,
+  type TQueueConnector,
   type TTimelockSkipReason,
 } from './timelock-prefetch'
 
@@ -51,6 +53,40 @@ describe('tallyQueuedOpsByNetwork', () => {
 
     expect(counts.has('worldchain')).toBe(false)
     expect(counts.get('worldchain') ?? 0).toBe(0)
+  })
+})
+
+describe('countQueuedOpsByNetwork', () => {
+  const connectorReturning = (
+    rows: { network: string }[],
+    close: () => Promise<void>
+  ): TQueueConnector =>
+    (async () => ({
+      client: { close },
+      timelockQueue: { find: () => ({ toArray: async () => rows }) },
+    })) as unknown as TQueueConnector
+
+  it('keeps the tally when closing the connection rejects', async () => {
+    const counts = await countQueuedOpsByNetwork(
+      ['tron'],
+      connectorReturning([{ network: 'tron' }], () =>
+        Promise.reject(new Error('connection reset during close'))
+      )
+    )
+
+    expect(counts.get('tron')).toBe(1)
+  })
+
+  it('closes the connection once the tally is done', async () => {
+    let closed = 0
+    await countQueuedOpsByNetwork(
+      ['tron'],
+      connectorReturning([], async () => {
+        closed++
+      })
+    )
+
+    expect(closed).toBe(1)
   })
 })
 

--- a/script/deploy/safe/timelock-prefetch.ts
+++ b/script/deploy/safe/timelock-prefetch.ts
@@ -239,7 +239,9 @@ export function classifyPrefetchResults(
   results: IPendingFetchResult[]
 ): IPrefetchOutcome {
   const withPending = results.filter((r) => r.pendingInMongoCount > 0)
-  const failed = results.filter((r) => r.fetchError)
+  // Must match how assemblePrefetchResults records a failure: a falsy thrown
+  // value would otherwise make the network read as checked-with-0-pending.
+  const failed = results.filter((r) => r.fetchError !== undefined)
   return {
     withPending,
     skipped: results.filter((r) => r.skipReason),

--- a/script/deploy/safe/timelock-prefetch.ts
+++ b/script/deploy/safe/timelock-prefetch.ts
@@ -1,0 +1,209 @@
+/**
+ * Fleet pre-check for the timelock executor: which networks have queued ops.
+ *
+ * Split out of `execute-pending-timelock-tx.ts` so the logic is importable —
+ * that module calls `runMain` at module scope, and the `import.meta.main` guard
+ * used elsewhere in this directory is not an option there: the script runs via
+ * `bunx tsx`, where `import.meta.main` is `undefined` and the guard would turn
+ * the CLI into a silent no-op.
+ */
+
+import { consola } from 'consola'
+
+import {
+  EnvironmentEnum,
+  type INetworksObject,
+  type SupportedChain,
+} from '../../common/types'
+import { getDeployments } from '../../utils/deploymentHelpers'
+
+import { getTimelockQueueCollection } from './timelock-queue'
+
+/** Why a network carries no production timelock and is skipped during prefetch. */
+export type TTimelockSkipReason = 'no-deployment-log' | 'no-timelock-deployed'
+
+/** Result of pre-checking a network (queue only, no RPC). Used to decide which networks to process; processNetwork always opens a fresh RPC and re-fetches queued ops to verify on-chain readiness. */
+export interface IPendingFetchResult {
+  network: INetworksObject[string]
+  /** Number of queued timelock ops for this network (on-chain ready count unknown until processNetwork runs). */
+  pendingInMongoCount: number
+  /** Set when prefetch failed; callers must not treat as "no pending" without checking. */
+  fetchError?: unknown
+  /** Set when the network has no production timelock to check — an expected skip, not a failure. */
+  skipReason?: TTimelockSkipReason
+}
+
+/** Row shape the tally needs; the query projects away everything else. */
+interface IQueuedNetworkRow {
+  network: string
+}
+
+/**
+ * Tallies queued ops per network, case-insensitively.
+ *
+ * @param rows - Queued rows, each carrying its network name.
+ * @returns Lowercased network name → count. Networks with no rows are absent.
+ */
+export function tallyQueuedOpsByNetwork(
+  rows: IQueuedNetworkRow[]
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const row of rows) {
+    const key = row.network.toLowerCase()
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  return counts
+}
+
+/**
+ * Counts queued timelock ops for many networks in one query over one connection.
+ *
+ * @param networkNames - Network names to count for (matched case-insensitively).
+ * @returns Lowercased network name → queued op count.
+ */
+export async function countQueuedOpsByNetwork(
+  networkNames: string[]
+): Promise<Map<string, number>> {
+  const { client, timelockQueue } = await getTimelockQueueCollection()
+  try {
+    const rows = await timelockQueue
+      .find(
+        {
+          network: { $in: networkNames.map((name) => name.toLowerCase()) },
+          status: 'queued',
+        },
+        { projection: { network: 1 } }
+      )
+      .toArray()
+    return tallyQueuedOpsByNetwork(rows)
+  } finally {
+    await client.close()
+  }
+}
+
+/**
+ * Resolves whether a network has a production timelock worth querying.
+ *
+ * A missing deployments file is an expected state for an active network that
+ * was never brought up in production (e.g. `tronshasta`), so it is reported as
+ * a skip rather than an error — otherwise it is indistinguishable from a
+ * genuine infrastructure failure in the prefetch summary.
+ *
+ * @param network - Network entry from `config/networks.json`.
+ * @returns A skip reason, or `undefined` when the network has a timelock.
+ */
+export async function resolveTimelockSkipReason(
+  network: INetworksObject[string]
+): Promise<TTimelockSkipReason | undefined> {
+  let deploymentData: { LiFiTimelockController?: string }
+  try {
+    deploymentData = (await getDeployments(
+      network.name as SupportedChain,
+      EnvironmentEnum.production
+    )) as { LiFiTimelockController?: string }
+  } catch {
+    return 'no-deployment-log'
+  }
+  return deploymentData.LiFiTimelockController
+    ? undefined
+    : 'no-timelock-deployed'
+}
+
+/**
+ * Assembles per-network results from the skip map and the queue tally.
+ *
+ * @param networks - Networks in the order results should be returned.
+ * @param skipReasons - Network name → skip reason for networks with no timelock.
+ * @param countsByNetwork - Lowercased network name → queued op count.
+ * @param fetchError - When set, every non-skipped network is marked as failed.
+ * @returns One result per input network, in input order.
+ */
+export function assemblePrefetchResults(
+  networks: INetworksObject[string][],
+  skipReasons: Map<string, TTimelockSkipReason>,
+  countsByNetwork: Map<string, number>,
+  fetchError?: unknown
+): IPendingFetchResult[] {
+  return networks.map((network) => {
+    const skipReason = skipReasons.get(network.name)
+    if (skipReason) return { network, pendingInMongoCount: 0, skipReason }
+    if (fetchError !== undefined)
+      return { network, pendingInMongoCount: 0, fetchError }
+    return {
+      network,
+      pendingInMongoCount: countsByNetwork.get(network.name.toLowerCase()) ?? 0,
+    }
+  })
+}
+
+/**
+ * Pre-checks every network using the queue only (no RPC), over a single MongoDB
+ * connection and a single query.
+ *
+ * Connection-per-network was the previous shape and does not scale: with a
+ * `mongodb+srv://` URI every `MongoClient` resolves its own SRV *and* TXT
+ * record before connecting, so fanning out over the fleet fired ~142 DNS
+ * queries at once, the local resolver rate-limited them, and every network
+ * whose lookup timed out was reported as "prefetch failed" and then silently
+ * not checked for ready operations.
+ *
+ * @param networks - Networks to pre-check.
+ * @returns One result per input network, in input order.
+ */
+export async function fetchPendingForNetworks(
+  networks: INetworksObject[string][]
+): Promise<IPendingFetchResult[]> {
+  const skipReasons = new Map<string, TTimelockSkipReason>()
+  for (const network of networks) {
+    const skipReason = await resolveTimelockSkipReason(network)
+    if (skipReason) skipReasons.set(network.name, skipReason)
+  }
+
+  const withTimelock = networks.filter((n) => !skipReasons.has(n.name))
+  if (withTimelock.length === 0)
+    return assemblePrefetchResults(networks, skipReasons, new Map())
+
+  try {
+    const countsByNetwork = await countQueuedOpsByNetwork(
+      withTimelock.map((n) => n.name)
+    )
+    return assemblePrefetchResults(networks, skipReasons, countsByNetwork)
+  } catch (err) {
+    consola.error(
+      `Prefetch failed for all ${withTimelock.length} network(s) with a timelock — could not read the timelock queue:`,
+      err
+    )
+    return assemblePrefetchResults(networks, skipReasons, new Map(), err)
+  }
+}
+
+/** How a completed prefetch should be reported and whether the run may continue. */
+export interface IPrefetchOutcome {
+  withPending: IPendingFetchResult[]
+  skipped: IPendingFetchResult[]
+  failed: IPendingFetchResult[]
+  /**
+   * True when there is no work AND some networks could not be checked: "0
+   * pending" is only trustworthy once every network was actually reached.
+   */
+  mustExitWithError: boolean
+}
+
+/**
+ * Classifies prefetch results into the buckets the CLI reports on.
+ *
+ * @param results - One result per pre-checked network.
+ * @returns The classified outcome.
+ */
+export function classifyPrefetchResults(
+  results: IPendingFetchResult[]
+): IPrefetchOutcome {
+  const withPending = results.filter((r) => r.pendingInMongoCount > 0)
+  const failed = results.filter((r) => r.fetchError)
+  return {
+    withPending,
+    skipped: results.filter((r) => r.skipReason),
+    failed,
+    mustExitWithError: withPending.length === 0 && failed.length > 0,
+  }
+}

--- a/script/deploy/safe/timelock-prefetch.ts
+++ b/script/deploy/safe/timelock-prefetch.ts
@@ -60,16 +60,21 @@ export function tallyQueuedOpsByNetwork(
   return counts
 }
 
+/** Opens the queue collection; injectable so the teardown path can be tested. */
+export type TQueueConnector = typeof getTimelockQueueCollection
+
 /**
  * Counts queued timelock ops for many networks in one query over one connection.
  *
  * @param networkNames - Network names to count for (matched case-insensitively).
+ * @param connect - Opens the queue collection; defaults to the real connection.
  * @returns Lowercased network name → queued op count.
  */
 export async function countQueuedOpsByNetwork(
-  networkNames: string[]
+  networkNames: string[],
+  connect: TQueueConnector = getTimelockQueueCollection
 ): Promise<Map<string, number>> {
-  const { client, timelockQueue } = await getTimelockQueueCollection()
+  const { client, timelockQueue } = await connect()
   try {
     const rows = await timelockQueue
       .find(
@@ -82,7 +87,14 @@ export async function countQueuedOpsByNetwork(
       .toArray()
     return tallyQueuedOpsByNetwork(rows)
   } finally {
-    await client.close()
+    // A rejecting close would otherwise replace an already-computed tally with a
+    // throw, and since this is now the fleet's only connection that turns a
+    // teardown hiccup into "every network failed to prefetch".
+    await client
+      .close()
+      .catch((err: unknown) =>
+        consola.warn('Failed to close the MongoDB connection:', err)
+      )
   }
 }
 
@@ -169,17 +181,23 @@ export async function fetchPendingForNetworks(
 ): Promise<IPendingFetchResult[]> {
   const skipReasons = new Map<string, TTimelockSkipReason>()
   const errorsByNetwork = new Map<string, unknown>()
-  for (const network of networks)
-    try {
-      const skipReason = await resolveTimelockSkipReason(network)
-      if (skipReason) skipReasons.set(network.name, skipReason)
-    } catch (err) {
-      consola.error(
-        `[${network.name}] Could not read the production deployments file:`,
-        err
-      )
-      errorsByNetwork.set(network.name, err)
-    }
+  const resolved = await Promise.all(
+    networks.map(async (network) => {
+      try {
+        return { network, skipReason: await resolveTimelockSkipReason(network) }
+      } catch (err) {
+        consola.error(
+          `[${network.name}] Could not read the production deployments file:`,
+          err
+        )
+        return { network, err }
+      }
+    })
+  )
+  for (const entry of resolved)
+    if ('err' in entry) errorsByNetwork.set(entry.network.name, entry.err)
+    else if (entry.skipReason)
+      skipReasons.set(entry.network.name, entry.skipReason)
 
   const toCheck = networks.filter(
     (n) => !skipReasons.has(n.name) && !errorsByNetwork.has(n.name)

--- a/script/deploy/safe/timelock-prefetch.ts
+++ b/script/deploy/safe/timelock-prefetch.ts
@@ -1,11 +1,11 @@
 /**
  * Fleet pre-check for the timelock executor: which networks have queued ops.
  *
- * Split out of `execute-pending-timelock-tx.ts` so the logic is importable —
- * that module calls `runMain` at module scope, and the `import.meta.main` guard
- * used elsewhere in this directory is not an option there: the script runs via
- * `bunx tsx`, where `import.meta.main` is `undefined` and the guard would turn
- * the CLI into a silent no-op.
+ * Lives outside `execute-pending-timelock-tx.ts` because that module calls
+ * `runMain` at module scope and so cannot be imported by tests. Guarding it with
+ * `import.meta.main`, as some siblings in this directory do, is not an option:
+ * the CLI runs under `bunx tsx`, where `import.meta.main` is `undefined`, so the
+ * guard would silently turn the whole command into a no-op.
  */
 
 import { consola } from 'consola'

--- a/script/deploy/safe/timelock-prefetch.ts
+++ b/script/deploy/safe/timelock-prefetch.ts
@@ -8,6 +8,8 @@
  * guard would silently turn the whole command into a no-op.
  */
 
+import { existsSync } from 'fs'
+
 import { consola } from 'consola'
 
 import {
@@ -15,7 +17,10 @@ import {
   type INetworksObject,
   type SupportedChain,
 } from '../../common/types'
-import { getDeployments } from '../../utils/deploymentHelpers'
+import {
+  getDeployments,
+  getDeploymentsFilePath,
+} from '../../utils/deploymentHelpers'
 
 import { getTimelockQueueCollection } from './timelock-queue'
 
@@ -95,13 +100,19 @@ export async function countQueuedOpsByNetwork(
 export async function resolveTimelockSkipReason(
   network: INetworksObject[string]
 ): Promise<TTimelockSkipReason | undefined> {
+  const chain = network.name as SupportedChain
   let deploymentData: { LiFiTimelockController?: string }
   try {
     deploymentData = (await getDeployments(
-      network.name as SupportedChain,
+      chain,
       EnvironmentEnum.production
     )) as { LiFiTimelockController?: string }
-  } catch {
+  } catch (err) {
+    // getDeployments reports a corrupt or unreadable file as not-found too, and
+    // skipping one of those would hide a network that does have a timelock —
+    // the very failure this prefetch exists to stop. Only an absent file skips.
+    if (existsSync(getDeploymentsFilePath(chain, EnvironmentEnum.production)))
+      throw err
     return 'no-deployment-log'
   }
   return deploymentData.LiFiTimelockController
@@ -115,20 +126,23 @@ export async function resolveTimelockSkipReason(
  * @param networks - Networks in the order results should be returned.
  * @param skipReasons - Network name → skip reason for networks with no timelock.
  * @param countsByNetwork - Lowercased network name → queued op count.
- * @param fetchError - When set, every non-skipped network is marked as failed.
+ * @param errorsByNetwork - Network name → the error that stopped it being checked.
  * @returns One result per input network, in input order.
  */
 export function assemblePrefetchResults(
   networks: INetworksObject[string][],
   skipReasons: Map<string, TTimelockSkipReason>,
   countsByNetwork: Map<string, number>,
-  fetchError?: unknown
+  errorsByNetwork: Map<string, unknown> = new Map()
 ): IPendingFetchResult[] {
   return networks.map((network) => {
     const skipReason = skipReasons.get(network.name)
     if (skipReason) return { network, pendingInMongoCount: 0, skipReason }
+
+    const fetchError = errorsByNetwork.get(network.name)
     if (fetchError !== undefined)
       return { network, pendingInMongoCount: 0, fetchError }
+
     return {
       network,
       pendingInMongoCount: countsByNetwork.get(network.name.toLowerCase()) ?? 0,
@@ -154,26 +168,52 @@ export async function fetchPendingForNetworks(
   networks: INetworksObject[string][]
 ): Promise<IPendingFetchResult[]> {
   const skipReasons = new Map<string, TTimelockSkipReason>()
-  for (const network of networks) {
-    const skipReason = await resolveTimelockSkipReason(network)
-    if (skipReason) skipReasons.set(network.name, skipReason)
-  }
+  const errorsByNetwork = new Map<string, unknown>()
+  for (const network of networks)
+    try {
+      const skipReason = await resolveTimelockSkipReason(network)
+      if (skipReason) skipReasons.set(network.name, skipReason)
+    } catch (err) {
+      consola.error(
+        `[${network.name}] Could not read the production deployments file:`,
+        err
+      )
+      errorsByNetwork.set(network.name, err)
+    }
 
-  const withTimelock = networks.filter((n) => !skipReasons.has(n.name))
-  if (withTimelock.length === 0)
-    return assemblePrefetchResults(networks, skipReasons, new Map())
+  const toCheck = networks.filter(
+    (n) => !skipReasons.has(n.name) && !errorsByNetwork.has(n.name)
+  )
+  if (toCheck.length === 0)
+    return assemblePrefetchResults(
+      networks,
+      skipReasons,
+      new Map(),
+      errorsByNetwork
+    )
 
   try {
     const countsByNetwork = await countQueuedOpsByNetwork(
-      withTimelock.map((n) => n.name)
+      toCheck.map((n) => n.name)
     )
-    return assemblePrefetchResults(networks, skipReasons, countsByNetwork)
+    return assemblePrefetchResults(
+      networks,
+      skipReasons,
+      countsByNetwork,
+      errorsByNetwork
+    )
   } catch (err) {
     consola.error(
-      `Prefetch failed for all ${withTimelock.length} network(s) with a timelock — could not read the timelock queue:`,
+      `Prefetch failed for all ${toCheck.length} network(s) with a timelock — could not read the timelock queue:`,
       err
     )
-    return assemblePrefetchResults(networks, skipReasons, new Map(), err)
+    for (const network of toCheck) errorsByNetwork.set(network.name, err)
+    return assemblePrefetchResults(
+      networks,
+      skipReasons,
+      new Map(),
+      errorsByNetwork
+    )
   }
 }
 

--- a/script/utils/deploymentHelpers.test.ts
+++ b/script/utils/deploymentHelpers.test.ts
@@ -7,7 +7,30 @@ import {
 
 import { type SupportedChain, EnvironmentEnum } from '../common/types'
 
-import { getDeployments } from './deploymentHelpers'
+import { getDeployments, getDeploymentsFilePath } from './deploymentHelpers'
+
+describe('getDeploymentsFilePath', () => {
+  it('resolves the production file inside deployments/', () => {
+    expect(
+      getDeploymentsFilePath('mainnet', EnvironmentEnum.production)
+    ).toEndWith('/deployments/mainnet.json')
+  })
+
+  it('resolves the staging file inside deployments/', () => {
+    expect(
+      getDeploymentsFilePath('mainnet', EnvironmentEnum.staging)
+    ).toEndWith('/deployments/mainnet.staging.json')
+  })
+
+  it('refuses a chain name that would escape deployments/', () => {
+    expect(() =>
+      getDeploymentsFilePath(
+        '../../config/networks' as SupportedChain,
+        EnvironmentEnum.production
+      )
+    ).toThrow('Invalid network name')
+  })
+})
 
 describe('getDeployments', () => {
   it('loads the deployments file for a chain and environment', async () => {

--- a/script/utils/deploymentHelpers.ts
+++ b/script/utils/deploymentHelpers.ts
@@ -26,19 +26,26 @@ const deploymentsCache = new Map<string, Promise<DeploymentsFileModule>>()
  * there but unreadable" need this: `getDeployments` reports both as not-found.
  *
  * @param chain - Chain the deployments file belongs to.
- * @param environment - Production or staging.
+ * @param environment - Production or staging. Required rather than defaulted:
+ * an omitted argument would silently answer for the wrong environment.
  * @returns Absolute path to the deployments file (which may not exist).
+ * @throws When `chain` resolves outside `deployments/`.
  */
 export const getDeploymentsFilePath = (
   chain: SupportedChain,
-  environment: EnvironmentEnum = EnvironmentEnum.staging
+  environment: EnvironmentEnum
 ): string => {
   const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const base = path.resolve(__dirname, '../../deployments')
   const fileName =
     environment === EnvironmentEnum.production
       ? `${chain}.json`
       : `${chain}.staging.json`
-  return path.resolve(__dirname, `../../deployments/${fileName}`)
+  const filePath = path.resolve(base, fileName)
+  const relativePath = path.relative(base, filePath)
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath))
+    throw new Error(`Invalid network name: ${chain}`)
+  return filePath
 }
 
 /**
@@ -56,11 +63,14 @@ export const getDeployments = async (
   const filePath = getDeploymentsFilePath(chain, environment)
 
   const loadPromise: Promise<DeploymentsFileModule> = import(filePath).catch(
-    () => {
+    (err: unknown) => {
       // Drop failed loads so a later call can retry instead of caching the rejection
       deploymentsCache.delete(cacheKey)
+      // A missing file and an unparseable one both land here; keep the cause so
+      // callers that must tell them apart are not left re-deriving it.
       throw new Error(
-        `Deployments file not found for ${chain} (${environment}): ${filePath}`
+        `Deployments file not found for ${chain} (${environment}): ${filePath}`,
+        { cause: err }
       )
     }
   )

--- a/script/utils/deploymentHelpers.ts
+++ b/script/utils/deploymentHelpers.ts
@@ -20,6 +20,28 @@ type DeploymentsFileModule = Record<string, string> & {
 const deploymentsCache = new Map<string, Promise<DeploymentsFileModule>>()
 
 /**
+ * Resolves the on-disk path of a chain's deployments file.
+ *
+ * Callers that must tell "this chain was never deployed" apart from "the file is
+ * there but unreadable" need this: `getDeployments` reports both as not-found.
+ *
+ * @param chain - Chain the deployments file belongs to.
+ * @param environment - Production or staging.
+ * @returns Absolute path to the deployments file (which may not exist).
+ */
+export const getDeploymentsFilePath = (
+  chain: SupportedChain,
+  environment: EnvironmentEnum = EnvironmentEnum.staging
+): string => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const fileName =
+    environment === EnvironmentEnum.production
+      ? `${chain}.json`
+      : `${chain}.staging.json`
+  return path.resolve(__dirname, `../../deployments/${fileName}`)
+}
+
+/**
  * Utility function to dynamically import the deployments file for a chain.
  * Results are cached per (chain, environment) for the lifetime of the process.
  */
@@ -31,12 +53,7 @@ export const getDeployments = async (
   const cached = deploymentsCache.get(cacheKey)
   if (cached) return cached
 
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
-  const fileName =
-    environment === EnvironmentEnum.production
-      ? `${chain}.json`
-      : `${chain}.staging.json`
-  const filePath = path.resolve(__dirname, `../../deployments/${fileName}`)
+  const filePath = getDeploymentsFilePath(chain, environment)
 
   const loadPromise: Promise<DeploymentsFileModule> = import(filePath).catch(
     () => {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-841](https://linear.app/lifi-linear/issue/EXSC-841/execute-pending-timelock-tx-dns-fan-out-silently-skips-networks-plus)

# Why did I implement it this way?

A single `bun execute-timelock` run produced 28 errors from three independent causes. The first is a correctness problem, not noise.

**The prefetch silently skipped 27 networks.** `fetchPendingForNetwork` was fanned out over all 71 active networks with a bare `Promise.all`, and every call opened its own `MongoClient` and closed it again. With a `mongodb+srv://` URI each client resolves its own SRV _and_ TXT record before connecting, so a run fired ~142 DNS queries in the same second at the local resolver. It rate-limited them, 27 timed out (`querySrv ETIMEOUT` / `queryTxt ETIMEOUT`), and those networks — **mainnet, base and bsc among them** — were never checked for ready operations. The run's headline ("2 have pending timelock tx(s)") was only true of the 44 that resolved; a ready op on mainnet would have gone unexecuted behind a single `warn` line.

The fix is one connection and one `$in` query for the whole fleet, so the per-network DNS resolution disappears rather than being retried. I deliberately did **not** build this on EXSC-794 / #2218: that helper retries via public DNS on a malformed SRV answer, which is a different failure. It would not have saved this run — it gates on `syscall === 'querySrv'` so the `queryTxt` timeouts rethrow untouched, its `fallbackApplied` latch is once-per-process so the 26 concurrent failures after the first skip the retry entirely, and 142 simultaneous queries would likely time out against a public resolver too. The two changes are complementary and touch disjoint files: after this lands, #2218's helper covers the single remaining connect instead of 71.

Rejected alternative: a concurrency limiter around the existing per-network client. It would have reduced the DNS burst without removing it, and left the connect-per-network cost in place for what is a read-only count.

**The prefetch logic now lives in `timelock-prefetch.ts`.** `execute-pending-timelock-tx.ts` calls `runMain` at module scope and so cannot be imported by a test. The `import.meta.main` guard used by siblings in that directory is not an option: the CLI runs under `bunx tsx`, where `import.meta.main` is `undefined` — I verified this, and adding the guard would silently turn the command into a no-op. Extracting the logic was the only way to get it under test. The two near-identical prefetch blocks in the `--executeAll` and interactive branches also collapse into one helper, so the fix cannot land in one branch and be missed in the other.

**`tronshasta` was an expected skip reported as a failure.** It is `status: active` but has no `deployments/tronshasta.json` (the only active testnet without one), so `getDeployments` threw and the prefetch logged a stack trace and counted it among the failures. A missing deployments file now classifies as a skip, distinct in both the output and the counts from a genuine fetch failure. The summary line reports "Checked N of M" so every network is accounted for.

The skip requires the file to be genuinely **absent**, which is why `getDeploymentsFilePath` is now exported: `getDeployments` reports a corrupt or unreadable file as not-found too, so treating every throw as a skip would silently drop a network that does have a timelock — the same bug class this PR exists to fix, in a narrower form. Anything other than an absent file is recorded as a per-network fetch error instead.

**Init calldata failed to decode when arguments contain nested bigints.** `formatDecodedArg` handled a top-level `bigint` but fell through to a plain `JSON.stringify` for tuples and arrays, which throws on nested bigints; both call sites swallow the throw. Hit on the FraxFacet cut on worldchain — `initFrax` carries `(chainId, eid)` pairs, so **the cut was approved at the interactive prompt with its init arguments never displayed**. That is a review-safety gap in the confirmation path, which is why it is fixed here rather than deferred.

## Verification

Run against the real fleet and the production timelock queue, before and after:

|                      | before               | after                        |
| -------------------- | -------------------- | ---------------------------- |
| networks reported on | 44 of 71             | **71 of 71**                 |
| prefetch failures    | 27                   | **0**                        |
| Mongo connections    | 71                   | **1**                        |
| `tronshasta`         | error + stack trace  | skip (`no-deployment-log`)   |

A full-fleet dry run reports `Checked 66 of 71 network(s); 1 have pending timelock tx(s): tron` with 5 skips itemised and no failures. Skips resolve correctly against real deployment logs: 4 testnets `no-timelock-deployed`, `tronshasta` `no-deployment-log`. Dry-runs also cover the single-network skip path, the missing-log path and the reached-but-empty path, and tron's queued op was confirmed untouched afterwards.

Every fix here was negative-controlled — each was reverted in turn and the corresponding test observed to fail (BigInt replacer: 2 tests; missing-deployments skip: 1; absent-vs-unreadable guard: 1) — so none of them pass vacuously.

The exit-1 path for "0 pending but some networks unreachable" is covered by unit test rather than by a live outage.

## Review round 2

Six findings from @melianessa, all answered in the threads; five changed code (`2cd33583f`).

- **A prefetch failure now fails the run even when other networks had work.** `mustExitWithError` only fires at zero pending, so a network that was never checked was passed over silently the moment any other chain had a queued op — the reporting half of the same silent skip this PR exists to close. `prefetchNetworksWithPendingOps` returns `failedCount`; both branches exit non-zero on it, after processing the reachable networks rather than instead of.
- **A rejecting `client.close()` no longer discards an already-computed tally.** Pre-PR that cost one network; with one connection for the fleet it would have turned a teardown hiccup into "every network failed to prefetch" — and, given the change above, an exit-1.
- **`getDeploymentsFilePath` refuses a chain name that resolves outside `deployments/`**, matching `getContractAddress` and the four `proposeAll*ChainIdMappings.ts` copies, and takes the environment explicitly rather than defaulting to staging.
- **`getDeployments` keeps the underlying import error as `cause`** instead of flattening it into "not found". The `existsSync` probe stays: classifying off the loader's error taxonomy is runtime-specific, and this CLI, the tests and the propose tasks run under three different ones.
- **Nested strings in a decoded arg get the same per-network address rendering as top-level ones** — a Tron address inside a tuple showed as raw hex at the approval prompt, which the round-1 JSDoc had already (correctly) promised it would not.
- Skip resolution runs over `Promise.all` per [CONV:PARALLEL-WORK]; it reads local files only, so there is no fan-out to bound. `prefetchNetworksWithPendingOps` returns the networks its callers actually use. The queue re-read in `processNetwork` is unchanged and deliberate: a queued row is not an executable operation, and on-chain `isOperationReady` remains the authority.

New behaviour is negative-controlled as before — reverting each fix in turn fails its test and only its test (close-rejection guard: 1; traversal guard: 1; nested address: 1). The exit-code change cannot be unit-tested (the exit sits in the module that calls `runMain` at scope), so it was driven against the real functions with a genuinely corrupt `deployments/tronshasta.json` plus a network carrying a queued op, reproducing the exact previously-green case; output is in the thread.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

