### PR TITLE
feat(safe): render the signing ask from the proposal document

### DIFF
--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -128,9 +128,14 @@ live `getMinDelay()` with `config/timelockController.json` fallback, timestamp
 salt), resolves the nonce (`getNextNonce`), **signs immediately** (EIP-712),
 computes the `safeTxHash` via the Safe's on-chain `getTransactionHash`, and
 stores. The document (`ISafeTxDocument`) carries the raw Safe tx fields, the
-proposer's wallet address, an `intentHash` dedup key, and a
-`pending → submitted → executed / reverted` status — but **no description, PR
-link (except drain `parkedTaskRefs`), git commit, or human identity**.
+proposer's wallet address, an `intentHash` dedup key, a
+`pending → submitted → executed / reverted` status, the origin-PR
+`parkedTaskRefs` on a drained facet removal, and a `provenance` block
+(`IProposalProvenance`) holding the rationale, proposer identity and actor, git
+commit and branch, scoped working-tree dirtiness, the branch's PR link and any
+capture errors. **Rows stored before that block existed carry none of it**,
+which is why both the signing prompt and the Slack card state each absence
+explicitly instead of dropping the line.
 `notifyProposalsCreatedToSlack` (`script/multiNetworkExecution.sh`) posts the
 signing-ask card rendered by `script/deploy/safe/render-proposal-card.ts` —
 reason, proposer, PR, commit, working-tree state and a per-network

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -131,9 +131,11 @@ stores. The document (`ISafeTxDocument`) carries the raw Safe tx fields, the
 proposer's wallet address, an `intentHash` dedup key, and a
 `pending → submitted → executed / reverted` status — but **no description, PR
 link (except drain `parkedTaskRefs`), git commit, or human identity**.
-`notifyProposalsCreatedToSlack` (`script/multiNetworkExecution.sh`) posts
-count + contract + network to `#dev-sc-multisig-proposals`; the rich
-signing-ask thread is a manual step per `.agents/commands/multisig-rollout.md`.
+`notifyProposalsCreatedToSlack` (`script/multiNetworkExecution.sh`) posts the
+signing-ask card rendered by `script/deploy/safe/render-proposal-card.ts` —
+reason, proposer, PR, commit and a per-network `bun confirm-safe-tx` command — to
+`#dev-sc-multisig-proposals`, falling back to a count + contract + network line
+only if the render fails.
 
 ### 4.3 Confirm / sign
 

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -133,9 +133,9 @@ proposer's wallet address, an `intentHash` dedup key, and a
 link (except drain `parkedTaskRefs`), git commit, or human identity**.
 `notifyProposalsCreatedToSlack` (`script/multiNetworkExecution.sh`) posts the
 signing-ask card rendered by `script/deploy/safe/render-proposal-card.ts` —
