### PR TITLE
fix(clear-signing): include testnet diamonds in registry sync (EXSC-889)

### DIFF
--- a/docs/ClearSigningProposal.md
+++ b/docs/ClearSigningProposal.md
@@ -217,7 +217,8 @@ verifyClearSigning.yml (BLOCKING):
 syncLedgerClearSigning.yml (push to main / monthly cron / manual dispatch):
   - runs generateLedgerClearSigning.ts
     - regenerates context.contract.abi from facet artifacts
-    - regenerates context.contract.deployments from deployments/*
+    - regenerates context.contract.deployments from deployments/* (all active
+      networks, testnets included)
     - merges display.formats from config/clearSigningProposal.json
   - pushes PR to ethereum/clear-signing-erc7730-registry
   - pings #sc-general via SLACK_WEBHOOK_SC_GENERAL on new upstream PRs

--- a/tasks/generateLedgerClearSigning.ts
+++ b/tasks/generateLedgerClearSigning.ts
@@ -64,7 +64,6 @@ interface IFoundryArtifact {
 interface INetworkConfig {
   chainId: number
   status?: string
-  type?: string
 }
 
 interface IClearSigningProposal {
@@ -305,9 +304,9 @@ function buildDeploymentsFromRepo(
     const cfg = networks[networkName]
     if (!cfg) continue
 
-    // Ledger file targets production deployments; ignore testnets/inactive networks
+    // Deprecated networks stay out: their diamonds are frozen at a facet set we no
+    // longer track, so the ABI regenerated here would not describe them
     if (cfg.status && cfg.status !== 'active') continue
-    if (cfg.type && cfg.type !== 'mainnet') continue
 
     const deploymentPath = path.resolve(deploymentsDir, file)
     const data = readJsonFile<Record<string, unknown>>(deploymentPath)

--- a/tasks/generateLedgerClearSigning.ts
+++ b/tasks/generateLedgerClearSigning.ts
@@ -304,8 +304,7 @@ function buildDeploymentsFromRepo(
     const cfg = networks[networkName]
     if (!cfg) continue
 
-    // Deprecated networks stay out: their diamonds are frozen at a facet set we no
-    // longer track, so the ABI regenerated here would not describe them
+    // Catches networks marked inactive whose deployment files are still present
     if (cfg.status && cfg.status !== 'active') continue
 
     const deploymentPath = path.resolve(deploymentsDir, file)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-889](https://linear.app/lifi-linear/issue/EXSC-889/clear-signing-sync-testnet-diamonds-to-the-erc-7730-registry)

# Why did I implement it this way?

`buildDeploymentsFromRepo` in `tasks/generateLedgerClearSigning.ts` gated the registry's `context.contract.deployments` on two conditions — network `status === 'active'` **and** `type === 'mainnet'`. The second gate dropped every testnet, so users signing against our testnet diamonds get a blind-signing blob instead of clear signing. That was not a deliberate policy, so the gate is removed; `status` stays, which keeps deprecated networks out.

Surfaced by [clear-signing-erc7730-registry#2929](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2929), where Sourcify discovered our arctestnet diamond (chain 5042002) and proposed adding it to the registry by hand. Since the sync regenerates the whole `deployments` array from this repo, a hand-added entry would be overwritten on the next run — the fix belongs here, and the entries then propagate on their own.

`INetworkConfig.type` is dropped along with the gate; nothing else in the file read it.

**Verified, not assumed** — ran the generator against a real registry `master` checkout of `registry/lifi/calldata-LIFIDiamond.json` with `--skipAbi`:

```text
Ledger deployments: 66
Local deployments:  70
Deployments added:  5

+ 84532     0x816fc6eee47e3157a666827a0c06205294c81770  (basesepolia)
+ 421614    0x816fc6eee47e3157a666827a0c06205294c81770  (arbitrumsepolia)
+ 5042002   0xff70f4a1d11995621854f3692acf286d8acd04b2  (arctestnet)
+ 11155111  0xecec3970ca674278da8d9b1c484acaf6b20181f5  (sepolia)
+ 11155420  0x2ec99f867e78445148974c36588805653f119787  (optimismsepolia)
```

The single removal in that run (`1284` moonbeam) is unrelated to this change — it is the chain-shutdown deprecation already carried by the pending sync PR [registry#2901](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2901).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
