### PR TITLE
chore(whitelist): allowlist Yggdrasil VM proxy on Arc

### DIFF
--- a/config/composerWhitelist.json
+++ b/config/composerWhitelist.json
@@ -57,6 +57,17 @@
       ]
     }
   ],
+  "arc": [
+    {
+      "address": "0xbfE34dF90A81113b7D3f943E9925DD1B44e96644",
+      "functionSelectors": [
+        {
+          "selector": "0x00a32e6c",
+          "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+        }
+      ]
+    }
+  ],
   "avalanche": [
     {
       "address": "0x9706b69De23Fe0B471Addd642175126B3A8BF071",

--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -5320,6 +5320,16 @@
             "signature": "validateNativeOutput(uint256,address)"
           }
         ]
+      },
+      {
+        "name": "Composer",
+        "address": "0xbfE34dF90A81113b7D3f943E9925DD1B44e96644",
+        "selectors": [
+          {
+            "selector": "0x00a32e6c",
+            "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+          }
+        ]
       }
     ],
     "arctestnet": [


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-892](https://linear.app/lifi-linear/issue/EXSC-892/allowlist-yggdrasil-vm-proxy-and-selector-on-arc)

This PR covers the **Arc** allowlist entry only. The ticket's Plasma re-verification item is tracked separately and intentionally not closed by this PR, hence `Ref` rather than `Fixes`.

# Why did I implement it this way?

The Yggdrasil/Composer VM proxy on Arc (`0xbfE34dF90A81113b7D3f943E9925DD1B44e96644`) and its `runVM` selector (`0x00a32e6c`) were not allowlisted on the Arc diamond, so zaps through the diamond reverted with `ContractCallNotAllowed()`. Verified on-chain that `isContractSelectorWhitelisted` returned `false` for the pair. Composer whitelist entries are sourced from `config/composerWhitelist.json` (the source of truth), from which `whitelist.json`'s PERIPHERY section is generated — so I added the `arc` key there (alphabetically, matching the existing `pharos` pattern) and regenerated `config/whitelist.json` with the canonical `script/tasks/updateWhitelistPeriphery.ts`. No hand-editing of the generated section. Per rule 502 this PR targets `main`. Applying the entry on-chain is a separate multisig/timelock rollout (the Arc diamond is owned by the LiFiTimelockController).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