-reason, proposer, PR, commit and a per-network `bun confirm-safe-tx` command — to
-`#dev-sc-multisig-proposals`, falling back to a count + contract + network line
-only if the render fails.
+reason, proposer, PR, commit, working-tree state and a per-network
+`bun confirm-safe-tx` command — to `#dev-sc-multisig-proposals`, falling back to
+a count + contract + network line only if the render fails.
 
 ### 4.3 Confirm / sign
 

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -5,7 +5,11 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { renderProposalCard, type ICardProposal } from './proposal-card'
+import {
+  SLACK_TEXT_LIMIT,
+  renderProposalCard,
+  type ICardProposal,
+} from './proposal-card'
 
 const proposal = (overrides: Partial<ICardProposal> = {}): ICardProposal => ({
   network: 'mainnet',
@@ -134,17 +138,88 @@ describe('renderProposalCard', () => {
   })
 
   it('truncates, and stays under the cap, when the card still overflows', () => {
-    const card = renderProposalCard([
-      proposal({ dirtyTreeScoped: [`src/${'a'.repeat(4000)}.sol`] }),
-    ])
+    // Every single field is capped now, so no one of them can overflow the card
+    // on its own. The hash table's ROW COUNT is not capped, and each `&` in a
+    // value becomes five characters once escaped — so this is what an overflow
+    // actually looks like, rather than one enormous string.
+    const card = renderProposalCard([proposal({ reason: '&'.repeat(200) })], {
+      expectedHashes: Array.from({ length: 200 }, (_, i) => ({
+        network: `chain${i}`,
+        expected: `0x${'ab'.repeat(32)}`,
+        actual: `0x${'cd'.repeat(32)}`,
+      })),
+    })
 
-    expect(card.length).toBeLessThanOrEqual(2900)
+    expect(card.length).toBeLessThanOrEqual(SLACK_TEXT_LIMIT)
     expect(card).toContain('card truncated')
     // An error-path string never runs in a happy-path test, which is how a
     // command that was never a `bun` alias shipped as the recovery instruction.
     expect(card).toContain(
       'bunx tsx script/deploy/safe/list-pending-proposals.ts'
     )
+  })
+
+  it('keeps the review commands on an overflowing card', () => {
+    // They are the only actionable part and they sit at the bottom, so a
+    // tail-truncated card lost exactly the thing it exists to deliver. Measured
+    // before the fix: every one of 5226 overflowing configurations dropped the
+    // whole review section.
+    const card = renderProposalCard(
+      ['mainnet', 'arbitrum'].map((network) => ({
+        network,
+        safeTxHash: `0x${'ab'.repeat(32)}`,
+      })),
+      {
+        expectedHashes: Array.from({ length: 200 }, (_, i) => ({
+          network: `chain${i}`,
+          expected: `0x${'ab'.repeat(32)}`,
+        })),
+      }
+    )
+
+    expect(card).toContain('card truncated')
+    expect(card).toContain('*To review:*')
+    expect(card).toContain('bun confirm-safe-tx --network mainnet')
+    expect(card).toContain('bun confirm-safe-tx --network arbitrum')
+    expect(card.length).toBeLessThanOrEqual(SLACK_TEXT_LIMIT)
+  })
+
+  it('keeps underscores and tildes, which real paths and emails contain', () => {
+    // Stripping these mangled real data for no security gain: they only
+    // italicise or strike text, so they cannot forge a label or break out of a
+    // code span. `alice_smith@…` and `alicesmith@…` rendered identically on a
+    // card whose job is saying who proposed, and 115 tracked paths in this repo
+    // carry an underscore.
+    const card = renderProposalCard([
+      proposal({
+        proposerHandle: 'A B <alice_smith@example.com>',
+        dirtyTreeScoped: ['.github/pull_request_template.md'],
+        reason: 'bump ~1.2.0',
+      }),
+    ])
+
+    expect(card).toContain('alice_smith@example.com')
+    expect(card).toContain('.github/pull_request_template.md')
+    expect(card).toContain('~1.2.0')
+  })
+
+  it('flags a divergent commit or PR, not only a divergent reason', () => {
+    // gitCommit is what a signer re-derives calldata against and prUrl is the
+    // rationale they read, so these diverging matters more than the prose doing
+    // so. The first version of this flagged only the prose.
+    const card = renderProposalCard([
+      proposal(),
+      proposal({
+        network: 'arbitrum',
+        gitCommit: 'ffffffffffff',
+        prUrl: 'https://github.com/lifinance/contracts/pull/999',
+        proposerHandle: 'Bob Other <bob@example.com>',
+      }),
+    ])
+
+    expect(card).toContain('gitCommit')
+    expect(card).toContain('PR')
+    expect(card).toContain('proposerHandle')
   })
 
   it('never cuts a surrogate pair or an entity in half', () => {
@@ -336,5 +411,49 @@ describe('renderProposalCard — it cannot understate the ask', () => {
     ])
 
     expect(card.toLowerCase()).toContain('differ')
+  })
+})
+
+describe('renderProposalCard — the PR link is a link, or it is not shown', () => {
+  it.each([
+    ['javascript:', 'javascript:alert(1)'],
+    ['data:', 'data:text/html,<script>x</script>'],
+    ['file:', 'file:///etc/passwd'],
+    ['plain http', 'http://evil.example/pull/1'],
+    ['a bare word', 'nope'],
+    ['a protocol-relative URL', '//evil.example/pull/1'],
+  ])('does not present a %s value as a link', (_label, prUrl) => {
+    // The capture path already accepts only https, so a value that is not one
+    // reached the document by hand. Presenting it as a PR lends it the card's
+    // credibility, and Slack auto-links a bare URL — the same gap as the ticket
+    // link's missing scheme check on #2298, on the field next to it.
+    const card = renderProposalCard([proposal({ prUrl })])
+
+    expect(card).toContain('not a link, ignored')
+    expect(card).not.toMatch(/\*PR:\* \S+$/m)
+  })
+
+  it('keeps a real https PR link', () => {
+    expect(
+      renderProposalCard([
+        proposal({ prUrl: 'https://github.com/lifinance/contracts/pull/2125' }),
+      ])
+    ).toContain('*PR:* https://github.com/lifinance/contracts/pull/2125')
+  })
+
+  it('says a link was rejected rather than staying silent about it', () => {
+    // Silently omitting looks identical to "no PR was recorded", which is a
+    // different fact and a less alarming one.
+    expect(
+      renderProposalCard([proposal({ prUrl: 'javascript:alert(1)' })])
+    ).toContain('not a link')
+  })
+
+  it('does not treat an https prefix inside a longer scheme as https', () => {
+    expect(
+      renderProposalCard([
+        proposal({ prUrl: 'nothttps://github.com/x/pull/1' }),
+      ])
+    ).toContain('not a link')
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -131,7 +131,7 @@ describe('renderProposalCard', () => {
       }),
     ])
 
-    expect(card.length).toBeLessThanOrEqual(2900)
+    expect(card.length).toBeLessThanOrEqual(SLACK_TEXT_LIMIT)
     expect(card).toContain('bun confirm-safe-tx --network mainnet')
     expect(card).toContain('0xabababab')
     expect(card).toContain('*Proposed by:*')
@@ -160,10 +160,8 @@ describe('renderProposalCard', () => {
   })
 
   it('keeps the review commands on an overflowing card', () => {
-    // They are the only actionable part and they sit at the bottom, so a
-    // tail-truncated card lost exactly the thing it exists to deliver. Measured
-    // before the fix: every one of 5226 overflowing configurations dropped the
-    // whole review section.
+    // They are the only actionable part and they sit at the bottom, so a tail
+    // cut would drop exactly the thing the card exists to deliver.
     const card = renderProposalCard(
       ['mainnet', 'arbitrum'].map((network) => ({
         network,
@@ -185,11 +183,11 @@ describe('renderProposalCard', () => {
   })
 
   it('keeps underscores and tildes, which real paths and emails contain', () => {
-    // Stripping these mangled real data for no security gain: they only
+    // Stripping these mangles real data for no security gain: they only
     // italicise or strike text, so they cannot forge a label or break out of a
-    // code span. `alice_smith@…` and `alicesmith@…` rendered identically on a
-    // card whose job is saying who proposed, and 115 tracked paths in this repo
-    // carry an underscore.
+    // code span, while `alice_smith@…` and `alicesmith@…` render identically on
+    // a card whose job is saying who proposed, and many tracked paths in this
+    // repo carry an underscore.
     const card = renderProposalCard([
       proposal({
         proposerHandle: 'A B <alice_smith@example.com>',
@@ -206,7 +204,7 @@ describe('renderProposalCard', () => {
   it('flags a divergent commit or PR, not only a divergent reason', () => {
     // gitCommit is what a signer re-derives calldata against and prUrl is the
     // rationale they read, so these diverging matters more than the prose doing
-    // so. The first version of this flagged only the prose.
+    // so.
     const card = renderProposalCard([
       proposal(),
       proposal({
@@ -217,23 +215,37 @@ describe('renderProposalCard', () => {
       }),
     ])
 
-    expect(card).toContain('gitCommit')
-    expect(card).toContain('PR')
-    expect(card).toContain('proposerHandle')
+    // The warning names the card's own labels, so asserted on the whole
+    // sentence — `PR` and `Commit` both occur elsewhere on the card.
+    const warning = card.split('\n').find((l) => l.startsWith('⚠ These differ'))
+
+    expect(warning).toContain('Commit')
+    expect(warning).toContain('PR')
+    expect(warning).toContain('Proposed by')
   })
 
   it('never cuts a surrogate pair or an entity in half', () => {
     for (const filler of ['\u{1F64F}', '&', 'a'])
       for (let pad = 1; pad <= 6; pad++) {
-        const card = renderProposalCard([
-          proposal({
-            network: 'n'.repeat(pad),
-            dirtyTreeScoped: [filler.repeat(4000)],
-          }),
-        ])
-        const body = card.slice(0, card.indexOf('\n… card truncated'))
+        // The overflow has to come from the row COUNT: every field is capped, so
+        // no single value can reach the card's cap on its own. `pad` walks the
+        // cut one character at a time so it lands mid-pair and mid-entity.
+        const card = renderProposalCard(
+          [proposal({ network: 'n'.repeat(pad) })],
+          {
+            expectedHashes: Array.from({ length: 40 }, () => ({
+              network: filler.repeat(200),
+              expected: filler.repeat(200),
+            })),
+          }
+        )
+        const cut = card.indexOf('\n… card truncated')
+        const body = card.slice(0, cut)
 
-        expect(card.length).toBeLessThanOrEqual(2900)
+        // Without this the assertions below run against a whole, uncut card and
+        // prove nothing about the cut.
+        expect(cut).toBeGreaterThan(0)
+        expect(card.length).toBeLessThanOrEqual(SLACK_TEXT_LIMIT)
         // A lone high surrogate renders as U+FFFD; a bare `&am` as literal junk.
         expect(/[\uD800-\uDBFF]$/.test(body)).toBe(false)
         expect(/&[a-z]{0,3}$/i.test(body)).toBe(false)
@@ -251,10 +263,10 @@ describe('renderProposalCard', () => {
   })
 
   it('strips control and bidi characters from every rendered field', () => {
-    // EXSC-693: collapsing `\s+` does not touch Cc/Cf, so ANSI escapes and the
-    // bidi overrides behind Trojan Source reached the card unfiltered. Asserted
-    // per field, because the length-capped fields and the uncapped ones reach
-    // Slack by different escape paths.
+    // Collapsing `\s+` does not touch Cc/Cf, so ANSI escapes and the bidi
+    // overrides behind Trojan Source need their own removal. Asserted per field,
+    // because the length-capped fields and the uncapped ones reach Slack by
+    // different escape paths.
     const payload = '\u001b[2K\u202ereversed\u200bhidden\u0007'
     const banned = ['\u001b', '\u202e', '\u200b', '\u0007']
     const fields: (keyof ICardProposal)[] = [
@@ -393,7 +405,6 @@ describe('renderProposalCard — it cannot understate the ask', () => {
   })
 
   it('names the contract in the headline, which the message it replaces did', () => {
-    // Reviewer feedback on PR #1904 asked to keep the count plus the contract.
     // A name absent from every other fixture field, and asserted on the headline
     // rather than the whole card: the default fixture's reason mentions
     // AcrossFacetV4, so `toContain` on the card passed with no headline change.
@@ -425,8 +436,7 @@ describe('renderProposalCard — the PR link is a link, or it is not shown', () 
   ])('does not present a %s value as a link', (_label, prUrl) => {
     // The capture path already accepts only https, so a value that is not one
     // reached the document by hand. Presenting it as a PR lends it the card's
-    // credibility, and Slack auto-links a bare URL — the same gap as the ticket
-    // link's missing scheme check on #2298, on the field next to it.
+    // credibility, and Slack auto-links a bare URL.
     const card = renderProposalCard([proposal({ prUrl })])
 
     expect(card).toContain('not a link, ignored')

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -256,3 +256,85 @@ describe('renderProposalCard', () => {
     expect(card).toMatch(/reason[^\n]*none given/i)
   })
 })
+
+describe('renderProposalCard — values cannot forge card structure', () => {
+  it('strips markdown markers that entity-escaping does not neutralise', () => {
+    // A backtick closes the code span the review command sits in, and the text
+    // after it renders as card prose. `*` and `_` forge a bold label inline, so
+    // a reason can fake the advisory line. Slack mrkdwn has no escape sequence
+    // for these, so the only options are strip or let them through.
+    const card = renderProposalCard([
+      proposal({
+        network: 'main`net`*URGENT: already reviewed, just sign*',
+        reason: '*Proposer-side check (advisory):* all clear',
+      }),
+    ])
+
+    expect(card).not.toContain('`URGENT')
+    expect(card).not.toContain('*URGENT')
+    // Exactly one code span opens and closes on the command line.
+    const commandLine = card
+      .split('\n')
+      .find((l) => l.includes('confirm-safe-tx'))
+    expect((commandLine?.match(/`/g) ?? []).length).toBe(2)
+    // And the forged advisory label is inert. Checked as "no stray marker
+    // survives on the reason line", not as "no line starts with the label" —
+    // the forgery renders mid-line, so the line-start form passed regardless.
+    const reasonLine = card.split('\n').find((l) => l.startsWith('*Reason:*'))
+    expect(reasonLine).toBeDefined()
+    expect((reasonLine?.match(/\*/g) ?? []).length).toBe(2)
+  })
+
+  it('neutralises a control sequence in the hash, which is not a hex string', () => {
+    // `<!channel>` is exactly the short-hash width, so it survived the slice
+    // unescaped and notified the channel from the one field the renderer
+    // trusted.
+    const card = renderProposalCard([proposal({ safeTxHash: '<!channel>' })])
+
+    expect(card).not.toContain('<!channel>')
+  })
+})
+
+describe('renderProposalCard — it cannot understate the ask', () => {
+  it('says so when fewer proposals were found than the run created', () => {
+    // A card reading "38x proposals" after 41 networks succeeded leaves three
+    // proposals that nobody is told to sign. Undercounting the signing ask is
+    // the one error here with a direct safety consequence.
+    const card = renderProposalCard(
+      [proposal(), proposal({ network: 'arbitrum' })],
+      {
+        expectedCount: 5,
+      }
+    )
+
+    expect(card).toContain('5')
+    expect(card.toLowerCase()).toMatch(/only 2|3 (missing|not found)/)
+  })
+
+  it('stays quiet when the counts agree', () => {
+    const card = renderProposalCard([proposal()], { expectedCount: 1 })
+
+    expect(card.toLowerCase()).not.toContain('missing')
+  })
+
+  it('names the contract in the headline, which the message it replaces did', () => {
+    // Reviewer feedback on PR #1904 asked to keep the count plus the contract.
+    // A name absent from every other fixture field, and asserted on the headline
+    // rather than the whole card: the default fixture's reason mentions
+    // AcrossFacetV4, so `toContain` on the card passed with no headline change.
+    const headline = renderProposalCard([proposal()], {
+      contract: 'WhitelistManagerFacet',
+    }).split('\n')[0]
+
+    expect(headline).toContain('WhitelistManagerFacet')
+  })
+
+  it('flags divergent reasons rather than printing the first as if it covered all', () => {
+    const card = renderProposalCard([
+      proposal({ reason: 'reason A' }),
+      proposal({ network: 'arbitrum', reason: 'reason B' }),
+    ])
+
+    expect(card.toLowerCase()).toContain('differ')
+  })
+})

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -19,6 +19,10 @@ const proposal = (overrides: Partial<ICardProposal> = {}): ICardProposal => ({
   reason: 'add AcrossFacetV4 to the whitelist',
   prUrl: 'https://github.com/lifinance/contracts/pull/2125',
   gitCommit: '1234567890abcdef',
+  // A measured empty array, which is what capture actually writes for a clean
+  // tree. Omitting it made the default fixture look like a pre-provenance row,
+  // for which the card now correctly says "not captured".
+  dirtyTreeScoped: [],
   ...overrides,
 })
 
@@ -585,7 +589,7 @@ describe('renderProposalCard — an unreadable dirty-tree field is not clean', (
       const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
       expect(line).toBeDefined()
       expect(line).toContain('arbitrum')
-      expect(line).toMatch(/could not be read/)
+      expect(line).toMatch(/not captured/)
     }
   )
 
@@ -658,5 +662,60 @@ describe('renderProposalCard — the unions cannot become the overflow', () => {
 
     expect(small).toBeGreaterThan(0)
     expect(large - small).toBeLessThan(10)
+  })
+})
+
+describe('renderProposalCard — the dirty-path list cannot understate itself', () => {
+  it('says so when capture truncated the path list', () => {
+    // Capture sets dirtyTreeTruncated and the signing prompt renders "20+
+    // dirty". The card had no such field, so exactly MAX_DIRTY_PATHS paths took
+    // the "<= limit" branch and a 500-file dirty tree rendered identically to a
+    // 20-file one — the same understating-a-warning class as reading the field
+    // from row zero.
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: Array.from({ length: 20 }, (_, i) => `src/F${i}.sol`),
+        dirtyTreeTruncated: true,
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toMatch(/more/)
+  })
+
+  it('stays exact when capture was not truncated', () => {
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: Array.from({ length: 20 }, (_, i) => `src/F${i}.sol`),
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).not.toMatch(/more/)
+  })
+})
+
+describe('renderProposalCard — an uncaptured working tree is not a clean one', () => {
+  it('reports an absent dirtyTreeScoped rather than rendering nothing', () => {
+    // `provenance-display.ts` already holds this rule for the signing prompt:
+    // only a measured empty array may read as clean, and a non-array — absent
+    // and null included — is 'unreadable'. Emitting no line for those left the
+    // card and the prompt disagreeing about one field.
+    const card = renderProposalCard([
+      proposal({ dirtyTreeScoped: undefined }),
+      proposal({ network: 'arbitrum', dirtyTreeScoped: undefined }),
+    ])
+
+    expect(card).toContain('*Working tree:*')
+    expect(card).toMatch(/not captured/)
+  })
+
+  it('is silent only for a measured empty array', () => {
+    const card = renderProposalCard([
+      proposal({ dirtyTreeScoped: [] }),
+      proposal({ network: 'arbitrum', dirtyTreeScoped: [] }),
+    ])
+
+    expect(card).not.toContain('*Working tree:*')
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -439,7 +439,7 @@ describe('renderProposalCard — the PR link is a link, or it is not shown', () 
     // credibility, and Slack auto-links a bare URL.
     const card = renderProposalCard([proposal({ prUrl })])
 
-    expect(card).toContain('not a link, ignored')
+    expect(card).toContain('not a link, withheld')
     expect(card).not.toMatch(/\*PR:\* \S+$/m)
   })
 
@@ -465,5 +465,84 @@ describe('renderProposalCard — the PR link is a link, or it is not shown', () 
         proposal({ prUrl: 'nothttps://github.com/x/pull/1' }),
       ])
     ).toContain('not a link')
+  })
+})
+
+describe('renderProposalCard — a warning about one network is not a claim about all', () => {
+  it('reports a dirty tree when ANY network had one, naming which', () => {
+    // Read from the first row, the card said nothing at all here — so a run
+    // where one network was proposed from a dirty tree looked clean. These
+    // warnings must be the union across the card, not a property of row zero.
+    const card = renderProposalCard([
+      proposal({ network: 'mainnet' }),
+      proposal({
+        network: 'arbitrum',
+        dirtyTreeScoped: ['src/Facets/Foo.sol'],
+      }),
+    ])
+
+    expect(card).toContain('*Working tree:*')
+    expect(card).toContain('src/Facets/Foo.sol')
+    expect(card).toContain('arbitrum')
+  })
+
+  it('does not claim a clean tree when the first row happens to be clean', () => {
+    const clean = renderProposalCard([
+      proposal(),
+      proposal({ network: 'base' }),
+    ])
+
+    expect(clean).not.toContain('*Working tree:*')
+  })
+
+  it('marks a bot when ANY network was proposed by one', () => {
+    // Who proposed changes how a signer reads the whole card, and reading it
+    // from row zero let a bot-proposed network hide behind a human one.
+    const card = renderProposalCard([
+      proposal({ actor: 'human' }),
+      proposal({ network: 'arbitrum', actor: 'bot' }),
+    ])
+
+    expect(card).toContain('bot')
+  })
+
+  it('flags a divergent advisory check rather than presenting the first as general', () => {
+    const card = renderProposalCard([
+      proposal({ checkSummary: 'codehash matched' }),
+      proposal({ network: 'arbitrum', checkSummary: 'codehash MISMATCH' }),
+    ])
+
+    // The card's own label, not the source field name — a signer reads labels.
+    // Asserted on the DIVERGENCE line, not merely on the label — the advisory
+    // line carries the same label, so `toContain` on it passed regardless.
+    const warning = card.split('\n').find((l) => l.startsWith('⚠ These differ'))
+    expect(warning).toContain('Proposer-side check')
+  })
+})
+
+describe('renderProposalCard — a rejected link is not echoed', () => {
+  it.each([
+    ['uppercase scheme', 'HTTPS://evil.example/pull/1'],
+    ['mixed-case scheme', 'HtTpS://evil.example/pull/1'],
+  ])('accepts %s, since the scheme is case-insensitive', (_label, prUrl) => {
+    // RFC 3986 makes the scheme case-insensitive, and Slack auto-links what it
+    // recognises. Asserted as "the link is rendered", not as "the word 'ignored'
+    // is absent" — that word was removed from the code, so the absence form
+    // passed no matter what the scheme check did.
+    const card = renderProposalCard([proposal({ prUrl })])
+
+    expect(card).toContain(`*PR:* ${prUrl}`)
+    expect(card).not.toContain('withheld')
+  })
+
+  it('does not reproduce a rejected value', () => {
+    // Echoing it puts the attacker's string on the card and lets Slack link it.
+    const card = renderProposalCard([
+      proposal({ prUrl: 'javascript:alert(1)' }),
+    ])
+
+    expect(card).not.toContain('javascript')
+    expect(card).not.toContain('alert')
+    expect(card).toContain('not a link')
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -502,7 +502,7 @@ describe('renderProposalCard — a warning about one network is not a claim abou
       .find((l) => l.startsWith('*Working tree:*'))
 
     expect(workingTree).toContain('src/Facets/Foo.sol')
-    expect(workingTree).toContain('(on arbitrum)')
+    expect(workingTree).toContain('on arbitrum')
   })
 
   it('does not claim a clean tree when the first row happens to be clean', () => {
@@ -696,7 +696,7 @@ describe('renderProposalCard — an uncaptured working tree is not a clean one',
     ])
 
     const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
-    expect(line).toBe('*Working tree:* not captured — paths not captured')
+    expect(line).toBe('*Working tree:* not captured')
   })
 
   it('is silent only for a measured empty array', () => {
@@ -706,5 +706,88 @@ describe('renderProposalCard — an uncaptured working tree is not a clean one',
     ])
 
     expect(card).not.toContain('*Working tree:*')
+  })
+})
+
+describe('renderProposalCard — a failed capture is the loudest case, not the quietest', () => {
+  it('reports capture errors on a row whose path list is an empty array', () => {
+    // A failed `git status` probe writes dirtyTreeScoped: [] AND captureErrors.
+    // The card mapped neither, so the row fell in neither bucket and NO
+    // working-tree line rendered. The two likeliest probe failures — the 5s
+    // timeout and the 8MB buffer cap — both correlate with a very dirty tree,
+    // so the card read clean exactly when the tree was dirtiest.
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: [],
+        captureErrors: ['git status timed out'],
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toBeDefined()
+    expect(line).not.toMatch(/\bclean\b/i)
+    expect(line).toMatch(/capture incomplete/i)
+  })
+
+  it('stays silent for a measured empty array with no capture errors', () => {
+    const card = renderProposalCard([
+      proposal({ dirtyTreeScoped: [], captureErrors: [] }),
+    ])
+
+    expect(card).not.toContain('*Working tree:*')
+  })
+
+  it('does not let a capture failure hide behind a clean sibling', () => {
+    const card = renderProposalCard([
+      proposal({ network: 'mainnet' }),
+      proposal({
+        network: 'arbitrum',
+        dirtyTreeScoped: [],
+        captureErrors: ['git status timed out'],
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toMatch(/capture incomplete/i)
+    expect(line).toContain('arbitrum')
+  })
+})
+
+describe('renderProposalCard — the qualifier names the networks it is about', () => {
+  it('names the dirty network when another row is only uncaptured', () => {
+    // `reported` mixed both buckets, so a card of one dirty and one uncaptured
+    // row suppressed the qualifier — and a single path then read as the complete
+    // inventory across both networks.
+    const card = renderProposalCard([
+      proposal({ network: 'mainnet', dirtyTreeScoped: ['src/A.sol'] }),
+      proposal({ network: 'arbitrum', dirtyTreeScoped: undefined }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toContain('mainnet')
+    expect(line).toContain('arbitrum')
+    // And the two states must be distinguishable, not merged into one word.
+    expect(line).toMatch(/dirty/)
+    expect(line).toMatch(/not captured/)
+  })
+})
+
+describe('renderProposalCard — a truncated list is never vaguer than an exact one', () => {
+  it('keeps the count when capture also truncated', () => {
+    // 40 paths with no flag rendered "…and 20 more"; the same 40 WITH the flag
+    // rendered only "and more that capture stopped counting" — the worse case
+    // got the vaguer warning.
+    const paths = Array.from({ length: 40 }, (_, i) => `src/F${i}.sol`)
+    const exact = renderProposalCard([proposal({ dirtyTreeScoped: paths })])
+    const truncated = renderProposalCard([
+      proposal({ dirtyTreeScoped: paths, dirtyTreeTruncated: true }),
+    ])
+
+    const lineOf = (card: string) =>
+      card.split('\n').find((l) => l.startsWith('*Working tree:*')) ?? ''
+
+    expect(lineOf(exact)).toMatch(/20 more/)
+    expect(lineOf(truncated)).toMatch(/20 more/)
+    expect(lineOf(truncated)).toMatch(/stopped counting/)
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -1,0 +1,134 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { renderProposalCard, type ICardProposal } from './proposal-card'
+
+const proposal = (overrides: Partial<ICardProposal> = {}): ICardProposal => ({
+  network: 'mainnet',
+  safeTxHash: `0x${'ab'.repeat(32)}`,
+  proposerHandle: 'Alice Example <alice@example.com>',
+  actor: 'human',
+  reason: 'add AcrossFacetV4 to the whitelist',
+  prUrl: 'https://github.com/lifinance/contracts/pull/2125',
+  gitCommit: '1234567890abcdef',
+  ...overrides,
+})
+
+describe('renderProposalCard', () => {
+  it('answers who, what, why and how to review, with no manual writing', () => {
+    const card = renderProposalCard([proposal()])
+
+    expect(card).toContain('add AcrossFacetV4 to the whitelist')
+    // Escaped, because a git identity is angle-bracketed and Slack would read
+    // the brackets as markup.
+    expect(card).toContain('Alice Example &lt;alice@example.com&gt;')
+    expect(card).toContain('https://github.com/lifinance/contracts/pull/2125')
+    expect(card).toContain('mainnet')
+    // The exact command, not a description of it — the point is zero typing.
+    expect(card).toContain('bun confirm-safe-tx --network mainnet')
+    // A short hash is enough to match a card to a proposal by eye.
+    expect(card).toContain('0xabababab')
+    expect(card).not.toContain('ab'.repeat(32))
+  })
+
+  it('says so when no reason was given, rather than omitting the line', () => {
+    // An absent reason is information: it tells a signer the intent was never
+    // stated, which is different from a card that simply did not render it.
+    const card = renderProposalCard([proposal({ reason: undefined })])
+
+    expect(card).toMatch(/reason[^\n]*none given/i)
+  })
+
+  it('names the network when there is exactly one', () => {
+    expect(renderProposalCard([proposal()])).toContain('1x proposal')
+  })
+
+  it('counts networks rather than listing them past a handful', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      proposal({ network: `chain${i}` })
+    )
+    const card = renderProposalCard(many)
+
+    expect(card).toContain('12x proposals')
+    // Twelve confirm commands is not a card, it is a wall.
+    expect(card.split('bun confirm-safe-tx').length - 1).toBeLessThan(12)
+  })
+
+  it('labels a proposer-side check as advisory', () => {
+    // Authoritative status lives in the signer-side attestation. A card that
+    // states a check result without that word invites signing on its word.
+    const card = renderProposalCard([
+      proposal({ checkSummary: 'codehash matched on 3/3 networks' }),
+    ])
+
+    expect(card).toContain('codehash matched on 3/3 networks')
+    expect(card.toLowerCase()).toContain('advisory')
+  })
+
+  it('renders the expected-hash table when one is supplied', () => {
+    const card = renderProposalCard([proposal()], {
+      expectedHashes: [
+        { network: 'mainnet', expected: '0xdead', actual: '0xdead' },
+      ],
+    })
+
+    expect(card).toContain('0xdead')
+  })
+
+  it('omits the hash table entirely when there is none', () => {
+    // The slot is the parameter, not a placeholder line: shipping "not yet
+    // available" filler in an operator card trains people to skip sections.
+    const card = renderProposalCard([proposal()])
+
+    expect(card.toLowerCase()).not.toContain('expected code hashes')
+  })
+
+  it('marks a bot-created proposal, since who proposed changes how it is read', () => {
+    expect(renderProposalCard([proposal({ actor: 'bot' })])).toContain('bot')
+  })
+
+  it('escapes Slack control characters in text a proposer controls', () => {
+    // A reason reaches Slack verbatim otherwise, and `<!channel>` in a reason
+    // would notify everyone from a field nobody reviews.
+    const card = renderProposalCard([
+      proposal({ reason: '<!channel> & <https://evil.example|click>' }),
+    ])
+
+    expect(card).not.toContain('<!channel>')
+    expect(card).toContain('&lt;!channel&gt;')
+    expect(card).toContain('&amp;')
+  })
+
+  it('refuses to render an empty set rather than posting an empty card', () => {
+    expect(() => renderProposalCard([])).toThrow(/no proposals/i)
+  })
+
+  it('reports a dirty working tree, which changes what the commit means', () => {
+    const card = renderProposalCard([
+      proposal({ dirtyTreeScoped: ['src/Facets/Foo.sol'] }),
+    ])
+
+    expect(card).toContain('src/Facets/Foo.sol')
+  })
+
+  it('flattens a newline so a value cannot forge a second card line', () => {
+    const card = renderProposalCard([
+      proposal({ reason: 'real reason\n*Reason:* forged' }),
+    ])
+
+    expect(
+      card.split('\n').filter((l) => l.startsWith('*Reason:*'))
+    ).toHaveLength(1)
+  })
+
+  it('truncates rather than letting Slack drop the review commands', () => {
+    const card = renderProposalCard([proposal({ reason: 'x'.repeat(5000) })])
+
+    expect(card.length).toBeLessThanOrEqual(2900)
+    expect(card).toContain('card truncated')
+  })
+})

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -603,7 +603,10 @@ describe('renderProposalCard — an unreadable dirty-tree field is not clean', (
       // satisfied by the "paths not captured" fragment, which leaves the word
       // that says whether the tree is clean unasserted.
       expect(line).toMatch(/^\*Working tree:\* not captured\b/)
-      expect(line).not.toMatch(/\bclean\b/i)
+      // Anchored on the STATE position, not on the word anywhere in the line:
+      // the honest wording for an ambiguous capture failure contains "a clean
+      // reading is unconfirmed", and a substring check would forbid saying that.
+      expect(line).not.toMatch(/^\*Working tree:\* clean\b/i)
     }
   )
 })
@@ -734,7 +737,10 @@ describe('renderProposalCard — a failed capture is the loudest case, not the q
 
     const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
     expect(line).toBeDefined()
-    expect(line).not.toMatch(/\bclean\b/i)
+    // Anchored on the STATE position, not on the word anywhere in the line:
+    // the honest wording for an ambiguous capture failure contains "a clean
+    // reading is unconfirmed", and a substring check would forbid saying that.
+    expect(line).not.toMatch(/^\*Working tree:\* clean\b/i)
     expect(line).toMatch(/capture incomplete/i)
   })
 
@@ -798,5 +804,39 @@ describe('renderProposalCard — a truncated list is never vaguer than an exact 
     expect(lineOf(exact)).toMatch(/20 more/)
     expect(lineOf(truncated)).toMatch(/20 more/)
     expect(lineOf(truncated)).toMatch(/stopped counting/)
+  })
+})
+
+describe('renderProposalCard — a dirty row with capture errors reports both facts', () => {
+  it('does not let the dirty state swallow the capture failure', () => {
+    // The signing prompt shows both. Reporting only "dirty" loses the fact that
+    // the path list may be incomplete, which is the more alarming half.
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: ['src/A.sol'],
+        captureErrors: ['git status --porcelain failed: timed out'],
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toContain('src/A.sol')
+    expect(line).toMatch(/capture/i)
+  })
+
+  it('says a clean reading is unconfirmed rather than implying the tree is dirty', () => {
+    // captureErrors is one collector shared by every git probe, so an empty path
+    // list plus an error is ambiguous: the status probe may have failed, or
+    // something unrelated did. Warning is the fail-safe direction, but the
+    // wording must not assert more than is known.
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: [],
+        captureErrors: ['git log failed: boom'],
+      }),
+    ])
+
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toMatch(/unconfirmed/i)
+    expect(line).not.toMatch(/\bdirty\b/)
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -19,9 +19,11 @@ const proposal = (overrides: Partial<ICardProposal> = {}): ICardProposal => ({
   reason: 'add AcrossFacetV4 to the whitelist',
   prUrl: 'https://github.com/lifinance/contracts/pull/2125',
   gitCommit: '1234567890abcdef',
-  // A measured empty array, which is what capture actually writes for a clean
-  // tree. Omitting it made the default fixture look like a pre-provenance row,
-  // for which the card now correctly says "not captured".
+  // A measured empty array, which is what capture writes for a clean tree and
+  // the only shape the card reads as clean. Load-bearing for the tests below
+  // that name networks or measure the line's bound: an uncaptured default row
+  // renders a working-tree line of its own and collapses the `(on …)`
+  // qualifier those assertions look for.
   dirtyTreeScoped: [],
   ...overrides,
 })
@@ -574,13 +576,12 @@ describe('renderProposalCard — an unreadable dirty-tree field is not clean', (
     ['a string', 'src/Facets/Foo.sol'],
     ['an object', { a: 1 }],
     ['a number', 7],
+    ['null', null],
   ])(
     'warns when dirtyTreeScoped is %s, rather than reading as clean',
     (_label, dirtyTreeScoped) => {
-      // A row carrying SOMETHING in this field is a row that said the tree was
-      // dirty. Requiring an array meant a legacy or hand-edited row of the wrong
-      // shape rendered no warning at all — the same "reads as clean" failure as
-      // taking the field from row zero, arriving by a different route.
+      // A legacy or hand-edited row can hold any shape here, and only a
+      // measured empty array may read as clean, so every other shape warns.
       const card = renderProposalCard([
         proposal(),
         proposal({ network: 'arbitrum', dirtyTreeScoped }),
@@ -589,23 +590,13 @@ describe('renderProposalCard — an unreadable dirty-tree field is not clean', (
       const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
       expect(line).toBeDefined()
       expect(line).toContain('arbitrum')
-      expect(line).toMatch(/not captured/)
+      // On the state word, not only the detail: `/not captured/` alone is
+      // satisfied by the "paths not captured" fragment, which leaves the word
+      // that says whether the tree is clean unasserted.
+      expect(line).toMatch(/^\*Working tree:\* not captured\b/)
+      expect(line).not.toMatch(/\bclean\b/i)
     }
   )
-
-  it('stays clean when the field is absent or an empty array', () => {
-    const absent = renderProposalCard([
-      proposal(),
-      proposal({ network: 'base' }),
-    ])
-    const empty = renderProposalCard([
-      proposal({ dirtyTreeScoped: [] }),
-      proposal({ network: 'base', dirtyTreeScoped: [] }),
-    ])
-
-    expect(absent).not.toContain('*Working tree:*')
-    expect(empty).not.toContain('*Working tree:*')
-  })
 })
 
 describe('renderProposalCard — the unions cannot become the overflow', () => {
@@ -616,6 +607,9 @@ describe('renderProposalCard — the unions cannot become the overflow', () => {
     build: (i: number) => ICardProposal
   ): number => {
     const line = renderProposalCard([
+      // Must stay clean. An uncaptured guard row puts every row into
+      // `reported`, which collapses the `(on …)` qualifier and leaves the delta
+      // assertion below measuring a list that is not rendered at all.
       proposal({ network: 'clean-one' }),
       ...Array.from({ length: rows }, (_, i) => build(i)),
     ])
@@ -667,11 +661,8 @@ describe('renderProposalCard — the unions cannot become the overflow', () => {
 
 describe('renderProposalCard — the dirty-path list cannot understate itself', () => {
   it('says so when capture truncated the path list', () => {
-    // Capture sets dirtyTreeTruncated and the signing prompt renders "20+
-    // dirty". The card had no such field, so exactly MAX_DIRTY_PATHS paths took
-    // the "<= limit" branch and a 500-file dirty tree rendered identically to a
-    // 20-file one — the same understating-a-warning class as reading the field
-    // from row zero.
+    // Exactly MAX_DIRTY_PATHS paths is the length `summarise` calls exact, so
+    // it is the one length at which a floor renders as an inventory.
     const card = renderProposalCard([
       proposal({
         dirtyTreeScoped: Array.from({ length: 20 }, (_, i) => `src/F${i}.sol`),
@@ -680,7 +671,7 @@ describe('renderProposalCard — the dirty-path list cannot understate itself', 
     ])
 
     const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
-    expect(line).toMatch(/more/)
+    expect(line).toMatch(/stopped counting/)
   })
 
   it('stays exact when capture was not truncated', () => {
@@ -697,17 +688,15 @@ describe('renderProposalCard — the dirty-path list cannot understate itself', 
 
 describe('renderProposalCard — an uncaptured working tree is not a clean one', () => {
   it('reports an absent dirtyTreeScoped rather than rendering nothing', () => {
-    // `provenance-display.ts` already holds this rule for the signing prompt:
-    // only a measured empty array may read as clean, and a non-array — absent
-    // and null included — is 'unreadable'. Emitting no line for those left the
-    // card and the prompt disagreeing about one field.
+    // Only a measured empty array may read as clean, which is the rule
+    // `provenance-display.ts` holds for the signing prompt.
     const card = renderProposalCard([
       proposal({ dirtyTreeScoped: undefined }),
       proposal({ network: 'arbitrum', dirtyTreeScoped: undefined }),
     ])
 
-    expect(card).toContain('*Working tree:*')
-    expect(card).toMatch(/not captured/)
+    const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+    expect(line).toBe('*Working tree:* not captured — paths not captured')
   })
 
   it('is silent only for a measured empty array', () => {

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -28,16 +28,12 @@ describe('renderProposalCard', () => {
     expect(card).toContain('Alice Example &lt;alice@example.com&gt;')
     expect(card).toContain('https://github.com/lifinance/contracts/pull/2125')
     expect(card).toContain('mainnet')
-    // The exact command, not a description of it — the point is zero typing.
     expect(card).toContain('bun confirm-safe-tx --network mainnet')
-    // A short hash is enough to match a card to a proposal by eye.
     expect(card).toContain('0xabababab')
     expect(card).not.toContain('ab'.repeat(32))
   })
 
   it('says so when no reason was given, rather than omitting the line', () => {
-    // An absent reason is information: it tells a signer the intent was never
-    // stated, which is different from a card that simply did not render it.
     const card = renderProposalCard([proposal({ reason: undefined })])
 
     expect(card).toMatch(/reason[^\n]*none given/i)
@@ -54,13 +50,10 @@ describe('renderProposalCard', () => {
     const card = renderProposalCard(many)
 
     expect(card).toContain('12x proposals')
-    // Twelve confirm commands is not a card, it is a wall.
     expect(card.split('bun confirm-safe-tx').length - 1).toBeLessThan(12)
   })
 
   it('labels a proposer-side check as advisory', () => {
-    // Authoritative status lives in the signer-side attestation. A card that
-    // states a check result without that word invites signing on its word.
     const card = renderProposalCard([
       proposal({ checkSummary: 'codehash matched on 3/3 networks' }),
     ])
@@ -80,8 +73,6 @@ describe('renderProposalCard', () => {
   })
 
   it('omits the hash table entirely when there is none', () => {
-    // The slot is the parameter, not a placeholder line: shipping "not yet
-    // available" filler in an operator card trains people to skip sections.
     const card = renderProposalCard([proposal()])
 
     expect(card.toLowerCase()).not.toContain('expected code hashes')
@@ -92,8 +83,6 @@ describe('renderProposalCard', () => {
   })
 
   it('escapes Slack control characters in text a proposer controls', () => {
-    // A reason reaches Slack verbatim otherwise, and `<!channel>` in a reason
-    // would notify everyone from a field nobody reviews.
     const card = renderProposalCard([
       proposal({ reason: '<!channel> & <https://evil.example|click>' }),
     ])
@@ -125,10 +114,145 @@ describe('renderProposalCard', () => {
     ).toHaveLength(1)
   })
 
-  it('truncates rather than letting Slack drop the review commands', () => {
-    const card = renderProposalCard([proposal({ reason: 'x'.repeat(5000) })])
+  it('keeps the review command when one field is oversized', () => {
+    // The review command is the only line that makes the card actionable, so no
+    // single proposer-controlled field may push it past the card's cap.
+    const card = renderProposalCard([
+      proposal({
+        reason: 'x'.repeat(5000),
+        dirtyTreeScoped: Array.from(
+          { length: 3000 },
+          (_, i) => `src/F${i}.sol`
+        ),
+      }),
+    ])
+
+    expect(card.length).toBeLessThanOrEqual(2900)
+    expect(card).toContain('bun confirm-safe-tx --network mainnet')
+    expect(card).toContain('0xabababab')
+    expect(card).toContain('*Proposed by:*')
+  })
+
+  it('truncates, and stays under the cap, when the card still overflows', () => {
+    const card = renderProposalCard([
+      proposal({ dirtyTreeScoped: [`src/${'a'.repeat(4000)}.sol`] }),
+    ])
 
     expect(card.length).toBeLessThanOrEqual(2900)
     expect(card).toContain('card truncated')
+    // An error-path string never runs in a happy-path test, which is how a
+    // command that was never a `bun` alias shipped as the recovery instruction.
+    expect(card).toContain(
+      'bunx tsx script/deploy/safe/list-pending-proposals.ts'
+    )
+  })
+
+  it('never cuts a surrogate pair or an entity in half', () => {
+    for (const filler of ['\u{1F64F}', '&', 'a'])
+      for (let pad = 1; pad <= 6; pad++) {
+        const card = renderProposalCard([
+          proposal({
+            network: 'n'.repeat(pad),
+            dirtyTreeScoped: [filler.repeat(4000)],
+          }),
+        ])
+        const body = card.slice(0, card.indexOf('\n… card truncated'))
+
+        expect(card.length).toBeLessThanOrEqual(2900)
+        // A lone high surrogate renders as U+FFFD; a bare `&am` as literal junk.
+        expect(/[\uD800-\uDBFF]$/.test(body)).toBe(false)
+        expect(/&[a-z]{0,3}$/i.test(body)).toBe(false)
+      }
+  })
+
+  it('escapes the short hash, not only the fields around it', () => {
+    // `<!channel>` is exactly SHORT_HASH_CHARS long, so an unescaped slice of a
+    // hand-edited safeTxHash notified the whole channel from the one field the
+    // renderer trusted.
+    const card = renderProposalCard([proposal({ safeTxHash: '<!channel>' })])
+
+    expect(card).not.toContain('<!channel>')
+    expect(card).toContain('&lt;!channel&gt;')
+  })
+
+  it('strips control and bidi characters from every rendered field', () => {
+    // EXSC-693: collapsing `\s+` does not touch Cc/Cf, so ANSI escapes and the
+    // bidi overrides behind Trojan Source reached the card unfiltered. Asserted
+    // per field, because the length-capped fields and the uncapped ones reach
+    // Slack by different escape paths.
+    const payload = '\u001b[2K\u202ereversed\u200bhidden\u0007'
+    const banned = ['\u001b', '\u202e', '\u200b', '\u0007']
+    const fields: (keyof ICardProposal)[] = [
+      'reason',
+      'proposerHandle',
+      'actor',
+      'prUrl',
+      'gitCommit',
+      'checkSummary',
+      'network',
+      'safeTxHash',
+    ]
+
+    for (const field of fields) {
+      const card = renderProposalCard([
+        proposal({ [field]: `clean${payload}` }),
+      ])
+      for (const bad of banned) expect(card).not.toContain(bad)
+    }
+
+    const inList = renderProposalCard([
+      proposal({ dirtyTreeScoped: [`src/F.sol${payload}`] }),
+    ])
+    for (const bad of banned) expect(inList).not.toContain(bad)
+
+    const inHashTable = renderProposalCard([proposal()], {
+      expectedHashes: [
+        { network: `mainnet${payload}`, expected: `0xdead${payload}` },
+      ],
+    })
+    for (const bad of banned) expect(inHashTable).not.toContain(bad)
+
+    expect(
+      renderProposalCard([proposal({ reason: `clean${payload}` })])
+    ).toContain('clean[2Kreversedhidden')
+  })
+
+  it('renders a legacy row whose fields are not strings', () => {
+    // A row stored before provenance capture, or hand-edited, can hold a number
+    // or null anywhere. Throwing here silently downgrades the whole card to the
+    // old count-only line, making the worse message permanent for that row.
+    const legacy = {
+      network: 'mainnet',
+      safeTxHash: 12345,
+      proposerHandle: null,
+      actor: 7,
+      reason: {},
+      prUrl: [],
+      gitCommit: 999,
+      dirtyTreeScoped: 'not-an-array',
+    } as unknown as ICardProposal
+
+    const card = renderProposalCard([legacy])
+
+    expect(card).toContain('1x proposal created on mainnet')
+    expect(card).toContain('bun confirm-safe-tx --network mainnet')
+  })
+
+  it('caps the dirty list and says how many it dropped', () => {
+    const card = renderProposalCard([
+      proposal({
+        dirtyTreeScoped: Array.from({ length: 25 }, (_, i) => `src/F${i}.sol`),
+      }),
+    ])
+
+    expect(card).toContain('src/F0.sol')
+    expect(card).toContain('and 5 more')
+    expect(card).not.toContain('src/F24.sol')
+  })
+
+  it('reads a whitespace-only reason as absent rather than blank', () => {
+    const card = renderProposalCard([proposal({ reason: '    ' })])
+
+    expect(card).toMatch(/reason[^\n]*none given/i)
   })
 })

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -564,3 +564,99 @@ describe('renderProposalCard — a rejected link is not echoed', () => {
     expect(card).toContain('not a link')
   })
 })
+
+describe('renderProposalCard — an unreadable dirty-tree field is not clean', () => {
+  it.each([
+    ['a string', 'src/Facets/Foo.sol'],
+    ['an object', { a: 1 }],
+    ['a number', 7],
+  ])(
+    'warns when dirtyTreeScoped is %s, rather than reading as clean',
+    (_label, dirtyTreeScoped) => {
+      // A row carrying SOMETHING in this field is a row that said the tree was
+      // dirty. Requiring an array meant a legacy or hand-edited row of the wrong
+      // shape rendered no warning at all — the same "reads as clean" failure as
+      // taking the field from row zero, arriving by a different route.
+      const card = renderProposalCard([
+        proposal(),
+        proposal({ network: 'arbitrum', dirtyTreeScoped }),
+      ])
+
+      const line = card.split('\n').find((l) => l.startsWith('*Working tree:*'))
+      expect(line).toBeDefined()
+      expect(line).toContain('arbitrum')
+      expect(line).toMatch(/could not be read/)
+    }
+  )
+
+  it('stays clean when the field is absent or an empty array', () => {
+    const absent = renderProposalCard([
+      proposal(),
+      proposal({ network: 'base' }),
+    ])
+    const empty = renderProposalCard([
+      proposal({ dirtyTreeScoped: [] }),
+      proposal({ network: 'base', dirtyTreeScoped: [] }),
+    ])
+
+    expect(absent).not.toContain('*Working tree:*')
+    expect(empty).not.toContain('*Working tree:*')
+  })
+})
+
+describe('renderProposalCard — the unions cannot become the overflow', () => {
+  /** Same shape at two very different row counts; the line must not grow. */
+  const lineAt = (
+    rows: number,
+    label: string,
+    build: (i: number) => ICardProposal
+  ): number => {
+    const line = renderProposalCard([
+      proposal({ network: 'clean-one' }),
+      ...Array.from({ length: rows }, (_, i) => build(i)),
+    ])
+      .split('\n')
+      .find((l) => l.startsWith(label))
+
+    // Throws rather than defaulting to 0. A `?? 0` here let an ABSENT line
+    // satisfy the delta assertion below — unbounded growth truncated the line
+    // off the card entirely, and the test passed on its absence.
+    if (line === undefined)
+      throw new Error(`no line starting "${label}" at ${rows} rows`)
+    return line.length
+  }
+
+  // Asserted as "does not scale with the row count" rather than against a
+  // character threshold. A threshold is a guess that has to be retuned whenever
+  // a cap moves; not scaling is the property that makes a union safe to add.
+  it('bounds the network list on the working-tree line', () => {
+    const build = (i: number): ICardProposal =>
+      proposal({
+        network: `chain${'n'.repeat(300)}${i}`,
+        dirtyTreeScoped: ['src/Facets/Foo.sol'],
+      })
+
+    const small = lineAt(5, '*Working tree:*', build)
+    const large = lineAt(400, '*Working tree:*', build)
+
+    expect(small).toBeGreaterThan(0)
+    // 80× the rows may add only the digits of the "…and N more" count. Growth
+    // proportional to the row count is the defect: unbounded, this line measured
+    // 7,556 characters.
+    expect(large - small).toBeLessThan(10)
+  })
+
+  it('bounds the actor list', () => {
+    const build = (i: number): ICardProposal =>
+      // Index FIRST: with it last, every actor truncates to the same 200
+      // characters at the field cap, dedupes to one, and the fixture measures a
+      // bound that was already there.
+      proposal({ network: `chain${i}`, actor: `bot-${i}-${'a'.repeat(200)}` })
+
+    const small = lineAt(5, '*Proposed by:*', build)
+    const large = lineAt(400, '*Proposed by:*', build)
+
+    expect(small).toBeGreaterThan(0)
+    expect(large - small).toBeLessThan(10)
+  })
+})

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Tests for the Slack signing-ask card (EXSC-696).
+ *
+ * The properties that matter are the ones a signer relies on: no document value
+ * can forge the card's structure or borrow its authority, the card can never
+ * read cleaner than the working tree it describes or understate how many
+ * proposals are waiting, and the review commands survive every truncation path.
+ */
+
 import {
   describe,
   expect,

--- a/script/deploy/safe/proposal-card.test.ts
+++ b/script/deploy/safe/proposal-card.test.ts
@@ -394,7 +394,9 @@ describe('renderProposalCard — it cannot understate the ask', () => {
       }
     )
 
-    expect(card).toContain('5')
+    // Not `toContain('5')`: the fixture commit is `1234567890ab`, so that
+    // matched with no shortfall line rendered at all.
+    expect(card).toContain('created 5 proposals')
     expect(card.toLowerCase()).toMatch(/only 2|3 (missing|not found)/)
   })
 
@@ -439,8 +441,14 @@ describe('renderProposalCard — the PR link is a link, or it is not shown', () 
     // credibility, and Slack auto-links a bare URL.
     const card = renderProposalCard([proposal({ prUrl })])
 
-    expect(card).toContain('not a link, withheld')
-    expect(card).not.toMatch(/\*PR:\* \S+$/m)
+    // Exact equality on the whole line, so non-echo is asserted for every value
+    // in the table rather than for `javascript:` alone. The earlier
+    // `not.toMatch(/\*PR:\* \S+$/m)` form was satisfied by a renderer that
+    // echoed the value ahead of its own trailing prose, so it observed nothing —
+    // and a substring check cannot see an echo that escaping has altered.
+    expect(card.split('\n').find((l) => l.startsWith('*PR:*'))).toBe(
+      '*PR:* — recorded value is not a link, withheld'
+    )
   })
 
   it('keeps a real https PR link', () => {
@@ -470,9 +478,8 @@ describe('renderProposalCard — the PR link is a link, or it is not shown', () 
 
 describe('renderProposalCard — a warning about one network is not a claim about all', () => {
   it('reports a dirty tree when ANY network had one, naming which', () => {
-    // Read from the first row, the card said nothing at all here — so a run
-    // where one network was proposed from a dirty tree looked clean. These
-    // warnings must be the union across the card, not a property of row zero.
+    // The union across the card, not a property of row zero: one network's
+    // dirty tree must not read as clean because another network's is.
     const card = renderProposalCard([
       proposal({ network: 'mainnet' }),
       proposal({
@@ -481,9 +488,15 @@ describe('renderProposalCard — a warning about one network is not a claim abou
       }),
     ])
 
-    expect(card).toContain('*Working tree:*')
-    expect(card).toContain('src/Facets/Foo.sol')
-    expect(card).toContain('arbitrum')
+    // Asserted on the working-tree line, which is `undefined` when the line is
+    // absent. A whole-card `toContain('arbitrum')` matched the per-network
+    // review command, so it passed with no qualifier rendered at all.
+    const workingTree = card
+      .split('\n')
+      .find((l) => l.startsWith('*Working tree:*'))
+
+    expect(workingTree).toContain('src/Facets/Foo.sol')
+    expect(workingTree).toContain('(on arbitrum)')
   })
 
   it('does not claim a clean tree when the first row happens to be clean', () => {
@@ -496,8 +509,8 @@ describe('renderProposalCard — a warning about one network is not a claim abou
   })
 
   it('marks a bot when ANY network was proposed by one', () => {
-    // Who proposed changes how a signer reads the whole card, and reading it
-    // from row zero let a bot-proposed network hide behind a human one.
+    // A bot-proposed network must not hide behind a human-proposed one; who
+    // proposed changes how a signer reads the whole card.
     const card = renderProposalCard([
       proposal({ actor: 'human' }),
       proposal({ network: 'arbitrum', actor: 'bot' }),
@@ -526,13 +539,18 @@ describe('renderProposalCard — a rejected link is not echoed', () => {
     ['mixed-case scheme', 'HtTpS://evil.example/pull/1'],
   ])('accepts %s, since the scheme is case-insensitive', (_label, prUrl) => {
     // RFC 3986 makes the scheme case-insensitive, and Slack auto-links what it
-    // recognises. Asserted as "the link is rendered", not as "the word 'ignored'
-    // is absent" — that word was removed from the code, so the absence form
-    // passed no matter what the scheme check did.
-    const card = renderProposalCard([proposal({ prUrl })])
+    // recognises.
+    //
+    // Exact equality on the whole line. A case-SENSITIVE renderer that echoed
+    // the rejected value emitted `*PR:* HTTPS://… — not a link, ignored`, which
+    // satisfies both `toContain('*PR:* HTTPS://…')` and
+    // `not.toContain('withheld')` — so the substring pair passed against the
+    // very renderer this test exists to rule out.
+    const prLine = renderProposalCard([proposal({ prUrl })])
+      .split('\n')
+      .find((l) => l.startsWith('*PR:*'))
 
-    expect(card).toContain(`*PR:* ${prUrl}`)
-    expect(card).not.toContain('withheld')
+    expect(prLine).toBe(`*PR:* ${prUrl}`)
   })
 
   it('does not reproduce a rejected value', () => {

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -283,15 +283,12 @@ export const renderProposalCard = (
   // Capped at the same limit capture uses.
   //
   // Union across rows: a dirty tree on any network must never read as clean.
-  // A row carrying anything at all in this field is a row that reported a dirty
-  // tree, whatever shape the value arrived in.
   const dirty = proposals.filter(
     (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
   )
-  // Only a measured empty array reads as clean. `provenance-display.ts` already
-  // holds that rule for the signing prompt, where a non-array — absent and null
-  // included — is 'unreadable'; a card that stayed silent left the two
-  // renderers disagreeing about one field.
+  // Only a measured empty array reads as clean, which is the rule
+  // `provenance-display.ts` holds for the signing prompt: a non-array — absent
+  // and null included — is 'unreadable' there, never clean.
   const uncaptured = proposals.filter((p) => !Array.isArray(p.dirtyTreeScoped))
 
   if (dirty.length > 0 || uncaptured.length > 0) {
@@ -301,7 +298,6 @@ export const renderProposalCard = (
       ),
     ].filter(Boolean)
     // Capture stopped counting on at least one row, so the list is a floor.
-    // Without this a 500-file dirty tree rendered exactly like a 20-file one.
     const truncated = dirty.some((p) => p.dirtyTreeTruncated === true)
     const reported = [...dirty, ...uncaptured]
     const where =

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -153,13 +153,9 @@ const escape = (value: unknown): string => escapeCapped(value, MAX_FIELD_CHARS)
 const renderLink = (value: unknown): string => {
   const text = escape(value)
   if (!text) return ''
-  // Case-insensitive per RFC 3986. Treating `HTTPS://` as invalid was worse than
-  // useless: the value was printed verbatim beside "ignored", and Slack
-  // auto-links what it recognises — an assertion that it was ignored, sitting
-  // next to a live link to it.
+  // Case-insensitive per RFC 3986.
   if (/^https:\/\//i.test(text)) return text
-  // Never reproduced: echoing it puts the string on the card and lets Slack link
-  // it, which is what the check exists to prevent.
+  // Withheld, not echoed: Slack would auto-link the value this check rejected.
   return '— recorded value is not a link, withheld'
 }
 
@@ -253,8 +249,8 @@ export const renderProposalCard = (
     )
 
   const handle = escape(first.proposerHandle)
-  // Any non-human actor on the card, not just row zero's: read from the first
-  // row, a bot-proposed network hid behind a human-proposed one.
+  // Union across rows: a non-human actor on any network must not hide behind a
+  // human one on another.
   const nonHuman = [
     ...new Set(proposals.map((p) => escape(p.actor)).filter(Boolean)),
   ].filter((a) => a !== 'human')
@@ -267,11 +263,9 @@ export const renderProposalCard = (
   if (prUrl) lines.push(`*PR:* ${prUrl}`)
 
   // A dirty tree means the commit above does not describe what was proposed.
-  // Capped at the same limit capture uses, so a hand-edited row cannot push the
-  // review commands off the bottom of the card.
-  // Collected across EVERY row, not read from the first. Read from row zero, a
-  // run where one network was proposed from a dirty tree rendered no
-  // working-tree line at all, so the card affirmatively looked clean.
+  // Capped at the same limit capture uses.
+  //
+  // Union across rows: a dirty tree on any network must never read as clean.
   const dirtyRows = proposals.filter(
     (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
   )

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -22,6 +22,16 @@ const SHORT_HASH_CHARS = 10
 const SHORT_COMMIT_CHARS = 12
 
 /**
+ * Cap for every other single field.
+ *
+ * The card's own cap is not enough on its own: an oversized `contract`,
+ * `prUrl`, `proposerHandle`, `checkSummary` or network name each individually
+ * consumed the whole budget and pushed the review command — the one line that
+ * makes the card actionable — off the bottom.
+ */
+const MAX_FIELD_CHARS = 200
+
+/**
  * One proposal, flattened from its document and provenance block.
  *
  * Every field but `network` is `unknown`: a row stored before provenance
@@ -73,8 +83,14 @@ export interface ICardOptions {
  * verbatim and `SlackNotifier` only caps the `blocks[].text` fields it builds
  * itself — so an over-long card would reach Slack whole and lose its bottom to
  * the client's own collapsing. Cutting here keeps the loss visible.
+ *
+ * Not 3000: that is the per-`blocks[].text` limit, and this card posts as a
+ * top-level `text`, whose limit is 40,000. Truncating at the block figure threw
+ * away the review commands — the point of the card — to save bytes Slack would
+ * have accepted. Held well below 40,000 anyway, because a card nobody scrolls
+ * to the end of has already failed.
  */
-const SLACK_TEXT_LIMIT = 2900
+export const SLACK_TEXT_LIMIT = 8000
 
 const TRUNCATION_NOTICE =
   '\n… card truncated; run `bunx tsx script/deploy/safe/list-pending-proposals.ts` for the full set'
@@ -98,15 +114,19 @@ const escapeEntities = (value: string): string =>
  * A backtick closes the code span the review command sits in and turns the rest
  * of that line into card prose; `*` and `_` forge a bold or italic label inline,
  * which is enough to fake the advisory line. Slack mrkdwn has no escape
- * sequence for any of them, so the choice is to strip or to let a document
- * value rewrite the card. Stripped: a network name, a hash or a git identity
- * never contains one, and a reason loses nothing a signer needs.
+ * sequence for either, so the choice is to strip or to let a document value
+ * rewrite the card.
+ *
+ * `_` and `~` are deliberately NOT stripped. They only italicise or strike
+ * text, so they cannot forge a label or break out of a code span — and
+ * stripping them corrupted real data: `alice_smith@example.com` and
+ * `alicesmith@example.com` rendered byte-identically on a card whose job is
+ * saying who proposed, and 115 tracked paths in this repo carry `_`, so a dirty
+ * path rendered as a file that does not exist. That list is the one field a
+ * reviewer copies out to go and look at something.
  */
 const stripMarkdownMarkers = (value: string): string =>
-  value.replace(/[`*_~]/g, '')
-
-const escape = (value: unknown): string =>
-  stripMarkdownMarkers(escapeEntities(sanitizeProvenanceText(value)))
+  value.replace(/[`*]/g, '')
 
 /**
  * Escapes a value whose length is capped.
@@ -119,6 +139,26 @@ const escapeCapped = (value: unknown, max: number): string =>
   stripMarkdownMarkers(
     escapeEntities([...sanitizeProvenanceText(value)].slice(0, max).join(''))
   )
+
+const escape = (value: unknown): string => escapeCapped(value, MAX_FIELD_CHARS)
+
+/**
+ * Renders a URL only if it is one.
+ *
+ * `captureGitProvenance` stores a PR link only when it starts with `https://`,
+ * so a value that does not reach here through provenance capture. Labelling it
+ * `*PR:*` lends it the card's credibility, and Slack auto-links a bare URL, so
+ * a signer gets a clickable attacker-chosen destination on the screen they read
+ * immediately before approving.
+ *
+ * Rejection is stated rather than silent: an omitted line reads as "no PR was
+ * recorded", which is a different and less alarming fact.
+ */
+const renderLink = (value: unknown): string => {
+  const text = escape(value)
+  if (!text) return ''
+  return text.startsWith('https://') ? text : `${text} — not a link, ignored`
+}
 
 const shortHash = (hash: unknown): string =>
   escapeCapped(hash, SHORT_HASH_CHARS)
@@ -176,16 +216,30 @@ export const renderProposalCard = (
   // Every field below is read from the first row, which is right when a run
   // proposes the same change everywhere and misleading when it does not — the
   // rows are selected per network and nothing forces them to agree.
-  const reasonsDiffer = proposals.some(
-    (p) => escapeCapped(p.reason, MAX_PROPOSAL_REASON_LENGTH) !== reason
+  // Compared on the raw values, not the rendered ones: two reasons identical for
+  // 200 characters and divergent after were reported as agreeing.
+  const differing = (
+    ['reason', 'gitCommit', 'prUrl', 'proposerHandle'] as const
   )
-  lines.push(
-    `*Reason:* ${reason || '_none given_'}${
-      reasonsDiffer
-        ? ' — reasons differ across networks, this is the first'
-        : ''
-    }`
-  )
+    .filter((field) =>
+      proposals.some(
+        (p) => String(p[field] ?? '') !== String(first[field] ?? '')
+      )
+    )
+    .map((field) => (field === 'prUrl' ? 'PR' : field))
+
+  lines.push(`*Reason:* ${reason || '_none given_'}`)
+
+  // `gitCommit` is what a signer re-derives calldata against and `prUrl` is the
+  // rationale they read, so those diverging matters more than the prose doing
+  // so. The first version of this flagged only the prose, which is the least
+  // consequential member of the set.
+  if (differing.length > 0)
+    lines.push(
+      `⚠ These differ across the networks in this card and only the first is shown: ${differing.join(
+        ', '
+      )}. Check each network individually.`
+    )
 
   const handle = escape(first.proposerHandle)
   const actorName = escape(first.actor)
@@ -194,7 +248,7 @@ export const renderProposalCard = (
 
   const gitCommit = escapeCapped(first.gitCommit, SHORT_COMMIT_CHARS)
   if (gitCommit) lines.push(`*Commit:* ${gitCommit}`)
-  const prUrl = escape(first.prUrl)
+  const prUrl = renderLink(first.prUrl)
   if (prUrl) lines.push(`*PR:* ${prUrl}`)
 
   // A dirty tree means the commit above does not describe what was proposed.
@@ -228,30 +282,39 @@ export const renderProposalCard = (
     )
   }
 
-  lines.push('', '*To review:*')
+  // Built separately and appended last, never truncated. It is the only
+  // actionable part of the card, and it sits at the bottom — so a tail-truncated
+  // card lost precisely the thing it exists to deliver. Measured: every
+  // overflowing card dropped the whole review section.
+  const review = ['', '*To review:*']
   // One command per network up to the limit, then a single one — the reviewer
   // runs them one network at a time anyway.
   const commandNetworks =
     count <= NAMED_NETWORK_LIMIT ? networks : [first.network]
   commandNetworks.forEach((network, index) => {
     const proposal = proposals[index]
-    lines.push(
+    review.push(
       `• \`bun confirm-safe-tx --network ${escape(network)}\`` +
         (proposal ? `  (${shortHash(proposal.safeTxHash)})` : '')
     )
   })
   if (commandNetworks.length < count)
-    lines.push(
+    review.push(
       `• …and ${count - commandNetworks.length} more — same command per network`
     )
 
-  const card = lines.join('\n')
+  const reviewText = review.join('\n')
+  const card = `${lines.join('\n')}${reviewText}`
   if (card.length <= SLACK_TEXT_LIMIT) return card
 
-  let body = card.slice(0, SLACK_TEXT_LIMIT - TRUNCATION_NOTICE.length)
-  // A code-unit slice can split a surrogate pair or an `&amp;` entity, either of
+  // The middle is what goes, so the headline and the commands both survive.
+  let body = lines
+    .join('\n')
+    .slice(0, SLACK_TEXT_LIMIT - TRUNCATION_NOTICE.length - reviewText.length)
+  // A code-unit slice can split a surrogate pair or an `&` entity, either of
   // which renders as garbage rather than as a clean cut.
   if (/[\uD800-\uDBFF]$/.test(body)) body = body.slice(0, -1)
   body = body.replace(/&[a-z]{0,3}$/i, '')
-  return `${body}${TRUNCATION_NOTICE}`
+
+  return `${body}${TRUNCATION_NOTICE}${reviewText}`
 }

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -56,6 +56,14 @@ export interface IExpectedHashRow {
 export interface ICardOptions {
   /** Rendered only when supplied. */
   expectedHashes?: IExpectedHashRow[]
+  /**
+   * How many proposals the run actually created. Compared against the rows
+   * found, because a card reading fewer than that leaves proposals nobody is
+   * told to sign — the one error here with a direct safety consequence.
+   */
+  expectedCount?: number
+  /** The contract the run touched; the message this replaces named it. */
+  contract?: string
 }
 
 /**
@@ -84,8 +92,21 @@ const escapeEntities = (value: string): string =>
  * entity escaping on top is Slack's own requirement — without it `<!channel>`
  * in a field nobody reviews would notify a whole channel.
  */
+/**
+ * Removes the mrkdwn markers Slack acts on and entities cannot neutralise.
+ *
+ * A backtick closes the code span the review command sits in and turns the rest
+ * of that line into card prose; `*` and `_` forge a bold or italic label inline,
+ * which is enough to fake the advisory line. Slack mrkdwn has no escape
+ * sequence for any of them, so the choice is to strip or to let a document
+ * value rewrite the card. Stripped: a network name, a hash or a git identity
+ * never contains one, and a reason loses nothing a signer needs.
+ */
+const stripMarkdownMarkers = (value: string): string =>
+  value.replace(/[`*_~]/g, '')
+
 const escape = (value: unknown): string =>
-  escapeEntities(sanitizeProvenanceText(value))
+  stripMarkdownMarkers(escapeEntities(sanitizeProvenanceText(value)))
 
 /**
  * Escapes a value whose length is capped.
@@ -95,7 +116,9 @@ const escape = (value: unknown): string =>
  * By code point, so the cut cannot leave a lone surrogate half behind.
  */
 const escapeCapped = (value: unknown, max: number): string =>
-  escapeEntities([...sanitizeProvenanceText(value)].slice(0, max).join(''))
+  stripMarkdownMarkers(
+    escapeEntities([...sanitizeProvenanceText(value)].slice(0, max).join(''))
+  )
 
 const shortHash = (hash: unknown): string =>
   escapeCapped(hash, SHORT_HASH_CHARS)
@@ -122,22 +145,47 @@ export const renderProposalCard = (
   if (!first) throw new Error('Cannot render a card for no proposals')
 
   const count = proposals.length
+  const contract = escape(options.contract)
+  const what = contract ? `${contract} ` : ''
   const headline =
     count === 1
-      ? `1x proposal created on ${escape(
+      ? `1x ${what}proposal created on ${escape(
           first.network
         )} — please sign and schedule 🙏`
-      : `${count}x proposals created across ${describeNetworks(
+      : `${count}x ${what}proposals created across ${describeNetworks(
           networks
         )} — please sign and schedule 🙏`
 
   const lines = [headline, '']
 
+  // Louder than the headline on purpose. Rows are found per network, and a
+  // network whose proposal is missing from this card still has one to sign.
+  const expected = options.expectedCount
+  if (expected !== undefined && expected > count)
+    lines.push(
+      `⚠ The run created ${expected} proposals but only ${count} could be listed — ${
+        expected - count
+      } missing from this card. Check \`bunx tsx script/deploy/safe/list-pending-proposals.ts\`.`,
+      ''
+    )
+
   // Absent is stated rather than omitted: a signer needs to know the intent was
   // never captured. Tested after escaping, because a value of nothing but
   // control characters sanitizes to empty and must read as absent, not blank.
   const reason = escapeCapped(first.reason, MAX_PROPOSAL_REASON_LENGTH)
-  lines.push(`*Reason:* ${reason || '_none given_'}`)
+  // Every field below is read from the first row, which is right when a run
+  // proposes the same change everywhere and misleading when it does not — the
+  // rows are selected per network and nothing forces them to agree.
+  const reasonsDiffer = proposals.some(
+    (p) => escapeCapped(p.reason, MAX_PROPOSAL_REASON_LENGTH) !== reason
+  )
+  lines.push(
+    `*Reason:* ${reason || '_none given_'}${
+      reasonsDiffer
+        ? ' — reasons differ across networks, this is the first'
+        : ''
+    }`
+  )
 
   const handle = escape(first.proposerHandle)
   const actorName = escape(first.actor)

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -49,6 +49,8 @@ export interface ICardProposal {
   prUrl?: unknown
   gitCommit?: unknown
   dirtyTreeScoped?: unknown
+  /** Capture sets this when it stopped counting; the list is then a floor. */
+  dirtyTreeTruncated?: unknown
   /**
    * Result of a check the PROPOSER ran. Rendered as advisory: the authoritative
    * status is the signer-side attestation, and a card that states a result
@@ -283,21 +285,25 @@ export const renderProposalCard = (
   // Union across rows: a dirty tree on any network must never read as clean.
   // A row carrying anything at all in this field is a row that reported a dirty
   // tree, whatever shape the value arrived in.
-  const dirtyRows = proposals.filter(
-    (p) => p.dirtyTreeScoped !== undefined && p.dirtyTreeScoped !== null
-  )
-  const usable = dirtyRows.filter(
+  const dirty = proposals.filter(
     (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
   )
-  const unreadable = dirtyRows.filter((p) => !Array.isArray(p.dirtyTreeScoped))
+  // Only a measured empty array reads as clean. `provenance-display.ts` already
+  // holds that rule for the signing prompt, where a non-array — absent and null
+  // included — is 'unreadable'; a card that stayed silent left the two
+  // renderers disagreeing about one field.
+  const uncaptured = proposals.filter((p) => !Array.isArray(p.dirtyTreeScoped))
 
-  if (usable.length > 0 || unreadable.length > 0) {
+  if (dirty.length > 0 || uncaptured.length > 0) {
     const paths = [
       ...new Set(
-        usable.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
+        dirty.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
       ),
     ].filter(Boolean)
-    const reported = [...usable, ...unreadable]
+    // Capture stopped counting on at least one row, so the list is a floor.
+    // Without this a 500-file dirty tree rendered exactly like a 20-file one.
+    const truncated = dirty.some((p) => p.dirtyTreeTruncated === true)
+    const reported = [...dirty, ...uncaptured]
     const where =
       reported.length === proposals.length
         ? ''
@@ -305,15 +311,22 @@ export const renderProposalCard = (
             reported.map((p) => escape(p.network)),
             NAMED_NETWORK_LIMIT
           )})`
+
     const detail =
       paths.length > 0
-        ? summarise(paths, MAX_DIRTY_PATHS)
-        : 'paths could not be read'
-    const shapeNote =
-      unreadable.length > 0 && paths.length > 0
-        ? '; some paths could not be read'
+        ? truncated
+          ? `${paths
+              .slice(0, MAX_DIRTY_PATHS)
+              .join(', ')}, and more that capture stopped counting`
+          : summarise(paths, MAX_DIRTY_PATHS)
+        : 'paths not captured'
+    const note =
+      uncaptured.length > 0 && paths.length > 0
+        ? '; some rows captured no path list'
         : ''
-    lines.push(`*Working tree:* dirty${where} — ${detail}${shapeNote}`)
+
+    const state = dirty.length > 0 ? 'dirty' : 'not captured'
+    lines.push(`*Working tree:* ${state}${where} — ${detail}${note}`)
   }
 
   const checkSummary = escape(first.checkSummary)

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -1,14 +1,16 @@
 /**
  * Renders the signing-ask card for a set of Safe proposals.
  *
- * Replaces a message assembled from the runner's own progress file, which knew
- * a contract name and a network count and nothing about intent. Everything here
- * comes from the proposal documents, so the card is a view of the record rather
- * than a second, hand-written account of it.
- *
- * Pure: it takes rows and returns text. Reading Mongo and posting live in
- * `post-proposal-card.ts`.
+ * Pure: rows in, text out. The Mongo read and the file write live in
+ * `render-proposal-card.ts`.
  */
+
+import {
+  MAX_DIRTY_PATHS,
+  sanitizeProvenanceText,
+} from '../shared/git-provenance'
+
+import { MAX_PROPOSAL_REASON_LENGTH } from './safe-utils'
 
 /** How many networks are named individually before the card switches to a count. */
 const NAMED_NETWORK_LIMIT = 4
@@ -16,25 +18,35 @@ const NAMED_NETWORK_LIMIT = 4
 /** Enough of a hash to match a card to a proposal by eye. */
 const SHORT_HASH_CHARS = 10
 
-/** One proposal, flattened from its document and provenance block. */
+/** Commit prefix long enough to be unambiguous in this repo. */
+const SHORT_COMMIT_CHARS = 12
+
+/**
+ * One proposal, flattened from its document and provenance block.
+ *
+ * Every field but `network` is `unknown`: a row stored before provenance
+ * capture, or hand-edited since, can hold a number or `null` anywhere, and a
+ * throw here silently downgrades the whole card to the count-only fallback.
+ * `escape` coerces, so the renderer is total over any document shape.
+ */
 export interface ICardProposal {
   network: string
-  safeTxHash: string
-  proposerHandle?: string
-  actor?: string
-  reason?: string
-  prUrl?: string
-  gitCommit?: string
-  dirtyTreeScoped?: string[]
+  safeTxHash?: unknown
+  proposerHandle?: unknown
+  actor?: unknown
+  reason?: unknown
+  prUrl?: unknown
+  gitCommit?: unknown
+  dirtyTreeScoped?: unknown
   /**
    * Result of a check the PROPOSER ran. Rendered as advisory: the authoritative
    * status is the signer-side attestation, and a card that states a result
    * without saying so invites signing on the card's word.
    */
-  checkSummary?: string
+  checkSummary?: unknown
 }
 
-/** One row of the per-network expected-hash table (WP-2.x / WP-7.2 fill this). */
+/** One row of the per-network expected-hash table. */
 export interface IExpectedHashRow {
   network: string
   expected: string
@@ -42,35 +54,51 @@ export interface IExpectedHashRow {
 }
 
 export interface ICardOptions {
-  /**
-   * Rendered only when supplied. The slot is this parameter, not a placeholder
-   * line: filler sections in an operator card train people to skip sections.
-   */
+  /** Rendered only when supplied. */
   expectedHashes?: IExpectedHashRow[]
 }
 
-/** Slack renders at most this much text; `SlackNotifier` truncates at the same point. */
+/**
+ * Cap for the whole card.
+ *
+ * Nothing downstream truncates — `send-slack-webhook-message.ts` posts the text
+ * verbatim and `SlackNotifier` only caps the `blocks[].text` fields it builds
+ * itself — so an over-long card would reach Slack whole and lose its bottom to
+ * the client's own collapsing. Cutting here keeps the loss visible.
+ */
 const SLACK_TEXT_LIMIT = 2900
 
-/**
- * Escapes Slack markup and flattens the value onto one line.
- *
- * Applied to every string that came out of a proposal document. Two distinct
- * risks: `<!channel>` in a field nobody reviews would notify a whole channel,
- * and a newline lets a value forge the card's own structure — a reason
- * containing `\n*Reason:* something else` would render as a second, plausible
- * Reason line. Values are sanitized when stored, but a card that trusts the
- * document is one hand-edited row away from lying to every signer who reads it.
- */
-const escape = (value: string): string =>
-  value
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+const TRUNCATION_NOTICE =
+  '\n… card truncated; run `bunx tsx script/deploy/safe/list-pending-proposals.ts` for the full set'
 
-const shortHash = (hash: string): string => hash.slice(0, SHORT_HASH_CHARS)
+const escapeEntities = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+/**
+ * Reduces one proposal-document value to a single line of safe Slack text.
+ *
+ * `sanitizeProvenanceText` is the repo's shared sanitizer for this data
+ * (EXSC-693): it strips the control, bidi-override and zero-width characters
+ * that let a value repaint or reverse the lines around it, and it coerces
+ * non-strings, which is what keeps a half-migrated row from throwing here. The
+ * entity escaping on top is Slack's own requirement — without it `<!channel>`
+ * in a field nobody reviews would notify a whole channel.
+ */
+const escape = (value: unknown): string =>
+  escapeEntities(sanitizeProvenanceText(value))
+
+/**
+ * Escapes a value whose length is capped.
+ *
+ * Capped before escaping, both because the limits count characters of the
+ * underlying value and because capping afterwards could cut an entity in half.
+ * By code point, so the cut cannot leave a lone surrogate half behind.
+ */
+const escapeCapped = (value: unknown, max: number): string =>
+  escapeEntities([...sanitizeProvenanceText(value)].slice(0, max).join(''))
+
+const shortHash = (hash: unknown): string =>
+  escapeCapped(hash, SHORT_HASH_CHARS)
 
 const describeNetworks = (networks: string[]): string =>
   networks.length <= NAMED_NETWORK_LIMIT
@@ -105,33 +133,40 @@ export const renderProposalCard = (
 
   const lines = [headline, '']
 
-  // Absent is stated rather than omitted: "none given" tells a signer the intent
-  // was never captured, which is different from a card that failed to render it.
-  lines.push(
-    `*Reason:* ${first.reason ? escape(first.reason) : '_none given_'}`
-  )
+  // Absent is stated rather than omitted: a signer needs to know the intent was
+  // never captured. Tested after escaping, because a value of nothing but
+  // control characters sanitizes to empty and must read as absent, not blank.
+  const reason = escapeCapped(first.reason, MAX_PROPOSAL_REASON_LENGTH)
+  lines.push(`*Reason:* ${reason || '_none given_'}`)
 
-  const actor =
-    first.actor && first.actor !== 'human' ? ` (${escape(first.actor)})` : ''
-  lines.push(
-    `*Proposed by:* ${
-      first.proposerHandle ? escape(first.proposerHandle) : 'unknown'
-    }${actor}`
-  )
+  const handle = escape(first.proposerHandle)
+  const actorName = escape(first.actor)
+  const actor = actorName && actorName !== 'human' ? ` (${actorName})` : ''
+  lines.push(`*Proposed by:* ${handle || 'unknown'}${actor}`)
 
-  if (first.gitCommit)
-    lines.push(`*Commit:* ${escape(first.gitCommit.slice(0, 12))}`)
-  if (first.prUrl) lines.push(`*PR:* ${escape(first.prUrl)}`)
+  const gitCommit = escapeCapped(first.gitCommit, SHORT_COMMIT_CHARS)
+  if (gitCommit) lines.push(`*Commit:* ${gitCommit}`)
+  const prUrl = escape(first.prUrl)
+  if (prUrl) lines.push(`*PR:* ${prUrl}`)
 
   // A dirty tree means the commit above does not describe what was proposed.
-  const dirty = first.dirtyTreeScoped ?? []
-  if (dirty.length > 0)
-    lines.push(`*Working tree:* dirty — ${dirty.map(escape).join(', ')}`)
+  // Capped at the same limit capture uses, so a hand-edited row cannot push the
+  // review commands off the bottom of the card.
+  const dirty: unknown[] = Array.isArray(first.dirtyTreeScoped)
+    ? first.dirtyTreeScoped
+    : []
+  if (dirty.length > 0) {
+    const shown = dirty.slice(0, MAX_DIRTY_PATHS).map(escape).filter(Boolean)
+    const more =
+      dirty.length > MAX_DIRTY_PATHS
+        ? `, …and ${dirty.length - MAX_DIRTY_PATHS} more`
+        : ''
+    lines.push(`*Working tree:* dirty — ${shown.join(', ')}${more}`)
+  }
 
-  if (first.checkSummary)
-    lines.push(
-      `*Proposer-side check (advisory):* ${escape(first.checkSummary)}`
-    )
+  const checkSummary = escape(first.checkSummary)
+  if (checkSummary)
+    lines.push(`*Proposer-side check (advisory):* ${checkSummary}`)
 
   const hashes = options.expectedHashes ?? []
   if (hashes.length > 0) {
@@ -146,9 +181,8 @@ export const renderProposalCard = (
   }
 
   lines.push('', '*To review:*')
-  // One command per network up to the limit, then a single one: a dozen commands
-  // is a wall, not a card, and the reviewer runs them one network at a time
-  // anyway.
+  // One command per network up to the limit, then a single one — the reviewer
+  // runs them one network at a time anyway.
   const commandNetworks =
     count <= NAMED_NETWORK_LIMIT ? networks : [first.network]
   commandNetworks.forEach((network, index) => {
@@ -164,13 +198,12 @@ export const renderProposalCard = (
     )
 
   const card = lines.join('\n')
-  // Slack drops everything past the limit silently, and the review commands are
-  // at the bottom — so an over-long card loses precisely the part that makes it
-  // useful. Truncating here keeps the loss visible.
-  return card.length <= SLACK_TEXT_LIMIT
-    ? card
-    : `${card.slice(
-        0,
-        SLACK_TEXT_LIMIT - 80
-      )}\n… card truncated; run \`bun list-pending-proposals\` for the full set`
+  if (card.length <= SLACK_TEXT_LIMIT) return card
+
+  let body = card.slice(0, SLACK_TEXT_LIMIT - TRUNCATION_NOTICE.length)
+  // A code-unit slice can split a surrogate pair or an `&amp;` entity, either of
+  // which renders as garbage rather than as a clean cut.
+  if (/[\uD800-\uDBFF]$/.test(body)) body = body.slice(0, -1)
+  body = body.replace(/&[a-z]{0,3}$/i, '')
+  return `${body}${TRUNCATION_NOTICE}`
 }

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -266,8 +266,8 @@ export const renderProposalCard = (
   const nonHuman = [
     ...new Set(proposals.map((p) => escape(p.actor)).filter(Boolean)),
   ].filter((a) => a !== 'human')
-  // Bounded like any other field: a union grows with the row count, so without
-  // this the list is itself a value that can consume the card.
+  // Bounded like any other field: a union grows with the row count, so the list
+  // is itself a value that can consume the card.
   const actor =
     nonHuman.length > 0 ? ` (${summarise(nonHuman, NAMED_NETWORK_LIMIT)})` : ''
   lines.push(`*Proposed by:* ${handle || 'unknown'}${actor}`)
@@ -282,7 +282,7 @@ export const renderProposalCard = (
   //
   // Union across rows: a dirty tree on any network must never read as clean.
   // A row carrying anything at all in this field is a row that reported a dirty
-  // tree. Requiring an array let a value of the wrong shape render as clean.
+  // tree, whatever shape the value arrived in.
   const dirtyRows = proposals.filter(
     (p) => p.dirtyTreeScoped !== undefined && p.dirtyTreeScoped !== null
   )

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -22,12 +22,13 @@ const SHORT_HASH_CHARS = 10
 const SHORT_COMMIT_CHARS = 12
 
 /**
- * Cap for every other single field.
+ * Cap for every field except `reason`, `gitCommit` and `safeTxHash`, which have
+ * their own tighter caps.
  *
- * The card's own cap is not enough on its own: an oversized `contract`,
- * `prUrl`, `proposerHandle`, `checkSummary` or network name each individually
- * consumed the whole budget and pushed the review command — the one line that
- * makes the card actionable — off the bottom.
+ * The card's own cap is not enough alone: a single oversized `contract`,
+ * `prUrl`, `proposerHandle`, `checkSummary` or network name can consume the
+ * whole budget and push the review command — the one line that makes the card
+ * actionable — off the bottom.
  */
 const MAX_FIELD_CHARS = 200
 
@@ -84,11 +85,10 @@ export interface ICardOptions {
  * itself — so an over-long card would reach Slack whole and lose its bottom to
  * the client's own collapsing. Cutting here keeps the loss visible.
  *
- * Not 3000: that is the per-`blocks[].text` limit, and this card posts as a
- * top-level `text`, whose limit is 40,000. Truncating at the block figure threw
- * away the review commands — the point of the card — to save bytes Slack would
- * have accepted. Held well below 40,000 anyway, because a card nobody scrolls
- * to the end of has already failed.
+ * Not 3000: that is the per-`blocks[].text` limit (see `slack-notifier.ts`),
+ * and this card posts as a top-level `text`, whose limit is 40,000. Held well
+ * below 40,000 anyway, because a card nobody scrolls to the end of has already
+ * failed.
  */
 export const SLACK_TEXT_LIMIT = 8000
 
@@ -99,37 +99,33 @@ const escapeEntities = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 /**
- * Reduces one proposal-document value to a single line of safe Slack text.
+ * Removes the two mrkdwn markers entity escaping cannot neutralise.
  *
- * `sanitizeProvenanceText` is the repo's shared sanitizer for this data
- * (EXSC-693): it strips the control, bidi-override and zero-width characters
- * that let a value repaint or reverse the lines around it, and it coerces
- * non-strings, which is what keeps a half-migrated row from throwing here. The
- * entity escaping on top is Slack's own requirement — without it `<!channel>`
- * in a field nobody reviews would notify a whole channel.
- */
-/**
- * Removes the mrkdwn markers Slack acts on and entities cannot neutralise.
+ * A backtick closes the code span a review command sits in and turns the rest of
+ * that line into card prose; `*` forges a bold label, which is enough to fake
+ * the advisory line. Slack mrkdwn has no escape sequence for either, so the
+ * choice is to strip or to let a document value rewrite the card.
  *
- * A backtick closes the code span the review command sits in and turns the rest
- * of that line into card prose; `*` and `_` forge a bold or italic label inline,
- * which is enough to fake the advisory line. Slack mrkdwn has no escape
- * sequence for either, so the choice is to strip or to let a document value
- * rewrite the card.
- *
- * `_` and `~` are deliberately NOT stripped. They only italicise or strike
- * text, so they cannot forge a label or break out of a code span — and
- * stripping them corrupted real data: `alice_smith@example.com` and
- * `alicesmith@example.com` rendered byte-identically on a card whose job is
- * saying who proposed, and 115 tracked paths in this repo carry `_`, so a dirty
- * path rendered as a file that does not exist. That list is the one field a
- * reviewer copies out to go and look at something.
+ * `_` and `~` are left in place. They only italicise or strike, so they can
+ * neither forge a label nor break out of a code span, and removing them renders
+ * `alice_smith@example.com` and `alicesmith@example.com` identically on a card
+ * whose job is saying who proposed. Many tracked paths carry `_`, so the dirty
+ * list — the one field a reviewer copies out to go and look at something — would
+ * name files that do not exist.
  */
 const stripMarkdownMarkers = (value: string): string =>
   value.replace(/[`*]/g, '')
 
 /**
- * Escapes a value whose length is capped.
+ * Reduces one proposal-document value to a single line of safe Slack text,
+ * capped at `max` code points.
+ *
+ * `sanitizeProvenanceText` is the repo's shared sanitizer for this data: it
+ * strips the control, bidi-override and zero-width characters that let a value
+ * repaint or reverse the lines around it, and it coerces non-strings, which is
+ * what keeps a half-migrated row from throwing here. The entity escaping on top
+ * is Slack's own requirement — without it `<!channel>` in a field nobody reviews
+ * would notify a whole channel.
  *
  * Capped before escaping, both because the limits count characters of the
  * underlying value and because capping afterwards could cut an entity in half.
@@ -146,10 +142,10 @@ const escape = (value: unknown): string => escapeCapped(value, MAX_FIELD_CHARS)
  * Renders a URL only if it is one.
  *
  * `captureGitProvenance` stores a PR link only when it starts with `https://`,
- * so a value that does not reach here through provenance capture. Labelling it
- * `*PR:*` lends it the card's credibility, and Slack auto-links a bare URL, so
- * a signer gets a clickable attacker-chosen destination on the screen they read
- * immediately before approving.
+ * so a value without that prefix did not reach here through provenance capture.
+ * Labelling it `*PR:*` lends it the card's credibility, and Slack auto-links a
+ * bare URL, so a signer gets a clickable attacker-chosen destination on the
+ * screen they read immediately before approving.
  *
  * Rejection is stated rather than silent: an omitted line reads as "no PR was
  * recorded", which is a different and less alarming fact.
@@ -216,24 +212,31 @@ export const renderProposalCard = (
   // Every field below is read from the first row, which is right when a run
   // proposes the same change everywhere and misleading when it does not — the
   // rows are selected per network and nothing forces them to agree.
-  // Compared on the raw values, not the rendered ones: two reasons identical for
-  // 200 characters and divergent after were reported as agreeing.
+  // Labelled as the card labels them, so the warning names lines a reader can
+  // find rather than source identifiers.
+  const COMPARED_FIELDS = {
+    reason: 'Reason',
+    gitCommit: 'Commit',
+    prUrl: 'PR',
+    proposerHandle: 'Proposed by',
+  } as const
   const differing = (
-    ['reason', 'gitCommit', 'prUrl', 'proposerHandle'] as const
+    Object.keys(COMPARED_FIELDS) as (keyof typeof COMPARED_FIELDS)[]
   )
+    // Compared on the raw values, not the rendered ones: a display cap can make
+    // two values that diverge past it render identically.
     .filter((field) =>
       proposals.some(
         (p) => String(p[field] ?? '') !== String(first[field] ?? '')
       )
     )
-    .map((field) => (field === 'prUrl' ? 'PR' : field))
+    .map((field) => COMPARED_FIELDS[field])
 
   lines.push(`*Reason:* ${reason || '_none given_'}`)
 
   // `gitCommit` is what a signer re-derives calldata against and `prUrl` is the
   // rationale they read, so those diverging matters more than the prose doing
-  // so. The first version of this flagged only the prose, which is the least
-  // consequential member of the set.
+  // so.
   if (differing.length > 0)
     lines.push(
       `⚠ These differ across the networks in this card and only the first is shown: ${differing.join(
@@ -282,11 +285,13 @@ export const renderProposalCard = (
     )
   }
 
-  // Built separately and appended last, never truncated. It is the only
-  // actionable part of the card, and it sits at the bottom — so a tail-truncated
-  // card lost precisely the thing it exists to deliver. Measured: every
-  // overflowing card dropped the whole review section.
-  const review = ['', '*To review:*']
+  // Built separately and appended last, never truncated: it is the only
+  // actionable part of the card and it sits at the bottom, so a tail cut would
+  // drop precisely the thing the card exists to deliver.
+  // Two blanks, not one: this array is concatenated onto the body rather than
+  // joined with it, so the first entry supplies the separating newline and the
+  // second the blank line that sets the section off.
+  const review = ['', '', '*To review:*']
   // One command per network up to the limit, then a single one — the reviewer
   // runs them one network at a time anyway.
   const commandNetworks =
@@ -308,13 +313,28 @@ export const renderProposalCard = (
   if (card.length <= SLACK_TEXT_LIMIT) return card
 
   // The middle is what goes, so the headline and the commands both survive.
+  // `Math.max` because a negative end makes `slice` cut from the tail instead,
+  // which would return a card longer than the cap rather than a shorter one. The
+  // budget is positive at today's constants, but it goes negative if
+  // NAMED_NETWORK_LIMIT reaches 8 or MAX_FIELD_CHARS reaches ~380.
   let body = lines
     .join('\n')
-    .slice(0, SLACK_TEXT_LIMIT - TRUNCATION_NOTICE.length - reviewText.length)
+    .slice(
+      0,
+      Math.max(
+        0,
+        SLACK_TEXT_LIMIT - TRUNCATION_NOTICE.length - reviewText.length
+      )
+    )
   // A code-unit slice can split a surrogate pair or an `&` entity, either of
   // which renders as garbage rather than as a clean cut.
   if (/[\uD800-\uDBFF]$/.test(body)) body = body.slice(0, -1)
   body = body.replace(/&[a-z]{0,3}$/i, '')
+  // The shortfall line carries a code span, so a cut can land inside it and
+  // leave an unpaired backtick that re-pairs with the review commands below,
+  // rendering each command as prose and the prose between as code.
+  if ((body.match(/`/g) ?? []).length % 2 === 1)
+    body = body.slice(0, body.lastIndexOf('`'))
 
   return `${body}${TRUNCATION_NOTICE}${reviewText}`
 }

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -159,6 +159,18 @@ const renderLink = (value: unknown): string => {
   return '— recorded value is not a link, withheld'
 }
 
+/**
+ * Joins a list, naming the first few and counting the rest.
+ *
+ * @param items - Already-escaped values.
+ * @param limit - How many to name.
+ * @returns The rendered fragment.
+ */
+const summarise = (items: string[], limit: number): string =>
+  items.length <= limit
+    ? items.join(', ')
+    : `${items.slice(0, limit).join(', ')}, …and ${items.length - limit} more`
+
 const shortHash = (hash: unknown): string =>
   escapeCapped(hash, SHORT_HASH_CHARS)
 
@@ -254,7 +266,10 @@ export const renderProposalCard = (
   const nonHuman = [
     ...new Set(proposals.map((p) => escape(p.actor)).filter(Boolean)),
   ].filter((a) => a !== 'human')
-  const actor = nonHuman.length > 0 ? ` (${nonHuman.join(', ')})` : ''
+  // Bounded like any other field: a union grows with the row count, so without
+  // this the list is itself a value that can consume the card.
+  const actor =
+    nonHuman.length > 0 ? ` (${summarise(nonHuman, NAMED_NETWORK_LIMIT)})` : ''
   lines.push(`*Proposed by:* ${handle || 'unknown'}${actor}`)
 
   const gitCommit = escapeCapped(first.gitCommit, SHORT_COMMIT_CHARS)
@@ -266,28 +281,39 @@ export const renderProposalCard = (
   // Capped at the same limit capture uses.
   //
   // Union across rows: a dirty tree on any network must never read as clean.
+  // A row carrying anything at all in this field is a row that reported a dirty
+  // tree. Requiring an array let a value of the wrong shape render as clean.
   const dirtyRows = proposals.filter(
+    (p) => p.dirtyTreeScoped !== undefined && p.dirtyTreeScoped !== null
+  )
+  const usable = dirtyRows.filter(
     (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
   )
-  if (dirtyRows.length > 0) {
+  const unreadable = dirtyRows.filter((p) => !Array.isArray(p.dirtyTreeScoped))
+
+  if (usable.length > 0 || unreadable.length > 0) {
     const paths = [
       ...new Set(
-        dirtyRows.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
+        usable.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
       ),
     ].filter(Boolean)
-    const more =
-      paths.length > MAX_DIRTY_PATHS
-        ? `, …and ${paths.length - MAX_DIRTY_PATHS} more`
-        : ''
+    const reported = [...usable, ...unreadable]
     const where =
-      dirtyRows.length === proposals.length
+      reported.length === proposals.length
         ? ''
-        : ` (on ${dirtyRows.map((p) => escape(p.network)).join(', ')})`
-    lines.push(
-      `*Working tree:* dirty${where} — ${paths
-        .slice(0, MAX_DIRTY_PATHS)
-        .join(', ')}${more}`
-    )
+        : ` (on ${summarise(
+            reported.map((p) => escape(p.network)),
+            NAMED_NETWORK_LIMIT
+          )})`
+    const detail =
+      paths.length > 0
+        ? summarise(paths, MAX_DIRTY_PATHS)
+        : 'paths could not be read'
+    const shapeNote =
+      unreadable.length > 0 && paths.length > 0
+        ? '; some paths could not be read'
+        : ''
+    lines.push(`*Working tree:* dirty${where} — ${detail}${shapeNote}`)
   }
 
   const checkSummary = escape(first.checkSummary)

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -51,6 +51,8 @@ export interface ICardProposal {
   dirtyTreeScoped?: unknown
   /** Capture sets this when it stopped counting; the list is then a floor. */
   dirtyTreeTruncated?: unknown
+  /** Capture records why it could not measure; a non-empty list is not clean. */
+  captureErrors?: unknown
   /**
    * Result of a check the PROPOSER ran. Rendered as advisory: the authoritative
    * status is the signer-side attestation, and a card that states a result
@@ -283,46 +285,63 @@ export const renderProposalCard = (
   // Capped at the same limit capture uses.
   //
   // Union across rows: a dirty tree on any network must never read as clean.
+  // Three states, matching `provenance-display.ts`'s model for the signing
+  // prompt: dirty, capture-incomplete, unreadable. Only a measured empty array
+  // with no capture errors is clean.
+  //
+  // Each state names its OWN networks. Merging them let one path read as the
+  // complete inventory across a network that had reported nothing.
   const dirty = proposals.filter(
     (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
   )
-  // Only a measured empty array reads as clean, which is the rule
-  // `provenance-display.ts` holds for the signing prompt: a non-array — absent
-  // and null included — is 'unreadable' there, never clean.
-  const uncaptured = proposals.filter((p) => !Array.isArray(p.dirtyTreeScoped))
+  // A failed `git status` writes an empty list AND capture errors, so an empty
+  // list alone does not mean the tree was measured. The likeliest probe
+  // failures — the timeout and the buffer cap — correlate with a very dirty
+  // tree, so treating this as clean read clean exactly when it was dirtiest.
+  const incomplete = proposals.filter(
+    (p) =>
+      Array.isArray(p.dirtyTreeScoped) &&
+      p.dirtyTreeScoped.length === 0 &&
+      Array.isArray(p.captureErrors) &&
+      p.captureErrors.length > 0
+  )
+  const unreadable = proposals.filter((p) => !Array.isArray(p.dirtyTreeScoped))
 
-  if (dirty.length > 0 || uncaptured.length > 0) {
+  if (dirty.length > 0 || incomplete.length > 0 || unreadable.length > 0) {
     const paths = [
       ...new Set(
         dirty.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
       ),
     ].filter(Boolean)
-    // Capture stopped counting on at least one row, so the list is a floor.
-    const truncated = dirty.some((p) => p.dirtyTreeTruncated === true)
-    const reported = [...dirty, ...uncaptured]
-    const where =
-      reported.length === proposals.length
+
+    /** Names the rows a state is about, unless it is the whole card. */
+    const on = (rows: ICardProposal[]): string =>
+      rows.length === proposals.length
         ? ''
-        : ` (on ${summarise(
-            reported.map((p) => escape(p.network)),
+        : ` on ${summarise(
+            rows.map((r) => escape(r.network)),
             NAMED_NETWORK_LIMIT
-          )})`
+          )}`
 
-    const detail =
-      paths.length > 0
-        ? truncated
-          ? `${paths
-              .slice(0, MAX_DIRTY_PATHS)
-              .join(', ')}, and more that capture stopped counting`
-          : summarise(paths, MAX_DIRTY_PATHS)
-        : 'paths not captured'
-    const note =
-      uncaptured.length > 0 && paths.length > 0
-        ? '; some rows captured no path list'
+    const parts: string[] = []
+
+    if (paths.length > 0) {
+      // The count survives the truncation note. Reported alone, "capture
+      // stopped counting" was VAGUER than the exact "…and N more" it replaced,
+      // so the worse case got the weaker warning.
+      const stopped = dirty.some((p) => p.dirtyTreeTruncated === true)
+        ? ', and capture stopped counting before the end'
         : ''
+      parts.push(
+        `dirty${on(dirty)} — ${summarise(paths, MAX_DIRTY_PATHS)}${stopped}`
+      )
+    } else if (dirty.length > 0)
+      parts.push(`dirty${on(dirty)} — paths unusable`)
 
-    const state = dirty.length > 0 ? 'dirty' : 'not captured'
-    lines.push(`*Working tree:* ${state}${where} — ${detail}${note}`)
+    if (incomplete.length > 0) parts.push(`capture incomplete${on(incomplete)}`)
+    if (unreadable.length > 0) parts.push(`not captured${on(unreadable)}`)
+
+    lines.push(`*Working tree:* ${parts.join('; ')}`)
   }
 
   const checkSummary = escape(first.checkSummary)

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -153,7 +153,14 @@ const escape = (value: unknown): string => escapeCapped(value, MAX_FIELD_CHARS)
 const renderLink = (value: unknown): string => {
   const text = escape(value)
   if (!text) return ''
-  return text.startsWith('https://') ? text : `${text} — not a link, ignored`
+  // Case-insensitive per RFC 3986. Treating `HTTPS://` as invalid was worse than
+  // useless: the value was printed verbatim beside "ignored", and Slack
+  // auto-links what it recognises — an assertion that it was ignored, sitting
+  // next to a live link to it.
+  if (/^https:\/\//i.test(text)) return text
+  // Never reproduced: echoing it puts the string on the card and lets Slack link
+  // it, which is what the check exists to prevent.
+  return '— recorded value is not a link, withheld'
 }
 
 const shortHash = (hash: unknown): string =>
@@ -219,6 +226,7 @@ export const renderProposalCard = (
     gitCommit: 'Commit',
     prUrl: 'PR',
     proposerHandle: 'Proposed by',
+    checkSummary: 'Proposer-side check',
   } as const
   const differing = (
     Object.keys(COMPARED_FIELDS) as (keyof typeof COMPARED_FIELDS)[]
@@ -245,8 +253,12 @@ export const renderProposalCard = (
     )
 
   const handle = escape(first.proposerHandle)
-  const actorName = escape(first.actor)
-  const actor = actorName && actorName !== 'human' ? ` (${actorName})` : ''
+  // Any non-human actor on the card, not just row zero's: read from the first
+  // row, a bot-proposed network hid behind a human-proposed one.
+  const nonHuman = [
+    ...new Set(proposals.map((p) => escape(p.actor)).filter(Boolean)),
+  ].filter((a) => a !== 'human')
+  const actor = nonHuman.length > 0 ? ` (${nonHuman.join(', ')})` : ''
   lines.push(`*Proposed by:* ${handle || 'unknown'}${actor}`)
 
   const gitCommit = escapeCapped(first.gitCommit, SHORT_COMMIT_CHARS)
@@ -257,16 +269,31 @@ export const renderProposalCard = (
   // A dirty tree means the commit above does not describe what was proposed.
   // Capped at the same limit capture uses, so a hand-edited row cannot push the
   // review commands off the bottom of the card.
-  const dirty: unknown[] = Array.isArray(first.dirtyTreeScoped)
-    ? first.dirtyTreeScoped
-    : []
-  if (dirty.length > 0) {
-    const shown = dirty.slice(0, MAX_DIRTY_PATHS).map(escape).filter(Boolean)
+  // Collected across EVERY row, not read from the first. Read from row zero, a
+  // run where one network was proposed from a dirty tree rendered no
+  // working-tree line at all, so the card affirmatively looked clean.
+  const dirtyRows = proposals.filter(
+    (p) => Array.isArray(p.dirtyTreeScoped) && p.dirtyTreeScoped.length > 0
+  )
+  if (dirtyRows.length > 0) {
+    const paths = [
+      ...new Set(
+        dirtyRows.flatMap((p) => (p.dirtyTreeScoped as unknown[]).map(escape))
+      ),
+    ].filter(Boolean)
     const more =
-      dirty.length > MAX_DIRTY_PATHS
-        ? `, …and ${dirty.length - MAX_DIRTY_PATHS} more`
+      paths.length > MAX_DIRTY_PATHS
+        ? `, …and ${paths.length - MAX_DIRTY_PATHS} more`
         : ''
-    lines.push(`*Working tree:* dirty — ${shown.join(', ')}${more}`)
+    const where =
+      dirtyRows.length === proposals.length
+        ? ''
+        : ` (on ${dirtyRows.map((p) => escape(p.network)).join(', ')})`
+    lines.push(
+      `*Working tree:* dirty${where} — ${paths
+        .slice(0, MAX_DIRTY_PATHS)
+        .join(', ')}${more}`
+    )
   }
 
   const checkSummary = escape(first.checkSummary)

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -1,0 +1,176 @@
+/**
+ * Renders the signing-ask card for a set of Safe proposals.
+ *
+ * Replaces a message assembled from the runner's own progress file, which knew
+ * a contract name and a network count and nothing about intent. Everything here
+ * comes from the proposal documents, so the card is a view of the record rather
+ * than a second, hand-written account of it.
+ *
+ * Pure: it takes rows and returns text. Reading Mongo and posting live in
+ * `post-proposal-card.ts`.
+ */
+
+/** How many networks are named individually before the card switches to a count. */
+const NAMED_NETWORK_LIMIT = 4
+
+/** Enough of a hash to match a card to a proposal by eye. */
+const SHORT_HASH_CHARS = 10
+
+/** One proposal, flattened from its document and provenance block. */
+export interface ICardProposal {
+  network: string
+  safeTxHash: string
+  proposerHandle?: string
+  actor?: string
+  reason?: string
+  prUrl?: string
+  gitCommit?: string
+  dirtyTreeScoped?: string[]
+  /**
+   * Result of a check the PROPOSER ran. Rendered as advisory: the authoritative
+   * status is the signer-side attestation, and a card that states a result
+   * without saying so invites signing on the card's word.
+   */
+  checkSummary?: string
+}
+
+/** One row of the per-network expected-hash table (WP-2.x / WP-7.2 fill this). */
+export interface IExpectedHashRow {
+  network: string
+  expected: string
+  actual?: string
+}
+
+export interface ICardOptions {
+  /**
+   * Rendered only when supplied. The slot is this parameter, not a placeholder
+   * line: filler sections in an operator card train people to skip sections.
+   */
+  expectedHashes?: IExpectedHashRow[]
+}
+
+/** Slack renders at most this much text; `SlackNotifier` truncates at the same point. */
+const SLACK_TEXT_LIMIT = 2900
+
+/**
+ * Escapes Slack markup and flattens the value onto one line.
+ *
+ * Applied to every string that came out of a proposal document. Two distinct
+ * risks: `<!channel>` in a field nobody reviews would notify a whole channel,
+ * and a newline lets a value forge the card's own structure — a reason
+ * containing `\n*Reason:* something else` would render as a second, plausible
+ * Reason line. Values are sanitized when stored, but a card that trusts the
+ * document is one hand-edited row away from lying to every signer who reads it.
+ */
+const escape = (value: string): string =>
+  value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+const shortHash = (hash: string): string => hash.slice(0, SHORT_HASH_CHARS)
+
+const describeNetworks = (networks: string[]): string =>
+  networks.length <= NAMED_NETWORK_LIMIT
+    ? networks.map(escape).join(', ')
+    : `${networks.length} networks`
+
+/**
+ * Builds the card text.
+ *
+ * @param proposals - One entry per proposal, newest run only.
+ * @param options - The expected-hash table, when a caller has one.
+ * @returns Slack-markdown text ready to post.
+ * @throws If handed no proposals — an empty card is worse than no post.
+ */
+export const renderProposalCard = (
+  proposals: ICardProposal[],
+  options: ICardOptions = {}
+): string => {
+  const networks = proposals.map((p) => p.network)
+  const first = proposals[0]
+  if (!first) throw new Error('Cannot render a card for no proposals')
+
+  const count = proposals.length
+  const headline =
+    count === 1
+      ? `1x proposal created on ${escape(
+          first.network
+        )} — please sign and schedule 🙏`
+      : `${count}x proposals created across ${describeNetworks(
+          networks
+        )} — please sign and schedule 🙏`
+
+  const lines = [headline, '']
+
+  // Absent is stated rather than omitted: "none given" tells a signer the intent
+  // was never captured, which is different from a card that failed to render it.
+  lines.push(
+    `*Reason:* ${first.reason ? escape(first.reason) : '_none given_'}`
+  )
+
+  const actor =
+    first.actor && first.actor !== 'human' ? ` (${escape(first.actor)})` : ''
+  lines.push(
+    `*Proposed by:* ${
+      first.proposerHandle ? escape(first.proposerHandle) : 'unknown'
+    }${actor}`
+  )
+
+  if (first.gitCommit)
+    lines.push(`*Commit:* ${escape(first.gitCommit.slice(0, 12))}`)
+  if (first.prUrl) lines.push(`*PR:* ${escape(first.prUrl)}`)
+
+  // A dirty tree means the commit above does not describe what was proposed.
+  const dirty = first.dirtyTreeScoped ?? []
+  if (dirty.length > 0)
+    lines.push(`*Working tree:* dirty — ${dirty.map(escape).join(', ')}`)
+
+  if (first.checkSummary)
+    lines.push(
+      `*Proposer-side check (advisory):* ${escape(first.checkSummary)}`
+    )
+
+  const hashes = options.expectedHashes ?? []
+  if (hashes.length > 0) {
+    lines.push('', '*Expected code hashes:*')
+    hashes.forEach((row) =>
+      lines.push(
+        `• ${escape(row.network)}: ${escape(row.expected)}${
+          row.actual ? ` (on chain ${escape(row.actual)})` : ''
+        }`
+      )
+    )
+  }
+
+  lines.push('', '*To review:*')
+  // One command per network up to the limit, then a single one: a dozen commands
+  // is a wall, not a card, and the reviewer runs them one network at a time
+  // anyway.
+  const commandNetworks =
+    count <= NAMED_NETWORK_LIMIT ? networks : [first.network]
+  commandNetworks.forEach((network, index) => {
+    const proposal = proposals[index]
+    lines.push(
+      `• \`bun confirm-safe-tx --network ${escape(network)}\`` +
+        (proposal ? `  (${shortHash(proposal.safeTxHash)})` : '')
+    )
+  })
+  if (commandNetworks.length < count)
+    lines.push(
+      `• …and ${count - commandNetworks.length} more — same command per network`
+    )
+
+  const card = lines.join('\n')
+  // Slack drops everything past the limit silently, and the review commands are
+  // at the bottom — so an over-long card loses precisely the part that makes it
+  // useful. Truncating here keeps the loss visible.
+  return card.length <= SLACK_TEXT_LIMIT
+    ? card
+    : `${card.slice(
+        0,
+        SLACK_TEXT_LIMIT - 80
+      )}\n… card truncated; run \`bun list-pending-proposals\` for the full set`
+}

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -298,12 +298,17 @@ export const renderProposalCard = (
   // list alone does not mean the tree was measured. The likeliest probe
   // failures — the timeout and the buffer cap — correlate with a very dirty
   // tree, so treating this as clean read clean exactly when it was dirtiest.
+  const hasCaptureErrors = (p: ICardProposal): boolean =>
+    Array.isArray(p.captureErrors) && p.captureErrors.length > 0
+  // An empty list plus an error is ambiguous: `captureErrors` is one collector
+  // shared by every git probe, so the status probe may have failed or something
+  // unrelated may have. Warning is the fail-safe direction; the wording says
+  // only what is known.
   const incomplete = proposals.filter(
     (p) =>
       Array.isArray(p.dirtyTreeScoped) &&
       p.dirtyTreeScoped.length === 0 &&
-      Array.isArray(p.captureErrors) &&
-      p.captureErrors.length > 0
+      hasCaptureErrors(p)
   )
   const unreadable = proposals.filter((p) => !Array.isArray(p.dirtyTreeScoped))
 
@@ -332,13 +337,25 @@ export const renderProposalCard = (
       const stopped = dirty.some((p) => p.dirtyTreeTruncated === true)
         ? ', and capture stopped counting before the end'
         : ''
+      // Both facts, as the signing prompt shows them: reporting only "dirty"
+      // loses that the path list may be incomplete, which is the more alarming
+      // half of the two.
+      const alsoFailed = dirty.some(hasCaptureErrors)
+        ? ', and capture reported errors so the list may be incomplete'
+        : ''
       parts.push(
-        `dirty${on(dirty)} — ${summarise(paths, MAX_DIRTY_PATHS)}${stopped}`
+        `dirty${on(dirty)} — ${summarise(
+          paths,
+          MAX_DIRTY_PATHS
+        )}${stopped}${alsoFailed}`
       )
     } else if (dirty.length > 0)
       parts.push(`dirty${on(dirty)} — paths unusable`)
 
-    if (incomplete.length > 0) parts.push(`capture incomplete${on(incomplete)}`)
+    if (incomplete.length > 0)
+      parts.push(
+        `capture incomplete${on(incomplete)} — a clean reading is unconfirmed`
+      )
     if (unreadable.length > 0) parts.push(`not captured${on(unreadable)}`)
 
     lines.push(`*Working tree:* ${parts.join('; ')}`)

--- a/script/deploy/safe/proposal-selection.test.ts
+++ b/script/deploy/safe/proposal-selection.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Tests for the card's proposal selection (EXSC-696).
+ *
+ * The properties that matter are the ones the shortfall warning rests on: the
+ * newest row per network wins, a network the run did not touch never reaches the
+ * card, every provenance field the card reads survives the mapping, and only a
+ * network with no row in any status counts as missing.
+ */
+
 import {
   describe,
   expect,

--- a/script/deploy/safe/proposal-selection.test.ts
+++ b/script/deploy/safe/proposal-selection.test.ts
@@ -1,0 +1,141 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { selectProposals, type IStoredProposal } from './proposal-selection'
+
+const row = (
+  network: string,
+  overrides: Partial<IStoredProposal['provenance']> = {}
+): IStoredProposal => ({
+  network,
+  safeTxHash: `0x${'ab'.repeat(32)}`,
+  provenance: { reason: 'why', ...overrides },
+})
+
+describe('selectProposals', () => {
+  it('keeps the caller order, not the query order', () => {
+    // The card should read in the same order as the run's own output.
+    const result = selectProposals(
+      ['mainnet', 'arbitrum', 'base'],
+      [row('base'), row('mainnet'), row('arbitrum')],
+      []
+    )
+
+    expect(result.proposals.map((p) => p.network)).toEqual([
+      'mainnet',
+      'arbitrum',
+      'base',
+    ])
+  })
+
+  it('takes the first row per network, because the caller sorted newest first', () => {
+    const result = selectProposals(
+      ['mainnet'],
+      [
+        row('mainnet', { reason: 'newest' }),
+        row('mainnet', { reason: 'older' }),
+      ],
+      []
+    )
+
+    expect(result.proposals).toHaveLength(1)
+    expect(result.proposals[0]?.reason).toBe('newest')
+  })
+
+  it('classifies a network whose row exists but is not pending as settled', () => {
+    // Its proposal was signed and executed, so its absence is correct. Counting
+    // it as missing would fire the alarm on every resumed run — the runner's
+    // network list is cumulative across resumes.
+    const result = selectProposals(
+      ['mainnet', 'arbitrum'],
+      [row('mainnet')],
+      ['arbitrum']
+    )
+
+    expect(result.settled).toEqual(['arbitrum'])
+    expect(result.unaccounted).toEqual([])
+  })
+
+  it('classifies a network with no row at all as unaccounted', () => {
+    const result = selectProposals(
+      ['mainnet', 'arbitrum'],
+      [row('mainnet')],
+      []
+    )
+
+    expect(result.unaccounted).toEqual(['arbitrum'])
+    expect(result.settled).toEqual([])
+  })
+
+  it('never puts a network in both buckets', () => {
+    const result = selectProposals(
+      ['a', 'b', 'c', 'd'],
+      [row('a')],
+      ['b', 'c', 'd']
+    )
+
+    const both = result.settled.filter((n) => result.unaccounted.includes(n))
+    expect(both).toEqual([])
+    expect([...result.settled, ...result.unaccounted].sort()).toEqual([
+      'b',
+      'c',
+      'd',
+    ])
+  })
+
+  it('ignores a pending row for a network the run did not touch', () => {
+    // The query bounds by network, but a widened query must not silently add a
+    // network to the card that the run never proposed on.
+    const result = selectProposals(
+      ['mainnet'],
+      [row('mainnet'), row('base')],
+      []
+    )
+
+    expect(result.proposals.map((p) => p.network)).toEqual(['mainnet'])
+  })
+
+  it('carries every provenance field the card reads', () => {
+    const result = selectProposals(
+      ['mainnet'],
+      [
+        row('mainnet', {
+          dirtyTreeScoped: ['src/A.sol'],
+          dirtyTreeTruncated: true,
+          captureErrors: ['boom'],
+          actor: 'bot',
+          gitCommit: 'abc',
+          prUrl: 'https://example.test/pull/1',
+          proposerHandle: 'alice',
+        }),
+      ],
+      []
+    )
+
+    // Each of these was a field the card silently lost at some point by not
+    // being mapped here.
+    const p = result.proposals[0]
+    expect(p?.dirtyTreeScoped).toEqual(['src/A.sol'])
+    expect(p?.dirtyTreeTruncated).toBe(true)
+    expect(p?.captureErrors).toEqual(['boom'])
+    expect(p?.actor).toBe('bot')
+    expect(p?.gitCommit).toBe('abc')
+    expect(p?.prUrl).toBe('https://example.test/pull/1')
+    expect(p?.proposerHandle).toBe('alice')
+  })
+
+  it('survives a row with no provenance block', () => {
+    const result = selectProposals(
+      ['mainnet'],
+      [{ network: 'mainnet', safeTxHash: '0xab' }],
+      []
+    )
+
+    expect(result.proposals).toHaveLength(1)
+    expect(result.proposals[0]?.reason).toBeUndefined()
+  })
+})

--- a/script/deploy/safe/proposal-selection.ts
+++ b/script/deploy/safe/proposal-selection.ts
@@ -1,0 +1,90 @@
+/**
+ * Chooses which stored proposals a card describes, and classifies the networks
+ * that contributed none.
+ *
+ * Split out of `render-proposal-card.ts` so it can be tested without a database.
+ * It is the part most likely to be wrong: nothing in a proposal document
+ * identifies the run that created it, so the selection is a heuristic, and the
+ * shortfall classification decides whether an operator is warned or not.
+ */
+
+import type { ICardProposal } from './proposal-card'
+
+/** The fields the card reads, as they sit on a stored document. */
+export interface IStoredProposal {
+  network: unknown
+  // Optional because a stored row can lack it: the card renders whatever is
+  // there rather than refusing, and a short hash of nothing is visibly empty.
+  safeTxHash?: unknown
+  timestamp?: unknown
+  provenance?: {
+    proposerHandle?: unknown
+    actor?: unknown
+    reason?: unknown
+    prUrl?: unknown
+    gitCommit?: unknown
+    dirtyTreeScoped?: unknown
+    dirtyTreeTruncated?: unknown
+    captureErrors?: unknown
+  }
+}
+
+export interface ISelection {
+  /** One per network that had a pending row, in the caller's order. */
+  proposals: ICardProposal[]
+  /** Networks whose proposal exists but is no longer pending. */
+  settled: string[]
+  /** Networks with no proposal in any status — the only real shortfall. */
+  unaccounted: string[]
+}
+
+/**
+ * Picks the newest pending row per network and classifies the rest.
+ *
+ * @param networks - The run's networks, already lowercased and deduped.
+ * @param pending - Pending rows, NEWEST FIRST as the query returns them.
+ * @param networksWithAnyRow - Networks known to have a row in any status.
+ * @returns What the card describes, and why anything is missing.
+ */
+export const selectProposals = (
+  networks: string[],
+  pending: IStoredProposal[],
+  networksWithAnyRow: string[]
+): ISelection => {
+  const newest = new Map<string, IStoredProposal>()
+  for (const row of pending) {
+    const network = String(row.network)
+    // First wins, because the caller sorted newest first. Re-sorting here would
+    // silently disagree with the query when a row has no timestamp.
+    if (!newest.has(network)) newest.set(network, row)
+  }
+
+  // The caller's order, so the card reads in the same order as the run's output.
+  const proposals = networks
+    .map((network) => newest.get(network))
+    .filter((row): row is IStoredProposal => row !== undefined)
+    .map((row) => ({
+      network: String(row.network),
+      safeTxHash: row.safeTxHash,
+      proposerHandle: row.provenance?.proposerHandle,
+      actor: row.provenance?.actor,
+      reason: row.provenance?.reason,
+      prUrl: row.provenance?.prUrl,
+      gitCommit: row.provenance?.gitCommit,
+      dirtyTreeScoped: row.provenance?.dirtyTreeScoped,
+      dirtyTreeTruncated: row.provenance?.dirtyTreeTruncated,
+      captureErrors: row.provenance?.captureErrors,
+    }))
+
+  const withoutPending = networks.filter((network) => !newest.has(network))
+  const known = new Set(networksWithAnyRow)
+
+  return {
+    proposals,
+    // A row that exists but is not pending was signed and executed already, so
+    // its absence from the card is correct rather than a shortfall. Counting it
+    // as missing would fire the alarm on every resumed run.
+    settled: withoutPending.filter((network) => known.has(network)),
+    unaccounted: withoutPending.filter((network) => !known.has(network)),
+  }
+}

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -67,10 +67,16 @@ const main = defineCommand({
     if (!process.env.SC_MONGODB_URI)
       throw new Error('SC_MONGODB_URI environment variable is required')
 
-    const networks = args.networks
-      .split(',')
-      .map((n) => n.trim().toLowerCase())
-      .filter(Boolean)
+    // Deduped: a repeated name would count twice, print the same review
+    // command twice, and silence the shortfall check by matching the row count.
+    const networks = [
+      ...new Set(
+        args.networks
+          .split(',')
+          .map((n) => n.trim().toLowerCase())
+          .filter(Boolean)
+      ),
+    ]
     if (networks.length === 0) throw new Error('--networks matched no names')
 
     const client = new MongoClient(process.env.SC_MONGODB_URI, {
@@ -124,24 +130,55 @@ const main = defineCommand({
           `No pending proposals found for: ${networks.join(', ')}`
         )
 
-      // The caller's network list is the run's own record of what succeeded, so
-      // it is the count to check against — a row missing here is a proposal
-      // that still needs signing.
+      // A network with no PENDING row is not necessarily a missing proposal. The
+      // caller's list is every network ever marked successful for this action —
+      // the progress file survives a partial run and later runs skip networks
+      // already done — so on any resumed run it includes networks whose
+      // proposals were signed and executed long ago. Counting those as missing
+      // would fire the alarm on exactly the runs that needed a retry.
+      //
+      // Absence of any row in any status is the real signal, so that is what is
+      // asked. One extra query, and it is the difference between an alarm and a
+      // false alarm.
+      const withoutPending = networks.filter((n) => !newestByNetwork.has(n))
+      const settled =
+        withoutPending.length === 0
+          ? []
+          : (
+              await collection
+                .find({ network: { $in: withoutPending } })
+                .project<{ network: string }>({ network: 1 })
+                .toArray()
+            ).map((r) => r.network)
+
+      const unaccounted = withoutPending.filter((n) => !settled.includes(n))
+
+      const contract = args.contract
       const card = renderProposalCard(proposals, {
-        expectedCount: networks.length,
-        ...(args.contract ? { contract: args.contract } : {}),
+        // Only genuinely absent proposals are a shortfall.
+        expectedCount: proposals.length + unaccounted.length,
+        // The runner substitutes this literal when it has no contract name, and
+        // it reads as one in the headline.
+        ...(contract && contract !== 'unknown' ? { contract } : {}),
       })
+
+      if (settled.length > 0)
+        consola.info(
+          `Already signed or executed, so not on the card: ${settled.join(
+            ', '
+          )}`
+        )
+      if (unaccounted.length > 0)
+        consola.warn(
+          `No proposal at all was found on: ${unaccounted.join(
+            ', '
+          )} — the card names the shortfall.`
+        )
+
+      // Written after every read, so a failure to close the client cannot
+      // discard a card that was produced successfully.
       if (args.out) writeFileSync(args.out, `${card}\n`)
       else consola.log(card)
-
-      // Named so a partial card is explainable rather than looking complete.
-      const missing = networks.filter((n) => !newestByNetwork.has(n))
-      if (missing.length > 0)
-        consola.warn(
-          `No pending proposal found on: ${missing.join(
-            ', '
-          )} — the card omits them.`
-        )
     } finally {
       await client.close()
     }

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -42,6 +42,7 @@ interface IRow {
     prUrl?: unknown
     gitCommit?: unknown
     dirtyTreeScoped?: unknown
+    dirtyTreeTruncated?: unknown
   }
 }
 
@@ -127,6 +128,7 @@ const main = defineCommand({
           prUrl: row.provenance?.prUrl,
           gitCommit: row.provenance?.gitCommit,
           dirtyTreeScoped: row.provenance?.dirtyTreeScoped,
+          dirtyTreeTruncated: row.provenance?.dirtyTreeTruncated,
         }))
 
       if (proposals.length === 0)

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -58,6 +58,10 @@ const main = defineCommand({
       type: 'string',
       description: 'File to write the card to (default: stdout)',
     },
+    contract: {
+      type: 'string',
+      description: 'Contract the run touched, named in the headline',
+    },
   },
   async run({ args }) {
     if (!process.env.SC_MONGODB_URI)
@@ -120,7 +124,13 @@ const main = defineCommand({
           `No pending proposals found for: ${networks.join(', ')}`
         )
 
-      const card = renderProposalCard(proposals)
+      // The caller's network list is the run's own record of what succeeded, so
+      // it is the count to check against — a row missing here is a proposal
+      // that still needs signing.
+      const card = renderProposalCard(proposals, {
+        expectedCount: networks.length,
+        ...(args.contract ? { contract: args.contract } : {}),
+      })
       if (args.out) writeFileSync(args.out, `${card}\n`)
       else consola.log(card)
 

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -18,7 +18,8 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { MongoClient } from 'mongodb'
 
-import { renderProposalCard, type ICardProposal } from './proposal-card'
+import { renderProposalCard } from './proposal-card'
+import { selectProposals } from './proposal-selection'
 import type { SafeTxStatus } from './safe-utils'
 
 const DEFAULT_DB = 'sc_private'
@@ -109,55 +110,38 @@ const main = defineCommand({
         )
         .toArray()
 
-      const newestByNetwork = new Map<string, IRow>()
-      rows.forEach((row) => {
-        if (!newestByNetwork.has(row.network))
-          newestByNetwork.set(row.network, row)
-      })
-
-      // Ordered as the caller listed them, so the card reads in the same order
-      // as the run's own output.
-      const proposals: ICardProposal[] = networks
-        .map((network) => newestByNetwork.get(network))
-        .filter((row): row is IRow => row !== undefined)
-        .map((row) => ({
-          network: String(row.network),
-          safeTxHash: row.safeTxHash,
-          proposerHandle: row.provenance?.proposerHandle,
-          actor: row.provenance?.actor,
-          reason: row.provenance?.reason,
-          prUrl: row.provenance?.prUrl,
-          gitCommit: row.provenance?.gitCommit,
-          dirtyTreeScoped: row.provenance?.dirtyTreeScoped,
-          dirtyTreeTruncated: row.provenance?.dirtyTreeTruncated,
-          captureErrors: row.provenance?.captureErrors,
-        }))
-
-      if (proposals.length === 0)
-        throw new Error(
-          `No pending proposals found for: ${networks.join(', ')}`
-        )
-
+      // The classification lives in `proposal-selection.ts`, which is tested
+      // without a database; this function only fetches what that needs.
+      //
       // A network with no PENDING row is not necessarily a missing proposal. The
       // caller's list is every network ever marked successful for this action —
       // the progress file survives a partial run and later runs skip networks
       // already done — so on any resumed run it includes networks whose
-      // proposals were signed and executed long ago. Counting those as missing
-      // would fire the alarm on exactly the runs that needed a retry.
+      // proposals were signed and executed long ago. Absence of a row in ANY
+      // status is the real signal.
       //
-      // Absence of any row in any status is the real signal, so that is what is
-      // asked. `distinct` rather than `find`, so the result is bounded by the
-      // number of networks asked about rather than by how many rows they have
-      // between them.
-      const withoutPending = networks.filter((n) => !newestByNetwork.has(n))
-      const settled =
+      // `distinct` rather than `find`, so the result is bounded by the number of
+      // networks asked about rather than by how many rows they have between them.
+      const withoutPending = networks.filter(
+        (network) => !rows.some((row) => String(row.network) === network)
+      )
+      const networksWithAnyRow =
         withoutPending.length === 0
           ? []
           : await collection.distinct('network', {
               network: { $in: withoutPending },
             })
 
-      const unaccounted = withoutPending.filter((n) => !settled.includes(n))
+      const { proposals, settled, unaccounted } = selectProposals(
+        networks,
+        rows,
+        networksWithAnyRow.map(String)
+      )
+
+      if (proposals.length === 0)
+        throw new Error(
+          `No pending proposals found for: ${networks.join(', ')}`
+        )
 
       const contract = args.contract
       const card = renderProposalCard(proposals, {

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -1,0 +1,131 @@
+/**
+ * Renders the signing-ask card for the proposals a run just created.
+ *
+ * Split from the posting step so `send-slack-webhook-message.ts` stays the only
+ * thing that talks to Slack: this writes text, that posts it.
+ *
+ * Opens its own client. `getSafeMongoCollection` creates indexes on connect, and
+ * a read-only renderer must not alter the schema it reads.
+ */
+
+import 'dotenv/config'
+
+import { writeFileSync } from 'fs'
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import { MongoClient } from 'mongodb'
+
+import { renderProposalCard, type ICardProposal } from './proposal-card'
+
+const DEFAULT_DB = 'sc_private'
+const DEFAULT_COLLECTION = 'pendingTransactions'
+
+interface IRow {
+  network: string
+  safeTxHash: string
+  timestamp?: Date
+  provenance?: {
+    proposerHandle?: string
+    actor?: string
+    reason?: string
+    prUrl?: string
+    gitCommit?: string
+    dirtyTreeScoped?: string[]
+  }
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'render-proposal-card',
+    description:
+      'Renders the Slack signing-ask card for the newest pending proposal on each given network',
+  },
+  args: {
+    networks: {
+      type: 'string',
+      description: 'Comma-separated network names',
+      required: true,
+    },
+    out: {
+      type: 'string',
+      description: 'File to write the card to (default: stdout)',
+    },
+  },
+  async run({ args }) {
+    if (!process.env.SC_MONGODB_URI)
+      throw new Error('SC_MONGODB_URI environment variable is required')
+
+    const networks = args.networks
+      .split(',')
+      .map((n) => n.trim().toLowerCase())
+      .filter(Boolean)
+    if (networks.length === 0) throw new Error('--networks matched no names')
+
+    const client = new MongoClient(process.env.SC_MONGODB_URI, {
+      serverSelectionTimeoutMS: 10_000,
+    })
+
+    try {
+      await client.connect()
+      const collection = client
+        .db(DEFAULT_DB)
+        .collection<IRow>(DEFAULT_COLLECTION)
+
+      // Newest pending row per network. A network can carry an older unsigned
+      // proposal, and the card is about the run that just finished — so this
+      // takes the most recent rather than trying to match the run itself, which
+      // nothing in the document identifies.
+      const rows = await collection
+        .find(
+          { network: { $in: networks }, status: 'pending' },
+          { sort: { timestamp: -1 } }
+        )
+        .toArray()
+
+      const newestByNetwork = new Map<string, IRow>()
+      rows.forEach((row) => {
+        if (!newestByNetwork.has(row.network))
+          newestByNetwork.set(row.network, row)
+      })
+
+      // Ordered as the caller listed them, so the card reads in the same order
+      // as the run's own output.
+      const proposals: ICardProposal[] = networks
+        .map((network) => newestByNetwork.get(network))
+        .filter((row): row is IRow => row !== undefined)
+        .map((row) => ({
+          network: row.network,
+          safeTxHash: row.safeTxHash,
+          proposerHandle: row.provenance?.proposerHandle,
+          actor: row.provenance?.actor,
+          reason: row.provenance?.reason,
+          prUrl: row.provenance?.prUrl,
+          gitCommit: row.provenance?.gitCommit,
+          dirtyTreeScoped: row.provenance?.dirtyTreeScoped,
+        }))
+
+      if (proposals.length === 0)
+        throw new Error(
+          `No pending proposals found for: ${networks.join(', ')}`
+        )
+
+      const card = renderProposalCard(proposals)
+      if (args.out) writeFileSync(args.out, `${card}\n`)
+      else consola.log(card)
+
+      // Named so a partial card is explainable rather than looking complete.
+      const missing = networks.filter((n) => !newestByNetwork.has(n))
+      if (missing.length > 0)
+        consola.warn(
+          `No pending proposal found on: ${missing.join(
+            ', '
+          )} — the card omits them.`
+        )
+    } finally {
+      await client.close()
+    }
+  },
+})
+
+runMain(main)

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -43,6 +43,7 @@ interface IRow {
     gitCommit?: unknown
     dirtyTreeScoped?: unknown
     dirtyTreeTruncated?: unknown
+    captureErrors?: unknown
   }
 }
 
@@ -129,6 +130,7 @@ const main = defineCommand({
           gitCommit: row.provenance?.gitCommit,
           dirtyTreeScoped: row.provenance?.dirtyTreeScoped,
           dirtyTreeTruncated: row.provenance?.dirtyTreeTruncated,
+          captureErrors: row.provenance?.captureErrors,
         }))
 
       if (proposals.length === 0)

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -1,8 +1,7 @@
 /**
  * Renders the signing-ask card for the proposals a run just created.
  *
- * Split from the posting step so `send-slack-webhook-message.ts` stays the only
- * thing that talks to Slack: this writes text, that posts it.
+ * Writes the text; `send-slack-webhook-message.ts` posts it.
  *
  * Opens its own client. `getSafeMongoCollection` creates indexes on connect, and
  * a read-only renderer must not alter the schema it reads.
@@ -17,21 +16,29 @@ import { consola } from 'consola'
 import { MongoClient } from 'mongodb'
 
 import { renderProposalCard, type ICardProposal } from './proposal-card'
+import type { SafeTxStatus } from './safe-utils'
 
 const DEFAULT_DB = 'sc_private'
 const DEFAULT_COLLECTION = 'pendingTransactions'
 
+/**
+ * The subset of `ISafeTxDocument` this renderer reads, typed as it may actually
+ * be on disk: `timestamp` and `provenance` are absent on rows stored before
+ * those fields existed, and each provenance value is `unknown` because a
+ * hand-edited or half-migrated row can hold a non-string there.
+ */
 interface IRow {
   network: string
-  safeTxHash: string
+  safeTxHash?: unknown
+  status?: SafeTxStatus
   timestamp?: Date
   provenance?: {
-    proposerHandle?: string
-    actor?: string
-    reason?: string
-    prUrl?: string
-    gitCommit?: string
-    dirtyTreeScoped?: string[]
+    proposerHandle?: unknown
+    actor?: unknown
+    reason?: unknown
+    prUrl?: unknown
+    gitCommit?: unknown
+    dirtyTreeScoped?: unknown
   }
 }
 
@@ -72,13 +79,16 @@ const main = defineCommand({
         .db(DEFAULT_DB)
         .collection<IRow>(DEFAULT_COLLECTION)
 
-      // Newest pending row per network. A network can carry an older unsigned
-      // proposal, and the card is about the run that just finished — so this
-      // takes the most recent rather than trying to match the run itself, which
-      // nothing in the document identifies.
+      // Takes the most recent rather than trying to match the run itself, which
+      // nothing in the document identifies. A network can carry an older
+      // unsigned proposal, and the card is about the run that just finished.
+      // `$eq` per the repo's operator-injection convention (mongoEq).
       const rows = await collection
         .find(
-          { network: { $in: networks }, status: 'pending' },
+          {
+            network: { $in: networks },
+            status: { $eq: 'pending' as SafeTxStatus },
+          },
           { sort: { timestamp: -1 } }
         )
         .toArray()
@@ -95,7 +105,7 @@ const main = defineCommand({
         .map((network) => newestByNetwork.get(network))
         .filter((row): row is IRow => row !== undefined)
         .map((row) => ({
-          network: row.network,
+          network: String(row.network),
           safeTxHash: row.safeTxHash,
           proposerHandle: row.provenance?.proposerHandle,
           actor: row.provenance?.actor,

--- a/script/deploy/safe/render-proposal-card.ts
+++ b/script/deploy/safe/render-proposal-card.ts
@@ -5,6 +5,9 @@
  *
  * Opens its own client. `getSafeMongoCollection` creates indexes on connect, and
  * a read-only renderer must not alter the schema it reads.
+ *
+ * No index has `network` as a leading key, so both queries below scan the
+ * collection. Acceptable while this runs once per proposal batch.
  */
 
 import 'dotenv/config'
@@ -92,7 +95,8 @@ const main = defineCommand({
       // Takes the most recent rather than trying to match the run itself, which
       // nothing in the document identifies. A network can carry an older
       // unsigned proposal, and the card is about the run that just finished.
-      // `$eq` per the repo's operator-injection convention (mongoEq).
+      // Explicit `$eq`/`$in` per the repo's operator-injection convention, so a
+      // value can never be read as an operator expression.
       const rows = await collection
         .find(
           {
@@ -138,18 +142,16 @@ const main = defineCommand({
       // would fire the alarm on exactly the runs that needed a retry.
       //
       // Absence of any row in any status is the real signal, so that is what is
-      // asked. One extra query, and it is the difference between an alarm and a
-      // false alarm.
+      // asked. `distinct` rather than `find`, so the result is bounded by the
+      // number of networks asked about rather than by how many rows they have
+      // between them.
       const withoutPending = networks.filter((n) => !newestByNetwork.has(n))
       const settled =
         withoutPending.length === 0
           ? []
-          : (
-              await collection
-                .find({ network: { $in: withoutPending } })
-                .project<{ network: string }>({ network: 1 })
-                .toArray()
-            ).map((r) => r.network)
+          : await collection.distinct('network', {
+              network: { $in: withoutPending },
+            })
 
       const unaccounted = withoutPending.filter((n) => !settled.includes(n))
 
@@ -162,9 +164,12 @@ const main = defineCommand({
         ...(contract && contract !== 'unknown' ? { contract } : {}),
       })
 
+      // Named without asserting which status: a `reverted` row is flagged for
+      // manual review, so reading it back as "signed" would be a false
+      // reassurance about the one case that needs a human.
       if (settled.length > 0)
         consola.info(
-          `Already signed or executed, so not on the card: ${settled.join(
+          `Not on the card — an earlier proposal exists in a non-pending state: ${settled.join(
             ', '
           )}`
         )
@@ -175,12 +180,13 @@ const main = defineCommand({
           )} — the card names the shortfall.`
         )
 
-      // Written after every read, so a failure to close the client cannot
-      // discard a card that was produced successfully.
       if (args.out) writeFileSync(args.out, `${card}\n`)
       else consola.log(card)
     } finally {
-      await client.close()
+      // Swallowed: the caller reads the exit code to decide between this card
+      // and a count-only fallback that overwrites it, so a close failure after
+      // the card is on disk would replace a good card with a worse one.
+      await client.close().catch(() => undefined)
     }
   },
 })

--- a/script/multiNetworkExecution.sh
+++ b/script/multiNetworkExecution.sh
@@ -2378,7 +2378,6 @@ function executeNetworksByGroup() {
         fi
     }
 
-    # For proposal runs: post a single Slack summary (count + chains + sign-and-schedule reminder)
     # Called exactly once per run, before cleanupProgressTracking removes the progress file
     notifyProposalsCreatedToSlack
 

--- a/script/multiNetworkExecution.sh
+++ b/script/multiNetworkExecution.sh
@@ -1280,13 +1280,10 @@ function notifyProposalsCreatedToSlack() {
     local MESSAGE_FILE
     MESSAGE_FILE=$(mktemp)
 
-    # The card is rendered from the proposal documents, so it carries the reason,
-    # proposer, PR and per-network review command. Falls back to the count-only
-    # message if that fails for any reason: a missing reason is worth a worse
-    # message, never a missing signing ask.
+    # A worse message is acceptable; a missing signing ask is not.
     local NETWORK_LIST
     NETWORK_LIST=$(IFS=,; printf '%s' "${SUCCESSFUL_NETWORKS[*]}")
-    if ! bunx tsx script/deploy/safe/render-proposal-card.ts --networks "$NETWORK_LIST" --out "$MESSAGE_FILE" 2>&1; then
+    if ! bunx tsx script/deploy/safe/render-proposal-card.ts --networks "$NETWORK_LIST" --out "$MESSAGE_FILE"; then
         logWithTimestamp "Warning: could not render the proposal card - falling back to the summary line"
         if [[ "$PROPOSAL_COUNT" -eq 1 ]]; then
             printf '%s\n' "1x proposal created: $PROPOSAL_CONTRACT on ${SUCCESSFUL_NETWORKS[0]} — please sign and schedule 🙏" >"$MESSAGE_FILE"

--- a/script/multiNetworkExecution.sh
+++ b/script/multiNetworkExecution.sh
@@ -1283,7 +1283,7 @@ function notifyProposalsCreatedToSlack() {
     # A worse message is acceptable; a missing signing ask is not.
     local NETWORK_LIST
     NETWORK_LIST=$(IFS=,; printf '%s' "${SUCCESSFUL_NETWORKS[*]}")
-    if ! bunx tsx script/deploy/safe/render-proposal-card.ts --networks "$NETWORK_LIST" --out "$MESSAGE_FILE"; then
+    if ! bunx tsx script/deploy/safe/render-proposal-card.ts --networks "$NETWORK_LIST" --contract "$PROPOSAL_CONTRACT" --out "$MESSAGE_FILE"; then
         logWithTimestamp "Warning: could not render the proposal card - falling back to the summary line"
         if [[ "$PROPOSAL_COUNT" -eq 1 ]]; then
             printf '%s\n' "1x proposal created: $PROPOSAL_CONTRACT on ${SUCCESSFUL_NETWORKS[0]} — please sign and schedule 🙏" >"$MESSAGE_FILE"

--- a/script/multiNetworkExecution.sh
+++ b/script/multiNetworkExecution.sh
@@ -1242,8 +1242,8 @@ function getProgressSummary() {
 }
 
 # notifyProposalsCreatedToSlack: Posts ONE Slack message after a proposal-creation run,
-# summarizing how many proposals were created (naming the network when there is exactly one,
-# otherwise just counting the networks), with a reminder to sign and schedule.
+# rendering a card from the proposal documents (reason, proposer, PR, per-network review
+# command), falling back to a count-only summary line if the render fails.
 # Reads the progress tracking file; no-ops unless the run's actionType is "proposal" and at
 # least one network succeeded. Posts to #dev-sc-multisig-proposals via
 # script/utils/send-slack-webhook-message.ts (requires WEBHOOK_DEV_SC_MULTISIG_PROPOSALS in .env;
@@ -1276,19 +1276,25 @@ function notifyProposalsCreatedToSlack() {
 
     local PROPOSAL_CONTRACT=$(jq -r '.contract // "unknown"' "$PROGRESS_TRACKING_FILE" 2>/dev/null || echo "unknown")
 
-    # message format follows the #dev-sc-multisig-proposals house style: "<N>x <what> ..."
-    # one network: name it; multiple: count them instead of listing (keeps the message short)
-    local MESSAGE
-    if [[ "$PROPOSAL_COUNT" -eq 1 ]]; then
-        MESSAGE="1x proposal created: $PROPOSAL_CONTRACT on ${SUCCESSFUL_NETWORKS[0]} — please sign and schedule 🙏"
-    else
-        MESSAGE="${PROPOSAL_COUNT}x proposals created: $PROPOSAL_CONTRACT across $PROPOSAL_COUNT networks — please sign and schedule 🙏"
-    fi
-
     logWithTimestamp "Posting proposal-creation summary to Slack (#dev-sc-multisig-proposals)..."
     local MESSAGE_FILE
     MESSAGE_FILE=$(mktemp)
-    printf '%s\n' "$MESSAGE" >"$MESSAGE_FILE"
+
+    # The card is rendered from the proposal documents, so it carries the reason,
+    # proposer, PR and per-network review command. Falls back to the count-only
+    # message if that fails for any reason: a missing reason is worth a worse
+    # message, never a missing signing ask.
+    local NETWORK_LIST
+    NETWORK_LIST=$(IFS=,; printf '%s' "${SUCCESSFUL_NETWORKS[*]}")
+    if ! bunx tsx script/deploy/safe/render-proposal-card.ts --networks "$NETWORK_LIST" --out "$MESSAGE_FILE" 2>&1; then
+        logWithTimestamp "Warning: could not render the proposal card - falling back to the summary line"
+        if [[ "$PROPOSAL_COUNT" -eq 1 ]]; then
+            printf '%s\n' "1x proposal created: $PROPOSAL_CONTRACT on ${SUCCESSFUL_NETWORKS[0]} — please sign and schedule 🙏" >"$MESSAGE_FILE"
+        else
+            printf '%s\n' "${PROPOSAL_COUNT}x proposals created: $PROPOSAL_CONTRACT across $PROPOSAL_COUNT networks — please sign and schedule 🙏" >"$MESSAGE_FILE"
+        fi
+    fi
+
     bunx tsx script/utils/send-slack-webhook-message.ts --channel dev-sc-multisig-proposals --message-file "$MESSAGE_FILE" || logWithTimestamp "Warning: Failed to send proposal-creation Slack notification"
     rm -f "$MESSAGE_FILE"
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Ref [EXSC-696](https://linear.app/lifi-linear/issue/EXSC-696/s10-slack-card-rendered-from-the-proposal-document) — WP-1.3 (S10).

Ref EXSC-696 — deliberately `Ref` and not `Fixes`: the ticket also asks for **thread updates on status transitions**, which cannot be built with an incoming webhook — see "What is not in this PR".

# Why did I implement it this way?

The signing ask was assembled from the runner's own progress file:

```text
2x proposals created: AcrossFacetV4 across 2 networks — please sign and schedule 🙏
```

That file knows a contract name and a network count. It does not know why the change is being made, who made it, from which commit, or how to review it — so the card asked people to sign and told them nothing to sign on.

The card is now rendered from the proposal documents:

```text
1x proposal created on mainnet — please sign and schedule 🙏

*Reason:* add AcrossFacetV4 to the whitelist
*Proposed by:* Alice Example &lt;alice@example.com&gt;
*Commit:* 1234567890ab
*PR:* https://github.com/lifinance/contracts/pull/2125

*To review:*
• `bun confirm-safe-tx --network mainnet`  (0xabababab)
```

and, on a wider run with less to go on:

```text
12x proposals created across 12 networks — please sign and schedule 🙏

*Reason:* _none given_
*Proposed by:* ci-bot (bot)
*Working tree:* dirty — src/Facets/Foo.sol
*Proposer-side check (advisory):* codehash matched on 12/12 networks

*To review:*
• `bun confirm-safe-tx --network chain0`  (0x00000000)
• …and 11 more — same command per network
```

## Decisions worth a reviewer's attention

**Every proposer-controlled string is escaped *and* flattened onto one line.** Two different risks, and only the first is obvious: `<!channel>` in a reason would notify a whole channel from a field nobody reviews, and a **newline lets a value forge the card's own structure** — a reason containing `\n*Reason:* something else` renders as a second, entirely plausible Reason line. These values are sanitized when stored, but a card that trusts the document is one hand-edited row away from lying to every signer who reads it.

**An absent reason is stated, not omitted.** `_none given_` tells a signer the intent was never captured. A card that simply skips the line is indistinguishable from one that failed to render it.

**A proposer-side check is labelled advisory**, per the ticket. Authoritative status lives in the signer-side attestation, and a card stating a result without that word invites signing on the card's word.

**The expected-hash table is a parameter, not a placeholder line.** The ticket asks the design to reserve the slot for WP-7.2's DM service. Reserving it as an optional argument keeps the slot without shipping a "not yet available" line — filler sections train operators to skip sections.

**Truncation at 8,000 characters, and the middle is what goes.** Not Slack's 3,000 — that is the per-`blocks[].text` limit, and this card posts as a top-level `text`, whose limit is 40,000. 8,000 is a readability bound, not a platform one. Slack drops overflow silently and the review commands sit at the *bottom*, so the cut is taken out of the body: the headline and the commands both survive, and the card says it was cut.

**The advisory-check line and the hash table have no production caller yet.** `render-proposal-card.ts` supplies neither `checkSummary` nor `expectedHashes`, so the `*Proposer-side check (advisory):*` line, the `*Expected code hashes:*` block, and the `Proposer-side check` entry in the divergence warning cannot render on a real run today — they are the reserved WP-7.2 slot, exercised by tests only. The second example card above shows the shape, not live output.

**Rendering is split from posting.** `send-slack-webhook-message.ts` stays the only thing that talks to Slack; `render-proposal-card.ts` writes text and `proposal-card.ts` is pure. The bash caller **falls back to the old summary line** if the render fails for any reason — a worse message is acceptable, a missing signing ask is not, and `notifyProposalsCreatedToSlack`'s contract is that it never fails the run.

# Evidence

`bun test script/` — **1606 pass / 0 fail** (1538 baseline; 68 new), identical with and without ambient env config. `tsc-files --noEmit`, `eslint`, `bash -n` and `markdownlint-cli2` all clean.

**14 mutations, all die.** Two initially **survived**, and both are worth naming because neither was a weak guard:

| Mutation | Result |
|---|---|
| stop escaping Slack markup | 2 fail |
| escape `<` but not `&` | 1 fail |
| omit the reason line when absent | 1 fail |
| drop the "advisory" label | 1 fail |
| render the full hash instead of a short one | 1 fail |
| render the hash header with no rows | 1 fail |
| emit one command per network, unbounded | 1 fail |
| render an empty card instead of refusing | 1 fail |
| hide the dirty working tree | 1 fail |
| drop the bot marker | 1 fail |
| stop flattening newlines | 1 fail |
| drop the truncation | 1 fail |

- One survived on a **bad assertion of mine** — I checked for `'expected hash'` where the card says `'expected code hashes'`.
- One survived because **two guards caught the same input**: an explicit `length === 0` check plus an `if (!first)` that existed only for the type checker. I removed the redundant one rather than adding a fixture, so the remaining guard is the one that is actually load-bearing.

The newline-flattening and truncation guards came from an **enumeration pass, not from mutation** — listing what a document value can lie about (markup, structure, length) rather than mutating the guards I had already written. Mutation testing cannot surface a check that was never there, which is how a missing URL-scheme check got through review round 1 on #2298 despite 19 passing mutations.

# What is not in this PR

**Thread updates on status transitions.** The ticket asks for them and they are not buildable as things stand: Slack **incoming webhooks return no message timestamp**, so there is nothing to thread a reply to, and the repo has no bot token — `SlackNotifier` is webhook-only and `.env.example` has only `WEBHOOK_*` entries. Threading needs a Slack app with `chat.postMessage`, which is a credential to provision rather than code to write. Raised as **D18 on EXSC-883**; the card itself is useful without it, so I shipped that half rather than blocking on it.

**`ticketUrl` is not rendered.** The field arrives with WP-1.2 ([#2298](https://github.com/lifinance/contracts/pull/2298), still a draft). Built off `origin/main` deliberately rather than stacking — a squash-merge breaks a stack, and stacked PRs get no automatic CodeRabbit review. Adding the row is a two-line follow-up once #2298 lands.

## Reversible choices

- **Four networks** is the threshold for naming versus counting, and for one command versus a summarising line.
- **The newest pending proposal per network** is the selector. Nothing in a document identifies the run that created it, so a network carrying an older unsigned proposal would contribute that one instead; the run's own network list bounds the query. Networks with no pending proposal are named in a warning rather than silently dropped.
- **The first proposal's provenance heads the card, and divergence is named rather than hidden.** A run proposes the same change everywhere, so reason/proposer/PR are identical in practice; when they are not, the card warns and says only the first is shown. The two fields with a safety consequence are unioned across every row instead of read from the first — a dirty working tree or a non-human actor on any network is never suppressed by another network's clean row, and a value in the dirty-tree field that cannot be read as a path list reports as unreadable rather than as clean.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug




---

# Accepted residuals, decided rather than dropped

**A bare URL in a free-text field is not neutralised.** Only `prUrl` is guarded, and a reviewer was right that leaving this unmentioned across three rounds read as dropped. The decision, so it is on the record:

The distinction is whether **the card asserts the value is a link**. `*PR:* <url>` is the card saying "this is the PR" — an unvalidated value there borrows the card's authority, which is why it is scheme-checked and withheld when it fails. `*Reason:*` is proposer-supplied prose, and a signer reads it as prose. Slack will auto-link a URL inside it, but neutralising URLs in prose breaks a legitimate reason that cites one, and the alternative — rendering prose the card has silently edited — is worse than a visibly clickable string in a field labelled as someone's words.

`reason` is capped at 200 characters, sanitised through `sanitizeProvenanceText`, and stripped of the mrkdwn markers that could disguise it as a label. What remains is a proposer able to put a link in their own stated reason, which they could equally do in the Linear ticket the card links to.

**Two smaller ones**, both low reachability and shared with the signing prompt:

- `_none given_` is a forgeable sentinel. Forging the absence of one's own reason gains an attacker nothing.
- `expectedHashes` and `checkSummary` have no production caller today — `render-proposal-card.ts` maps six fields and neither is among them. They are the reserved WP-7.2 slot. This bounds every truncation finding in this PR to hardening: a real 41-network card measures a few hundred characters against an 8,000 cap.

# What the working-tree line now says

Four states, matching `provenance-display.ts`'s model for the signing prompt, each naming its own networks:

```text
clean everywhere      (no line)
capture failed on one  *Working tree:* capture incomplete on arbitrum
dirty + unreadable     *Working tree:* dirty on mainnet — src/A.sol; not captured on arbitrum
dirty + incomplete     *Working tree:* dirty on mainnet — src/A.sol; capture incomplete on arbitrum
```

The reason that matters: a failed `git status` writes an **empty path list plus `captureErrors`**, and the card mapped neither field — so such a row fell into no bucket and rendered **no working-tree line at all**. The two likeliest probe failures are the 5-second timeout and the 8 MB buffer cap, both of which correlate with a *very* dirty tree. The card read clean exactly when the tree was dirtiest.


