### PR TITLE
fix(ci): bump foundry-toolchain to v1.9.1 (EXSC-852)

### DIFF
--- a/.github/actions/setup-foundry/action.yml
+++ b/.github/actions/setup-foundry/action.yml
@@ -108,7 +108,7 @@ runs:
           foundry-toolchain-${{ runner.os }}-${{ steps.pin.outputs.version }}-
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+      uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
       with:
         version: ${{ steps.pin.outputs.version }}
         # Its built-in cache covers ~/.foundry/cache with a key of

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -56,6 +56,7 @@ jobs:
               - 'package.json'
               - 'bun.lockb'
               - '.github/workflows/deploy-smoke-test.yml'
+              - '.github/actions/setup-foundry/**'
 
   deploy-smoke-test:
     # Always run on manual dispatch; for PRs, skip drafts, require main as the base,

--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -57,6 +57,7 @@ jobs:
               - 'bun.lockb'
               - '.github/workflows/deploy-smoke-test.yml'
               - '.github/actions/setup-foundry/**'
+              - '.foundry-version'
 
   deploy-smoke-test:
     # Always run on manual dispatch; for PRs, skip drafts, require main as the base,

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -58,6 +58,7 @@ jobs:
               - 'lib/**'
               - '.gitmodules'
               - '.github/workflows/forge-unit-tests.yml'
+              - '.github/actions/setup-foundry/**'
 
   run-unit-tests:
     # Runs on PRs (once out of draft) and on push/workflow_dispatch.

--- a/.github/workflows/forge-unit-tests.yml
+++ b/.github/workflows/forge-unit-tests.yml
@@ -59,6 +59,7 @@ jobs:
               - '.gitmodules'
               - '.github/workflows/forge-unit-tests.yml'
               - '.github/actions/setup-foundry/**'
+              - '.foundry-version'
 
   run-unit-tests:
     # Runs on PRs (once out of draft) and on push/workflow_dispatch.

--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -60,6 +60,7 @@ jobs:
               - 'lib/**'
               - '.gitmodules'
               - '.github/workflows/solc-floor-build.yml'
+              - '.github/actions/setup-foundry/**'
 
   solc-floor-build:
     # Runs on PRs (once out of draft) and on push/workflow_dispatch.

--- a/.github/workflows/solc-floor-build.yml
+++ b/.github/workflows/solc-floor-build.yml
@@ -61,6 +61,7 @@ jobs:
               - '.gitmodules'
               - '.github/workflows/solc-floor-build.yml'
               - '.github/actions/setup-foundry/**'
+              - '.foundry-version'
 
   solc-floor-build:
     # Runs on PRs (once out of draft) and on push/workflow_dispatch.

--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -65,6 +65,7 @@ jobs:
               - 'bun.lock'
               - 'tsconfig.json'
               - '.github/workflows/validateScripts.yml'
+              - '.github/actions/setup-foundry/**'
 
   validate-scripts:
     # Runs on PRs (once out of draft) and on workflow_dispatch.

--- a/.github/workflows/validateScripts.yml
+++ b/.github/workflows/validateScripts.yml
@@ -66,6 +66,7 @@ jobs:
               - 'tsconfig.json'
               - '.github/workflows/validateScripts.yml'
               - '.github/actions/setup-foundry/**'
+              - '.foundry-version'
 
   validate-scripts:
     # Runs on PRs (once out of draft) and on workflow_dispatch.

--- a/.github/workflows/verifyClearSigning.yml
+++ b/.github/workflows/verifyClearSigning.yml
@@ -1,6 +1,7 @@
 # Verify Clear-Signing Proposal is Current
 # - Purpose: block PRs that change facets / the generator / the proposal JSON without keeping `config/clearSigningProposal.json` in sync with the generator's output. Also blocks PRs that introduce a user-facing function the generator can't template.
-# - Triggers: pull_request on src/Facets/**, tasks/buildClearSigningProposal.ts, config/clearSigningProposal.json, and the workflow itself
+# - Triggers: pull_request on src/Facets/**, tasks/buildClearSigningProposal.ts, config/clearSigningProposal.json, the workflow itself,
+#   and the shared foundry setup action + .foundry-version its toolchain comes from
 # - Key behaviors: builds forge artifacts, runs `tasks/buildClearSigningProposal.ts` (strict-by-default; exits non-zero on unrecognized or shape-mismatched functions), then `git diff --exit-code` on the committed JSON
 # - Failure modes (and remedy):
 #     - Generator exited non-zero: a user-facing function doesn't match a template. Either align the facet's struct shape with LiFi.BridgeData / LibSwap.SwapData, or extend the generator (`tasks/buildClearSigningProposal.ts`) to handle the new shape.

