### PR TITLE
fix(ci): raise Tron timelock exec fee limit so multi-call batches can execute (EXSC-842)

### DIFF
--- a/.github/workflows/runPendingTimelockTXs.yml
+++ b/.github/workflows/runPendingTimelockTXs.yml
@@ -99,6 +99,9 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TIMELOCK_SLACK_WEBHOOK_URL }}
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
           GH_TOKEN: ${{ github.token }} # required by `gh api` to resolve the job's html_url
+          # The devkit default of 50 TRX caps a Tron tx at 500k energy, which a multi-call
+          # timelock batch exceeds — it aborts mid-SSTORE as OUT_OF_ENERGY and is retried forever.
+          TRON_SAFE_EXEC_FEE_LIMIT_SUN: '150000000'
           # Fallback link (run overview); upgraded to a deep job link below when the jobs API is reachable.
           RUN_OVERVIEW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-842](https://linear.app/lifi-linear/issue/EXSC-842/tron-timelock-auto-execution-raise-per-tx-fee-limit-so-multi-call)

# Why did I implement it this way?

The Timelock Auto Execution workflow could not execute **multi-call** timelock batches on Tron. It retried every 10 minutes and failed every time with `OUT_OF_ENERGY`, so a ready op sat in the queue indefinitely. It surfaced on the `FeeForwarder` v2.0.0 rollout (#2251), whose second op is a 3-call batch.

This is **not** a funding problem — the executor holds ~1,493 TRX. It is the per-tx fee limit. `@lifi/tron-devkit`'s `parseFeeLimitSun()` falls back to `TRON_SAFE_EXEC_DEFAULT_FEE_LIMIT_SUN` = 50 TRX, and at the current energy price (`getEnergyFee` = 100 sun/energy) that caps a tx at exactly **500,000 energy**. This workflow never set an override, so every Tron execution ran under that ceiling.

The receipt shows the ceiling, not a revert:

```text
fee_limit = 50000000 (sun)
revert    = false
info.resMessage = "Not enough energy for 'SSTORE' operation executing:
                   curInvokeEnergyLimit[500000], curOpEnergy[5000], usedEnergy[496348]"
```

A `wallet/triggerconstantcontract` simulation of the same calldata returns `result: true` with **`energy_used = 501386`** — over the cap by ~0.3%. So the batch dies mid-`SSTORE` after completing 2 of its 3 internal calls. The single-call registration batch in the same rollout used only 21,162 energy and executed fine, which is why this ceiling was never hit before.

`150000000` sun = 150 TRX = 1.5M energy at the current price, roughly 3x the measured requirement. I picked a fixed constant with headroom rather than a computed value to keep this a one-line config fix; deriving the limit from a pre-broadcast energy estimate is the better long-term shape and is noted as a follow-up on the ticket.

Worth knowing: **the fee limit is a ceiling, not a charge.** Only energy actually consumed is billed, so raising it costs nothing on the happy path — it only widens the headroom before a batch aborts. The failure mode it removes is strictly worse than the cost it risks.

I verified the env var actually reaches this code path rather than assuming it:

`execute-pending-timelock-tx.ts` → `chainCaller.call()` → `TronChainCaller` (`script/deploy/safe/executors/tron-caller.ts`) → `broadcastTronContractCall()` (`@lifi/tron-devkit/safe`) → `parseFeeLimitSun()` → `fee_limit`

and that the value parses (`parseFeeLimitSun` requires a positive integer in sun) and lands on the right step with the other five env entries intact.

Also checked that `TRON_SAFE_EXEC_FEE_LIMIT_SUN` is absent from `.env`, so it does not collide with the earlier step that exports `.env` into `$GITHUB_ENV` — step-level `env:` would win regardless, but there is no contention either way.

**This does not take effect until merge.** GitHub runs `schedule` triggers from the default branch only, so the 10-minute cron keeps using the 50 TRX default while this sits unmerged and the stuck op stays stuck. To execute it before merge, the workflow can be dispatched against this branch (`gh workflow run runPendingTimelockTXs.yml --ref fix/tron-timelock-exec-fee-limit`) — a manual dispatch always runs regardless of `ENABLE_TIMELOCK_AUTO_EXECUTION` and uses the ref's copy of the workflow.

Staked energy on the executor is separately drained (1,950 of 700,999 remaining), which is why these batches burn TRX instead of drawing on staked energy. That is a cost issue rather than a correctness one and belongs to EXSC-506, not here.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
