### PR TITLE
chore(deployments): prune 4 stale tron facets after removal cut executed (EXSC-724)

### DIFF
--- a/deployments/tron.diamond.json
+++ b/deployments/tron.diamond.json
@@ -17,20 +17,12 @@
         "Name": "WithdrawFacet",
         "Version": "1.0.0"
       },
-      "TPDdY4Qqy9gU8eD3bJ63pUFhHr4WWnabks": {
-        "Name": "DexManagerFacet",
-        "Version": "1.0.2"
-      },
       "TLqbL8MKosbLxrJ9iTDTpZTzcXRWq8bFJ3": {
         "Name": "AccessManagerFacet",
         "Version": "1.0.0"
       },
       "TA9z2Lmg6g4tAwn31CK57ekjpmVXCr8kum": {
         "Name": "PeripheryRegistryFacet",
-        "Version": "1.0.0"
-      },
-      "TPccg9MTwWVxcSrMA3dYRxzpAGaiLeZmxS": {
-        "Name": "GenericSwapFacet",
         "Version": "1.0.0"
       },
       "TZD2bfN2dKawq3TeJkbRopeTD4kAbXceWN": {
@@ -45,17 +37,9 @@
         "Name": "EmergencyPauseFacet",
         "Version": "1.0.1"
       },
-      "TAXonvq4chZufsFS1NdTLaK4zq8ruPct8f": {
-        "Name": "SymbiosisFacet",
-        "Version": "1.0.0"
-      },
       "TR15epdwXG9kBXtEBnF5bv6kSYRY5w6mXY": {
         "Name": "AllBridgeFacet",
         "Version": "2.2.0"
-      },
-      "TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8": {
-        "Name": "EcoFacet",
-        "Version": "1.0.0"
       },
       "TG6586TTEv664XWSD875tMk6yDuwedphpW": {
         "Name": "EcoFacet",

--- a/deployments/tron.json
+++ b/deployments/tron.json
@@ -1,11 +1,9 @@
 {
   "AccessManagerFacet": "TLqbL8MKosbLxrJ9iTDTpZTzcXRWq8bFJ3",
   "CalldataVerificationFacet": "TFJLkNo9rHYTkp6w5G5ETnTBzzybRTqwQf",
-  "DexManagerFacet": "TPDdY4Qqy9gU8eD3bJ63pUFhHr4WWnabks",
   "DiamondCutFacet": "TNGUuj9GYbeUDn4GbTH2711kNyE4WcMbb4",
   "DiamondLoupeFacet": "TSFek3JXzdwPHH6bs9TBF7wviJ71ZxRC5j",
   "EmergencyPauseFacet": "TNDAp17M3vKJ432TLPGGEokuhzf4GTQXR6",
-  "GenericSwapFacet": "TPccg9MTwWVxcSrMA3dYRxzpAGaiLeZmxS",
   "OwnershipFacet": "TVofq5iFiwsDf4M3xcucpV7HCX5M6XpcHW",
   "PeripheryRegistryFacet": "TA9z2Lmg6g4tAwn31CK57ekjpmVXCr8kum",
   "LiFiDiamond": "TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt",


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-724](https://linear.app/lifi-linear/issue/EXSC-724/remove-deprecated-genericswapfacet-from-the-tron-production-diamond)

Related (not closed by this PR): the tron slice of EXSC-818 (fleet-wide deploy-log prune), and the tron instance of the superseded facets tracked in EXSC-750 / EXSC-787.

# Why did I implement it this way?

The tron stale-facet removal cut executed on-chain, so both deploy logs now describe a state that no longer exists. Per `docs/DeploymentLogs.md` both `deployments/tron.json` and `deployments/tron.diamond.json` describe what is live on that chain **now**, so the four removed facets have to come out.

Executed timelock operation:

| Field | Value |
| --- | --- |
| operationId | `0x916e65f80f4e7a378ec77a79c52f303508f51a3266299418440ae1bcd84c3f3c` |
| execution tx | `d4d3816d837c542efb35a4789d81c022fcbecddef657b269c55167168da35a66` |
| block | 85661789 |
| energy used | 424,394 |

Removed from the diamond (`TU3ymitEKCWQFtASkEeHaPb8NfZcJtCHLt`), 13 selectors total:

| Facet | Address | Selectors |
| --- | --- | --- |
| DexManagerFacet 1.0.2 | `TPDdY4Qqy9gU8eD3bJ63pUFhHr4WWnabks` | 8 |
| GenericSwapFacet 1.0.0 | `TPccg9MTwWVxcSrMA3dYRxzpAGaiLeZmxS` | 1 (`swapTokensGeneric`) |
| EcoFacet 1.0.0 | `TMLwFQAjLQqCJDUNVCVd9c9Q8LLqbmhaW8` | 2 |
| SymbiosisFacet 1.0.0 | `TAXonvq4chZufsFS1NdTLaK4zq8ruPct8f` | 2 |

**The flat log is pruned by address, not by name.** `deployments/tron.json` holds one address per facet name, and its `EcoFacet` / `SymbiosisFacet` entries point at the *kept* versions (`TG6586TTEv664XWSD875tMk6yDuwedphpW` 1.1.0 and `TMY1N6rC61Fu1C8qvZEhwb3WLR7iY1ERuW` 2.0.0). Only `DexManagerFacet` and `GenericSwapFacet` — whose entries did point at the removed addresses — are deleted there. Deleting by name would have wiped two live entries.

Edits were applied programmatically with an assertion per key (address present, and `Name`/`Version` matching the expected facet) and written back at the file's existing `indent=2`, so the diff is deletions-only with no reformatting of untouched lines. `deployments/tron.diamond.json` goes from 20 facet entries to 16, matching the on-chain `facets()` count after the cut.

Verified after execution: `isOperationDone` is true, and `facetAddress()` returns the zero address for a representative selector from each of the four removed facets (`0x536db266`, `0x4630a0d8`, `0xb4d70eae`, `0xb70fb9a5`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