--- a/.github/workflows/verifyClearSigning.yml
+++ b/.github/workflows/verifyClearSigning.yml
@@ -17,6 +17,8 @@ on:
       - 'tasks/buildClearSigningProposal.ts'
       - 'config/clearSigningProposal.json'
       - '.github/workflows/verifyClearSigning.yml'
+      - '.github/actions/setup-foundry/**'
+      - '.foundry-version'
 
 permissions:
   contents: read # required to fetch repository contents

--- a/.github/workflows/verifyEmergencyPauseReadiness.yml
+++ b/.github/workflows/verifyEmergencyPauseReadiness.yml
@@ -29,7 +29,8 @@
 #   manual run always reports back. PR runs post nothing.
 # - Does NOT cover the pause WRITE/propose path (EXSC-368) - this is read-only.
 # - Triggers: weekly cron (Thu 07:00 UTC ≈ 09:00 CEST / 08:00 CET) + workflow_dispatch (manual) + pull_request limited to the
-#   paths below (config/global.json, config/networks.json, the involved scripts, this workflow).
+#   paths below (config/global.json, config/networks.json, the involved scripts, this workflow,
+#   and the shared foundry setup action + .foundry-version its toolchain comes from).
 # - Known limitations: needs RPCs (MongoDB) + deploy logs. Transient RPC errors are retried before
 #   failing — the readiness checks via rpcCallWithRetry, the funds path via estimatePauseCost +
 #   balance retries — and the funds check FAILS (rather than false-greening) if EVERY network errors.
@@ -50,6 +51,8 @@ on:
       - script/universalCast.sh
       - script/helperFunctions.sh
       - .github/workflows/verifyEmergencyPauseReadiness.yml
