### PR TITLE
chore(whitelist): enable Fly on injective, sepolia, basesepolia, arbitrumsepolia (EXBE-538)

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4241,6 +4241,38 @@
               "0x46ec278a": "swapWithBackendSignature(bytes)"
             }
           }
+        ],
+        "injective": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
+        ],
+        "sepolia": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
+        ],
+        "basesepolia": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
+        ],
+        "arbitrumsepolia": [
+          {
+            "address": "0x20f6ee51340adeed01a59b0e65cb3703f3dc860c",
+            "functions": {
+              "0x46ec278a": "swapWithBackendSignature(bytes)"
+            }
+          }
         ]
       }
     },


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXBE-538/be-enable-fly-on-multiple-chains

# Why did I implement it this way?

Backend-side Fly support (EXBE-538) only makes the API willing to build a Fly
route — execution still goes through the diamond's on-chain allowlist
(`LibAllowList` / `WhitelistManagerFacet`), so without this config the swap
reverts with `ContractCallNotAllowed`. This PR is the on-chain half.

Adds four new network keys to the existing `Fly` entry in `config/whitelist.json`:
`injective`, `sepolia`, `basesepolia`, `arbitrumsepolia`. Config-only, no
contract changes.

Only the backend-signature router is whitelisted:

| | |
|---|---|
| Address | `0x20f6ee51340adeed01a59b0e65cb3703f3dc860c` |
| Selector | `0x46ec278a` — `swapWithBackendSignature(bytes)` |

Verified before whitelisting, via `eth_getCode` on each of the four chains:

- the router is deployed at that address on all four, and its bytecode is
  byte-identical to the already-whitelisted mainnet router, so this is the same
  deterministic deployment we have reviewed on the other 33 chains;
- the bytecode contains selector `0x46ec278a`;
- the Magpie-signature routers (`swapWithMagpieSignature(bytes)` /
  `swapWithUserSignature(bytes)`, e.g. `0xa6e941ea…` on mainnet) return `0x` on
  all four chains — not deployed, therefore deliberately not whitelisted here.

New keys are appended rather than sorted, matching the existing append order of
the `Fly` contracts object (`mainnet`, `optimism`, …, `robinhood`), which keeps
the diff to pure additions.

Rollout after merge:
`./script/tasks/syncWhitelistToNetworks.sh injective sepolia basesepolia arbitrumsepolia --production`
— direct send on the three testnets (no Safe configured), Safe proposal plus the
3h `LiFiTimelockController` delay (`minDelay: 10800`) on Injective.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
