### PR TITLE
fix(healthCheck): remove the skipHealthcheck blanket flag, check all 66 networks (EXSC-786)

### DIFF
--- a/.agents/commands/add-network.md
+++ b/.agents/commands/add-network.md
@@ -114,7 +114,7 @@ If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` whe
 - [ ] Permit2: add to permit2Proxy.json if has code; if no code, omit this network from permit2Proxy.json only (do not edit global.json).
 - [ ] Gas.zip: add to gaszip.json + networks.json if available; if not, set gasZipChainId = 0 in networks.json and omit from gaszip.json only (do not edit global.json).
 - [ ] Bridges: for each indicated, add to bridge config and validate addresses with cast code.
-- [ ] Health check: nothing to add unless a core contract cannot exist here — then add a reasoned exemption-table entry.
+- [ ] Health check: set `feeTokenAddress` if `nativeCurrency` is `"N/A"`; otherwise nothing to add unless a core contract cannot exist here — then add a reasoned exemption-table entry.
 
 ---
 

--- a/.agents/commands/add-network.md
+++ b/.agents/commands/add-network.md
@@ -83,6 +83,16 @@ For other bridges, open the corresponding `config/<bridge>.json` and follow any 
 
 ---
 
+## Step 8: Health check
+
+No per-network work in the normal case. Both health-check workflows share one invariant registry (`script/deploy/healthCheckInvariants.ts`) that derives what to enforce from `config/global.json`, `_targetState.json` and the deploy logs, so a new network is fully checked as soon as it is in config. `healthCheckForNewNetworkDeployment.yml` runs it on the onboarding PR (hard-failing without a `_targetState.json` entry and a `deployments/<network>.json`); the daily sweep covers it from then on.
+
+Two fields set in earlier steps change what runs: `gasZipChainId: 0` skips the GasZip invariants, and `safeAddress` drives `safe-config`. On a chain with no native asset (`nativeCurrency: "N/A"`) also set `feeTokenAddress`, or `pauser-funded` cannot read a gas balance and only warns.
+
+If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. **Never** use `skipHealthcheck` — it disables every check on that network for good, which is how three chains went unverified for months (EXSC-786).
+
+---
+
 ## Warnings to show
 
 1. Multicall no code → provide valid address or abort.
@@ -104,6 +114,7 @@ For other bridges, open the corresponding `config/<bridge>.json` and follow any 
 - [ ] Permit2: add to permit2Proxy.json if has code; if no code, omit this network from permit2Proxy.json only (do not edit global.json).
 - [ ] Gas.zip: add to gaszip.json + networks.json if available; if not, set gasZipChainId = 0 in networks.json and omit from gaszip.json only (do not edit global.json).
 - [ ] Bridges: for each indicated, add to bridge config and validate addresses with cast code.
+- [ ] Health check: nothing to add unless a core contract cannot exist here — then use the exemption tables, never `skipHealthcheck`.
 
 ---
 

--- a/.agents/commands/add-network.md
+++ b/.agents/commands/add-network.md
@@ -89,7 +89,7 @@ No per-network work in the normal case. Both health-check workflows share one in
 
 Two fields set in earlier steps change what runs: `gasZipChainId: 0` skips the GasZip invariants, and `safeAddress` drives `safe-config`. On a chain with no native asset (`nativeCurrency: "N/A"`) also set `feeTokenAddress`, or `pauser-funded` cannot read a gas balance and only warns.
 
-If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. There is deliberately no way to disable the check for a whole network — the blanket flag that used to exist left three chains unverified for months (EXSC-786).
+If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. No single flag disables the check for a whole network any more: every carve-out is per-invariant or per-contract and prints its reason. The blanket flag that used to exist left three chains unverified for months (EXSC-786).
 
 ---
 

--- a/.agents/commands/add-network.md
+++ b/.agents/commands/add-network.md
@@ -89,7 +89,7 @@ No per-network work in the normal case. Both health-check workflows share one in
 
 Two fields set in earlier steps change what runs: `gasZipChainId: 0` skips the GasZip invariants, and `safeAddress` drives `safe-config`. On a chain with no native asset (`nativeCurrency: "N/A"`) also set `feeTokenAddress`, or `pauser-funded` cannot read a gas balance and only warns.
 
-If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. **Never** use `skipHealthcheck` — it disables every check on that network for good, which is how three chains went unverified for months (EXSC-786).
+If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. There is deliberately no way to disable the check for a whole network — the blanket flag that used to exist left three chains unverified for months (EXSC-786).
 
 ---
 
@@ -114,7 +114,7 @@ If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` whe
 - [ ] Permit2: add to permit2Proxy.json if has code; if no code, omit this network from permit2Proxy.json only (do not edit global.json).
 - [ ] Gas.zip: add to gaszip.json + networks.json if available; if not, set gasZipChainId = 0 in networks.json and omit from gaszip.json only (do not edit global.json).
 - [ ] Bridges: for each indicated, add to bridge config and validate addresses with cast code.
-- [ ] Health check: nothing to add unless a core contract cannot exist here — then use the exemption tables, never `skipHealthcheck`.
+- [ ] Health check: nothing to add unless a core contract cannot exist here — then add a reasoned exemption-table entry.
 
 ---
 

--- a/.agents/commands/add-network.md
+++ b/.agents/commands/add-network.md
@@ -89,7 +89,7 @@ No per-network work in the normal case. Both health-check workflows share one in
 
 Two fields set in earlier steps change what runs: `gasZipChainId: 0` skips the GasZip invariants, and `safeAddress` drives `safe-config`. On a chain with no native asset (`nativeCurrency: "N/A"`) also set `feeTokenAddress`, or `pauser-funded` cannot read a gas balance and only warns.
 
-If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. No single flag disables the check for a whole network any more: every carve-out is per-invariant or per-contract and prints its reason. The blanket flag that used to exist left three chains unverified for months (EXSC-786).
+If a core contract genuinely cannot exist on this chain (e.g. `TokenWrapper` where there is no native asset to wrap), add a reasoned entry to `CORE_PERIPHERY_EXEMPTIONS` / `CORE_FACET_EXEMPTIONS`, or to `HEALTH_CHECK_EXCLUSIONS` for a whole invariant. No single flag disables the check for a whole network: every carve-out is per-invariant or per-contract and prints its reason. The blanket flag that used to exist left three chains unverified for months (EXSC-786).
 
 ---
 

--- a/config/networks.json
+++ b/config/networks.json
@@ -170,8 +170,7 @@
     "targetEvmVersion": "cancun",
     "create3Factory": "0xDe367507f70A1f57a7203bD7A88ced24A79fb53d",
     "castSendAsync": true,
