### PR TITLE
fix(EXSC-423): address Vault Wrapper V1 peer-review feedback

### DIFF
--- a/docs/VaultWrapper/LiFiVaultWrapperFactory.md
+++ b/docs/VaultWrapper/LiFiVaultWrapperFactory.md
@@ -121,6 +121,23 @@ the same instance address on every chain — provided the factory and the beacon
 sit at identical addresses per chain, which the CREATE3 system deploy
 (`DeployLiFiVaultWrapperFactory.s.sol`) provides.
 
+`_nonce` is the only disambiguator for a repeated
+(namespace, adapter, underlying) triple. The salt preimage is deliberately
+**not** versioned: it is `abi.encode`d (fixed-width, so no packing ambiguity),
+and a repeated triple simply makes `Create2.deploy` revert on the occupied
+address rather than colliding into one. A future factory version that needs a
+fresh address for an existing triple bumps the nonce.
+
+**The beacon address is parity-critical.** `_proxyInitCode()` embeds `beacon`
+into the init code that fixes every instance address, and `beacon` lives in
+factory *proxy storage*. It is written once in `initialize` and no setter
+exists, which is what keeps addresses stable today — but a timelocked
+factory-logic upgrade could introduce one. Changing the beacon after the first
+deploy would silently move every subsequently predicted address and break parity
+against chains already deployed. Treat `beacon` as write-once for the life of
+the system; replace the *implementation* through the beacon's `upgradeTo`, never
+the beacon itself.
+
 ## Related contracts
 
 - [LiFiVaultWrapper](./LiFiVaultWrapper.md) — the per-instance ERC-4626 vault.

