### PR TITLE
fix(healthcheck): a stalled parked claim is not removal coverage (EXSC-867)

### DIFF
--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -628,8 +628,11 @@ All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
   it through no automated path: the drain claims only `queued`, `reconcileDecision`
   returns `keep` without a proposal status, and `repair-orphaned-parked-tasks.ts` skips
   it for manual review. `no-stale-registered-facets` fails the health check once such a
-  claim passes `STALE_PARKED_CLAIM_DAYS` (EXSC-867); clearing it needs the operator CLI
-  (EXSC-715).
+  claim passes `STALE_PARKED_CLAIM_DAYS` (EXSC-867). Clearing it has **no shipped operator
+  path**: `revertToQueued` still has no CLI (EXSC-715), and re-enqueueing is not a
+  workaround — an address-keyed task is refused by the dedup gate, while a legacy
+  name-keyed one is not and would silently open a second task for the same address.
+  Until EXSC-715 lands this is a manual queue write; escalate to the SC on-call.
 - **queued/proposed → superseded**: `markSuperseded` (`:360`, accepts both open states)
   — the facet is already absent on-chain (removed via another route); self-healing
   reconcile.

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -623,7 +623,12 @@ All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
   `reconcile.ts` sweep pattern (extend it, or a small standalone job — §14 Q7).
 - **proposed → queued**: `revertToQueued` (`:402`) — if the linked proposal `reverted`
   (Fact 7) the removal didn't happen; it clears `proposedAt`/`safeTxHash` so the next
-  drain re-proposes cleanly.
+  drain re-proposes cleanly. A claim with **no** linked proposal at all (the drain died
+  between `claimForProposal` and `linkToProposal`) needs the same transition but reaches
+  it through no automated path: the drain claims only `queued`, `reconcileDecision`
+  returns `keep` without a proposal status, and `repair-orphaned-parked-tasks.ts` skips
+  it for manual review. `no-stale-registered-facets` fails the health check once such a
+  claim is a week old (EXSC-867); clearing it needs the operator CLI (EXSC-715).
 - **queued/proposed → superseded**: `markSuperseded` (`:360`, accepts both open states)
   — the facet is already absent on-chain (removed via another route); self-healing
   reconcile.
@@ -942,7 +947,9 @@ PR-link surfacing + reconcile/TTL job + the loupe-by-address affordance, as a
    detection. The drain resolves removals by stored `facetAddress` and never by
    name, so a pruned or ambiguous log entry cannot mis-resolve one; the queue-aware
    health-check invariant `no-stale-registered-facets` flags any
-   deprecated-but-registered facet with no open parked task, and the reconcile job
+   deprecated-but-registered facet with no *live* open parked task — a claim that has
+   sat `proposed` with no `safeTxHash` for a week is a dead drain, not coverage, and
+   fails the check rather than silencing it (EXSC-867) — and the reconcile job
    reports deploy-log entries that are safe to prune once the covering removal is
    loupe-verified off-chain (`executed`/`superseded`, never `cancelled`).
 6. **Opt-in default (§6/§11).** Semantics **decided**: `DRAIN_PARKED_TASKS` default off,

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -628,7 +628,8 @@ All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
   it through no automated path: the drain claims only `queued`, `reconcileDecision`
   returns `keep` without a proposal status, and `repair-orphaned-parked-tasks.ts` skips
   it for manual review. `no-stale-registered-facets` fails the health check once such a
-  claim is a week old (EXSC-867); clearing it needs the operator CLI (EXSC-715).
+  claim passes `STALE_PARKED_CLAIM_DAYS` (EXSC-867); clearing it needs the operator CLI
+  (EXSC-715).
 - **queued/proposed → superseded**: `markSuperseded` (`:360`, accepts both open states)
   — the facet is already absent on-chain (removed via another route); self-healing
   reconcile.
@@ -948,8 +949,9 @@ PR-link surfacing + reconcile/TTL job + the loupe-by-address affordance, as a
    name, so a pruned or ambiguous log entry cannot mis-resolve one; the queue-aware
    health-check invariant `no-stale-registered-facets` flags any
    deprecated-but-registered facet with no *live* open parked task — a claim that has
-   sat `proposed` with no `safeTxHash` for a week is a dead drain, not coverage, and
-   fails the check rather than silencing it (EXSC-867) — and the reconcile job
+   sat `proposed` with no `safeTxHash` past `STALE_PARKED_CLAIM_DAYS` is a dead drain,
+   not coverage, and fails the check rather than silencing it (EXSC-867) — and the
+   reconcile job
    reports deploy-log entries that are safe to prune once the covering removal is
    loupe-verified off-chain (`executed`/`superseded`, never `cancelled`).
 6. **Opt-in default (§6/§11).** Semantics **decided**: `DRAIN_PARKED_TASKS` default off,

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -4,7 +4,7 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
-import { type Hex } from 'viem'
+import { type Address, type Hex } from 'viem'
 
 import globalConfig from '../../config/global.json'
 import networksConfig from '../../config/networks.json'
@@ -38,6 +38,7 @@ import {
   type ICorePeripheryExemption,
   type IInvariantExclusion,
 } from './healthCheckInvariants'
+import { DAY_MS } from './shared/constants'
 import { getFacetPeripheryCouplings } from './shared/facetPeripheryCouplings'
 
 /** Minimal in-scope context for driving the runner without any RPC. */
