### PR TITLE
fix(targetState): add three missing mantle facet entries

### DIFF
--- a/script/deploy/_targetState.json
+++ b/script/deploy/_targetState.json
@@ -908,7 +908,10 @@
         "SquidFacet": "1.0.0",
         "StargateFacetV2": "1.0.1",
         "ReceiverStargateV2": "1.1.0",
-        "SymbiosisFacet": "2.0.0"
+        "SymbiosisFacet": "2.0.0",
+        "GlacisFacet": "1.2.0",
+        "LiFiIntentEscrowFacetV2": "1.0.0",
+        "RelayDepositoryFacet": "1.0.0"
       }
     }
   },


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-885](https://linear.app/lifi-linear/issue/EXSC-885/add-three-missing-mantle-facet-entries-to-targetstatejson)

# Why did I implement it this way?

`LiFiIntentEscrowFacetV2`, `RelayDepositoryFacet` and `GlacisFacet` are deployed and routed on mantle but were absent from mantle's block in `script/deploy/_targetState.json`, so every `cleanUpProdDiamond.ts --network mantle --auto` run emitted:

```text
🛑 TARGET-STATE BUG: protected facet(s) missing from _targetState.json (kept, but fix target state): LiFiIntentEscrowFacetV2
↔️  DRIFT: on-chain & absent from target state but source still exists — NOT removed: RelayDepositoryFacet, GlacisFacet
```

The guards behaved correctly — all three were kept and never proposed for removal — but the recurring noise obscures genuine findings on a script whose whole purpose is flagging facets that should be removed from a production diamond.

The three entries are added at the versions already deployed on mantle, which also match `@custom:version` in source and the rest of the fleet, so no judgement call was involved:

| Facet | Version | Also in target state on |
| --- | --- | --- |
| `GlacisFacet` | 1.2.0 | 26 networks |
| `LiFiIntentEscrowFacetV2` | 1.0.0 | 14 networks |
| `RelayDepositoryFacet` | 1.0.0 | 34 networks |

They are appended to the end of mantle's block, matching the append-on-add convention used elsewhere in the file, which keeps the diff to three lines and avoids reordering churn. The file is edited in place rather than reformatted — `config`/`script` JSON in this repo is not prettier-managed, and reformatting would bury a three-line change in whitespace.

**Verification**

- `cleanUpProdDiamond.ts --network mantle --environment production --auto` (dry-run): both warnings gone, and the computed removal set is **unchanged** — still `GenericSwapFacet` only, same 4 selectors, same timelock-wrapped calldata.
- `healthCheck.ts --network mantle`: `exit=0`, 76 checks passed, 0 errors.
- Audited both directions for mantle: no on-chain facet is missing from target state any more (only `GenericSwapFacet`, correctly excluded as deprecated), and no target-state entry lacks a deployment.

**Deliberately out of scope**

Four version gaps remain on mantle where target state is intentionally *ahead* of on-chain — pending upgrade work, correct as written, each needing its own rollout and audit gate: `GenericSwapFacetV3` 1.0.0→2.0.0, `CalldataVerificationFacet` 1.1.1→1.3.1, `WhitelistManagerFacet` 1.0.0→1.1.0, `GasZipFacet` 2.0.4→2.0.5. Target state expresses intent, so lowering these toward the deployed versions would be the bug.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