--- a/docs/VaultWrapper/README.md
+++ b/docs/VaultWrapper/README.md
@@ -144,6 +144,19 @@ Consolidated from the per-contract docs; each links to its full treatment.
   Sources that charge deposit/exit fees or credit fewer shares than assets are
   unsupported and require a dedicated adapter — see
   [ERC4626Adapter assumptions](./ERC4626Adapter.md#assumptions).
+- **Yield sources are trusted to report price per share honestly.** The wrapper
+  takes the source's `totalAssets` at face value, so a source that misreports its
+  price per share — a broken or manipulable oracle, not necessarily malice — for
+  even a single block distorts the performance fee in both directions: a spike
+  charges a fee on a gain that never existed (permanently diluting holders), and
+  because the high-water mark ratchets up-only to the spiked price, genuine later
+  gains then accrue no performance fee until they exceed the spike. Accrual runs on
+  deposit/withdraw and on the permissionless `distributeFees`, so an attacker who can
+  move the source's price for one block can pick the moment. The root cause always
+  lies in the underlying, and the control is curation: only a governance-allowlisted
+  underlying reached through an approved adapter can ever be wrapped. Onboarding a
+  source whose price per share is cheaply manipulable is therefore a governance
+  decision, not something the wrapper can defend against.
 - **No enforced minimum share supply.** Inflation/donation defense is the
   virtual-share decimals offset (floored at 6) plus a `ZeroSharesMinted` revert.
   Accepted bounds: [donation griefing](./LiFiVaultWrapper.md#donation-griefing--accepted-bounds).

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1352,11 +1352,11 @@ contract LiFiVaultWrapper is
         address _token,
         uint256 _integratorTotal
     ) private returns (uint256 retained) {
-        FeeReceiver[] memory receivers = integratorFeeReceivers;
-        uint256 count = receivers.length;
+        uint256 count = integratorFeeReceivers.length;
         uint256 distributed;
 
         for (uint256 i; i < count; ++i) {
+            FeeReceiver storage receiver = integratorFeeReceivers[i];
             uint256 share;
             if (i + 1 == count) {
                 // last receiver gets the whole remainder to avoid rounding dust
@@ -1364,14 +1364,14 @@ contract LiFiVaultWrapper is
             } else {
                 // other receivers get their bps share, rounded down
                 share = _integratorTotal.mulDiv(
-                    receivers[i].bps,
+                    receiver.bps,
                     LibVaultWrapperMath.BASIS_POINT_SCALE
                 );
             }
             distributed += share;
             if (share == 0) continue;
 
-            address wallet = receivers[i].wallet;
+            address wallet = receiver.wallet;
             // we use trySafeTransfer here so a failed transfer doesn't block the distribution
             if (SafeERC20.trySafeTransfer(IERC20(_token), wallet, share)) {
                 continue;

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1352,11 +1352,11 @@ contract LiFiVaultWrapper is
         address _token,
         uint256 _integratorTotal
     ) private returns (uint256 retained) {
-        uint256 count = integratorFeeReceivers.length;
+        FeeReceiver[] memory receivers = integratorFeeReceivers;
+        uint256 count = receivers.length;
         uint256 distributed;
 
         for (uint256 i; i < count; ++i) {
-            FeeReceiver storage receiver = integratorFeeReceivers[i];
             uint256 share;
             if (i + 1 == count) {
                 // last receiver gets the whole remainder to avoid rounding dust
@@ -1364,14 +1364,14 @@ contract LiFiVaultWrapper is
             } else {
                 // other receivers get their bps share, rounded down
                 share = _integratorTotal.mulDiv(
-                    receiver.bps,
+                    receivers[i].bps,
                     LibVaultWrapperMath.BASIS_POINT_SCALE
                 );
             }
             distributed += share;
             if (share == 0) continue;
 
-            address wallet = receiver.wallet;
+            address wallet = receivers[i].wallet;
             // we use trySafeTransfer here so a failed transfer doesn't block the distribution
             if (SafeERC20.trySafeTransfer(IERC20(_token), wallet, share)) {
                 continue;

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -1352,11 +1352,11 @@ contract LiFiVaultWrapper is
         address _token,
         uint256 _integratorTotal
     ) private returns (uint256 retained) {
-        FeeReceiver[] memory receivers = integratorFeeReceivers;
-        uint256 count = receivers.length;
+        uint256 count = integratorFeeReceivers.length;
         uint256 distributed;
 
         for (uint256 i; i < count; ++i) {
+            FeeReceiver memory receiver = integratorFeeReceivers[i];
             uint256 share;
             if (i + 1 == count) {
                 // last receiver gets the whole remainder to avoid rounding dust
@@ -1364,14 +1364,14 @@ contract LiFiVaultWrapper is
             } else {
                 // other receivers get their bps share, rounded down
                 share = _integratorTotal.mulDiv(
-                    receivers[i].bps,
+                    receiver.bps,
                     LibVaultWrapperMath.BASIS_POINT_SCALE
                 );
             }
             distributed += share;
             if (share == 0) continue;
 
-            address wallet = receivers[i].wallet;
+            address wallet = receiver.wallet;
             // we use trySafeTransfer here so a failed transfer doesn't block the distribution
             if (SafeERC20.trySafeTransfer(IERC20(_token), wallet, share)) {
                 continue;

--- a/src/VaultWrapper/LiFiVaultWrapper.sol
+++ b/src/VaultWrapper/LiFiVaultWrapper.sol
@@ -17,11 +17,6 @@ import { IYieldAdapter } from "./interfaces/IYieldAdapter.sol";
 import { FeeConfig, FeeType, FeeReceiver, FEE_TYPE_COUNT } from "./LiFiVaultWrapperTypes.sol";
 import { LibVaultWrapperMath } from "./libraries/LibVaultWrapperMath.sol";
 
-// One over solhint's 15-state default: the 16th declaration is the write-once
-// `shareDecimalsOffset` (inflation protection), which packs into the `accessGate`
-// slot rather than widening the storage layout.
-// solhint-disable max-states-count
-
 /// @title LiFiVaultWrapper
 /// @author LI.FI (https://li.fi)
 /// @notice Per-integrator-product ERC-4626 vault that wraps an underlying yield source. Shares


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-423](https://linear.app/lifi-linear/issue/EXSC-423/s15-security-review-and-audit-support) — S15, Security review & audit support.

# Why did I implement it this way?

Addresses the peer-review comments from @reednaa on #2092. Targets `dev-vault-wrapper` so the fixes land in the audited slice.

His review verdict was that the code is defensible with no issues found — the report was 1 INFO plus a couple of GAS notes. This PR lands the two changes that are unambiguous; the four gas threads are answered on #2092 rather than changed, with reasoning below.

### 1. `chore`: drop the dead solhint `max-states-count` disable

@reednaa suspected the pragma was left over from when `factory` was storage rather than the `FACTORY` immutable. Confirmed three ways:

- `solhint/lib/rules/best-practices/max-states-count.js` filters on `!isDeclaredConst && !isImmutable`, so immutables do not count.
- Parsing the contract with solhint's own parser gives exactly **15** counted state variables, against a rule that only trips above 15.
- `bunx solhint src/VaultWrapper/LiFiVaultWrapper.sol` reports no `max-states-count` problem with the pragma removed.

The justification comment above it was also wrong on its own terms — it named a 16th declaration that does not exist, and `shareDecimalsOffset` is the 6th, not the 16th.

### 2. `docs`: underlying price-per-share is a trust assumption

Records the INFO from `LibVaultWrapperMath.sol:163`. The wrapper takes the source's `totalAssets` at face value, so a source misreporting price per share for even one block distorts the performance fee in both directions: the spike charges a fee on a gain that never existed, and because the high-water mark ratchets up-only to the spiked price, genuine later gains then accrue no fee until they exceed it. Accrual runs on deposit/withdraw and on the permissionless `distributeFees`, so the moment is attacker-selectable.

Root cause is always in the underlying and the only control is curation, so this is a documented accepted bound rather than a code change. The trust model previously covered "sources are curated" and "must be standard ERC-4626" but never honest price reporting.

### 3. `docs`: the beacon is address-parity-critical

`_proxyInitCode()` embeds `beacon` in the init code that fixes every instance address, and `beacon` lives in factory proxy storage. It is write-once today (set in `initialize`, no setter), but the factory now sits behind a `TransparentUpgradeableProxy`, so a timelocked upgrade could add one — and changing it after the first deploy would silently relocate every predicted address and break parity against already-deployed chains.

Also records why the CREATE2 salt preimage is deliberately unversioned (the `LiFiVaultWrapperFactory.sol:375` thread): it is `abi.encode`d so there is no packing ambiguity, a repeated (namespace, adapter, underlying) triple makes `Create2.deploy` revert on the occupied address rather than colliding into one, and `_nonce` already serves as the disambiguator.

### 4. `perf`: copy each receiver entry into memory in the payout loop

`_payIntegrators` copied the whole `integratorFeeReceivers` array into memory up front; it now reads one entry at a time. `FeeReceiver` packs into a single 32-byte slot (`forge inspect`: `wallet@slot0+off0`, `bps@slot0+off20`), so an entry costs one SLOAD and both fields then come from memory.

Commits 2 and 4 in this branch are an earlier attempt at this and its revert — that attempt used a `storage` pointer, which pays a warm re-read of the same slot, and @reednaa correctly rejected it. Left in history rather than squashed so the review thread still lines up.

Measured on `distributeFees` (both fee pools, real contract, cold and warm — the deltas are identical in both):

| receivers | whole-array | storage pointer | per-entry (landed) | hoist last receiver |
|---|---|---|---|---|
| 1 | 108,115 | 107,912 | 107,992 | 107,756 |
| 5 | 220,568 | 220,228 | **220,220** | — |
| 50 | 1,485,700 | 1,483,783 | **1,482,807** | 1,479,070 |

Per-entry wins from five receivers up. The whole spread is under 0.1% on a call dominated by ERC-20 transfers, so this is a tidy-up, not a meaningful saving.

Two things left alone deliberately:

- **Hoisting the last receiver out of the loop** only pays off if the transfer/retain/emit block is duplicated inline. Extracted into a helper it is a net regression at the cap (1,486,153 vs 1,483,783).
- **`unchecked`** on that loop is sound — see below — but not worth swapping a compiler-enforced invariant for a prose one here.

On `unchecked`: the boundedness argument holds — `_setIntegratorFeeReceivers` is the sole writer and admits 1..50 entries whose bps sum to exactly 10000, so `i` is bounded, each non-last share is `≤ _integratorTotal`, `distributed` is a sum of floors that cannot exceed it, and `retained ≤ distributed`. Not applied: ~260–400 gas at realistic receiver counts, in exchange for replacing a compiler-enforced invariant with a prose one in the fee-distribution loop, with the audit as the next gate.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

No new tests: the Solidity changes are deleting an inert lint pragma and a storage-access refactor with identical semantics, whose fan-out, last-receiver remainder and retain-failed-payout paths are already covered in `VaultWrapperDistribution.t.sol`. The full VaultWrapper suite (377 tests) passes unchanged. The gas probes used for the measurements above were throwaway and are not committed.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