@@ -170,7 +171,7 @@ describe('findDuplicateSelectors', () => {
 
 describe('isStalledParkedClaim', () => {
   const NOW = new Date('2026-08-28T00:00:00.000Z')
-  const ago = (days: number) => new Date(NOW.getTime() - days * 86_400_000)
+  const ago = (days: number) => new Date(NOW.getTime() - days * DAY_MS)
   const task = (over: Partial<IOpenParkedCoverage>): IOpenParkedCoverage => ({
     prUrl: 'https://github.com/lifinance/contracts/pull/1',
     status: 'proposed',
@@ -222,9 +223,9 @@ describe('isStalledParkedClaim', () => {
 })
 
 describe('collapseOpenParkedTasks', () => {
-  const ADDR = '0x00000000000000000000000000000000000000A1'
+  const ADDR: Address = '0x00000000000000000000000000000000000000A1'
   const NOW = new Date('2026-08-28T00:00:00.000Z')
-  const ago = (days: number) => new Date(NOW.getTime() - days * 86_400_000)
+  const ago = (days: number) => new Date(NOW.getTime() - days * DAY_MS)
 
   // A legacy name-keyed row and an address-keyed row do NOT collide on the open-status
   // unique index, so both can be open for one address at once.
@@ -279,8 +280,7 @@ describe('splitByParkedCoverage', () => {
     address: address as Hex,
     selectors: ['0xdeadbeef'] as Hex[],
   })
-  const daysBefore = (days: number) =>
-    new Date(NOW.getTime() - days * 86_400_000)
+  const daysBefore = (days: number) => new Date(NOW.getTime() - days * DAY_MS)
   /** A live queued task (the common case): no claim, next drain picks it up. */
   const queued = (createdAt = daysBefore(1)): IOpenParkedCoverage => ({
     prUrl: 'https://github.com/lifinance/contracts/pull/1',
@@ -625,7 +625,7 @@ describe('no-stale-registered-facets claim liveness', () => {
     return ctx
   }
 
-  const at = (daysAgo: number) => new Date(Date.now() - daysAgo * 86_400_000)
+  const at = (daysAgo: number) => new Date(Date.now() - daysAgo * DAY_MS)
 
   const withTask = (task: IOpenParkedCoverage): OpenParkedByNetwork =>
     new Map([['mantle', new Map([[DEPRECATED.toLowerCase(), task]])]])
@@ -1850,9 +1850,9 @@ describe('no-unexpected-facets parked-removal coverage', () => {
               {
                 prUrl: PR_URL,
                 status: 'proposed' as const,
-                createdAt: new Date(Date.now() - 40 * 86_400_000),
+                createdAt: new Date(Date.now() - 40 * DAY_MS),
                 proposedAt: new Date(
-                  Date.now() - (STALE_PARKED_CLAIM_DAYS + 2) * 86_400_000
+                  Date.now() - (STALE_PARKED_CLAIM_DAYS + 2) * DAY_MS
                 ),
               },
             ],

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -1787,6 +1787,34 @@ describe('no-unexpected-facets parked-removal coverage', () => {
     expect(ctx.warnings).toHaveLength(1)
   })
 
+  it('does NOT downgrade when the covering task is a stalled claim', async () => {
+    // The prune was licensed by an open task; once that claim dies this invariant is the
+    // only one left watching the address, since the other resolves names via the log.
+    const ctx = makePrunedCtx(
+      new Map([
+        [
+          'testnet1',
+          new Map([
+            [
+              PRUNED.toLowerCase(),
+              {
+                prUrl: PR_URL,
+                status: 'proposed' as const,
+                createdAt: new Date(Date.now() - 40 * 86_400_000),
+                proposedAt: new Date(
+                  Date.now() - (STALE_PARKED_CLAIM_DAYS + 2) * 86_400_000
+                ),
+              },
+            ],
+          ]),
+        ],
+      ])
+    )
+    await invariant('no-unexpected-facets').run(ctx)
+    expect(ctx.warnings).toHaveLength(1)
+    expect(ctx.warnings[0]).toContain('no longer progressing')
+  })
+
   it('warns on the uncovered facet while downgrading the covered one', async () => {
     const UNCOVERED = '0xEEEE000000000000000000000000000000000005'
     const ctx = makePrunedCtx(covering(), {

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -20,6 +20,9 @@ import {
   RECEIVER_EXECUTOR_GETTERS,
   findDeprecatedLiveFacets,
   splitByParkedCoverage,
+  STALE_PARKED_CLAIM_DAYS,
+  type IOpenParkedCoverage,
+  type OpenParkedByNetwork,
   findDuplicateSelectors,
   getExemptCoreFacets,
   getExemptCorePeriphery,
@@ -166,47 +169,159 @@ describe('findDuplicateSelectors', () => {
 describe('splitByParkedCoverage', () => {
   const V1 = '0x00000000000000000000000000000000000000A1'
   const V2 = '0x00000000000000000000000000000000000000a2'
+  const NOW = new Date('2026-08-28T00:00:00.000Z')
   const facet = (name: string, address: string) => ({
     name,
     address: address as Hex,
     selectors: ['0xdeadbeef'] as Hex[],
   })
+  const daysBefore = (days: number) =>
+    new Date(NOW.getTime() - days * 86_400_000)
+  /** A live queued task (the common case): no claim, next drain picks it up. */
+  const queued = (createdAt = daysBefore(1)): IOpenParkedCoverage => ({
+    prUrl: 'https://github.com/lifinance/contracts/pull/1',
+    status: 'queued',
+    createdAt,
+  })
+  const coverage = (
+    entries: [string, IOpenParkedCoverage][]
+  ): Map<string, IOpenParkedCoverage> =>
+    new Map(entries.map(([a, t]) => [a.toLowerCase(), t]))
 
   it('counts a facet as covered when an open task carries its exact address', () => {
-    const { parked, unparked } = splitByParkedCoverage(
+    const { live, stalled, unparked } = splitByParkedCoverage(
       [facet('SymbiosisFacet', V1)],
-      new Set([V1.toLowerCase()])
+      coverage([[V1, queued()]]),
+      NOW
     )
-    expect(parked.map((f) => f.address)).toEqual([V1])
+    expect(live.map((f) => f.address)).toEqual([V1])
+    expect(stalled).toHaveLength(0)
     expect(unparked).toHaveLength(0)
   })
 
   it('does NOT count a same-NAME task on a different address as coverage', () => {
     // Both SymbiosisFacet versions routed (EXSC-750) with a task for v1 only: keying
     // on the name would classify v2 as expected-pending and never warn about it.
-    const { parked, unparked } = splitByParkedCoverage(
+    const { live, unparked } = splitByParkedCoverage(
       [facet('SymbiosisFacet', V1), facet('SymbiosisFacet', V2)],
-      new Set([V1.toLowerCase()])
+      coverage([[V1, queued()]]),
+      NOW
     )
-    expect(parked.map((f) => f.address)).toEqual([V1])
+    expect(live.map((f) => f.address)).toEqual([V1])
     expect(unparked.map((f) => f.address)).toEqual([V2])
   })
 
   it('matches addresses case-insensitively', () => {
-    const { parked } = splitByParkedCoverage(
+    const { live } = splitByParkedCoverage(
       [facet('SymbiosisFacet', V1)],
-      new Set([V1.toUpperCase().replace('0X', '0x').toLowerCase()])
+      coverage([[V1.toUpperCase().replace('0X', '0x'), queued()]]),
+      NOW
     )
-    expect(parked).toHaveLength(1)
+    expect(live).toHaveLength(1)
   })
 
   it('reports everything as uncovered when the queue holds no open task', () => {
-    const { parked, unparked } = splitByParkedCoverage(
+    const { live, unparked } = splitByParkedCoverage(
       [facet('SymbiosisFacet', V1)],
-      new Set()
+      coverage([]),
+      NOW
     )
-    expect(parked).toHaveLength(0)
+    expect(live).toHaveLength(0)
     expect(unparked).toHaveLength(1)
+  })
+
+  it('classifies a long-claimed task with no Safe proposal as stalled, not covered', () => {
+    // The mantle GenericSwapFacet failure mode: the drain flipped queued→proposed and
+    // died before linking a proposal, so nothing unattended can ever move it again.
+    const { live, stalled, unparked } = splitByParkedCoverage(
+      [facet('GenericSwapFacet', V1)],
+      coverage([
+        [
+          V1,
+          {
+            prUrl: 'https://github.com/lifinance/contracts/pull/2046',
+            status: 'proposed',
+            createdAt: daysBefore(29),
+            proposedAt: daysBefore(STALE_PARKED_CLAIM_DAYS + 3),
+          },
+        ],
+      ]),
+      NOW
+    )
+    expect(stalled.map((f) => f.address)).toEqual([V1])
+    expect(live).toHaveLength(0)
+    expect(unparked).toHaveLength(0)
+  })
+
+  it('still counts a freshly claimed task as live (a drain holds it briefly)', () => {
+    const { live, stalled } = splitByParkedCoverage(
+      [facet('GenericSwapFacet', V1)],
+      coverage([
+        [
+          V1,
+          {
+            prUrl: 'https://github.com/lifinance/contracts/pull/2046',
+            status: 'proposed',
+            createdAt: daysBefore(29),
+            proposedAt: daysBefore(STALE_PARKED_CLAIM_DAYS - 1),
+          },
+        ],
+      ]),
+      NOW
+    )
+    expect(live.map((f) => f.address)).toEqual([V1])
+    expect(stalled).toHaveLength(0)
+  })
+
+  it('counts an old claim WITH a linked Safe proposal as live (reconcile resolves it)', () => {
+    const { live, stalled } = splitByParkedCoverage(
+      [facet('SymbiosisFacet', V1)],
+      coverage([
+        [
+          V1,
+          {
+            prUrl: 'https://github.com/lifinance/contracts/pull/2108',
+            status: 'proposed',
+            createdAt: daysBefore(60),
+            proposedAt: daysBefore(45),
+            safeTxHash: '0xabc',
+          },
+        ],
+      ]),
+      NOW
+    )
+    expect(live).toHaveLength(1)
+    expect(stalled).toHaveLength(0)
+  })
+
+  it('falls back to createdAt when a proposed task has no proposedAt stamp', () => {
+    const { stalled } = splitByParkedCoverage(
+      [facet('GenericSwapFacet', V1)],
+      coverage([
+        [
+          V1,
+          {
+            prUrl: 'https://github.com/lifinance/contracts/pull/2046',
+            status: 'proposed',
+            createdAt: daysBefore(STALE_PARKED_CLAIM_DAYS + 1),
+          },
+        ],
+      ]),
+      NOW
+    )
+    expect(stalled).toHaveLength(1)
+  })
+
+  it('never treats a queued task as stalled, however old', () => {
+    // `queued` is always reachable: the next drain claims it. Age alone is backlog,
+    // not breakage, and flagging it would red every chain with a slow rollout.
+    const { live, stalled } = splitByParkedCoverage(
+      [facet('SymbiosisFacet', V1)],
+      coverage([[V1, queued(daysBefore(120))]]),
+      NOW
+    )
+    expect(live).toHaveLength(1)
+    expect(stalled).toHaveLength(0)
   })
 })
 
@@ -373,15 +488,96 @@ describe('HEALTH_CHECK_INVARIANTS registry', () => {
     expect(names).toContain('receiver-executor-binding')
   })
 
-  it('includes the queue-aware stale-facet invariant as a production warning', () => {
+  it('includes the queue-aware stale-facet invariant as a production error', () => {
     const inv = HEALTH_CHECK_INVARIANTS.find(
       (i) => i.name === 'no-stale-registered-facets'
     )
     expect(inv).toBeDefined()
-    expect(inv?.severity).toBe('warning')
+    expect(inv?.severity).toBe('error')
     expect(inv?.scope.environments).toEqual(['production'])
     expect(inv?.scope.skipTestnet).toBe(true)
     expect(inv?.readsOnChainFacets).toBe(true)
+  })
+})
+
+describe('no-stale-registered-facets claim liveness', () => {
+  // mantle, because the invariant resolves expected facets from the real
+  // _targetState.json and a synthetic network has no entry (it would early-return).
+  const DEPRECATED = '0x2b7D2C78bd801Cc06DDCF91DeE2e8fAE22814f7e'
+  const PR_URL = 'https://github.com/lifinance/contracts/pull/2046'
+
+  function makeStaleCtx(
+    openParkedRemovals: IHealthCheckContext['openParkedRemovals']
+  ): IHealthCheckContext {
+    const ctx = makeCtx()
+    Object.assign(ctx, {
+      networkLower: 'mantle',
+      // GenericSwapFacet: absent from mantle target state and no src/ source left,
+      // which is exactly the deprecated-but-routed shape this invariant detects.
+      onChainFacets: [{ address: DEPRECATED, selectors: ['0x4630a0d8'] }],
+      deployedContracts: { GenericSwapFacet: DEPRECATED },
+      openParkedRemovals,
+    })
+    return ctx
+  }
+
+  const at = (daysAgo: number) => new Date(Date.now() - daysAgo * 86_400_000)
+
+  const withTask = (task: IOpenParkedCoverage): OpenParkedByNetwork =>
+    new Map([['mantle', new Map([[DEPRECATED.toLowerCase(), task]])]])
+
+  it('fails the run when the covering task is a stalled claim', async () => {
+    const ctx = makeStaleCtx(
+      withTask({
+        prUrl: PR_URL,
+        status: 'proposed',
+        createdAt: at(29),
+        proposedAt: at(STALE_PARKED_CLAIM_DAYS + 3),
+      })
+    )
+    await invariant('no-stale-registered-facets').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('STALLED')
+    expect(ctx.errors[0]).toContain(DEPRECATED)
+    expect(ctx.errors[0]).toContain(PR_URL)
+  })
+
+  it('fails the run when nothing covers the deprecated facet', async () => {
+    const ctx = makeStaleCtx(new Map())
+    await invariant('no-stale-registered-facets').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('NO open parked-removal task')
+  })
+
+  it('stays green while a live queued task covers it', async () => {
+    const ctx = makeStaleCtx(
+      withTask({ prUrl: PR_URL, status: 'queued', createdAt: at(120) })
+    )
+    await invariant('no-stale-registered-facets').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(ctx.warnings).toEqual([])
+  })
+
+  it('stays green while a claimed task carries a real Safe proposal', async () => {
+    const ctx = makeStaleCtx(
+      withTask({
+        prUrl: PR_URL,
+        status: 'proposed',
+        createdAt: at(60),
+        proposedAt: at(45),
+        safeTxHash: '0xabc',
+      })
+    )
+    await invariant('no-stale-registered-facets').run(ctx)
+    expect(ctx.errors).toEqual([])
+  })
+
+  it('warns without failing when the queue is unreachable', async () => {
+    const ctx = makeStaleCtx({ unreachable: 'connect ECONNREFUSED' })
+    await invariant('no-stale-registered-facets').run(ctx)
+    expect(ctx.errors).toEqual([])
+    expect(ctx.warnings).toHaveLength(1)
+    expect(ctx.warnings[0]).toContain('unreachable')
   })
 })
 
@@ -1481,8 +1677,15 @@ describe('no-unexpected-facets parked-removal coverage', () => {
     return ctx
   }
 
-  const covering = (): Map<string, Map<string, string>> =>
-    new Map([['testnet1', new Map([[PRUNED.toLowerCase(), PR_URL]])]])
+  /** A live queued task — this invariant only reads `prUrl`, but the shape must match. */
+  const task = (): IOpenParkedCoverage => ({
+    prUrl: PR_URL,
+    status: 'queued',
+    createdAt: new Date('2026-08-27T00:00:00.000Z'),
+  })
+
+  const covering = (): OpenParkedByNetwork =>
+    new Map([['testnet1', new Map([[PRUNED.toLowerCase(), task()]])]])
 
   it('downgrades a routed-but-pruned facet to expected-pending when a parked removal covers it', async () => {
     const ctx = makePrunedCtx(covering())
@@ -1495,7 +1698,7 @@ describe('no-unexpected-facets parked-removal coverage', () => {
       new Map([
         [
           'testnet1',
-          new Map([['0xdddd000000000000000000000000000000000004', PR_URL]]),
+          new Map([['0xdddd000000000000000000000000000000000004', task()]]),
         ],
       ])
     )
@@ -1505,7 +1708,7 @@ describe('no-unexpected-facets parked-removal coverage', () => {
 
   it('keys coverage by network, not fleet-wide', async () => {
     const ctx = makePrunedCtx(
-      new Map([['othernet', new Map([[PRUNED.toLowerCase(), PR_URL]])]])
+      new Map([['othernet', new Map([[PRUNED.toLowerCase(), task()]])]])
     )
     await invariant('no-unexpected-facets').run(ctx)
     expect(ctx.warnings).toHaveLength(1)

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -21,6 +21,7 @@ import {
   findDeprecatedLiveFacets,
   splitByParkedCoverage,
   isStalledParkedClaim,
+  collapseOpenParkedTasks,
   STALE_PARKED_CLAIM_DAYS,
   type IOpenParkedCoverage,
   type OpenParkedByNetwork,
@@ -217,6 +218,55 @@ describe('isStalledParkedClaim', () => {
         NOW
       )
     ).toBe(true)
+  })
+})
+
+describe('collapseOpenParkedTasks', () => {
+  const ADDR = '0x00000000000000000000000000000000000000A1'
+  const NOW = new Date('2026-08-28T00:00:00.000Z')
+  const ago = (days: number) => new Date(NOW.getTime() - days * 86_400_000)
+
+  // A legacy name-keyed row and an address-keyed row do NOT collide on the open-status
+  // unique index, so both can be open for one address at once.
+  const stalledClaim = {
+    network: 'mantle',
+    facetAddress: ADDR,
+    prUrl: 'https://github.com/lifinance/contracts/pull/2046',
+    status: 'proposed' as const,
+    createdAt: ago(29),
+    proposedAt: ago(STALE_PARKED_CLAIM_DAYS + 3),
+  }
+  const freshQueued = {
+    network: 'mantle',
+    facetAddress: ADDR,
+    prUrl: 'https://github.com/lifinance/contracts/pull/9999',
+    status: 'queued' as const,
+    createdAt: ago(1),
+  }
+
+  it('keeps the stalled claim when a livelier task for the same address follows it', () => {
+    const got = collapseOpenParkedTasks([stalledClaim, freshQueued], NOW)
+    expect(got.get('mantle')?.get(ADDR.toLowerCase())?.status).toBe('proposed')
+  })
+
+  it('keeps the stalled claim when it arrives second', () => {
+    // Order-independence is the whole point: the queue's sort must not decide coverage.
+    const got = collapseOpenParkedTasks([freshQueued, stalledClaim], NOW)
+    expect(got.get('mantle')?.get(ADDR.toLowerCase())?.status).toBe('proposed')
+  })
+
+  it('keeps a single live task when nothing is stalled', () => {
+    const got = collapseOpenParkedTasks([freshQueued], NOW)
+    expect(got.get('mantle')?.get(ADDR.toLowerCase())?.status).toBe('queued')
+  })
+
+  it('keys tasks under their own network', () => {
+    const got = collapseOpenParkedTasks(
+      [freshQueued, { ...freshQueued, network: 'base' }],
+      NOW
+    )
+    expect(got.get('mantle')?.size).toBe(1)
+    expect(got.get('base')?.size).toBe(1)
   })
 })
 

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -172,6 +172,12 @@ describe('findDuplicateSelectors', () => {
 describe('isStalledParkedClaim', () => {
   const NOW = new Date('2026-08-28T00:00:00.000Z')
   const ago = (days: number) => new Date(NOW.getTime() - days * DAY_MS)
+
+  // Fixtures and the staleness bound both divide by DAY_MS, so a wrong DAY_MS
+  // cancels out and every age assertion below still passes. Pin it literally.
+  it('measures ages in whole days', () => {
+    expect(DAY_MS).toBe(86_400_000)
+  })
   const task = (over: Partial<IOpenParkedCoverage>): IOpenParkedCoverage => ({
     prUrl: 'https://github.com/lifinance/contracts/pull/1',
     status: 'proposed',

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -20,6 +20,7 @@ import {
   RECEIVER_EXECUTOR_GETTERS,
   findDeprecatedLiveFacets,
   splitByParkedCoverage,
+  isStalledParkedClaim,
   STALE_PARKED_CLAIM_DAYS,
   type IOpenParkedCoverage,
   type OpenParkedByNetwork,
@@ -163,6 +164,59 @@ describe('findDuplicateSelectors', () => {
       { address: '0xAAA', selectors: ['0x11111111', '0x11111111'] },
     ])
     expect(result).toEqual([])
+  })
+})
+
+describe('isStalledParkedClaim', () => {
+  const NOW = new Date('2026-08-28T00:00:00.000Z')
+  const ago = (days: number) => new Date(NOW.getTime() - days * 86_400_000)
+  const task = (over: Partial<IOpenParkedCoverage>): IOpenParkedCoverage => ({
+    prUrl: 'https://github.com/lifinance/contracts/pull/1',
+    status: 'proposed',
+    createdAt: ago(30),
+    ...over,
+  })
+
+  it('flags a claim with no linked proposal once it passes the bound', () => {
+    expect(
+      isStalledParkedClaim(
+        task({ proposedAt: ago(STALE_PARKED_CLAIM_DAYS) }),
+        NOW
+      )
+    ).toBe(true)
+  })
+
+  it('does not flag a claim one day inside the bound', () => {
+    expect(
+      isStalledParkedClaim(
+        task({ proposedAt: ago(STALE_PARKED_CLAIM_DAYS - 1) }),
+        NOW
+      )
+    ).toBe(false)
+  })
+
+  it('never flags a task that carries a linked Safe proposal', () => {
+    expect(
+      isStalledParkedClaim(
+        task({ proposedAt: ago(90), safeTxHash: '0xabc' }),
+        NOW
+      )
+    ).toBe(false)
+  })
+
+  it('never flags a queued task, whatever its age', () => {
+    expect(
+      isStalledParkedClaim(task({ status: 'queued', createdAt: ago(400) }), NOW)
+    ).toBe(false)
+  })
+
+  it('measures from createdAt when proposedAt is missing', () => {
+    expect(
+      isStalledParkedClaim(
+        task({ createdAt: ago(STALE_PARKED_CLAIM_DAYS + 1) }),
+        NOW
+      )
+    ).toBe(true)
   })
 })
 

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1354,6 +1354,50 @@ export function splitByParkedCoverage(
 }
 
 /**
+ * Groups open parked tasks by network and facet address for coverage lookups.
+ *
+ * Two open tasks CAN share one address: the open-status unique index is on `taskKey`, and
+ * a legacy name-keyed row does not collide with the address-keyed key `computeTaskKey`
+ * mints today (mantle still carries such a row). Collapsing them therefore has to fail
+ * **closed** — a stalled claim, once seen, is never replaced by a livelier sibling, which
+ * would otherwise mask it and re-open exactly the gap this coverage check exists to close.
+ * The result must not depend on the order the queue returned the tasks in.
+ *
+ * @param tasks - Open (`queued`/`proposed`) tasks, in any order.
+ * @returns Network (lowercased) → lowercased facet address → the task that governs coverage.
+ */
+export function collapseOpenParkedTasks(
+  tasks: readonly {
+    network: string
+    facetAddress: string
+    prUrl: string
+    status: ParkedTaskStatus
+    createdAt: Date
+    proposedAt?: Date
+    safeTxHash?: string
+  }[],
+  now: Date = new Date()
+): OpenParkedByNetwork {
+  const byNetwork: OpenParkedByNetwork = new Map()
+  for (const task of tasks) {
+    const map =
+      byNetwork.get(task.network) ?? new Map<string, IOpenParkedCoverage>()
+    const address = task.facetAddress.toLowerCase()
+    const existing = map.get(address)
+    if (!existing || !isStalledParkedClaim(existing, now))
+      map.set(address, {
+        prUrl: task.prUrl,
+        status: task.status,
+        createdAt: task.createdAt,
+        proposedAt: task.proposedAt,
+        safeTxHash: task.safeTxHash,
+      })
+    byNetwork.set(task.network, map)
+  }
+  return byNetwork
+}
+
+/**
  * Open parked tasks fleet-wide, fetched once per process and grouped by network
  * (lowercased `facetAddress` → PR URL maps). The health check evaluates dozens of networks
  * concurrently in one process, and a Mongo connect/index-check/teardown per stale
@@ -1379,21 +1423,7 @@ function fetchOpenParkedAddressesByNetwork(): Promise<
           environment: EnvironmentEnum.production,
           status: OPEN_STATUSES,
         })
-        const byNetwork: OpenParkedByNetwork = new Map()
-        for (const task of open) {
-          const map =
-            byNetwork.get(task.network) ??
-            new Map<string, IOpenParkedCoverage>()
-          map.set(task.facetAddress.toLowerCase(), {
-            prUrl: task.prUrl,
-            status: task.status,
-            createdAt: task.createdAt,
-            proposedAt: task.proposedAt,
-            safeTxHash: task.safeTxHash,
-          })
-          byNetwork.set(task.network, map)
-        }
-        return byNetwork
+        return collapseOpenParkedTasks(open)
       } finally {
         await client.close()
       }
@@ -2591,7 +2621,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     scope: { environments: ['production'], skipTestnet: true },
     readsOnChainFacets: true,
     remediation:
-      'No task: enqueue the removal (script/deploy/safe/enqueue-parked-task.ts, with the deprecation PR URL) or run `cleanUpProdDiamond --auto --network <network>`. Stalled claim: the task is `proposed` with no Safe proposal and no unattended job can move it — it needs `revertToQueued` before a drain will re-claim it (EXSC-715). Do NOT re-enqueue (the open task blocks the dedup gate) and do NOT cancel (that abandons a live deprecation). See docs/DeferredDiamondCleanupQueue.md.',
+      'No task: enqueue the removal (script/deploy/safe/enqueue-parked-task.ts, with the deprecation PR URL) or run `cleanUpProdDiamond --auto --network <network>`. Stalled claim: the task is `proposed` with no Safe proposal and no unattended job can move it — it needs `revertToQueued` before a drain will re-claim it, and no operator CLI ships that yet (EXSC-715), so escalate to the SC on-call rather than hand-editing the queue. Do NOT re-enqueue: an address-keyed task is refused by the dedup gate, and a legacy name-keyed one is NOT — it would silently open a second task for the same address. Do NOT cancel (that abandons a live deprecation). See docs/DeferredDiamondCleanupQueue.md.',
     run: async (ctx) => {
       if (ctx.onChainFacets.length === 0) {
         consola.info(

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -68,6 +68,28 @@ import {
 /** Severity of a failed invariant: `error` fails the run (exit 1); `warning` is reported but non-fatal. */
 export type HealthCheckSeverity = 'error' | 'warning'
 
+/**
+ * How long a claimed-but-unproposed parked task may sit before it stops counting as
+ * coverage. Signing and executing a removal proposal takes at most ~48h in practice, so a
+ * claim with no linked proposal past a week is not slow — it is a drain that died between
+ * `claimForProposal` and `linkToProposal`, and no unattended job recovers it: the drain
+ * only claims `queued`, `reconcileDecision` returns `keep` without a linked proposal, and
+ * `repair-orphaned-parked-tasks.ts` skips it for manual review.
+ */
+export const STALE_PARKED_CLAIM_DAYS = 7
+
+/** The fields of an open parked task that coverage decisions read. */
+export interface IOpenParkedCoverage {
+  prUrl: string
+  status: string
+  createdAt: Date
+  proposedAt?: Date
+  safeTxHash?: string
+}
+
+/** Network (lowercased) → lowercased facet address → the open task covering it. */
+export type OpenParkedByNetwork = Map<string, Map<string, IOpenParkedCoverage>>
+
 /** Coarse applicability gate for an invariant; finer branching lives inside `run()`. */
 export interface IHealthCheckScope {
   /** Environments the invariant applies to. Omitted = both production and staging. */
@@ -146,13 +168,11 @@ export interface IHealthCheckContext {
    */
   peripheryRegistryCache?: Map<string, Promise<string | null>>
   /**
-   * Open parked-removal coverage (network → lowercased facet address → PR URL). Undefined =
+   * Open parked-removal coverage (network → lowercased facet address → task). Undefined =
    * fetch from the parked-task queue (the default); injectable so the queue-aware invariants
    * are testable without a MongoDB connection.
    */
-  openParkedRemovals?:
-    | Map<string, Map<string, string>>
-    | { unreachable: string }
+  openParkedRemovals?: OpenParkedByNetwork | { unreachable: string }
   errors: string[]
   warnings: string[]
   logError: (msg: string) => void
@@ -1263,8 +1283,37 @@ export function findDeprecatedLiveFacets(params: {
 }
 
 /**
- * Splits deprecated-but-routed facets into the ones an open parked task actually
- * covers and the ones nothing is tracking.
+ * Whether a parked task has stopped being live coverage.
+ *
+ * A `queued` task is always live — the next drain claims it. A `proposed` task with a
+ * linked `safeTxHash` is live too: a real Safe proposal exists, and `reconcile` resolves it
+ * once that proposal executes or reverts. A `proposed` task with NO `safeTxHash` is the dead
+ * end (see {@link STALE_PARKED_CLAIM_DAYS}) — tolerated briefly, because a drain legitimately
+ * holds that state for the seconds between claiming and linking.
+ *
+ * @param task - The open task covering the facet address.
+ * @param now - Evaluation instant (injected so the bound is testable).
+ */
+export function isStalledParkedClaim(
+  task: IOpenParkedCoverage,
+  now: Date = new Date()
+): boolean {
+  if (task.status !== 'proposed') return false
+  if (task.safeTxHash) return false
+  const claimedAt = new Date(task.proposedAt ?? task.createdAt).getTime()
+  const days = (now.getTime() - claimedAt) / 86_400_000
+  return days >= STALE_PARKED_CLAIM_DAYS
+}
+
+/** Whole-day age of a queue timestamp, for operator-facing lines (`unknown` if absent). */
+function formatDaysAgo(at: Date | undefined, now: Date = new Date()): string {
+  if (!at) return 'unknown'
+  const days = Math.floor((now.getTime() - new Date(at).getTime()) / 86_400_000)
+  return `${days}d ago`
+}
+
+/**
+ * Splits deprecated-but-routed facets by whether a *live* open parked task covers them.
  *
  * Coverage is matched by ADDRESS, like the drain and the reconcile. A name maps to
  * exactly one deploy-log address, so a task whose address is not the stale facet
@@ -1272,20 +1321,35 @@ export function findDeprecatedLiveFacets(params: {
  * silence this backstop for the very facet it exists to surface (two co-registered
  * versions under one name, EXSC-750/EXSC-775).
  *
+ * Existence of a task is not coverage: a stalled claim is unreachable by every unattended
+ * job, so counting it would keep this check green forever while the facet stays routed
+ * (mantle GenericSwapFacet sat `proposed` with no proposal for 29 days, EXSC-867).
+ *
  * @param deprecated - Deprecated facets the loupe still routes.
- * @param openParkedAddresses - Lowercased `facetAddress` of every open parked task.
- * @returns The covered (`parked`) and uncovered (`unparked`) partitions.
+ * @param openParked - Lowercased `facetAddress` → open task, for this network.
+ * @param now - Evaluation instant, forwarded to {@link isStalledParkedClaim}.
+ * @returns `live` (covered, progressing), `stalled` (covered by a dead-end claim) and
+ *   `unparked` (nothing tracking them) partitions.
  */
 export function splitByParkedCoverage(
   deprecated: IFacetRemoval[],
-  openParkedAddresses: Set<string>
-): { parked: IFacetRemoval[]; unparked: IFacetRemoval[] } {
-  const isParked = (facet: IFacetRemoval): boolean =>
-    openParkedAddresses.has(facet.address.toLowerCase())
-  return {
-    parked: deprecated.filter(isParked),
-    unparked: deprecated.filter((f) => !isParked(f)),
+  openParked: Map<string, IOpenParkedCoverage>,
+  now: Date = new Date()
+): {
+  live: IFacetRemoval[]
+  stalled: IFacetRemoval[]
+  unparked: IFacetRemoval[]
+} {
+  const live: IFacetRemoval[] = []
+  const stalled: IFacetRemoval[] = []
+  const unparked: IFacetRemoval[] = []
+  for (const facet of deprecated) {
+    const task = openParked.get(facet.address.toLowerCase())
+    if (!task) unparked.push(facet)
+    else if (isStalledParkedClaim(task, now)) stalled.push(facet)
+    else live.push(facet)
   }
+  return { live, stalled, unparked }
 }
 
 /**
@@ -1299,10 +1363,10 @@ export function splitByParkedCoverage(
  * failing promise, so a hard outage costs at most one attempt per network.
  */
 let openParkedByNetworkPromise:
-  | Promise<Map<string, Map<string, string>> | { unreachable: string }>
+  | Promise<OpenParkedByNetwork | { unreachable: string }>
   | undefined
 function fetchOpenParkedAddressesByNetwork(): Promise<
-  Map<string, Map<string, string>> | { unreachable: string }
+  OpenParkedByNetwork | { unreachable: string }
 > {
   return (openParkedByNetworkPromise ??= (async () => {
     try {
@@ -1314,10 +1378,18 @@ function fetchOpenParkedAddressesByNetwork(): Promise<
           environment: EnvironmentEnum.production,
           status: OPEN_STATUSES,
         })
-        const byNetwork = new Map<string, Map<string, string>>()
+        const byNetwork: OpenParkedByNetwork = new Map()
         for (const task of open) {
-          const map = byNetwork.get(task.network) ?? new Map<string, string>()
-          map.set(task.facetAddress.toLowerCase(), task.prUrl)
+          const map =
+            byNetwork.get(task.network) ??
+            new Map<string, IOpenParkedCoverage>()
+          map.set(task.facetAddress.toLowerCase(), {
+            prUrl: task.prUrl,
+            status: task.status,
+            createdAt: task.createdAt,
+            proposedAt: task.proposedAt,
+            safeTxHash: task.safeTxHash,
+          })
           byNetwork.set(task.network, map)
         }
         return byNetwork
@@ -2452,7 +2524,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       // expected-pending, not rogue. The queue is a production-mainnet construct
       // (see no-stale-registered-facets), and an unreachable queue must not
       // suppress the warning — degrade to reporting as if nothing were covered.
-      let parkedRemovals = new Map<string, string>()
+      let parkedRemovals = new Map<string, IOpenParkedCoverage>()
       if (ctx.environment === 'production' && !ctx.isTestnet) {
         const openParked =
           ctx.openParkedRemovals ?? (await fetchOpenParkedAddressesByNetwork())
@@ -2465,10 +2537,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       const compiledSelectors =
         ctx.compiledFacetSelectors ?? loadCompiledFacetSelectors()
       for (const facet of unlogged) {
-        const prUrl = parkedRemovals.get(facet.address.toLowerCase())
-        if (prUrl) {
+        const parked = parkedRemovals.get(facet.address.toLowerCase())
+        if (parked) {
           consola.info(
-            `Facet ${facet.address} is routed on-chain but pruned from the deploy log — expected-pending: parked removal (PR ${prUrl})`
+            `Facet ${facet.address} is routed on-chain but pruned from the deploy log — expected-pending: parked removal (PR ${parked.prUrl})`
           )
           continue
         }
@@ -2496,15 +2568,19 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
   {
     name: 'no-stale-registered-facets',
     description:
-      'Deprecated facets still routed on-chain are covered by an open parked-removal task',
-    severity: 'warning',
+      'Deprecated facets still routed on-chain are covered by a LIVE open parked-removal task',
+    severity: 'error',
     // skipTestnet: the parked queue is a production-mainnet construct — testnet
     // diamonds are EOA-owned and clean up directly, so queue coverage is
-    // meaningless there and the warning would never resolve.
+    // meaningless there and the warning would never resolve. Dropping the flag
+    // would not extend the check to testnets anyway: no testnet has a
+    // `production` target-state entry, so `getExpectedFacetNames` returns
+    // undefined and the run below early-returns. Covering testnets means giving
+    // them target state first (EXSC-868), not relaxing this scope.
     scope: { environments: ['production'], skipTestnet: true },
     readsOnChainFacets: true,
     remediation:
-      'Enqueue the removal (script/deploy/safe/enqueue-parked-task.ts, with the deprecation PR URL) or run `cleanUpProdDiamond --auto --network <network>` (docs/DeferredDiamondCleanupQueue.md).',
+      'No task: enqueue the removal (script/deploy/safe/enqueue-parked-task.ts, with the deprecation PR URL) or run `cleanUpProdDiamond --auto --network <network>`. Stalled claim: the task is `proposed` with no Safe proposal and no unattended job can move it — it needs `revertToQueued` before a drain will re-claim it (EXSC-715). Do NOT re-enqueue (the open task blocks the dedup gate) and do NOT cancel (that abandons a live deprecation). See docs/DeferredDiamondCleanupQueue.md.',
     run: async (ctx) => {
       if (ctx.onChainFacets.length === 0) {
         consola.info(
@@ -2556,35 +2632,48 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         )
         return
       }
-      const openParkedAddresses = new Set(
-        (openParked.get(ctx.networkLower) ?? new Map<string, string>()).keys()
-      )
+      const openForNetwork =
+        openParked.get(ctx.networkLower) ??
+        new Map<string, IOpenParkedCoverage>()
 
-      const { parked, unparked } = splitByParkedCoverage(
+      const { live, stalled, unparked } = splitByParkedCoverage(
         deprecated,
-        openParkedAddresses
+        openForNetwork
       )
-      if (parked.length > 0)
+      if (live.length > 0)
         consola.info(
           `${
-            parked.length
-          } deprecated facet(s) awaiting their parked removal (expected-pending): ${parked
+            live.length
+          } deprecated facet(s) awaiting their parked removal (expected-pending): ${live
             .map((f) => f.name)
             .join(', ')}`
         )
-      // One aggregated warning per network, not one per facet: the fleet-wide
+      // One aggregated line per network per class, not one per facet: the fleet-wide
       // backlog is large enough that per-facet lines would drown the report.
+      if (stalled.length > 0)
+        ctx.logError(
+          `${
+            stalled.length
+          } deprecated facet(s) still routed behind a STALLED parked claim (\`proposed\` with no Safe proposal for >=${STALE_PARKED_CLAIM_DAYS}d — no drain or reconcile will move it): ${stalled
+            .map((f) => {
+              const task = openForNetwork.get(f.address.toLowerCase())
+              return `${f.name} (${f.address}, claimed ${formatDaysAgo(
+                task?.proposedAt ?? task?.createdAt
+              )}, PR ${task?.prUrl ?? 'unknown'})`
+            })
+            .join(', ')}`
+        )
       if (unparked.length > 0)
-        ctx.logWarn(
+        ctx.logError(
           `${
             unparked.length
           } deprecated facet(s) still routed with NO open parked-removal task: ${unparked
             .map((f) => `${f.name} (${f.address})`)
             .join(', ')}`
         )
-      else
+      if (stalled.length === 0 && unparked.length === 0)
         consola.success(
-          'All stale registered facets are covered by parked removals'
+          'All stale registered facets are covered by live parked removals'
         )
     },
   },

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -43,8 +43,8 @@ import {
   cachedSourceContractNames,
   type IFacetRemoval,
 } from './safe/diamondRemovalDiff'
-import type { ParkedTaskStatus } from './safe/parked-tasks'
-import { SAFE_THRESHOLD } from './shared/constants'
+import type { IParkedTask } from './safe/parked-tasks'
+import { DAY_MS, SAFE_THRESHOLD } from './shared/constants'
 import {
   evaluateFacetPeripheryCouplings,
   getFacetPeripheryCouplings,
@@ -80,13 +80,10 @@ export type HealthCheckSeverity = 'error' | 'warning'
 export const STALE_PARKED_CLAIM_DAYS = 7
 
 /** The fields of an open parked task that coverage decisions read. */
-export interface IOpenParkedCoverage {
-  prUrl: string
-  status: ParkedTaskStatus
-  createdAt: Date
-  proposedAt?: Date
-  safeTxHash?: string
-}
+export type IOpenParkedCoverage = Pick<
+  IParkedTask,
+  'prUrl' | 'status' | 'createdAt' | 'proposedAt' | 'safeTxHash'
+>
 
 /** Network (lowercased) → lowercased facet address → the open task covering it. */
 export type OpenParkedByNetwork = Map<string, Map<string, IOpenParkedCoverage>>
@@ -1302,14 +1299,14 @@ export function isStalledParkedClaim(
   if (task.status !== 'proposed') return false
   if (task.safeTxHash) return false
   const claimedAt = new Date(task.proposedAt ?? task.createdAt).getTime()
-  const days = (now.getTime() - claimedAt) / 86_400_000
+  const days = (now.getTime() - claimedAt) / DAY_MS
   return days >= STALE_PARKED_CLAIM_DAYS
 }
 
 /** Whole-day age of a queue timestamp, for operator-facing lines (`unknown` if absent). */
 function formatDaysAgo(at: Date | undefined, now: Date = new Date()): string {
   if (!at) return 'unknown'
-  const days = Math.floor((now.getTime() - new Date(at).getTime()) / 86_400_000)
+  const days = Math.floor((now.getTime() - new Date(at).getTime()) / DAY_MS)
   return `${days}d ago`
 }
 
@@ -1367,15 +1364,8 @@ export function splitByParkedCoverage(
  * @returns Network (lowercased) → lowercased facet address → the task that governs coverage.
  */
 export function collapseOpenParkedTasks(
-  tasks: readonly {
-    network: string
-    facetAddress: string
-    prUrl: string
-    status: ParkedTaskStatus
-    createdAt: Date
-    proposedAt?: Date
-    safeTxHash?: string
-  }[],
+  tasks: readonly (IOpenParkedCoverage &
+    Pick<IParkedTask, 'network' | 'facetAddress'>)[],
   now: Date = new Date()
 ): OpenParkedByNetwork {
   const byNetwork: OpenParkedByNetwork = new Map()
@@ -1385,13 +1375,7 @@ export function collapseOpenParkedTasks(
     const address = task.facetAddress.toLowerCase()
     const existing = map.get(address)
     if (!existing || !isStalledParkedClaim(existing, now))
-      map.set(address, {
-        prUrl: task.prUrl,
-        status: task.status,
-        createdAt: task.createdAt,
-        proposedAt: task.proposedAt,
-        safeTxHash: task.safeTxHash,
-      })
+      map.set(address, task)
     byNetwork.set(task.network, map)
   }
   return byNetwork

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -2539,9 +2539,19 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         ctx.compiledFacetSelectors ?? loadCompiledFacetSelectors()
       for (const facet of unlogged) {
         const parked = parkedRemovals.get(facet.address.toLowerCase())
-        if (parked) {
+        if (parked && !isStalledParkedClaim(parked)) {
           consola.info(
             `Facet ${facet.address} is routed on-chain but pruned from the deploy log — expected-pending: parked removal (PR ${parked.prUrl})`
+          )
+          continue
+        }
+        // A pruned entry is licensed by an OPEN task, and once that task stalls this is the
+        // only invariant left watching the facet: `no-stale-registered-facets` resolves
+        // names through the deploy log, so it cannot see an address the log no longer
+        // carries. Downgrading on a dead claim here would hide the facet in both.
+        if (parked) {
+          ctx.logWarn(
+            `Facet ${facet.address} is routed on-chain and pruned from the deploy log, but its parked removal (PR ${parked.prUrl}) has been claimed with no Safe proposal for >=${STALE_PARKED_CLAIM_DAYS}d — the prune was licensed by a task that is no longer progressing`
           )
           continue
         }

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -43,6 +43,7 @@ import {
   cachedSourceContractNames,
   type IFacetRemoval,
 } from './safe/diamondRemovalDiff'
+import type { ParkedTaskStatus } from './safe/parked-tasks'
 import { SAFE_THRESHOLD } from './shared/constants'
 import {
   evaluateFacetPeripheryCouplings,
@@ -81,7 +82,7 @@ export const STALE_PARKED_CLAIM_DAYS = 7
 /** The fields of an open parked task that coverage decisions read. */
 export interface IOpenParkedCoverage {
   prUrl: string
-  status: string
+  status: ParkedTaskStatus
   createdAt: Date
   proposedAt?: Date
   safeTxHash?: string

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -66,6 +66,7 @@ import { redactErrorReason } from '../../utils/redactUrls'
 import { isUnattendedRun, SlackNotifier } from '../../utils/slack-notifier'
 import { getEnvVar } from '../../utils/utils'
 import { getAllActiveNetworks } from '../../utils/viemScriptHelpers'
+import { DAY_MS } from '../shared/constants'
 
 import { computeFacetRemovalsByAddress } from './diamondRemovalDiff'
 import {
@@ -80,9 +81,6 @@ import {
   type ParkedTaskStatus,
 } from './parked-tasks'
 import { getSafeMongoCollection, type SafeTxStatus } from './safe-utils'
-
-/** Milliseconds in a day. */
-const DAY_MS = 24 * 60 * 60 * 1000
 
 /** Default cold-network TTL before a "still open" alert fires (spec §14 Q10). */
 const DEFAULT_TTL_DAYS = 60

--- a/script/deploy/shared/constants.ts
+++ b/script/deploy/shared/constants.ts
@@ -71,6 +71,9 @@ export const INITIAL_CALL_DELAY = 2000 // 2s
  */
 export const RETRY_DELAY = 2000 // 2s
 
+/** Milliseconds in a day. */
+export const DAY_MS = 24 * 60 * 60 * 1000
+
 // File paths
 export const DEPLOYMENT_FILE_SUFFIX = (
   environment: DeploymentFileSuffixInput


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-867](https://linear.app/lifi-linear/issue/EXSC-867/harden-no-stale-registered-facets-a-stalled-parked-claim-must-not)

# Why did I implement it this way?

`no-stale-registered-facets` treated the mere **existence** of an open parked task as coverage for a deprecated-but-routed facet. It could not distinguish "cleanup in flight" from "cleanup silently dead", so a stalled task kept the check green indefinitely while the facet stayed routed in production.

Found live during a fleet sweep of the parked queue: mantle `GenericSwapFacet` v2.0.0 at `0x2b7D2C78bd801Cc06DDCF91DeE2e8fAE22814f7e` (origin #2046) sat `status: proposed` with **no `safeTxHash`** — no Safe transaction was ever created for anyone to sign — for 29 days, still routing 4 selectors, while the check reported green the whole time.

**Root cause.** The drain flips `queued → proposed` (`claimForProposal`) *before* the Safe proposal exists and stamps `safeTxHash` afterwards (`linkToProposal`). A drain that dies between the two leaves a record no unattended job can move:

| Path | Behaviour on such a record |
|---|---|
| `drain-parked-tasks.ts` | claims `status: 'queued'` only → never re-claims it |
| `reconcileDecision()` | returns `'keep'` (facet on-chain, no linked proposal status) |
| `repair-orphaned-parked-tasks.ts` | counts it `unlinked`, logs "leaving for manual review", skips |
| `cancel-parked-task.ts` | refuses — `markCancelled` is `queued`-only |

So coverage had to become **liveness**, not existence:

- `queued` → always live. The next drain claims it; age alone is backlog, not breakage. Flagging old `queued` tasks would red every chain with a slow rollout (there are 16 such tasks right now from #2108).
- `proposed` **with** `safeTxHash` → live. A real proposal exists and `reconcile` resolves it once that proposal executes or reverts.
- `proposed` **without** `safeTxHash` past `STALE_PARKED_CLAIM_DAYS` → stalled. 7 days is deliberately generous: proposals are signed and executed within ~48h in practice, so a week without one is unambiguous breakage rather than slowness. The bound is not zero because a healthy drain legitimately holds that state for the seconds between claiming and linking.

`severity` also went `warning` → `error`, and both the stalled and the uncovered class now report via `ctx.logError` instead of `ctx.logWarn`. `failed = errors.length > 0` in `executeInvariant`, so previously *nothing* gated on this check; `severity: 'error'` additionally buys the transient-RPC re-verify pass. The `live` class stays an info line.

The remediation string is now split per class, because the two need opposite actions — a stalled claim must **not** be re-enqueued (the open task blocks the dedup gate) and must **not** be cancelled (that abandons a live deprecation); it needs `revertToQueued`, whose missing operator CLI is [EXSC-715](https://linear.app/lifi-linear/issue/EXSC-715/add-operator-cli-to-revert-or-cancel-a-parked-diamond-cleanup-task).

## Both halves of the hole

`no-stale-registered-facets` and `no-unexpected-facets` are the two halves of detection for this failure, as `docs/DeferredDiamondCleanupQueue.md` states: the first sees a deprecated facet **while the deploy log still names it**, the second sees it **once the deprecation PR prunes that entry** (pruning is explicitly licensed by an open `queued`/`proposed` task).

Gating only the first on liveness would have left the pruned half still downgrading a dead claim to an info line — hiding the same defect in the place the other invariant structurally cannot look, since it resolves names through the deploy log. So `no-unexpected-facets` now declines the expected-pending downgrade for a stalled claim and warns instead.

That branch cannot fire on today's fleet: the one stalled claim (mantle) is still deploy-logged, so its address never reaches the `unlogged` set. It is also warning-severity, so it cannot red a run.

## Deliberately NOT changed: `skipTestnet`

`skipTestnet: true` was the suspected reason deprecated facets survived on four testnets. It is not the cause, so flipping it would have been a cosmetic fix hiding a real gap. No testnet has a `production` target-state entry in `_targetState.json` — the entries exist but are empty objects — so `getExpectedFacetNames()` returns `undefined` and the invariant early-returns whatever the flag says. Verified by running the real `findDeprecatedLiveFacets` over the 5 active non-mainnet networks: 3 skipped for "no target-state entry", 0 findings. The comment now records this so nobody "fixes" the flag expecting a behaviour change, and the actual gap is [EXSC-868](https://linear.app/lifi-linear/issue/EXSC-868/testnet-diamonds-have-no-target-state-so-every-target-state-health).

## Falsification on real data

Same-PR tests are not evidence a new check can fire, so the shipped `splitByParkedCoverage` was run against live `facets()` reads and the live queue across **all 66 active mainnet networks** (zero unreadable):

```text
networks evaluated: 66  (STALE_PARKED_CLAIM_DAYS=7)
mantle  deprecated=1 parked=0 UNPARKED=0 STALLED=1
    stalled: GenericSwapFacet@0x2b7D2C78bd801Cc06DDCF91DeE2e8fAE22814f7e status=proposed safeTxHash=ABSENT
TOTALS: would-error-on-unparked=0, would-error-on-stalled=1
```

- fires on exactly the one known real defect, and on nothing else
- `unparked = 0` fleet-wide, so the `logError` flip reds no network that is healthy today — this change does not turn on a fleet-wide red

Negative controls are unit-tested: `queued` at 400 days, `proposed` with a `safeTxHash` at 90 days, a claim one day inside the bound, and an unreachable queue all stay green.

**Note:** mantle's queue row is being repaired in parallel, so once that lands the fleet goes green on this check. The snapshot above is from 2026-08-28T09:14Z.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