-    "devNotes": "Native gas asset is USDC, exposed via the ERC20 predeploy at 0x3600000000000000000000000000000000000000 (nativeAddress); wrappedNativeAddress is a dummy because the native path is not activated. TokenWrapper is intentionally not deployed (nothing to wrap), so the automated periphery healthcheck cannot pass: skipHealthcheck is set and the healthcheck is run manually before merge to verify deployed addresses.",
-    "skipHealthcheck": true
+    "devNotes": "Native gas asset is USDC, exposed via the ERC20 predeploy at 0x3600000000000000000000000000000000000000 (nativeAddress); wrappedNativeAddress is a dummy because the native path is not activated. TokenWrapper is intentionally not deployed (nothing to wrap) and is exempted in CORE_PERIPHERY_EXEMPTIONS (EXSC-786)."
   },
   "avalanche": {
     "name": "avalanche",
@@ -1013,7 +1012,6 @@
     "targetEvmVersion": "cancun",
     "create3Factory": "0xe514Ab33F262ccCff8b8ec46a7ca8e2F0bfD1b95",
     "customDeployFlags": "--with-gas-price 110000000",
-    "skipHealthcheck": true,
     "devNotes": "Successful deployment only with GAS_ESTIMATE_MULTIPLIER=500 in .env"
   },
   "ronin": {
@@ -1232,8 +1230,7 @@
     "create3Factory": "0xDe367507f70A1f57a7203bD7A88ced24A79fb53d",
     "customDeployFlags": "--gas-limit 40000000",
     "gasEstimateMultiplier": 200,
-    "devNotes": "Deploys use the pinned gasEstimateMultiplier of 200: tempo caps the transaction gas limit at 30M, and higher multipliers push large-estimate contracts over the cap (SquidFacet's ~11.7M estimate x 5.5 was rejected with 'transaction gas limit greater than the cap'). Exception: LiFiDEXAggregator historically needed a multiplier of 500-550 (below 500 it fails with out of gas, above 550 with gas limit exceeded) - temporarily raise this gasEstimateMultiplier field when redeploying it (setting GAS_ESTIMATE_MULTIPLIER in .env has no effect on deploys while this field is set, since the field overrides the env var; diamond-cut/update scripts still read the env var). Moreover we use dummy wrapped native address for AcrossFacetV4 because we don't activate the native path. Gas is paid in TIP-20 stablecoins (no native asset; eth_getBalance returns a sentinel): the default fee token is pathUSD (feeTokenAddress), and an account can override it via the FeeManager predeploy (feeManagerAddress) userTokens(account). eth_gasPrice is quoted in attodollars (1e18) per gas.",
-    "skipHealthcheck": true
+    "devNotes": "Deploys use the pinned gasEstimateMultiplier of 200: tempo caps the transaction gas limit at 30M, and higher multipliers push large-estimate contracts over the cap (SquidFacet's ~11.7M estimate x 5.5 was rejected with 'transaction gas limit greater than the cap'). Exception: LiFiDEXAggregator historically needed a multiplier of 500-550 (below 500 it fails with out of gas, above 550 with gas limit exceeded) - temporarily raise this gasEstimateMultiplier field when redeploying it (setting GAS_ESTIMATE_MULTIPLIER in .env has no effect on deploys while this field is set, since the field overrides the env var; diamond-cut/update scripts still read the env var). Moreover we use dummy wrapped native address for AcrossFacetV4 because we don't activate the native path. Gas is paid in TIP-20 stablecoins (no native asset; eth_getBalance returns a sentinel): the default fee token is pathUSD (feeTokenAddress), and an account can override it via the FeeManager predeploy (feeManagerAddress) userTokens(account). eth_gasPrice is quoted in attodollars (1e18) per gas."
   },
   "unichain": {
     "name": "unichain",

--- a/docs/TronFork.md
+++ b/docs/TronFork.md
@@ -66,7 +66,7 @@ of the fork rather than an unanswerable question in `main`.
 ### What actually differs in the fork (the delta)
 
 The fork stays close to upstream, but the delta is more than one line:
-**~20 files across 7 categories** (verified by a clean upstream→fork merge
+**~19 files across 6 categories** (verified by a clean upstream→fork merge
 of 69 commits with **zero conflicts**, then diffing the fully-synced tree
 against `main`). Everything here is Tron-enablement, CI, test, config or
 audit — **no product features**.

--- a/docs/TronFork.md
+++ b/docs/TronFork.md
@@ -95,8 +95,6 @@ audit — **no product features**.
 - **Agent rules (2)** — `100-solidity-basics.md` documents the `-tron`
   versioning overlay; `400-solidity-tests.md` uses a Tron test-naming
   example.
-- **Config (1)** — `config/networks.json`: `somnia.skipHealthcheck = true`
-  (see the sync-pain section below).
 - **Audit (2)** — `auditLog.json` entries for `LibAsset 2.1.3-tron` and
   `WithdrawablePeriphery 1.0.0-tron`, plus the
   `2026.05.22_TronCanonicalUSDT(Part-2).pdf` report.
@@ -203,9 +201,14 @@ Concrete example that blocked sync PR #13: an unrelated upstream commit
 changed the _expected_ `ERC20Proxy` owner across networks from the Safe to
 the `refundWallet`. On `somnia` (newly added via that sync) the on-chain
 owner was still the Safe, so the healthcheck failed — on a PR that
-introduced **zero** fork-authored code. Short-term fix: set the existing
-`skipHealthcheck` flag for `somnia` in `config/networks.json` on the fork
-(temporary).
+introduced **zero** fork-authored code. The stopgap then was a
+`skipHealthcheck` flag for `somnia` on the fork; that flag no longer exists
+(EXSC-786 removed it upstream, since it disabled every invariant on a network
+rather than the one that misfired). `somnia` now passes the upstream sweep with
+a deploy log identical to the fork's, so the stopgap is obsolete — drop the dead
+key from the fork's `config/networks.json`. Should a sync PR red on upstream
+on-chain state again, add a reasoned `HEALTH_CHECK_EXCLUSIONS` entry for that
+one invariant instead.
 
 **General class:** any required check keyed to on-chain / production state
 will fire on sync PRs. A new dev should expect this and **verify the real

--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -109,19 +109,6 @@ export interface INetwork {
    */
   gasPrice?: number
   /**
-   * When true, script/deploy/healthCheck.ts runs no invariant on this network and reports it as
-   * skipped with a warning, so the lost coverage still reaches the consolidated report and Slack.
-   *
-   * Reach for a narrower carve-out first — CORE_FACET_EXEMPTIONS and CORE_PERIPHERY_EXEMPTIONS
-   * drop one contract from the expected set, HEALTH_CHECK_EXCLUSIONS drops one invariant, and
-   * everything else stays enforced. A contract that is intentionally not deployed on a network
-   * (TokenWrapper where there is no native asset to wrap) belongs in the exemption table, not here.
-   *
-   * No upstream network sets this. It exists for the contracts-tron fork, where sync PRs would
-   * otherwise fail on upstream on-chain state (see docs/TronFork.md).
-   */
-  skipHealthcheck?: boolean
-  /**
    * Chains with no native currency (`nativeCurrency: "N/A"`, e.g. tempo): the ERC20 token gas is
    * paid in by default (tempo: the pathUSD TIP-20 predeploy). Funding audits read this token's
    * balance instead of eth_getBalance, which returns a meaningless sentinel on such chains.

--- a/script/common/types.ts
+++ b/script/common/types.ts
@@ -109,11 +109,16 @@ export interface INetwork {
    */
   gasPrice?: number
   /**
-   * When true, the deployment healthcheck (script/deploy/healthCheck.ts) exits successfully without running checks.
-   * Use only on an exceptional basis when the healthcheck cannot pass otherwise (e.g. core periphery contracts
-   * such as GasZipPeriphery or TokenWrapper are intentionally not deployed on that network).
-   * Before merging: still run the healthcheck manually for that network and verify all addresses and configuration
-   * are correct; this flag only allows CI to pass.
+   * When true, script/deploy/healthCheck.ts runs no invariant on this network and reports it as
+   * skipped with a warning, so the lost coverage still reaches the consolidated report and Slack.
+   *
+   * Reach for a narrower carve-out first — CORE_FACET_EXEMPTIONS and CORE_PERIPHERY_EXEMPTIONS
+   * drop one contract from the expected set, HEALTH_CHECK_EXCLUSIONS drops one invariant, and
+   * everything else stays enforced. A contract that is intentionally not deployed on a network
+   * (TokenWrapper where there is no native asset to wrap) belongs in the exemption table, not here.
+   *
+   * No upstream network sets this. It exists for the contracts-tron fork, where sync PRs would
+   * otherwise fail on upstream on-chain state (see docs/TronFork.md).
    */
   skipHealthcheck?: boolean
   /**

--- a/script/deploy/_targetState.json
+++ b/script/deploy/_targetState.json
@@ -2231,7 +2231,6 @@
         "GasZipPeriphery": "1.0.2",
         "OutputValidator": "1.0.0",
         "Permit2Proxy": "1.0.4",
-        "TokenWrapper": "1.2.1",
         "PolymerCCTPFacet": "3.0.0",
         "ReceiverOIF": "1.0.0"
       }

--- a/script/deploy/healthCheck.ts
+++ b/script/deploy/healthCheck.ts
@@ -110,31 +110,6 @@ export async function runHealthCheckForNetwork(
       '../../config/networks.json'
     )
 
-    // Optional bypass: config/networks.json skipHealthcheck (see INetwork.skipHealthcheck in script/common/types.ts).
-    const networkEntry = (
-      networksConfig as Record<
-        string,
-        { skipHealthcheck?: boolean } | undefined
-      >
-    )[networkLower]
-    if (networkEntry?.skipHealthcheck === true) {
-      // A skip is reduced coverage, not a clean bill of health, so it is reported as a warning:
-      // that puts it in the consolidated report and the Slack digest instead of leaving a chain
-      // silently unchecked. Prefer a narrower carve-out over this flag — CORE_FACET_EXEMPTIONS /
-      // CORE_PERIPHERY_EXEMPTIONS drop one contract, HEALTH_CHECK_EXCLUSIONS drops one invariant;
-      // this drops all of them. It exists for the contracts-tron fork, where sync PRs otherwise
-      // fail on upstream on-chain state (see docs/TronFork.md).
-      const skipWarning = `Network '${networkLower}' is fully unchecked: skipHealthcheck is set in config/networks.json`
-      consola.warn(skipWarning)
-      return {
-        network: networkStr,
-        status: 'skipped',
-        errors: [],
-        warnings: [skipWarning],
-        skipReason: 'skipHealthcheck: true in config/networks.json',
-      }
-    }
-
     // Skip GasZip checks for networks where the integration is intentionally unsupported.
     const networkGasZipConfig = (
       networksConfig as Record<string, { gasZipChainId?: number } | undefined>

--- a/script/deploy/healthCheck.ts
+++ b/script/deploy/healthCheck.ts
@@ -26,6 +26,7 @@ import {
 import targetStateImport from './_targetState.json'
 import {
   getExemptCoreFacets,
+  getExemptCorePeriphery,
   runHealthCheckInvariants,
   type IHealthCheckContext,
 } from './healthCheckInvariants'
@@ -116,14 +117,23 @@ export async function runHealthCheckForNetwork(
         { skipHealthcheck?: boolean } | undefined
       >
     )[networkLower]
-    if (networkEntry?.skipHealthcheck === true)
+    if (networkEntry?.skipHealthcheck === true) {
+      // A skip is reduced coverage, not a clean bill of health, so it is reported as a warning:
+      // that puts it in the consolidated report and the Slack digest instead of leaving a chain
+      // silently unchecked. Prefer a narrower carve-out over this flag — CORE_FACET_EXEMPTIONS /
+      // CORE_PERIPHERY_EXEMPTIONS drop one contract, HEALTH_CHECK_EXCLUSIONS drops one invariant;
+      // this drops all of them. It exists for the contracts-tron fork, where sync PRs otherwise
+      // fail on upstream on-chain state (see docs/TronFork.md).
+      const skipWarning = `Network '${networkLower}' is fully unchecked: skipHealthcheck is set in config/networks.json`
+      consola.warn(skipWarning)
       return {
         network: networkStr,
         status: 'skipped',
         errors: [],
-        warnings: [],
+        warnings: [skipWarning],
         skipReason: 'skipHealthcheck: true in config/networks.json',
       }
+    }
 
     // Skip GasZip checks for networks where the integration is intentionally unsupported.
     const networkGasZipConfig = (
@@ -137,6 +147,11 @@ export async function runHealthCheckForNetwork(
     for (const { facet, reason } of exemptCoreFacets)
       consola.info(
         `⏭  Not requiring core facet [${facet}] on ${networkLower} — exempt: ${reason}`
+      )
+
+    for (const { contract, reason } of getExemptCorePeriphery(networkLower))
+      consola.info(
+        `⏭  Not requiring core periphery [${contract}] on ${networkLower} — exempt: ${reason}`
       )
 
     const coreFacetExclusions = [

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -78,12 +78,17 @@ describe('summarizeHealthChecks', () => {
         warnings: ['reduced coverage', 'stale pair'],
         detail: '',
       },
-      { network: 'tron', status: 'skipped', warnings: [], detail: 'skipHc' },
+      {
+        network: 'tronshasta',
+        status: 'skipped',
+        warnings: [],
+        detail: 'Health checks are not implemented for Tron Shasta testnet',
+      },
     ])
     expect(summary.total).toBe(4)
     expect(summary.passed).toEqual(['arbitrum', 'polygon'])
     expect(summary.failed).toEqual(['optimism'])
-    expect(summary.skipped).toEqual(['tron'])
+    expect(summary.skipped).toEqual(['tronshasta'])
     // A passed-but-warned network is surfaced so reduced coverage isn't invisible.
     expect(summary.warned).toEqual(['arbitrum'])
   })

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -96,7 +96,7 @@ describe('summarizeHealthChecks', () => {
         network: 'somechain',
         status: 'skipped',
         warnings: ['fully unchecked: skipHealthcheck is set'],
-        detail: 'skipHealthcheck',
+        detail: 'skipHealthcheck: true in config/networks.json',
       },
     ])
     expect(summary.skipped).toEqual(['somechain'])
@@ -243,7 +243,7 @@ describe('groupFailuresByCause', () => {
           network: 'somechain',
           status: 'skipped',
           warnings: [],
-          detail: 'skipHealthcheck',
+          detail: 'skipHealthcheck: true in config/networks.json',
         },
       ])
     ).toEqual([])

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -88,6 +88,21 @@ describe('summarizeHealthChecks', () => {
     expect(summary.warned).toEqual(['arbitrum'])
   })
 
+  // A skipHealthcheck network is unchecked, not healthy: runHealthCheckForNetwork attaches a
+  // warning so the skip reaches the Slack digest instead of being a silent hole.
+  it('counts a skipped network as warned when it reports a skip warning', () => {
+    const summary = summarizeHealthChecks([
+      {
+        network: 'somechain',
+        status: 'skipped',
+        warnings: ['fully unchecked: skipHealthcheck is set'],
+        detail: 'skipHealthcheck',
+      },
+    ])
+    expect(summary.skipped).toEqual(['somechain'])
+    expect(summary.warned).toEqual(['somechain'])
+  })
+
   it('handles the all-passed case', () => {
     const summary = summarizeHealthChecks([
       { network: 'polygon', status: 'passed', warnings: [], detail: '' },
@@ -225,7 +240,7 @@ describe('groupFailuresByCause', () => {
           detail: '',
         },
         {
-          network: 'arc',
+          network: 'somechain',
           status: 'skipped',
           warnings: [],
           detail: 'skipHealthcheck',

--- a/script/deploy/healthCheckAllNetworks.test.ts
+++ b/script/deploy/healthCheckAllNetworks.test.ts
@@ -88,21 +88,6 @@ describe('summarizeHealthChecks', () => {
     expect(summary.warned).toEqual(['arbitrum'])
   })
 
-  // A skipHealthcheck network is unchecked, not healthy: runHealthCheckForNetwork attaches a
-  // warning so the skip reaches the Slack digest instead of being a silent hole.
-  it('counts a skipped network as warned when it reports a skip warning', () => {
-    const summary = summarizeHealthChecks([
-      {
-        network: 'somechain',
-        status: 'skipped',
-        warnings: ['fully unchecked: skipHealthcheck is set'],
-        detail: 'skipHealthcheck: true in config/networks.json',
-      },
-    ])
-    expect(summary.skipped).toEqual(['somechain'])
-    expect(summary.warned).toEqual(['somechain'])
-  })
-
   it('handles the all-passed case', () => {
     const summary = summarizeHealthChecks([
       { network: 'polygon', status: 'passed', warnings: [], detail: '' },
@@ -243,7 +228,7 @@ describe('groupFailuresByCause', () => {
           network: 'somechain',
           status: 'skipped',
           warnings: [],
-          detail: 'skipHealthcheck: true in config/networks.json',
+          detail: 'Health checks are not implemented for Tron Shasta testnet',
         },
       ])
     ).toEqual([])

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -619,11 +619,115 @@ describe('CORE_PERIPHERY_EXEMPTIONS table integrity', () => {
   it('no exempt network still lists the contract in its production target state', () => {
     for (const exemption of CORE_PERIPHERY_EXEMPTIONS)
       for (const network of exemption.networks) {
-        const contracts =
-          (targetState as TargetState)[network.toLowerCase()]?.production
-            ?.LiFiDiamond ?? {}
-        expect(Object.keys(contracts)).not.toContain(exemption.contract)
+        // Assert the target state resolves before reading it: defaulting a missing entry to {}
+        // would pass this test for a network that has no production target state at all, which
+        // is the reduced-coverage case healthCheck.ts warns about, not agreement between sources.
+        const contracts = (targetState as TargetState)[network.toLowerCase()]
+          ?.production?.LiFiDiamond
+        expect(contracts).toBeDefined()
+        expect(Object.keys(contracts ?? {})).not.toContain(exemption.contract)
       }
+  })
+})
+
+describe('pauser-funded gas-balance source', () => {
+  const PAUSER = '0x00000000000000000000000000000000000000P1'.replace('P', 'a')
+  const FEE_TOKEN = '0x20C0000000000000000000000000000000000000'
+  const FEE_MANAGER = '0xfeec000000000000000000000000000000000000'
+  const OVERRIDE_TOKEN = '0x00000000000000000000000000000000000000ff'
+  // tempo answers eth_getBalance with this sentinel: any test that reaches getBalance on a
+  // no-native-asset chain would report the pauser as funded, which is the bug being fixed.
+  const SENTINEL = 4242424242424242424242424242424242424242424242424242n
+
+  function makePauserCtx(
+    networkConfig: Record<string, string>,
+    balances: Record<string, bigint>,
+    override: string = ZERO
+  ) {
+    const calls: string[] = []
+    const ctx = makeCtx()
+    Object.assign(ctx, {
+      networkLower: 'somechain',
+      pauserWallet: PAUSER,
+      networkConfig,
+      publicClient: {
+        getBalance: async () => {
+          calls.push('getBalance')
+          return SENTINEL
+        },
+        readContract: async ({
+          address,
+          functionName,
+        }: {
+          address: string
+          functionName: string
+        }) => {
+          calls.push(`${functionName}@${address.toLowerCase()}`)
+          if (functionName === 'userTokens') return override
+          if (functionName === 'decimals') return 6
+          if (functionName === 'symbol') return 'pathUSD'
+          return balances[address.toLowerCase()] ?? 0n
+        },
+      },
+    })
+    return { ctx, calls }
+  }
+
+  const feeTokenConfig = {
+    nativeCurrency: 'N/A',
+    feeTokenAddress: FEE_TOKEN,
+    feeManagerAddress: FEE_MANAGER,
+  }
+
+  it('reads the fee token, never the sentinel native balance, on a no-native-asset chain', async () => {
+    const { ctx, calls } = makePauserCtx(feeTokenConfig, {
+      [FEE_TOKEN.toLowerCase()]: 5_000_000n,
+    })
+    await invariant('pauser-funded').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(calls).not.toContain('getBalance')
+  })
+
+  it('errors when the fee-token balance is zero', async () => {
+    const { ctx, calls } = makePauserCtx(feeTokenConfig, {})
+    await invariant('pauser-funded').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('pathUSD')
+    expect(calls).not.toContain('getBalance')
+  })
+
+  it('follows the FeeManager per-account override to a different token', async () => {
+    const { ctx, calls } = makePauserCtx(
+      feeTokenConfig,
+      { [OVERRIDE_TOKEN.toLowerCase()]: 1n },
+      OVERRIDE_TOKEN
+    )
+    await invariant('pauser-funded').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(calls).toContain(`balanceOf@${OVERRIDE_TOKEN.toLowerCase()}`)
+    expect(calls).not.toContain(`balanceOf@${FEE_TOKEN.toLowerCase()}`)
+  })
+
+  // Without a fee token there is no readable gas balance; falling through to getBalance would
+  // read the sentinel and report any pauser as funded.
+  it('warns instead of passing when a no-native-asset chain has no fee token configured', async () => {
+    const { ctx, calls } = makePauserCtx({ nativeCurrency: 'N/A' }, {})
+    await invariant('pauser-funded').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(ctx.warnings).toHaveLength(1)
+    expect(ctx.warnings[0]).toContain('coverage is reduced')
+    expect(calls).not.toContain('getBalance')
+  })
+
+  it('keeps chains with an ERC20 gas asset but standard accounting on the native path', async () => {
+    // arc pays gas in USDC via a predeploy, yet eth_getBalance IS the gas balance there.
+    const { ctx, calls } = makePauserCtx(
+      { nativeCurrency: 'USDC', feeTokenAddress: FEE_TOKEN },
+      {}
+    )
+    await invariant('pauser-funded').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(calls).toEqual(['getBalance'])
   })
 })
 

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -631,14 +631,18 @@ describe('CORE_PERIPHERY_EXEMPTIONS table integrity', () => {
 })
 
 describe('pauser-funded gas-balance source', () => {
-  const PAUSER = '0x00000000000000000000000000000000000000P1'.replace('P', 'a')
+  const PAUSER = '0x00000000000000000000000000000000000000a1'
+  const OTHER_WALLET = '0x00000000000000000000000000000000000000b2'
   const FEE_TOKEN = '0x20C0000000000000000000000000000000000000'
   const FEE_MANAGER = '0xfeec000000000000000000000000000000000000'
   const OVERRIDE_TOKEN = '0x00000000000000000000000000000000000000ff'
-  // tempo answers eth_getBalance with this sentinel: any test that reaches getBalance on a
-  // no-native-asset chain would report the pauser as funded, which is the bug being fixed.
+  // tempo answers eth_getBalance with this sentinel on every account.
   const SENTINEL = 4242424242424242424242424242424242424242424242424242n
 
+  /**
+   * Every recorded call carries the account it was made for, so a read against the wrong wallet
+   * fails the assertions rather than passing on the right contract with the wrong subject.
+   */
   function makePauserCtx(
     networkConfig: Record<string, string>,
     balances: Record<string, bigint>,
@@ -649,20 +653,25 @@ describe('pauser-funded gas-balance source', () => {
     Object.assign(ctx, {
       networkLower: 'somechain',
       pauserWallet: PAUSER,
+      refundWallet: OTHER_WALLET,
+      deployerWallet: OTHER_WALLET,
       networkConfig,
       publicClient: {
-        getBalance: async () => {
-          calls.push('getBalance')
+        getBalance: async ({ address }: { address: string }) => {
+          calls.push(`getBalance:${address.toLowerCase()}`)
           return SENTINEL
         },
         readContract: async ({
           address,
           functionName,
+          args,
         }: {
           address: string
           functionName: string
+          args?: unknown[]
         }) => {
-          calls.push(`${functionName}@${address.toLowerCase()}`)
+          const account = String(args?.[0] ?? '').toLowerCase()
+          calls.push(`${functionName}@${address.toLowerCase()}:${account}`)
           if (functionName === 'userTokens') return override
           if (functionName === 'decimals') return 6
           if (functionName === 'symbol') return 'pathUSD'
@@ -685,15 +694,20 @@ describe('pauser-funded gas-balance source', () => {
     })
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toEqual([])
-    expect(calls).not.toContain('getBalance')
+    expect(calls).toContain(`balanceOf@${FEE_TOKEN.toLowerCase()}:${PAUSER}`)
+    expect(calls.some((c) => c.startsWith('getBalance'))).toBe(false)
   })
 
-  it('errors when the fee-token balance is zero', async () => {
-    const { ctx, calls } = makePauserCtx(feeTokenConfig, {})
+  it('errors when the pauser fee-token balance is zero', async () => {
+    const { ctx, calls } = makePauserCtx(feeTokenConfig, {
+      // A funded OTHER wallet must not make the check pass for the pauser.
+      [OVERRIDE_TOKEN.toLowerCase()]: 5_000_000n,
+    })
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toHaveLength(1)
     expect(ctx.errors[0]).toContain('pathUSD')
-    expect(calls).not.toContain('getBalance')
+    expect(calls).toContain(`balanceOf@${FEE_TOKEN.toLowerCase()}:${PAUSER}`)
+    expect(calls.some((c) => c.startsWith('getBalance'))).toBe(false)
   })
 
   it('follows the FeeManager per-account override to a different token', async () => {
@@ -704,8 +718,13 @@ describe('pauser-funded gas-balance source', () => {
     )
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toEqual([])
-    expect(calls).toContain(`balanceOf@${OVERRIDE_TOKEN.toLowerCase()}`)
-    expect(calls).not.toContain(`balanceOf@${FEE_TOKEN.toLowerCase()}`)
+    expect(calls).toContain(`userTokens@${FEE_MANAGER.toLowerCase()}:${PAUSER}`)
+    expect(calls).toContain(
+      `balanceOf@${OVERRIDE_TOKEN.toLowerCase()}:${PAUSER}`
+    )
+    expect(
+      calls.some((c) => c.startsWith(`balanceOf@${FEE_TOKEN.toLowerCase()}`))
+    ).toBe(false)
   })
 
   // Without a fee token there is no readable gas balance; falling through to getBalance would
@@ -716,7 +735,7 @@ describe('pauser-funded gas-balance source', () => {
     expect(ctx.errors).toEqual([])
     expect(ctx.warnings).toHaveLength(1)
     expect(ctx.warnings[0]).toContain('coverage is reduced')
-    expect(calls).not.toContain('getBalance')
+    expect(calls).toEqual([])
   })
 
   it('keeps chains with an ERC20 gas asset but standard accounting on the native path', async () => {
@@ -727,7 +746,7 @@ describe('pauser-funded gas-balance source', () => {
     )
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toEqual([])
-    expect(calls).toEqual(['getBalance'])
+    expect(calls).toEqual([`getBalance:${PAUSER}`])
   })
 })
 

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -639,9 +639,13 @@ describe('pauser-funded gas-balance source', () => {
   // tempo answers eth_getBalance with this sentinel on every account.
   const SENTINEL = 4242424242424242424242424242424242424242424242424242n
 
+  /** Balances are keyed `token:account`, so funding a wallet other than the pauser is expressible. */
+  const bal = (token: string, account: string) =>
+    `${token.toLowerCase()}:${account.toLowerCase()}`
+
   /**
-   * Every recorded call carries the account it was made for, so a read against the wrong wallet
-   * fails the assertions rather than passing on the right contract with the wrong subject.
+   * Both the recorded calls and the returned balances carry the account they were made for, so a
+   * read against the wrong wallet fails rather than passing on the right contract, wrong subject.
    */
   function makePauserCtx(
     networkConfig: Record<string, string>,
@@ -675,7 +679,7 @@ describe('pauser-funded gas-balance source', () => {
           if (functionName === 'userTokens') return override
           if (functionName === 'decimals') return 6
           if (functionName === 'symbol') return 'pathUSD'
-          return balances[address.toLowerCase()] ?? 0n
+          return balances[bal(address, account)] ?? 0n
         },
       },
     })
@@ -690,7 +694,7 @@ describe('pauser-funded gas-balance source', () => {
 
   it('reads the fee token, never the sentinel native balance, on a no-native-asset chain', async () => {
     const { ctx, calls } = makePauserCtx(feeTokenConfig, {
-      [FEE_TOKEN.toLowerCase()]: 5_000_000n,
+      [bal(FEE_TOKEN, PAUSER)]: 5_000_000n,
     })
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toEqual([])
@@ -698,10 +702,9 @@ describe('pauser-funded gas-balance source', () => {
     expect(calls.some((c) => c.startsWith('getBalance'))).toBe(false)
   })
 
-  it('errors when the pauser fee-token balance is zero', async () => {
+  it('errors when the pauser fee-token balance is zero, however funded other wallets are', async () => {
     const { ctx, calls } = makePauserCtx(feeTokenConfig, {
-      // A funded OTHER wallet must not make the check pass for the pauser.
-      [OVERRIDE_TOKEN.toLowerCase()]: 5_000_000n,
+      [bal(FEE_TOKEN, OTHER_WALLET)]: 5_000_000n,
     })
     await invariant('pauser-funded').run(ctx)
     expect(ctx.errors).toHaveLength(1)
@@ -713,7 +716,7 @@ describe('pauser-funded gas-balance source', () => {
   it('follows the FeeManager per-account override to a different token', async () => {
     const { ctx, calls } = makePauserCtx(
       feeTokenConfig,
-      { [OVERRIDE_TOKEN.toLowerCase()]: 1n },
+      { [bal(OVERRIDE_TOKEN, PAUSER)]: 1n },
       OVERRIDE_TOKEN
     )
     await invariant('pauser-funded').run(ctx)

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -8,10 +8,12 @@ import { type Hex } from 'viem'
 
 import globalConfig from '../../config/global.json'
 import networksConfig from '../../config/networks.json'
-import { EnvironmentEnum } from '../common/types'
+import { EnvironmentEnum, type TargetState } from '../common/types'
 
+import targetState from './_targetState.json'
 import {
   CORE_FACET_EXEMPTIONS,
+  CORE_PERIPHERY_EXEMPTIONS,
   HEALTH_CHECK_EXCLUSIONS,
   HEALTH_CHECK_INVARIANTS,
   isDeterministicReadFailure,
@@ -20,6 +22,7 @@ import {
   splitByParkedCoverage,
   findDuplicateSelectors,
   getExemptCoreFacets,
+  getExemptCorePeriphery,
   getExpectedPairs,
   getInvariantExclusion,
   isInvariantApplicable,
@@ -27,6 +30,7 @@ import {
   type IHealthCheckContext,
   type IHealthCheckInvariant,
   type ICoreFacetExemption,
+  type ICorePeripheryExemption,
   type IInvariantExclusion,
 } from './healthCheckInvariants'
 import { getFacetPeripheryCouplings } from './shared/facetPeripheryCouplings'
@@ -560,6 +564,66 @@ describe('CORE_FACET_EXEMPTIONS table integrity', () => {
       const lower = exemption.networks.map((n) => n.toLowerCase())
       expect(new Set(lower).size).toBe(lower.length)
     }
+  })
+})
+
+describe('getExemptCorePeriphery', () => {
+  const sample: ICorePeripheryExemption[] = [
+    { contract: 'SomePeriphery', reason: 'because', networks: ['somechain'] },
+  ]
+
+  it('returns the contract and reason for an exempt network', () => {
+    expect(getExemptCorePeriphery('somechain', sample)).toEqual([
+      { contract: 'SomePeriphery', reason: 'because' },
+    ])
+  })
+
+  it('matches the network case-insensitively', () => {
+    expect(getExemptCorePeriphery('SomeChain', sample)).toHaveLength(1)
+  })
+
+  it('returns nothing for a network that is not listed, so new chains stay enforced', () => {
+    expect(getExemptCorePeriphery('brandnewchain', sample)).toEqual([])
+  })
+})
+
+describe('CORE_PERIPHERY_EXEMPTIONS table integrity', () => {
+  const corePeriphery = new Set<string>(globalConfig.corePeriphery)
+  const knownNetworks = new Set(Object.keys(networksConfig))
+
+  it('every exemption targets a contract that is actually core periphery', () => {
+    for (const exemption of CORE_PERIPHERY_EXEMPTIONS)
+      expect(corePeriphery).toContain(exemption.contract)
+  })
+
+  it('every exempt network is a known network', () => {
+    for (const exemption of CORE_PERIPHERY_EXEMPTIONS)
+      for (const network of exemption.networks)
+        expect(knownNetworks).toContain(network.toLowerCase())
+  })
+
+  it('every exemption carries a non-empty reason', () => {
+    for (const exemption of CORE_PERIPHERY_EXEMPTIONS)
+      expect(exemption.reason.trim().length).toBeGreaterThan(0)
+  })
+
+  it('lists no network twice per contract', () => {
+    for (const exemption of CORE_PERIPHERY_EXEMPTIONS) {
+      const lower = exemption.networks.map((n) => n.toLowerCase())
+      expect(new Set(lower).size).toBe(lower.length)
+    }
+  })
+
+  // An exemption that the target state still demands would be silently re-imposed by
+  // periphery-registered, so the two sources must agree.
+  it('no exempt network still lists the contract in its production target state', () => {
+    for (const exemption of CORE_PERIPHERY_EXEMPTIONS)
+      for (const network of exemption.networks) {
+        const contracts =
+          (targetState as TargetState)[network.toLowerCase()]?.production
+            ?.LiFiDiamond ?? {}
+        expect(Object.keys(contracts)).not.toContain(exemption.contract)
+      }
   })
 })
 

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -479,17 +479,23 @@ const FEE_MANAGER_ABI = parseAbi([
  * The discriminator is `nativeCurrency: "N/A"` — deliberately NOT "gas is paid in a token".
  * Chains like arc, celo and metis expose an ERC20 gas asset but keep standard EVM accounting,
  * where `eth_getBalance` IS the gas balance; only a chain with no native asset at all decouples
- * the two. Where the chain also configures a FeeManager predeploy, an account may override the
- * chain-default token, so the override is resolved first. Mirrors the resolution order in
+ * the two. The chain-default `feeTokenAddress` is then replaced by the account's own preference
+ * where the chain configures a FeeManager predeploy. Mirrors the resolution order in
  * `script/utils/checkPauserFunds.sh`, which owns the stronger affordability check.
+ *
+ * A no-native-asset chain with no fee token configured yields `NO_GAS_BALANCE_SOURCE` rather than
+ * falling through: its native balance is a sentinel, so reading it would report any pauser as
+ * funded. Nothing can be asserted there, and the caller has to say so instead of passing.
  */
+const NO_GAS_BALANCE_SOURCE = 'noGasBalanceSource'
+
 async function resolvePauserFeeToken(
   ctx: IHealthCheckContext
-): Promise<Address | undefined> {
+): Promise<Address | typeof NO_GAS_BALANCE_SOURCE | undefined> {
   const { nativeCurrency, feeTokenAddress, feeManagerAddress } =
     ctx.networkConfig
-  if (nativeCurrency !== 'N/A' || !feeTokenAddress || !ctx.publicClient)
-    return undefined
+  if (nativeCurrency !== 'N/A' || !ctx.publicClient) return undefined
+  if (!feeTokenAddress) return NO_GAS_BALANCE_SOURCE
 
   let feeToken = getAddress(feeTokenAddress)
   if (feeManagerAddress) {
@@ -2278,6 +2284,12 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       // gas the pauser can actually pay for. Read the ERC20 fee token instead, matching the
       // discriminator and the preference hierarchy in script/utils/checkPauserFunds.sh.
       const feeToken = await resolvePauserFeeToken(ctx)
+      if (feeToken === NO_GAS_BALANCE_SOURCE) {
+        ctx.logWarn(
+          `${ctx.networkLower} has no native asset and no feeTokenAddress in config/networks.json, so the pauser's gas balance cannot be read; coverage is reduced`
+        )
+        return
+      }
       if (feeToken) {
         const token = getContract({
           address: feeToken,

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -19,6 +19,7 @@ import { consola } from 'consola'
 import type { TronWeb } from 'tronweb'
 import {
   formatEther,
+  formatUnits,
   getAddress,
   getContract,
   parseAbi,
@@ -107,7 +108,16 @@ export interface IHealthCheckContext {
   deployedContracts: Record<string, Address | string>
   globalConfig: IHealthCheckGlobalConfig
   targetState: TargetState
-  networkConfig: { rpcUrl?: string; safeAddress?: string }
+  networkConfig: {
+    rpcUrl?: string
+    safeAddress?: string
+    /** `"N/A"` marks a chain with no native asset, where `eth_getBalance` is not the gas balance. */
+    nativeCurrency?: string
+    /** Chain-default ERC20 gas token on such a chain (tempo's pathUSD). */
+    feeTokenAddress?: string
+    /** Predeploy resolving a per-account fee-token preference that overrides the default. */
+    feeManagerAddress?: string
+  }
   publicClient?: PublicClient
   tronWeb?: TronWeb
   tronRpcUrl?: string
@@ -338,6 +348,56 @@ export function getExemptCoreFacets(
 }
 
 /**
+ * A core periphery contract that cannot exist on some chains, together with those chains.
+ * The periphery counterpart of {@link ICoreFacetExemption}, and preferred over an
+ * {@link IInvariantExclusion} for the same reason: excluding `core-periphery-deployed` on a
+ * network would stop asserting ERC20Proxy, Executor, FeeForwarder and the rest there, whereas
+ * this drops one contract from the expected set and leaves everything else enforced.
+ *
+ * Unlike the facet table this is not always a shrinking to-do — an entry can be permanent when
+ * the chain makes the contract meaningless (nothing to wrap on a chain with no native asset).
+ */
+export interface ICorePeripheryExemption {
+  /** Periphery name as listed in `config/global.json` → `corePeriphery`. */
+  contract: string
+  /** Why these networks are exempt, including the ticket that documents the decision. */
+  reason: string
+  /** Network keys (as in config/networks.json) the contract is not expected on. */
+  networks: string[]
+}
+
+/**
+ * Per-network core-periphery exemptions. See {@link ICorePeripheryExemption}.
+ *
+ * Validated in `healthCheckInvariants.test.ts` the same way as the facet table: the contract
+ * must really be in `corePeriphery`, every network must exist in `config/networks.json`, and
+ * the reason must be non-empty.
+ */
+export const CORE_PERIPHERY_EXEMPTIONS: ICorePeripheryExemption[] = [
+  {
+    contract: 'TokenWrapper',
+    reason:
+      'TokenWrapper wraps a chain native asset into its ERC20 form. Arc has no activated native path (gas is USDC via the ERC20 predeploy) and tempo has no native asset at all (gas is paid in TIP-20 fee tokens), so on both chains there is nothing to wrap and the contract is intentionally never deployed (EXSC-786).',
+    networks: ['arc', 'tempo'],
+  },
+]
+
+/**
+ * Core periphery contracts the given network is exempt from, with the reason for each. Pure;
+ * network match is case-insensitive. A network absent from every entry gets an empty list, so
+ * new chains are enforced by default.
+ */
+export function getExemptCorePeriphery(
+  network: string,
+  exemptions: ICorePeripheryExemption[] = CORE_PERIPHERY_EXEMPTIONS
+): Array<{ contract: string; reason: string }> {
+  const networkLower = network.toLowerCase()
+  return exemptions
+    .filter((e) => e.networks.some((n) => n.toLowerCase() === networkLower))
+    .map((e) => ({ contract: e.contract, reason: e.reason }))
+}
+
+/**
  * Decide whether an invariant applies to the given context. Pure: depends only on the
  * invariant scope and the environment/chain/testnet/gaszip flags in the context.
  */
@@ -401,6 +461,47 @@ const OWNABLE_ABI = parseAbi([
 
 const getOwnableContract = (address: Address, client: PublicClient) =>
   getContract({ address, abi: OWNABLE_ABI, client })
+
+const ERC20_BALANCE_ABI = parseAbi([
+  'function balanceOf(address account) external view returns (uint256)',
+  'function decimals() external view returns (uint8)',
+  'function symbol() external view returns (string)',
+])
+
+const FEE_MANAGER_ABI = parseAbi([
+  'function userTokens(address account) external view returns (address)',
+])
+
+/**
+ * The ERC20 token the pauser would actually pay gas with, or undefined when the chain uses
+ * standard native accounting.
+ *
+ * The discriminator is `nativeCurrency: "N/A"` — deliberately NOT "gas is paid in a token".
+ * Chains like arc, celo and metis expose an ERC20 gas asset but keep standard EVM accounting,
+ * where `eth_getBalance` IS the gas balance; only a chain with no native asset at all decouples
+ * the two. Where the chain also configures a FeeManager predeploy, an account may override the
+ * chain-default token, so the override is resolved first. Mirrors the resolution order in
+ * `script/utils/checkPauserFunds.sh`, which owns the stronger affordability check.
+ */
+async function resolvePauserFeeToken(
+  ctx: IHealthCheckContext
+): Promise<Address | undefined> {
+  const { nativeCurrency, feeTokenAddress, feeManagerAddress } =
+    ctx.networkConfig
+  if (nativeCurrency !== 'N/A' || !feeTokenAddress || !ctx.publicClient)
+    return undefined
+
+  let feeToken = getAddress(feeTokenAddress)
+  if (feeManagerAddress) {
+    const userToken = await getContract({
+      address: getAddress(feeManagerAddress),
+      abi: FEE_MANAGER_ABI,
+      client: ctx.publicClient,
+    }).read.userTokens([ctx.pauserWallet as Address])
+    if (userToken && userToken !== zeroAddress) feeToken = getAddress(userToken)
+  }
+  return feeToken
+}
 
 /**
  * Assert an EVM contract's `owner()` equals `expectedOwner`. No-op when the contract is
@@ -1377,6 +1478,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         peripheryToCheck = peripheryToCheck.filter(
           (contract) => contract !== 'LiFiTimelockController'
         )
+      const exemptPeriphery = getExemptCorePeriphery(ctx.networkLower)
+      peripheryToCheck = peripheryToCheck.filter(
+        (contract) => !exemptPeriphery.some((e) => e.contract === contract)
+      )
 
       for (const contract of peripheryToCheck)
         await checkAndLogDeployment(contract, ctx, 'Periphery contract')
@@ -1576,6 +1681,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         contractsToCheck = contractsToCheck.filter(
           (contract) => contract !== 'GasZipPeriphery'
         )
+      const exemptPeriphery = getExemptCorePeriphery(ctx.networkLower)
+      contractsToCheck = contractsToCheck.filter(
+        (contract) => !exemptPeriphery.some((e) => e.contract === contract)
+      )
 
       if (contractsToCheck.length === 0) return
 
@@ -2136,14 +2245,14 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     // run. This lightweight floor closes both: it runs on Tron and at deploy time (the sweep's
     // push trigger), while the readiness workflow remains the authoritative affordability gate.
     name: 'pauser-funded',
-    description: 'Pauser wallet has a non-zero native balance',
+    description: 'Pauser wallet has a non-zero gas balance',
     severity: 'error',
     // skipTestnet: the two coverage gaps this closes are both mainnet (Tron mainnet pauser +
     // freshly deployed EVM mainnet pausers); testnet pausers (incl. the localanvil smoke-test
     // sandbox, whose pauser is unfunded) are not a production readiness invariant.
     scope: { environments: ['production'], skipTestnet: true },
     remediation:
-      'Fund the pauser wallet with native gas so it can broadcast pauseDiamond() in an incident.',
+      'Fund the pauser wallet with the gas asset of that chain (its fee token where the chain has no native asset) so it can broadcast pauseDiamond() in an incident.',
     run: async (ctx) => {
       if (ctx.isTron && ctx.tronWeb) {
         const pauserTronAddress = ensureTronAddress(
@@ -2163,6 +2272,37 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       }
 
       if (!ctx.publicClient) return
+
+      // A chain with no native asset decouples eth_getBalance from the gas balance: tempo
+      // answers it with a sentinel (4242…4242), which reads as "funded" no matter how much
+      // gas the pauser can actually pay for. Read the ERC20 fee token instead, matching the
+      // discriminator and the preference hierarchy in script/utils/checkPauserFunds.sh.
+      const feeToken = await resolvePauserFeeToken(ctx)
+      if (feeToken) {
+        const token = getContract({
+          address: feeToken,
+          abi: ERC20_BALANCE_ABI,
+          client: ctx.publicClient,
+        })
+        const [rawBalance, decimals, symbol] = await Promise.all([
+          token.read.balanceOf([ctx.pauserWallet as Address]),
+          token.read.decimals(),
+          token.read.symbol(),
+        ])
+        if (!rawBalance)
+          ctx.logError(
+            `Pauser wallet ${ctx.pauserWallet} has no ${symbol} (${feeToken}) balance, and ${ctx.networkLower} pays gas in that fee token`
+          )
+        else
+          consola.success(
+            `Pauser wallet ${ctx.pauserWallet} is funded: ${formatUnits(
+              rawBalance,
+              decimals
+            )} ${symbol} (fee token ${feeToken})`
+          )
+        return
+      }
+
       const balance = await ctx.publicClient.getBalance({
         address: ctx.pauserWallet as Address,
       })

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -472,23 +472,23 @@ const FEE_MANAGER_ABI = parseAbi([
   'function userTokens(address account) external view returns (address)',
 ])
 
+const NO_GAS_BALANCE_SOURCE = 'noGasBalanceSource'
+
 /**
- * The ERC20 token the pauser would actually pay gas with, or undefined when the chain uses
- * standard native accounting.
+ * The ERC20 token the pauser would actually pay gas with; `undefined` when the chain uses standard
+ * native accounting, `NO_GAS_BALANCE_SOURCE` when no gas balance can be read at all.
  *
  * The discriminator is `nativeCurrency: "N/A"` — deliberately NOT "gas is paid in a token".
  * Chains like arc, celo and metis expose an ERC20 gas asset but keep standard EVM accounting,
  * where `eth_getBalance` IS the gas balance; only a chain with no native asset at all decouples
- * the two. The chain-default `feeTokenAddress` is then replaced by the account's own preference
- * where the chain configures a FeeManager predeploy. Mirrors the resolution order in
+ * the two. On such a chain the account may override the chain-default `feeTokenAddress` through a
+ * FeeManager predeploy, so that preference wins where it is set. Mirrors the resolution order in
  * `script/utils/checkPauserFunds.sh`, which owns the stronger affordability check.
  *
  * A no-native-asset chain with no fee token configured yields `NO_GAS_BALANCE_SOURCE` rather than
  * falling through: its native balance is a sentinel, so reading it would report any pauser as
  * funded. Nothing can be asserted there, and the caller has to say so instead of passing.
  */
-const NO_GAS_BALANCE_SOURCE = 'noGasBalanceSource'
-
 async function resolvePauserFeeToken(
   ctx: IHealthCheckContext
 ): Promise<Address | typeof NO_GAS_BALANCE_SOURCE | undefined> {


### PR DESCRIPTION
# Which Linear task belongs to this PR?

- Fixes [EXSC-786](https://linear.app/lifi-linear/issue/EXSC-786/remove-skiphealthcheck-blanket-flag-targeted) — remove the `skipHealthcheck` blanket flag (T4 of [EXSC-782](https://linear.app/lifi-linear/issue/EXSC-782/complete-the-facetperiphery-health-check-hardening-exsc-684-follow-ups))
- Fixes [EXSC-859](https://linear.app/lifi-linear/issue/EXSC-859/health-check-pauser-funded-is-vacuously-green-on-chains-with-no-native) — `pauser-funded` is vacuously green on a chain with no native asset (surfaced by the above, fixed here because un-skipping tempo without it would replace a silent hole with a green lie)

# Why did I implement it this way?

`skipHealthcheck: true` returned from `runHealthCheckForNetwork` before a single invariant ran, so `arc`, `robinhood` and `tempo` were unchecked in the daily sweep, in new-network onboarding, and in the deploy smoke test alike — 60 assertions never made.

**I measured what was actually blocking them** rather than trusting the devNotes: dropped the flag, ran the real check against live chains, and all 20 invariants executed on all three with no RPC failures.

| network | actual blocker |
| --- | --- |
| `robinhood` | none — passes 20/20 as-is. The flag came in with the `outlaw`→`robinhood` rename (#2006) and nothing justified it. |
| `arc`, `tempo` | one intentional condition: `TokenWrapper` is deliberately never deployed (arc's native path is not activated, tempo has no native asset). |

So the blackout existed to suppress a single-contract exemption. It is replaced with a targeted one.

**`CORE_PERIPHERY_EXEMPTIONS`, not `HEALTH_CHECK_EXCLUSIONS`.** The existing invariant-level carve-out would have disabled `core-periphery-deployed` and `periphery-registered` wholesale on arc/tempo, dropping ERC20Proxy, Executor, FeeForwarder and the rest with it. The new table mirrors `CORE_FACET_EXEMPTIONS` exactly — reason mandatory, printed as `⏭ Not requiring core periphery [X] on <net>` on every run, integrity-tested — and drops one contract while everything else stays enforced.

**The flag is removed entirely, including the `INetwork` field and the early return.** My first pass kept it, because `docs/TronFork.md` documents `somnia.skipHealthcheck = true` on the `contracts-tron` fork and deleting the field looked like it would break sync PRs there. That premise turned out to be stale, and the checks are worth recording:

- the fork does still set it on `somnia`, but the reason is gone — TronFork.md describes it as a stopgap for somnia's `ERC20Proxy` owner still being the Safe after an upstream change;
- **`somnia` passes the upstream sweep today**, and the fork's `deployments/somnia.json` is byte-identical to upstream's, so the same invariants run against the same chain and the same log;
- no fork-delta rule (`checkTronForkDelta.ts` / `tronForkDelta.ts`) and no config test references the field, so removing it breaks no machinery.

Keeping a network-wide kill switch to protect an expired stopgap is the same mistake one level down. `TronFork.md` now drops its config-delta entry and points at a one-invariant `HEALTH_CHECK_EXCLUSIONS` entry for the next sync-PR red. The fork's own `somnia` key becomes inert (nothing reads it) and can be dropped in a small follow-up; `arc`/`robinhood`/`tempo` clear themselves on the next `networks.json` sync.

**Two defects the blackout was hiding, fixed here:**

1. **arc's target state contradicted its own config.** `_targetState.json` demanded `TokenWrapper` on arc while `networks.json` devNotes said it is never deployed — which is why arc failed two invariants and tempo only one. Removed from arc's target state, and a new integrity test asserts no exempt network still lists an exempted contract, so the two sources cannot drift apart again.
2. **`pauser-funded` was meaningless on tempo (EXSC-859).** It read `eth_getBalance`, which tempo answers with a sentinel (`4242…4242`), reported as `funded: 4242424242424242424242424242424242424242424242424242424242.424242`. Gas there is paid in TIP-20 fee tokens. The invariant now mirrors the resolution already implemented in `script/utils/checkPauserFunds.sh`: discriminate on `nativeCurrency: "N/A"` (**not** "gas is paid in a token" — arc/celo/metis expose an ERC20 gas asset but keep standard EVM accounting, so they stay on the native path), resolve the FeeManager per-account override, then read `balanceOf(pauser)`. Tempo now reports `1 pathUSD`. Where such a chain has no fee token configured the invariant warns rather than falling back to the sentinel. `checkPauserFunds.sh` remains the authoritative affordability gate; this stays a non-zero floor.

**Documentation.** `add-network.md` never mentioned the health check, so the only visible lever when an onboarding PR went red was the blanket flag — which is how three chains ended up permanently unchecked. It now has a short step: nothing to do in the normal case, the two config fields that change what runs, and the exemption tables for a contract that genuinely cannot exist on a chain.

**Entry criterion.** EXSC-782 says land T4 last, once the sweep is otherwise green — it was: full fleet on `origin/main` was 63/66 passed, 0 failed, 0 warned, 3 skipped.

## Verification

Full production fleet against live chains, in CI on this branch ([run 33032768494](https://github.com/lifinance/contracts/actions/runs/33032768494)) and locally after the flag removal:

| | passed | failed | skipped | warned |
| --- | --- | --- | --- | --- |
| `origin/main` | 63/66 | 0 | **3** | 0 |
| this branch | **66/66** | 0 | **0** | 0 |

Per-network exemption output is surfaced, not silent:

```text
ℹ ⏭  Not requiring core periphery [TokenWrapper] on arc — exempt: TokenWrapper wraps a chain native asset into its ERC20 form. …
✔ Pauser wallet 0xf9D8…1A4A is funded: 1 pathUSD (fee token 0x20C0000000000000000000000000000000000000)
```

Two fleet reds surfaced along the way were transport, not drift, and are fixed independently of this PR: `gravity` and `pharos` were hitting anonymous RPC quotas from the GitHub runner ([EXSC-860](https://linear.app/lifi-linear/issue/EXSC-860/health-check-gravity-fails-the-fleet-sweep-in-ci-on-rpc-rate-limits), closed — keyed endpoints provisioned).

Also run: `bun test script/deploy/` (904 pass, 0 fail), `bunx tsc-files --noEmit` and `bunx eslint` on every changed TS file, `bunx markdownlint-cli2` on both changed docs — all clean.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

