### PR TITLE
fix(healthCheck): exclude LiFiTimelockController from periphery-registry-log-sync (EXSC-845)

### DIFF
--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -976,6 +976,16 @@ describe('periphery-registry-log-sync invariant', () => {
     expect(ctx.warnings[0]).toContain('the on-chain registry has')
   })
 
+  it('leaves the timelock alone - it is the diamond owner, not periphery', async () => {
+    const { ctx, registryQueries } = makeReceiverCtx({
+      registry: { LiFiTimelockController: WRONG },
+      deployedContracts: { LiFiTimelockController: OIF_ON_CHAIN },
+    })
+    await sync().run(ctx)
+    expect(registryQueries).not.toContain('LiFiTimelockController')
+    expect(ctx.warnings).toEqual([])
+  })
+
   it('stays silent when the registry and the deploy log agree', async () => {
     const { ctx } = makeReceiverCtx({
       registry: { ReceiverOIF: OIF_ON_CHAIN },

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1686,7 +1686,12 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       // that can only ever return the zero address. Matching on `includes` mirrors
       // deriveNonCoreFacets and catches the packed/versioned variants; no periphery name contains
       // "Facet".
+      // The timelock is the diamond's owner, not a contract the diamond calls, so a registry
+      // entry for it is not the address anything resolves - owner() is. periphery-registered
+      // already skips it for the same reason; without the skip here a leftover entry from an
+      // earlier bring-up reads as drift against a log that is correct.
       const notPeriphery = (name: string): boolean =>
+        name === 'LiFiTimelockController' ||
         name.includes('Facet') ||
         name.startsWith('LiFiDiamond') ||
         ctx.coreFacetsToCheck.includes(name) ||

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1686,10 +1686,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       // that can only ever return the zero address. Matching on `includes` mirrors
       // deriveNonCoreFacets and catches the packed/versioned variants; no periphery name contains
       // "Facet".
-      // The timelock is the diamond's owner, not a contract the diamond calls, so a registry
-      // entry for it is not the address anything resolves - owner() is. periphery-registered
-      // already skips it for the same reason; without the skip here a leftover entry from an
-      // earlier bring-up reads as drift against a log that is correct.
+      // The timelock is the diamond's owner, not a contract the diamond calls: every consumer
+      // reads its address from the deploy log, and diamond-owner validates that against
+      // owner(). A registry entry for it is therefore not an address anything resolves.
+      // periphery-registered skips it for the same reason.
       const notPeriphery = (name: string): boolean =>
         name === 'LiFiTimelockController' ||
         name.includes('Facet') ||


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-845/health-check-periphery-registry-log-sync-treats-lifitimelockcontroller

# Why did I implement it this way?

`periphery-registry-log-sync` probes the PeripheryRegistry for `LiFiTimelockController`, but the timelock is the diamond's **owner**, not a contract the diamond calls — its address resolves through `owner()` and never through the registry.

The exclusion already existed in three other places in the same file, and this invariant is the only one of the four that disagreed:

- `:1378` — `contract !== 'LiFiTimelockController'`
- `:1589`, `:1652` — `if (periphery === 'LiFiTimelockController') continue` (both branches of `periphery-registered`)

So the fix is to carry that same exclusion into `notPeriphery`, rather than to change any deploy log or on-chain state.

## How it surfaced, and why nothing is actually broken

`healthCheck.ts --network jovay --environment production` emitted one warning: the deploy log has `0xDDB12A93…`, the registry has `0x707F90DF…`. Verified on-chain at block 11889136:

| | deploy log `0xDDB12A93…` | registry `0x707F90DF…` |
|---|---|---|
| owns the diamond | **yes** | no |
| admin / proposer | jovay Safe `0xb53FAC3E…` | `0x4ca0bd9a…` (an older Safe) |
| deployed | 2026-02-06 | 2025-12-22 |

Both addresses hold genuine `LiFiTimelockController` code (identical runtime keccak). The registry entry is a leftover from an abandoned December 2025 bring-up: the February handover redeployed the timelock under the real Safe, moved diamond ownership to it, and recorded it in the deploy log — but never re-registered it. Nothing reads that entry, and `diamond-owner` (error severity) already covers the property that matters and passes on jovay.

jovay is the only chain that surfaces it because it is the only one whose leftover entry disagrees with the log — flow and hemi have entries that happen to match, and stable/plasma/monad/megaeth are `address(0)`, which the invariant already skips.

## Scope notes

- `corePeriphery` in `config/global.json` keeps the timelock; it is legitimately deployed as core periphery. The category error was reusing that list as "must be in the PeripheryRegistry".
- No deploy-log change: `deployments/jovay.json` is already correct. `LiFiTimelockController` is absent from `.LiFiDiamond.Periphery` in all 69 `*.diamond.json` files, so that is the convention, not a gap.
- The stale on-chain entry on jovay is left in place — clearing it would cost a production Safe proposal plus timelock execution for no functional gain. Noted in EXSC-845.

## Tests

Added one case to `periphery-registry-log-sync`: a timelock whose registry address disagrees with the deploy log must be neither probed nor warned about. Confirmed it is a real check — it **fails** with the new line removed and passes with it. `bun test script/deploy/healthCheckInvariants.test.ts` → 117 pass / 0 fail.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