+      - .github/actions/setup-foundry/**
+      - .foundry-version
 
 permissions:
   contents: read # required to checkout the repository and read config/deploy logs


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-852](https://linear.app/lifi-linear/issue/EXSC-852)

# Why did I implement it this way?

**Symptom:** every CI job that installs Foundry has been failing repo-wide since ~00:37 UTC on 2026-08-26, at the **Install Foundry** step, before any Solidity is compiled:

```text
Running: foundryup --install 1.7.1
##[error]/home/runner/.foundry/bin/foundryup: cannot execute binary file
##[error]Error: Command failed: bash "/home/runner/.foundry/bin/foundryup" --install 1.7.1
```

**Root cause is upstream, not in this repo.** `foundry-rs/foundry-toolchain@v1.8.0` did two things that together made this inevitable:

1. It fetched the installer from a **moving branch HEAD** — `https://raw.githubusercontent.com/foundry-rs/foundry/HEAD/foundryup/install`.
2. It then ran the installed foundryup **through bash** — `run(`bash "${foundryup}" ${args}`)` — with the source comment "use bash since foundryup is a shell script".

Upstream has since moved foundryup into its own repo and shipped **foundryup-init 2.0.0**, whose header states it "detects the platform, downloads the appropriate binary, and runs it". foundryup is a **compiled binary** now. `bash <native binary>` yields exactly `cannot execute binary file`. Because the installer URL tracked HEAD, that change reached every CI run the moment it was published — no commit here was involved. On PR #2271 the same workflow passed at 00:35 and failed at 00:37 with nothing changed in between.

**The fix** bumps to `v1.9.1`. The installer rewrite itself landed in **v1.9.0** ([#152](https://github.com/foundry-rs/foundry-toolchain/pull/152)); v1.9.1 is four Dependabot bumps on top of it, and is pinned here simply because it is the latest patch. The behaviour that matters:

- pins the installer to an **immutable commit** (`foundry-rs/foundryup@a27902ef…/foundryup-init.sh`) instead of a moving HEAD;
- executes foundryup **directly** instead of via bash;
- uses `execFileSync(file, args[])` rather than `execSync(string)`, removing a shell-interpolation surface.

Inputs (`version`, `cache`, `cache-key`, `cache-restore-keys`) are unchanged between v1.8.0 and v1.9.1, so this is a drop-in. Pinned by full commit SHA with a version comment, matching the convention already used in this file.

**Security framing — and its limit.** The real defect was never just a broken invocation: v1.8.0 downloaded and executed an installer from a moving branch HEAD on every CI run, so whatever sat at that HEAD executed on our runners. A benign upstream refactor is, from our side, indistinguishable from a malicious one — and the benign one is what broke us.

v1.9.1's commit-pinned installer closes that specific hole, but **it does not make the toolchain reproducible, and I want to be precise rather than oversell it.** The action never sets `FOUNDRYUP_VERSION`, so `foundryup-init.sh` takes its `releases/latest` branch and the foundryup **binary** is still fetched from whatever `foundry-rs/foundryup` tags as latest at run time. The same class of moving-target risk survives one layer down. Pinning that too is a real follow-up (EXSC-853), deliberately not bundled into an unblock-CI change.

Do not read the installer's `attestation.txt` handling as a mitigation either: it greps a sha256 out of a fetched payload with no signature, certificate, or Rekor validation, and it fails open with a warning when no hash is found.

**Deliberately not touched:** `.github/workflows/runPendingTimelockTXs.yml` still pins v1.6. It is unaffected — v1.6 never uses foundryup, it downloads the Foundry release archive directly via `toolCache.downloadTool` — and it kept passing throughout the outage. Bumping a scheduled, on-chain-executing timelock workflow is out of scope for an unblock-CI PR and belongs in its own change. Two references in `.github/workflows_deactivated/` are likewise untouched.

**Commits 2 and 3 — why they're here.** The bump alone could not be verified. Every workflow that installs Foundry gates its job behind a `dorny/paths-filter`, and none of those filters referenced `.github/actions/setup-foundry/**` — even though each already self-references its own workflow file, on exactly the "re-run when the definition changes" logic. So a change to the shared composite action that four workflows depend on shipped with all of them **skipped**, reporting green via the `*-required` gate stubs.

That is a real hole independent of this outage: any future edit to the shared Foundry setup is untested by construction. Adding the action path to the four filters (`solc-floor-build`, `forge-unit-tests`, `deploy-smoke-test`, `validateScripts`) closes it — and, usefully, makes this PR verify itself.

The third commit extends the same reasoning to two gaps a review pass surfaced:

- **`.foundry-version` was in no filter at all.** The composite action exists to install whatever that file pins (`action.yml:44`), so a Foundry version bump — the highest-risk toolchain change in the repo — triggered none of the jobs that would catch a bad one. It is now listed in all four filters.
- **`verifyClearSigning.yml` had the same gap via a different mechanism.** It gates at the trigger level with `on.pull_request.paths` rather than `dorny/paths-filter`, and already self-references its own workflow file on the same "re-run when the definition changes" logic. It consumes the shared action — `verify-clear-signing` was among the jobs that failed in this outage — so it now lists the action path and `.foundry-version` too.

A fourth commit covers **`verifyEmergencyPauseReadiness.yml`**, the fifth PR-gated consumer. An earlier revision of this description wrongly filed it under schedule-only workflows; it is not — it gates on `on.pull_request.paths` exactly like `verifyClearSigning`, and installs its toolchain through the shared action. Its header trigger list is updated in step.

**Known remaining gaps, deliberately not in this PR:** `script/utils/hashForkBlockPins.sh` and `script/utils/verify-foundry-version.sh` are shelled out to by the action but covered only by the `smoke` filter (pre-existing; `smoke` already carries `script/utils/**`). `syncLedgerClearSigning` and `healthCheckAllNetworks` have the same trigger-level shape but are genuinely push/schedule, not PR gates.

**Cost note:** `deploy-smoke-test` is the expensive job in that set, and it will now fire on action-only PRs. That is intended — it is one of the consumers whose breakage we are trying to catch — but it is a real added cost per such PR.

**Verification — and what it does and does not prove.** The jobs ran for real this time: `solc-floor-build`, all five `run-unit-tests` shards, `validate-scripts`, `deploy-smoke-test` and `verify-clear-signing` all show `Downloading foundryup installer from foundry-rs/foundryup@a27902ef…`, then `foundryup --install 1.7.1`, then `forge Version: 1.7.1`. The toolchain cache is restored before that step, but the action downloads and runs foundryup regardless, so this is not a cache-hit false green.

What it does **not** prove is the new filter globs. Every workflow touched here already self-referenced its own file, so these commits would have triggered those jobs even without the added `setup-foundry/**` / `.foundry-version` lines. The globs look right by inspection — `action.yml` lives under `setup-foundry/`, `.foundry-version` is at the repo root — but the first PR that touches *only* those paths is what will actually exercise them. Treat this run as evidence for the bump, not for the filter math.

For contrast, the first draft push of this PR reported "0 failing of 35" while every Foundry job silently skipped — the exact failure mode commits 2-4 exist to close.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

