### PR TITLE
fix(networks): mark tronshasta inactive to stop timelock auto-execution failures

### DIFF
--- a/config/networks.json
+++ b/config/networks.json
@@ -1357,7 +1357,7 @@
     "nativeAddress": "0x0000000000000000000000000000000000000000",
     "nativeCurrency": "TRX",
     "wrappedNativeAddress": "TYsbWxNnyTgsZaTFaue9hqpxkU3Fkco94a",
-    "status": "active",
+    "status": "inactive",
     "type": "testnet",
     "rpcUrl": "https://api.shasta.trongrid.io",
     "verificationType": "tronscan",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

_None — single-line config fix, labelled `trivial` per the carve-out in `.agents/context.md`._

# Why did I implement it this way?

`Timelock Auto Execution` has failed on **every** scheduled run since 2026-08-24 16:21 UTC (23+ consecutive runs, one Slack alert each in `#dev-sc-timelock-executions`).

Root cause: PR #2252 (EXSC-818 deploy-log pruning) deleted `deployments/tronshasta.json`, but `tronshasta` was still `status: "active"` in `config/networks.json`. The auto-executor iterates active networks; `fetchPendingForNetwork` calls `getDeployments`, which **throws** when the deployments file is absent rather than reporting "no timelock here":

```text
[error] [tronshasta] Prefetch failed: Deployments file not found for tronshasta (production)
[info] Checked 71 network(s) (MongoDB only); 0 have pending timelock tx(s)
[warn] Prefetch failed for 1 network(s): tronshasta
[error] No networks with pending timelock txs; some networks failed to fetch. Exiting with error…
```

The guard at `execute-pending-timelock-tx.ts:240` exits 1 when zero networks have pending work **and** at least one failed to fetch. That is why the alerts started ~8h after #2252 merged: until 16:05 UTC there was genuine pending work (injective + plasma), so the tronshasta error stayed a warning. The moment the queue drained, every run began failing.

No timelock work was ever missed — this was pure false-alarm noise.

Fix: `tronshasta` has no deployed diamond, no deploy log, no Safe address, and no `foundry.toml` entry. It is a Tron testnet reached only through the `contracts-tron` fork's TronWeb scripts, which do not read `status`. Marking it `inactive` removes it from `getAllActiveNetworks()` and therefore from the executor's network set, so no prefetch is attempted and the guard no longer fires.

Verified:

- Active network count 71 → 70; `tronshasta` excluded, `tron` (mainnet) still included.
- `tronshasta` appears in no other config — only `config/networks.json`. No deploy log, no `foundry.toml` entry, no `whitelist`/`clearSigning` reference.
- `bun test script/` → **1056 pass, 0 fail** (48 files).
- Prettier untouched on `config/networks.json` (insertion-only one-line diff, per repo convention that JSON is not formatter-managed).

Known follow-up (deliberately **not** in this PR): the underlying fragility remains — `getDeployments` cannot distinguish "no deployment log" from a real fetch error, so any future active network without a deploy log will break the cron the same way. Treating a missing deployments file as "no timelock deployed" in `fetchPendingForNetwork` is the durable fix.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
