### PR TITLE
feat(codehash): trailer, immutable masking and attested-set compare (EXSC-906)

### DIFF
--- a/script/deploy/codehash/attested-set.test.ts
+++ b/script/deploy/codehash/attested-set.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Fixtures are the two lineage hashes measured on this repo's own artifacts:
+ * `AccessManagerFacet` built at the default profile (solc 0.8.29 / cancun) and
+ * at `solc_floor` (solc 0.8.17 / london), each stripped of its metadata trailer
+ * and hashed. Provenance and the raw bytes are in `bytecode-trailer.test.ts`.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { compareToAttestedSet } from './attested-set'
+import type { IAttestedBuild } from './attested-set'
+
+const CANCUN_HASH =
+  // pre-commit-checker: not a secret — keccak of public runtime bytecode
+  '0x9b36461a723520f9ae8b561962cd5622e15a7268f7d978eab84dfb848466a2d9'
+const LONDON_HASH =
+  // pre-commit-checker: not a secret — keccak of public runtime bytecode
+  '0x632dab2dd5d993b30427c6e779ba627ff5a9db3621b26901502a773aa0938f86'
+/** Neither lineage produces this; it stands in for code that is not ours. */
+const FOREIGN_HASH = `0x${'ab'.repeat(32)}`
+
+const ATTESTED: IAttestedBuild[] = [
+  {
+    lineage: 'upstream cancun',
+    solcVersion: '0.8.29',
+    maskedHash: CANCUN_HASH,
+  },
+  {
+    lineage: 'upstream london',
+    solcVersion: '0.8.17',
+    maskedHash: LONDON_HASH,
+  },
+]
+
+describe('compareToAttestedSet', () => {
+  it('accepts a build from any attested lineage, not one privileged profile', () => {
+    // E1: a record claiming 0.8.29 must not turn an honest london build red.
+    // Both lineages are legitimate builds of main, so both are GREEN.
+    for (const [hash, version, lineage] of [
+      [CANCUN_HASH, '0.8.29', 'upstream cancun'],
+      [LONDON_HASH, '0.8.17', 'upstream london'],
+    ] as const) {
+      const result = compareToAttestedSet(
+        { maskedHash: hash, solcVersion: version },
+        ATTESTED
+      )
+
+      expect(result.verdict).toBe('MATCH')
+      expect(result.matchedLineages).toEqual([lineage])
+      expect(result.blocksSigning).toBe(false)
+    }
+  })
+
+  it('does not depend on the order the attested builds are listed in', () => {
+    // Kills any implementation that compares against `builds[0]`.
+    const reversed = [...ATTESTED].reverse()
+
+    expect(
+      compareToAttestedSet(
+        { maskedHash: LONDON_HASH, solcVersion: '0.8.17' },
+        reversed
+      ).verdict
+    ).toBe('MATCH')
+    expect(
+      compareToAttestedSet(
+        { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+        reversed
+      ).verdict
+    ).toBe('MATCH')
+  })
+
+  it('calls a foreign hash from an attested lineage a MISMATCH', () => {
+    // We built this exact lineage, so a disagreement is a real finding.
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      ATTESTED
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+    expect(result.blocksSigning).toBe(true)
+    expect(result.reason).toContain('0.8.29')
+  })
+
+  it('calls a foreign hash from an UNBUILT lineage UNVERIFIABLE, not a MISMATCH', () => {
+    // Nothing was ever built at 0.8.31, so a non-match is ignorance, not
+    // evidence. Reporting it as RED would train signers to wave through red.
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
+      ATTESTED
+    )
+
+    expect(result.verdict).toBe('UNVERIFIABLE')
+    expect(result.blocksSigning).toBe(true)
+    expect(result.reason).toContain('0.8.31')
+  })
+
+  it('is UNVERIFIABLE when the deployed code carries no compiler version', () => {
+    // No trailer means the lineage cannot be established, so neither a match
+    // nor a mismatch can be claimed.
+    const result = compareToAttestedSet({ maskedHash: FOREIGN_HASH }, ATTESTED)
+
+    expect(result.verdict).toBe('UNVERIFIABLE')
+    expect(result.blocksSigning).toBe(true)
+    expect(result.reason).toMatch(/no readable compiler version/i)
+  })
+
+  it('is UNVERIFIABLE with an empty attested set rather than vacuously RED', () => {
+    const result = compareToAttestedSet(
+      { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+      []
+    )
+
+    expect(result.verdict).toBe('UNVERIFIABLE')
+    expect(result.blocksSigning).toBe(true)
+    // The verdict alone does not distinguish this from an unbuilt lineage, so
+    // assert the message: without its own branch the signer is told the code
+    // came from a compiler "no attested build used ()" — an empty list.
+    expect(result.reason).toContain('no attested build of main is available')
+  })
+
+  it('keeps GREY distinct from RED while blocking on both', () => {
+    const grey = compareToAttestedSet({ maskedHash: FOREIGN_HASH }, ATTESTED)
+    const red = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      ATTESTED
+    )
+
+    // Fail closed: both block. Visibly distinct: the verdicts differ, and the
+    // renderer downstream keys off the verdict, never off `blocksSigning`.
+    expect([grey.blocksSigning, red.blocksSigning]).toEqual([true, true])
+    expect(grey.verdict).not.toBe(red.verdict)
+  })
+
+  it('matches a hash reached by two lineages without preferring either', () => {
+    // Two compilers can emit identical code once the trailer is off; the
+    // masked hash carries no version, so both lineages are named.
+    const twins: IAttestedBuild[] = [
+      {
+        lineage: 'upstream cancun',
+        solcVersion: '0.8.29',
+        maskedHash: CANCUN_HASH,
+      },
+      { lineage: 'tron fork', solcVersion: '0.8.29', maskedHash: CANCUN_HASH },
+    ]
+    const result = compareToAttestedSet(
+      { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+      twins
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.matchedLineages).toEqual(['upstream cancun', 'tron fork'])
+  })
+
+  it('ignores case and 0x-prefix differences between hashes', () => {
+    const result = compareToAttestedSet(
+      { maskedHash: CANCUN_HASH.slice(2).toUpperCase(), solcVersion: '0.8.29' },
+      ATTESTED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+  })
+})

--- a/script/deploy/codehash/attested-set.test.ts
+++ b/script/deploy/codehash/attested-set.test.ts
@@ -1,8 +1,8 @@
 /**
- * Fixtures are the two lineage hashes measured on this repo's own artifacts:
- * `AccessManagerFacet` built at the default profile (solc 0.8.29 / cancun) and
- * at `solc_floor` (solc 0.8.17 / london), each stripped of its metadata trailer
- * and hashed. Provenance and the raw bytes are in `bytecode-trailer.test.ts`.
+ * Fixtures are measured on this repo's own artifacts: `AccessManagerFacet` built
+ * at the default profile (solc 0.8.29 / cancun, 1423 bytes) and at `solc_floor`
+ * (solc 0.8.17 / london, 1440 bytes), each stripped of its metadata trailer and
+ * hashed. Provenance and the raw bytes are in `bytecode-trailer.test.ts`.
  */
 
 import {
@@ -18,9 +18,11 @@ import type { IAttestedBuild } from './attested-set'
 const CANCUN_HASH =
   // pre-commit-checker: not a secret — keccak of public runtime bytecode
   '0x9b36461a723520f9ae8b561962cd5622e15a7268f7d978eab84dfb848466a2d9'
+const CANCUN_BYTES = 1423
 const LONDON_HASH =
   // pre-commit-checker: not a secret — keccak of public runtime bytecode
   '0x632dab2dd5d993b30427c6e779ba627ff5a9db3621b26901502a773aa0938f86'
+const LONDON_BYTES = 1440
 /** Neither lineage produces this; it stands in for code that is not ours. */
 const FOREIGN_HASH = `0x${'ab'.repeat(32)}`
 
@@ -29,11 +31,13 @@ const ATTESTED: IAttestedBuild[] = [
     lineage: 'upstream cancun',
     solcVersion: '0.8.29',
     maskedHash: CANCUN_HASH,
+    rawByteLength: CANCUN_BYTES,
   },
   {
     lineage: 'upstream london',
     solcVersion: '0.8.17',
     maskedHash: LONDON_HASH,
+    rawByteLength: LONDON_BYTES,
   },
 ]
 
@@ -45,13 +49,13 @@ const OPEN = { isClosedSet: false }
 describe('compareToAttestedSet', () => {
   it('accepts a build from any attested lineage, not one privileged profile', () => {
     // E1: a record claiming 0.8.29 must not turn an honest london build red.
-    for (const [hash, version, lineage] of [
-      [CANCUN_HASH, '0.8.29', 'upstream cancun'],
-      [LONDON_HASH, '0.8.17', 'upstream london'],
+    for (const [hash, version, bytes, lineage] of [
+      [CANCUN_HASH, '0.8.29', CANCUN_BYTES, 'upstream cancun'],
+      [LONDON_HASH, '0.8.17', LONDON_BYTES, 'upstream london'],
     ] as const)
       for (const scope of [CLOSED, OPEN]) {
         const result = compareToAttestedSet(
-          { maskedHash: hash, solcVersion: version },
+          { maskedHash: hash, solcVersion: version, rawByteLength: bytes },
           ATTESTED,
           scope
         )
@@ -66,20 +70,17 @@ describe('compareToAttestedSet', () => {
     // Kills any implementation that compares against `builds[0]`.
     const reversed = [...ATTESTED].reverse()
 
-    expect(
-      compareToAttestedSet(
-        { maskedHash: LONDON_HASH, solcVersion: '0.8.17' },
-        reversed,
-        CLOSED
-      ).verdict
-    ).toBe('MATCH')
-    expect(
-      compareToAttestedSet(
-        { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
-        reversed,
-        CLOSED
-      ).verdict
-    ).toBe('MATCH')
+    for (const [hash, version, bytes] of [
+      [LONDON_HASH, '0.8.17', LONDON_BYTES],
+      [CANCUN_HASH, '0.8.29', CANCUN_BYTES],
+    ] as const)
+      expect(
+        compareToAttestedSet(
+          { maskedHash: hash, solcVersion: version, rawByteLength: bytes },
+          reversed,
+          CLOSED
+        ).verdict
+      ).toBe('MATCH')
   })
 
   it('matches a hash reached by two lineages without preferring either', () => {
@@ -90,11 +91,21 @@ describe('compareToAttestedSet', () => {
         lineage: 'upstream cancun',
         solcVersion: '0.8.29',
         maskedHash: CANCUN_HASH,
+        rawByteLength: CANCUN_BYTES,
       },
-      { lineage: 'tron fork', solcVersion: '0.8.29', maskedHash: CANCUN_HASH },
+      {
+        lineage: 'tron fork',
+        solcVersion: '0.8.29',
+        maskedHash: CANCUN_HASH,
+        rawByteLength: CANCUN_BYTES,
+      },
     ]
     const result = compareToAttestedSet(
-      { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+      {
+        maskedHash: CANCUN_HASH,
+        solcVersion: '0.8.29',
+        rawByteLength: CANCUN_BYTES,
+      },
       twins,
       CLOSED
     )
@@ -105,7 +116,11 @@ describe('compareToAttestedSet', () => {
 
   it('ignores case and 0x-prefix differences between hashes', () => {
     const result = compareToAttestedSet(
-      { maskedHash: CANCUN_HASH.slice(2).toUpperCase(), solcVersion: '0.8.29' },
+      {
+        maskedHash: CANCUN_HASH.slice(2).toUpperCase(),
+        solcVersion: '0.8.29',
+        rawByteLength: CANCUN_BYTES,
+      },
       ATTESTED,
       CLOSED
     )
@@ -116,7 +131,11 @@ describe('compareToAttestedSet', () => {
   it('is UNVERIFIABLE with an empty attested set, under either scope', () => {
     for (const scope of [CLOSED, OPEN]) {
       const result = compareToAttestedSet(
-        { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+        {
+          maskedHash: CANCUN_HASH,
+          solcVersion: '0.8.29',
+          rawByteLength: CANCUN_BYTES,
+        },
         [],
         scope
       )
@@ -128,6 +147,71 @@ describe('compareToAttestedSet', () => {
       // came from a compiler "no attested build used ()" — an empty list.
       expect(result.reason).toContain('no attested build of main is available')
     }
+  })
+})
+
+describe('when the normalised hash matches but the deployed length does not', () => {
+  // The trailer's length word decides how many bytes come off before hashing,
+  // and it is part of the deployed code. Appending a payload plus a length word
+  // covering it leaves the stripped prefix — and so the masked hash — untouched.
+  it.each([
+    ['a payload appended', LONDON_BYTES + 3002],
+    ['four bytes appended', LONDON_BYTES + 4],
+    ['bytes missing', LONDON_BYTES - 8],
+  ])('refuses code with %s', (_label, rawByteLength) => {
+    for (const scope of [CLOSED, OPEN]) {
+      const result = compareToAttestedSet(
+        { maskedHash: LONDON_HASH, solcVersion: '0.8.17', rawByteLength },
+        ATTESTED,
+        scope
+      )
+
+      expect(result.verdict).toBe('MISMATCH')
+      expect(result.blocksSigning).toBe(true)
+      expect(result.reason).toContain('not accounted for')
+    }
+  })
+
+  it('says how many bytes are unaccounted for, not merely that it differs', () => {
+    const result = compareToAttestedSet(
+      {
+        maskedHash: LONDON_HASH,
+        solcVersion: '0.8.17',
+        rawByteLength: LONDON_BYTES + 3002,
+      },
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.reason).toContain('3002 bytes')
+    expect(result.reason).toContain('upstream london')
+  })
+
+  it('still matches the attested build whose length agrees', () => {
+    // Two builds of one source can share a stripped hash and differ in trailer
+    // length — a metadata setting, not a tamper. The one that agrees is a MATCH,
+    // and only that one is named.
+    const both: IAttestedBuild[] = [
+      ...ATTESTED,
+      {
+        lineage: 'london, metadata hash off',
+        solcVersion: '0.8.17',
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES - 44,
+      },
+    ]
+    const result = compareToAttestedSet(
+      {
+        maskedHash: LONDON_HASH,
+        solcVersion: '0.8.17',
+        rawByteLength: LONDON_BYTES - 44,
+      },
+      both,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.matchedLineages).toEqual(['london, metadata hash off'])
   })
 })
 
@@ -143,7 +227,11 @@ describe('with a closed set of legitimate builds', () => {
     'calls foreign code a MISMATCH though it reports %s',
     (_label, version) => {
       const result = compareToAttestedSet(
-        { maskedHash: FOREIGN_HASH, solcVersion: version },
+        {
+          maskedHash: FOREIGN_HASH,
+          solcVersion: version,
+          rawByteLength: CANCUN_BYTES,
+        },
         ATTESTED,
         CLOSED
       )
@@ -158,7 +246,7 @@ describe('with a closed set of legitimate builds', () => {
     // Stripping the trailer, or compiling with `bytecodeHash: "none"`, is the
     // cheapest way to report nothing. It must not buy a softer verdict either.
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH },
+      { maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES },
       ATTESTED,
       CLOSED
     )
@@ -171,10 +259,22 @@ describe('with a closed set of legitimate builds', () => {
     // verdict, no matter what the code says about itself.
     const verdicts = new Set(
       [
-        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
-        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.17' },
-        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.99' },
-        { maskedHash: FOREIGN_HASH },
+        {
+          maskedHash: FOREIGN_HASH,
+          solcVersion: '0.8.29',
+          rawByteLength: 1423,
+        },
+        {
+          maskedHash: FOREIGN_HASH,
+          solcVersion: '0.8.17',
+          rawByteLength: 1423,
+        },
+        {
+          maskedHash: FOREIGN_HASH,
+          solcVersion: '0.8.99',
+          rawByteLength: 9999,
+        },
+        { maskedHash: FOREIGN_HASH, rawByteLength: 12 },
       ].map(
         (observed) => compareToAttestedSet(observed, ATTESTED, CLOSED).verdict
       )
@@ -187,7 +287,11 @@ describe('with a closed set of legitimate builds', () => {
 describe('with an open set of legitimate builds', () => {
   it('calls a foreign hash from an attested lineage a MISMATCH', () => {
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      {
+        maskedHash: FOREIGN_HASH,
+        solcVersion: '0.8.29',
+        rawByteLength: CANCUN_BYTES,
+      },
       ATTESTED,
       OPEN
     )
@@ -201,7 +305,11 @@ describe('with an open set of legitimate builds', () => {
     // non-match is ignorance rather than evidence. This is the branch the
     // closed-set tests above prove cannot be reached by a tamperer.
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
+      {
+        maskedHash: FOREIGN_HASH,
+        solcVersion: '0.8.31',
+        rawByteLength: CANCUN_BYTES,
+      },
       ATTESTED,
       OPEN
     )
@@ -213,7 +321,7 @@ describe('with an open set of legitimate builds', () => {
 
   it('is UNVERIFIABLE when the deployed code carries no compiler version', () => {
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH },
+      { maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES },
       ATTESTED,
       OPEN
     )
@@ -224,12 +332,20 @@ describe('with an open set of legitimate builds', () => {
 
   it('keeps GREY distinct from RED while blocking on both', () => {
     const grey = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
+      {
+        maskedHash: FOREIGN_HASH,
+        solcVersion: '0.8.31',
+        rawByteLength: CANCUN_BYTES,
+      },
       ATTESTED,
       OPEN
     )
     const red = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      {
+        maskedHash: FOREIGN_HASH,
+        solcVersion: '0.8.29',
+        rawByteLength: CANCUN_BYTES,
+      },
       ATTESTED,
       OPEN
     )

--- a/script/deploy/codehash/attested-set.test.ts
+++ b/script/deploy/codehash/attested-set.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'bun:test'
 
 import { compareToAttestedSet } from './attested-set'
-import type { IAttestedBuild } from './attested-set'
+import type { IAttestedBuild, IObservedCode } from './attested-set'
 
 const CANCUN_HASH =
   // pre-commit-checker: not a secret — keccak of public runtime bytecode
@@ -26,18 +26,30 @@ const LONDON_BYTES = 1440
 /** Neither lineage produces this; it stands in for code that is not ours. */
 const FOREIGN_HASH = `0x${'ab'.repeat(32)}`
 
+/** Builds an observation; each test overrides only the field it is about. */
+const seen = (
+  over: Partial<IObservedCode> & { maskedHash: string }
+): IObservedCode => ({
+  rawByteLength: CANCUN_BYTES,
+  rawHash: `0x${'11'.repeat(32)}`,
+  maskedByteCount: 0,
+  ...over,
+})
+
 const ATTESTED: IAttestedBuild[] = [
   {
     lineage: 'upstream cancun',
     solcVersion: '0.8.29',
     maskedHash: CANCUN_HASH,
     rawByteLength: CANCUN_BYTES,
+    rawHash: undefined,
   },
   {
     lineage: 'upstream london',
     solcVersion: '0.8.17',
     maskedHash: LONDON_HASH,
     rawByteLength: LONDON_BYTES,
+    rawHash: undefined,
   },
 ]
 
@@ -55,7 +67,11 @@ describe('compareToAttestedSet', () => {
     ] as const)
       for (const scope of [CLOSED, OPEN]) {
         const result = compareToAttestedSet(
-          { maskedHash: hash, solcVersion: version, rawByteLength: bytes },
+          seen({
+            maskedHash: hash,
+            solcVersion: version,
+            rawByteLength: bytes,
+          }),
           ATTESTED,
           scope
         )
@@ -76,7 +92,11 @@ describe('compareToAttestedSet', () => {
     ] as const)
       expect(
         compareToAttestedSet(
-          { maskedHash: hash, solcVersion: version, rawByteLength: bytes },
+          seen({
+            maskedHash: hash,
+            solcVersion: version,
+            rawByteLength: bytes,
+          }),
           reversed,
           CLOSED
         ).verdict
@@ -92,20 +112,22 @@ describe('compareToAttestedSet', () => {
         solcVersion: '0.8.29',
         maskedHash: CANCUN_HASH,
         rawByteLength: CANCUN_BYTES,
+        rawHash: undefined,
       },
       {
         lineage: 'tron fork',
         solcVersion: '0.8.29',
         maskedHash: CANCUN_HASH,
         rawByteLength: CANCUN_BYTES,
+        rawHash: undefined,
       },
     ]
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: CANCUN_HASH,
         solcVersion: '0.8.29',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       twins,
       CLOSED
     )
@@ -116,11 +138,11 @@ describe('compareToAttestedSet', () => {
 
   it('ignores case and 0x-prefix differences between hashes', () => {
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: CANCUN_HASH.slice(2).toUpperCase(),
         solcVersion: '0.8.29',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       ATTESTED,
       CLOSED
     )
@@ -131,11 +153,11 @@ describe('compareToAttestedSet', () => {
   it('is UNVERIFIABLE with an empty attested set, under either scope', () => {
     for (const scope of [CLOSED, OPEN]) {
       const result = compareToAttestedSet(
-        {
+        seen({
           maskedHash: CANCUN_HASH,
           solcVersion: '0.8.29',
           rawByteLength: CANCUN_BYTES,
-        },
+        }),
         [],
         scope
       )
@@ -161,7 +183,7 @@ describe('when the normalised hash matches but the deployed length does not', ()
   ])('refuses code with %s', (_label, rawByteLength) => {
     for (const scope of [CLOSED, OPEN]) {
       const result = compareToAttestedSet(
-        { maskedHash: LONDON_HASH, solcVersion: '0.8.17', rawByteLength },
+        seen({ maskedHash: LONDON_HASH, solcVersion: '0.8.17', rawByteLength }),
         ATTESTED,
         scope
       )
@@ -174,11 +196,11 @@ describe('when the normalised hash matches but the deployed length does not', ()
 
   it('says how many bytes are unaccounted for, not merely that it differs', () => {
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: LONDON_HASH,
         solcVersion: '0.8.17',
         rawByteLength: LONDON_BYTES + 3002,
-      },
+      }),
       ATTESTED,
       CLOSED
     )
@@ -197,15 +219,17 @@ describe('when the normalised hash matches but the deployed length does not', ()
         lineage: 'london, metadata hash off',
         solcVersion: '0.8.17',
         maskedHash: LONDON_HASH,
-        rawByteLength: LONDON_BYTES - 44,
+        rawByteLength: LONDON_BYTES - 41,
+        rawHash: undefined,
       },
     ]
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: LONDON_HASH,
         solcVersion: '0.8.17',
-        rawByteLength: LONDON_BYTES - 44,
-      },
+        rawByteLength: LONDON_BYTES - 41,
+        rawHash: undefined,
+      }),
       both,
       CLOSED
     )
@@ -227,11 +251,7 @@ describe('with a closed set of legitimate builds', () => {
     'calls foreign code a MISMATCH though it reports %s',
     (_label, version) => {
       const result = compareToAttestedSet(
-        {
-          maskedHash: FOREIGN_HASH,
-          solcVersion: version,
-          rawByteLength: CANCUN_BYTES,
-        },
+        seen({ maskedHash: FOREIGN_HASH, solcVersion: version }),
         ATTESTED,
         CLOSED
       )
@@ -246,7 +266,7 @@ describe('with a closed set of legitimate builds', () => {
     // Stripping the trailer, or compiling with `bytecodeHash: "none"`, is the
     // cheapest way to report nothing. It must not buy a softer verdict either.
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES },
+      seen({ maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES }),
       ATTESTED,
       CLOSED
     )
@@ -259,22 +279,14 @@ describe('with a closed set of legitimate builds', () => {
     // verdict, no matter what the code says about itself.
     const verdicts = new Set(
       [
-        {
-          maskedHash: FOREIGN_HASH,
-          solcVersion: '0.8.29',
-          rawByteLength: 1423,
-        },
-        {
-          maskedHash: FOREIGN_HASH,
-          solcVersion: '0.8.17',
-          rawByteLength: 1423,
-        },
-        {
+        seen({ maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' }),
+        seen({ maskedHash: FOREIGN_HASH, solcVersion: '0.8.17' }),
+        seen({
           maskedHash: FOREIGN_HASH,
           solcVersion: '0.8.99',
           rawByteLength: 9999,
-        },
-        { maskedHash: FOREIGN_HASH, rawByteLength: 12 },
+        }),
+        seen({ maskedHash: FOREIGN_HASH, rawByteLength: 12 }),
       ].map(
         (observed) => compareToAttestedSet(observed, ATTESTED, CLOSED).verdict
       )
@@ -287,11 +299,11 @@ describe('with a closed set of legitimate builds', () => {
 describe('with an open set of legitimate builds', () => {
   it('calls a foreign hash from an attested lineage a MISMATCH', () => {
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: FOREIGN_HASH,
         solcVersion: '0.8.29',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       ATTESTED,
       OPEN
     )
@@ -305,11 +317,11 @@ describe('with an open set of legitimate builds', () => {
     // non-match is ignorance rather than evidence. This is the branch the
     // closed-set tests above prove cannot be reached by a tamperer.
     const result = compareToAttestedSet(
-      {
+      seen({
         maskedHash: FOREIGN_HASH,
         solcVersion: '0.8.31',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       ATTESTED,
       OPEN
     )
@@ -321,7 +333,7 @@ describe('with an open set of legitimate builds', () => {
 
   it('is UNVERIFIABLE when the deployed code carries no compiler version', () => {
     const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES },
+      seen({ maskedHash: FOREIGN_HASH, rawByteLength: CANCUN_BYTES }),
       ATTESTED,
       OPEN
     )
@@ -332,20 +344,20 @@ describe('with an open set of legitimate builds', () => {
 
   it('keeps GREY distinct from RED while blocking on both', () => {
     const grey = compareToAttestedSet(
-      {
+      seen({
         maskedHash: FOREIGN_HASH,
         solcVersion: '0.8.31',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       ATTESTED,
       OPEN
     )
     const red = compareToAttestedSet(
-      {
+      seen({
         maskedHash: FOREIGN_HASH,
         solcVersion: '0.8.29',
         rawByteLength: CANCUN_BYTES,
-      },
+      }),
       ATTESTED,
       OPEN
     )
@@ -354,5 +366,100 @@ describe('with an open set of legitimate builds', () => {
     // renderer downstream keys off the verdict, never off `blocksSigning`.
     expect([grey.blocksSigning, red.blocksSigning]).toEqual([true, true])
     expect(grey.verdict).not.toBe(red.verdict)
+  })
+})
+
+describe('what a MATCH does not cover', () => {
+  it('says so when bytes were excluded as immutables', () => {
+    // Layer 1 hashes the code with immutables masked out, so a contract whose
+    // immutables hold attacker-chosen call targets matches an honest build.
+    // Filling ReceiverStargateV2's 15 occurrences is 480 such bytes.
+    const result = compareToAttestedSet(
+      seen({ maskedHash: CANCUN_HASH, maskedByteCount: 480 }),
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.excludedByteCount).toBe(480)
+    expect(result.reason).toContain('480 bytes')
+    expect(result.reason).toMatch(/still have to be checked/)
+  })
+
+  it('does not qualify a match for a contract with no immutables', () => {
+    // The control: the qualification has to be absent here, or it is noise on
+    // every verdict and stops being read.
+    const result = compareToAttestedSet(
+      seen({ maskedHash: CANCUN_HASH }),
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.excludedByteCount).toBe(0)
+    expect(result.reason).not.toMatch(/still have to be checked/)
+  })
+
+  it('carries the excluded count on a blocking verdict too', () => {
+    // A signer reading a MISMATCH should not have to guess whether the immutable
+    // values were part of what disagreed.
+    const result = compareToAttestedSet(
+      seen({ maskedHash: FOREIGN_HASH, maskedByteCount: 96 }),
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+    expect(result.excludedByteCount).toBe(96)
+  })
+})
+
+describe('when the attestation pins the exact deployed bytes', () => {
+  const RAW = `0x${'cd'.repeat(32)}`
+  const PINNED: IAttestedBuild[] = [
+    {
+      lineage: 'upstream london, exact bytes',
+      solcVersion: '0.8.17',
+      maskedHash: LONDON_HASH,
+      rawByteLength: LONDON_BYTES,
+      rawHash: RAW,
+    },
+  ]
+
+  it('matches when the deployed bytes are those bytes', () => {
+    const result = compareToAttestedSet(
+      seen({
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES,
+        rawHash: RAW,
+      }),
+      PINNED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+  })
+
+  it('refuses code identical outside the trailer, naming the trailer', () => {
+    // This is the 47-byte window: same length, same normalised hash, different
+    // metadata bytes. Tolerated when the attestation compares on the normalised
+    // form; refused when it pins exact bytes.
+    const observed = seen({
+      maskedHash: LONDON_HASH,
+      rawByteLength: LONDON_BYTES,
+      rawHash: `0x${'ef'.repeat(32)}`,
+    })
+
+    expect(compareToAttestedSet(observed, PINNED, CLOSED).verdict).toBe(
+      'MISMATCH'
+    )
+    expect(compareToAttestedSet(observed, PINNED, CLOSED).reason).toMatch(
+      /outside its metadata trailer/
+    )
+    // And the same observation against an attestation that does not pin bytes is
+    // a MATCH — otherwise this test would pass for a reader that ignores rawHash.
+    expect(compareToAttestedSet(observed, ATTESTED, CLOSED).verdict).toBe(
+      'MATCH'
+    )
   })
 })

--- a/script/deploy/codehash/attested-set.test.ts
+++ b/script/deploy/codehash/attested-set.test.ts
@@ -463,3 +463,90 @@ describe('when the attestation pins the exact deployed bytes', () => {
     )
   })
 })
+
+describe('what a pinned rawHash covers, and what a pinned mismatch may be', () => {
+  const RAW = `0x${'cd'.repeat(32)}`
+  const PINNED: IAttestedBuild[] = [
+    {
+      lineage: 'upstream london, exact bytes',
+      solcVersion: '0.8.17',
+      maskedHash: LONDON_HASH,
+      rawByteLength: LONDON_BYTES,
+      rawHash: RAW,
+    },
+  ]
+
+  it('excludes nothing when the match came from a byte-for-byte comparison', () => {
+    // A pinned rawHash covers every deployed byte, immutables included. Saying
+    // 480 bytes went unchecked would send a signer to run a layer-2 check that
+    // this verdict already subsumes.
+    const result = compareToAttestedSet(
+      seen({
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES,
+        rawHash: RAW,
+        maskedByteCount: 480,
+      }),
+      PINNED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.excludedByteCount).toBe(0)
+    expect(result.reason).not.toMatch(/still have to be checked/)
+  })
+
+  it('still excludes the immutables when the match came from the normalised form', () => {
+    // The contrast that makes the assertion above mean something: same
+    // observation, an attestation that does not pin bytes.
+    const result = compareToAttestedSet(
+      seen({
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES,
+        rawHash: RAW,
+        maskedByteCount: 480,
+      }),
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MATCH')
+    expect(result.excludedByteCount).toBe(480)
+    expect(result.reason).toMatch(/still have to be checked/)
+  })
+
+  it('does not blame the trailer for a difference that may be in the immutables', () => {
+    // Both the trailer and the masked immutables are outside the normalised
+    // comparison, so a pinned mismatch here cannot be attributed to the trailer
+    // alone — and the immutables are the half that changes behaviour.
+    const result = compareToAttestedSet(
+      seen({
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES,
+        rawHash: `0x${'ef'.repeat(32)}`,
+        maskedByteCount: 480,
+      }),
+      PINNED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+    expect(result.reason).toContain('480 bytes holding immutables')
+  })
+
+  it('does name the trailer alone when the contract has no immutables', () => {
+    const result = compareToAttestedSet(
+      seen({
+        maskedHash: LONDON_HASH,
+        rawByteLength: LONDON_BYTES,
+        rawHash: `0x${'ef'.repeat(32)}`,
+      }),
+      PINNED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+    expect(result.reason).toMatch(/outside its metadata trailer/)
+    expect(result.reason).not.toContain('holding immutables')
+  })
+})

--- a/script/deploy/codehash/attested-set.test.ts
+++ b/script/deploy/codehash/attested-set.test.ts
@@ -37,23 +37,29 @@ const ATTESTED: IAttestedBuild[] = [
   },
 ]
 
+/** The network's legitimate toolchains are fully enumerated in ATTESTED. */
+const CLOSED = { isClosedSet: true }
+/** They are not — e.g. a zkEVM network, whose trailer this repo cannot yet read. */
+const OPEN = { isClosedSet: false }
+
 describe('compareToAttestedSet', () => {
   it('accepts a build from any attested lineage, not one privileged profile', () => {
     // E1: a record claiming 0.8.29 must not turn an honest london build red.
-    // Both lineages are legitimate builds of main, so both are GREEN.
     for (const [hash, version, lineage] of [
       [CANCUN_HASH, '0.8.29', 'upstream cancun'],
       [LONDON_HASH, '0.8.17', 'upstream london'],
-    ] as const) {
-      const result = compareToAttestedSet(
-        { maskedHash: hash, solcVersion: version },
-        ATTESTED
-      )
+    ] as const)
+      for (const scope of [CLOSED, OPEN]) {
+        const result = compareToAttestedSet(
+          { maskedHash: hash, solcVersion: version },
+          ATTESTED,
+          scope
+        )
 
-      expect(result.verdict).toBe('MATCH')
-      expect(result.matchedLineages).toEqual([lineage])
-      expect(result.blocksSigning).toBe(false)
-    }
+        expect(result.verdict).toBe('MATCH')
+        expect(result.matchedLineages).toEqual([lineage])
+        expect(result.blocksSigning).toBe(false)
+      }
   })
 
   it('does not depend on the order the attested builds are listed in', () => {
@@ -63,82 +69,22 @@ describe('compareToAttestedSet', () => {
     expect(
       compareToAttestedSet(
         { maskedHash: LONDON_HASH, solcVersion: '0.8.17' },
-        reversed
+        reversed,
+        CLOSED
       ).verdict
     ).toBe('MATCH')
     expect(
       compareToAttestedSet(
         { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
-        reversed
+        reversed,
+        CLOSED
       ).verdict
     ).toBe('MATCH')
   })
 
-  it('calls a foreign hash from an attested lineage a MISMATCH', () => {
-    // We built this exact lineage, so a disagreement is a real finding.
-    const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
-      ATTESTED
-    )
-
-    expect(result.verdict).toBe('MISMATCH')
-    expect(result.blocksSigning).toBe(true)
-    expect(result.reason).toContain('0.8.29')
-  })
-
-  it('calls a foreign hash from an UNBUILT lineage UNVERIFIABLE, not a MISMATCH', () => {
-    // Nothing was ever built at 0.8.31, so a non-match is ignorance, not
-    // evidence. Reporting it as RED would train signers to wave through red.
-    const result = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
-      ATTESTED
-    )
-
-    expect(result.verdict).toBe('UNVERIFIABLE')
-    expect(result.blocksSigning).toBe(true)
-    expect(result.reason).toContain('0.8.31')
-  })
-
-  it('is UNVERIFIABLE when the deployed code carries no compiler version', () => {
-    // No trailer means the lineage cannot be established, so neither a match
-    // nor a mismatch can be claimed.
-    const result = compareToAttestedSet({ maskedHash: FOREIGN_HASH }, ATTESTED)
-
-    expect(result.verdict).toBe('UNVERIFIABLE')
-    expect(result.blocksSigning).toBe(true)
-    expect(result.reason).toMatch(/no readable compiler version/i)
-  })
-
-  it('is UNVERIFIABLE with an empty attested set rather than vacuously RED', () => {
-    const result = compareToAttestedSet(
-      { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
-      []
-    )
-
-    expect(result.verdict).toBe('UNVERIFIABLE')
-    expect(result.blocksSigning).toBe(true)
-    // The verdict alone does not distinguish this from an unbuilt lineage, so
-    // assert the message: without its own branch the signer is told the code
-    // came from a compiler "no attested build used ()" — an empty list.
-    expect(result.reason).toContain('no attested build of main is available')
-  })
-
-  it('keeps GREY distinct from RED while blocking on both', () => {
-    const grey = compareToAttestedSet({ maskedHash: FOREIGN_HASH }, ATTESTED)
-    const red = compareToAttestedSet(
-      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
-      ATTESTED
-    )
-
-    // Fail closed: both block. Visibly distinct: the verdicts differ, and the
-    // renderer downstream keys off the verdict, never off `blocksSigning`.
-    expect([grey.blocksSigning, red.blocksSigning]).toEqual([true, true])
-    expect(grey.verdict).not.toBe(red.verdict)
-  })
-
   it('matches a hash reached by two lineages without preferring either', () => {
-    // Two compilers can emit identical code once the trailer is off; the
-    // masked hash carries no version, so both lineages are named.
+    // Two compilers can emit identical code once the trailer is off; the masked
+    // hash carries no version, so both lineages are named.
     const twins: IAttestedBuild[] = [
       {
         lineage: 'upstream cancun',
@@ -149,7 +95,8 @@ describe('compareToAttestedSet', () => {
     ]
     const result = compareToAttestedSet(
       { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
-      twins
+      twins,
+      CLOSED
     )
 
     expect(result.verdict).toBe('MATCH')
@@ -159,9 +106,137 @@ describe('compareToAttestedSet', () => {
   it('ignores case and 0x-prefix differences between hashes', () => {
     const result = compareToAttestedSet(
       { maskedHash: CANCUN_HASH.slice(2).toUpperCase(), solcVersion: '0.8.29' },
-      ATTESTED
+      ATTESTED,
+      CLOSED
     )
 
     expect(result.verdict).toBe('MATCH')
+  })
+
+  it('is UNVERIFIABLE with an empty attested set, under either scope', () => {
+    for (const scope of [CLOSED, OPEN]) {
+      const result = compareToAttestedSet(
+        { maskedHash: CANCUN_HASH, solcVersion: '0.8.29' },
+        [],
+        scope
+      )
+
+      expect(result.verdict).toBe('UNVERIFIABLE')
+      expect(result.blocksSigning).toBe(true)
+      // The verdict alone does not distinguish this from an unbuilt lineage, so
+      // assert the message: without its own branch a signer is told the code
+      // came from a compiler "no attested build used ()" — an empty list.
+      expect(result.reason).toContain('no attested build of main is available')
+    }
+  })
+})
+
+describe('with a closed set of legitimate builds', () => {
+  it.each([
+    ['a version we did build', '0.8.29'],
+    // The downgrade attempt: three bytes inside the metadata trailer, no
+    // executable code touched. The trailer is part of the deployed code, so the
+    // proposer writes it — it must not be able to soften the verdict.
+    ['a version we never built', '0.8.99'],
+    ['a nonsensical version', '237.234.219'],
+  ])(
+    'calls foreign code a MISMATCH though it reports %s',
+    (_label, version) => {
+      const result = compareToAttestedSet(
+        { maskedHash: FOREIGN_HASH, solcVersion: version },
+        ATTESTED,
+        CLOSED
+      )
+
+      expect(result.verdict).toBe('MISMATCH')
+      expect(result.blocksSigning).toBe(true)
+      expect(result.reason).toContain('not a build of main')
+    }
+  )
+
+  it('calls foreign code a MISMATCH when it reports no version at all', () => {
+    // Stripping the trailer, or compiling with `bytecodeHash: "none"`, is the
+    // cheapest way to report nothing. It must not buy a softer verdict either.
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH },
+      ATTESTED,
+      CLOSED
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+  })
+
+  it('reaches the same verdict for every trailer a tamperer could write', () => {
+    // One fact — this hash is in none of the attested builds — must produce one
+    // verdict, no matter what the code says about itself.
+    const verdicts = new Set(
+      [
+        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.17' },
+        { maskedHash: FOREIGN_HASH, solcVersion: '0.8.99' },
+        { maskedHash: FOREIGN_HASH },
+      ].map(
+        (observed) => compareToAttestedSet(observed, ATTESTED, CLOSED).verdict
+      )
+    )
+
+    expect([...verdicts]).toEqual(['MISMATCH'])
+  })
+})
+
+describe('with an open set of legitimate builds', () => {
+  it('calls a foreign hash from an attested lineage a MISMATCH', () => {
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      ATTESTED,
+      OPEN
+    )
+
+    expect(result.verdict).toBe('MISMATCH')
+    expect(result.reason).toContain('0.8.29')
+  })
+
+  it('calls a foreign hash from an unbuilt lineage UNVERIFIABLE', () => {
+    // With the set open we may simply never have built this toolchain, so a
+    // non-match is ignorance rather than evidence. This is the branch the
+    // closed-set tests above prove cannot be reached by a tamperer.
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
+      ATTESTED,
+      OPEN
+    )
+
+    expect(result.verdict).toBe('UNVERIFIABLE')
+    expect(result.blocksSigning).toBe(true)
+    expect(result.reason).toContain('0.8.31')
+  })
+
+  it('is UNVERIFIABLE when the deployed code carries no compiler version', () => {
+    const result = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH },
+      ATTESTED,
+      OPEN
+    )
+
+    expect(result.verdict).toBe('UNVERIFIABLE')
+    expect(result.reason).toMatch(/no readable compiler version/i)
+  })
+
+  it('keeps GREY distinct from RED while blocking on both', () => {
+    const grey = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.31' },
+      ATTESTED,
+      OPEN
+    )
+    const red = compareToAttestedSet(
+      { maskedHash: FOREIGN_HASH, solcVersion: '0.8.29' },
+      ATTESTED,
+      OPEN
+    )
+
+    // Fail closed: both block. Visibly distinct: the verdicts differ, and the
+    // renderer downstream keys off the verdict, never off `blocksSigning`.
+    expect([grey.blocksSigning, red.blocksSigning]).toEqual([true, true])
+    expect(grey.verdict).not.toBe(red.verdict)
   })
 })

--- a/script/deploy/codehash/attested-set.ts
+++ b/script/deploy/codehash/attested-set.ts
@@ -1,23 +1,9 @@
 /**
- * Layer 1 of the codehash primitive: does the deployed code hash to something
- * this repo is known to have built?
+ * Layer 1 of the codehash check: is the deployed code a hash this repo built?
  *
- * The comparison is SET MEMBERSHIP against every attested build of main for this
- * contract, never equality against one profile derived from the deployment
- * record or from the network. One source legitimately produces different
- * bytecode per build lineage — the repo's own `AccessManagerFacet` hashes
- * differently at solc 0.8.29 / cancun and at the 0.8.17 / london floor — so a
- * single expected value turns honest builds red, and a signer who has seen red
- * on an honest proposal will wave through the dishonest one.
- *
- * Three verdicts, because collapsing them is what makes a gate ignorable:
- *
- * - MATCH — the hash is one we built.
- * - MISMATCH — it is not, and we DID build the lineage the code claims, so the
- *   disagreement is evidence about the code.
- * - UNVERIFIABLE — we cannot tell: no lineage to compare within, or nothing
- *   attested. This blocks too (fail closed on unexplained), but it is a
- *   statement about our knowledge, not about the code.
+ * Import this after normalising code with `stripMetadataTrailer` and
+ * `maskImmutables`. The comparison is set membership against every attested
+ * build, never equality against one record- or network-derived profile.
  */
 
 /** A build of main this repo can vouch for, produced locally or in CI. */
@@ -34,10 +20,22 @@ export interface IAttestedBuild {
 export interface IObservedCode {
   maskedHash: string
   /**
-   * Decoded from the deployed code's own trailer. Absent when there is no
-   * readable trailer, which is itself a reason not to claim a verdict.
+   * Decoded from the deployed code's own trailer, so chosen by whoever deployed
+   * it. Absent when no version can be read.
    */
   solcVersion?: string
+}
+
+/** How completely the attested set describes what this contract may be. */
+export interface ILineageScope {
+  /**
+   * True when `attested` enumerates every toolchain the contract can
+   * legitimately have been built with, so code matching none of them is not a
+   * build of main. Derive it from repo configuration — the network's declared
+   * EVM version and whether it is zkEVM — and never from the deployed
+   * bytecode, which the proposer controls.
+   */
+  isClosedSet: boolean
 }
 
 export type CodehashVerdict = 'MATCH' | 'MISMATCH' | 'UNVERIFIABLE'
@@ -53,15 +51,40 @@ export interface ICodehashComparison {
 }
 
 const normalizeHash = (hash: string): string =>
-  (hash.startsWith('0x') ? hash.slice(2) : hash).toLowerCase()
+  (/^0x/i.test(hash) ? hash.slice(2) : hash).toLowerCase()
+
+const blocked = (
+  verdict: 'MISMATCH' | 'UNVERIFIABLE',
+  reason: string
+): ICodehashComparison => ({
+  verdict,
+  matchedLineages: [],
+  reason,
+  blocksSigning: true,
+})
 
 /**
+ * Grades deployed code against the builds this repo can vouch for.
+ *
+ * Three verdicts, because a gate whose red means "we could not tell" is one
+ * signers learn to click through. MISMATCH is a statement about the code;
+ * UNVERIFIABLE is a statement about our knowledge. Both block.
+ *
+ * Known limitation, and the reason `scope` exists: with an open set, the only
+ * thing distinguishing "we never built that toolchain" from "this is not our
+ * code" is the compiler version in the deployed trailer, which the proposer
+ * writes. An open-set MISMATCH can therefore be moved to UNVERIFIABLE by three
+ * bytes. A closed set does not consult the trailer at all.
+ *
  * @param observed - The code found on chain, already stripped and masked.
- * @param attested - Every build of main for this contract. Order is irrelevant.
+ * @param attested - Every attested build for this contract. Order is irrelevant.
+ * @param scope - Whether `attested` is the complete set of legitimate builds.
+ * @returns The verdict, the lineages that matched, and why.
  */
 export const compareToAttestedSet = (
   observed: IObservedCode,
-  attested: IAttestedBuild[]
+  attested: IAttestedBuild[],
+  scope: ILineageScope
 ): ICodehashComparison => {
   const target = normalizeHash(observed.maskedHash)
   const matchedLineages = attested
@@ -79,46 +102,42 @@ export const compareToAttestedSet = (
     }
 
   if (attested.length === 0)
-    return {
-      verdict: 'UNVERIFIABLE',
-      matchedLineages: [],
-      reason:
-        'no attested build of main is available for this contract, so nothing can be compared',
-      blocksSigning: true,
-    }
+    return blocked(
+      'UNVERIFIABLE',
+      'no attested build of main is available for this contract, so nothing can be compared'
+    )
+
+  // With the legitimate set complete, non-membership settles it on its own and
+  // nothing the deployed bytecode says about itself can soften the verdict.
+  if (scope.isClosedSet)
+    return blocked(
+      'MISMATCH',
+      `the deployed code matches none of the ${attested.length} builds this contract can legitimately have, so it is not a build of main`
+    )
 
   if (!observed.solcVersion)
-    return {
-      verdict: 'UNVERIFIABLE',
-      matchedLineages: [],
-      reason:
-        'the deployed code carries no readable compiler version, so its build lineage cannot be established',
-      blocksSigning: true,
-    }
+    return blocked(
+      'UNVERIFIABLE',
+      'the deployed code carries no readable compiler version, and the set of legitimate builds is open, so its lineage cannot be established'
+    )
 
-  // The distinction that keeps RED meaningful: a non-match only tells us about
-  // the code if we built the lineage the code says it came from.
   const builtVersions = new Set(attested.map((build) => build.solcVersion))
   if (!builtVersions.has(observed.solcVersion))
-    return {
-      verdict: 'UNVERIFIABLE',
-      matchedLineages: [],
-      reason: `the deployed code was built with solc ${
+    return blocked(
+      'UNVERIFIABLE',
+      `the deployed code reports solc ${
         observed.solcVersion
       }, which no attested build used (${[...builtVersions]
         .sort()
-        .join(', ')}), so a non-match proves nothing`,
-      blocksSigning: true,
-    }
+        .join(', ')}), and the set of legitimate builds is open`
+    )
 
-  return {
-    verdict: 'MISMATCH',
-    matchedLineages: [],
-    reason: `the deployed code does not match any attested build, including the ${
+  return blocked(
+    'MISMATCH',
+    `the deployed code does not match any attested build, including the ${
       observed.solcVersion
-    } one it claims to come from (${attested.length} build${
+    } one it reports (${attested.length} build${
       attested.length === 1 ? '' : 's'
-    } compared)`,
-    blocksSigning: true,
-  }
+    } compared)`
+  )
 }

--- a/script/deploy/codehash/attested-set.ts
+++ b/script/deploy/codehash/attested-set.ts
@@ -1,0 +1,124 @@
+/**
+ * Layer 1 of the codehash primitive: does the deployed code hash to something
+ * this repo is known to have built?
+ *
+ * The comparison is SET MEMBERSHIP against every attested build of main for this
+ * contract, never equality against one profile derived from the deployment
+ * record or from the network. One source legitimately produces different
+ * bytecode per build lineage — the repo's own `AccessManagerFacet` hashes
+ * differently at solc 0.8.29 / cancun and at the 0.8.17 / london floor — so a
+ * single expected value turns honest builds red, and a signer who has seen red
+ * on an honest proposal will wave through the dishonest one.
+ *
+ * Three verdicts, because collapsing them is what makes a gate ignorable:
+ *
+ * - MATCH — the hash is one we built.
+ * - MISMATCH — it is not, and we DID build the lineage the code claims, so the
+ *   disagreement is evidence about the code.
+ * - UNVERIFIABLE — we cannot tell: no lineage to compare within, or nothing
+ *   attested. This blocks too (fail closed on unexplained), but it is a
+ *   statement about our knowledge, not about the code.
+ */
+
+/** A build of main this repo can vouch for, produced locally or in CI. */
+export interface IAttestedBuild {
+  /** Human label for the toolchain, e.g. `upstream cancun`. */
+  lineage: string
+  /** Read from the build's own metadata trailer, never from a record. */
+  solcVersion: string
+  /** keccak of the runtime code after trailer-stripping and immutable masking. */
+  maskedHash: string
+}
+
+/** What was actually found at the address, normalised the same way. */
+export interface IObservedCode {
+  maskedHash: string
+  /**
+   * Decoded from the deployed code's own trailer. Absent when there is no
+   * readable trailer, which is itself a reason not to claim a verdict.
+   */
+  solcVersion?: string
+}
+
+export type CodehashVerdict = 'MATCH' | 'MISMATCH' | 'UNVERIFIABLE'
+
+export interface ICodehashComparison {
+  verdict: CodehashVerdict
+  /** Every attested lineage reaching this hash, in the order given. */
+  matchedLineages: string[]
+  /** One line a signer can act on. */
+  reason: string
+  /** True for everything but MATCH. Render the verdict, never this flag. */
+  blocksSigning: boolean
+}
+
+const normalizeHash = (hash: string): string =>
+  (hash.startsWith('0x') ? hash.slice(2) : hash).toLowerCase()
+
+/**
+ * @param observed - The code found on chain, already stripped and masked.
+ * @param attested - Every build of main for this contract. Order is irrelevant.
+ */
+export const compareToAttestedSet = (
+  observed: IObservedCode,
+  attested: IAttestedBuild[]
+): ICodehashComparison => {
+  const target = normalizeHash(observed.maskedHash)
+  const matchedLineages = attested
+    .filter((build) => normalizeHash(build.maskedHash) === target)
+    .map((build) => build.lineage)
+
+  if (matchedLineages.length > 0)
+    return {
+      verdict: 'MATCH',
+      matchedLineages,
+      reason: `code matches the attested build from ${matchedLineages.join(
+        ' and '
+      )}`,
+      blocksSigning: false,
+    }
+
+  if (attested.length === 0)
+    return {
+      verdict: 'UNVERIFIABLE',
+      matchedLineages: [],
+      reason:
+        'no attested build of main is available for this contract, so nothing can be compared',
+      blocksSigning: true,
+    }
+
+  if (!observed.solcVersion)
+    return {
+      verdict: 'UNVERIFIABLE',
+      matchedLineages: [],
+      reason:
+        'the deployed code carries no readable compiler version, so its build lineage cannot be established',
+      blocksSigning: true,
+    }
+
+  // The distinction that keeps RED meaningful: a non-match only tells us about
+  // the code if we built the lineage the code says it came from.
+  const builtVersions = new Set(attested.map((build) => build.solcVersion))
+  if (!builtVersions.has(observed.solcVersion))
+    return {
+      verdict: 'UNVERIFIABLE',
+      matchedLineages: [],
+      reason: `the deployed code was built with solc ${
+        observed.solcVersion
+      }, which no attested build used (${[...builtVersions]
+        .sort()
+        .join(', ')}), so a non-match proves nothing`,
+      blocksSigning: true,
+    }
+
+  return {
+    verdict: 'MISMATCH',
+    matchedLineages: [],
+    reason: `the deployed code does not match any attested build, including the ${
+      observed.solcVersion
+    } one it claims to come from (${attested.length} build${
+      attested.length === 1 ? '' : 's'
+    } compared)`,
+    blocksSigning: true,
+  }
+}

--- a/script/deploy/codehash/attested-set.ts
+++ b/script/deploy/codehash/attested-set.ts
@@ -143,30 +143,38 @@ export const compareToAttestedSet = (
 
   if (exact.length > 0) {
     const matchedLineages = exact.map((build) => build.lineage)
+    // A build that pins exact bytes was compared byte for byte, immutables
+    // included, so nothing was excluded on that path however many bytes are
+    // masked.
+    const excludedByteCount = exact.some((build) => build.rawHash !== undefined)
+      ? 0
+      : observed.maskedByteCount
     return {
       verdict: 'MATCH',
       matchedLineages,
       reason:
-        observed.maskedByteCount === 0
+        excludedByteCount === 0
           ? `code matches the attested build from ${matchedLineages.join(
               ' and '
             )}`
           : `code matches the attested build from ${matchedLineages.join(
               ' and '
-            )} outside its immutables; the ${
-              observed.maskedByteCount
-            } bytes holding those were not compared and their values still have to be checked`,
-      excludedByteCount: observed.maskedByteCount,
+            )} outside its immutables; the ${excludedByteCount} bytes holding those were not compared and their values still have to be checked`,
+      excludedByteCount,
       blocksSigning: false,
     }
   }
 
   // Only reachable for an attestation that pins exact bytes: the code agrees
-  // everywhere the comparison looks, and the bytes it does not look at do not.
+  // everywhere the normalised comparison looks, and the bytes it does not look
+  // at do not. Those are the metadata trailer AND any masked immutables, so
+  // naming only the trailer would point a signer at the harmless half.
   if (sameLength.length > 0)
     return blocked(
       'MISMATCH',
-      `the deployed code is identical to the attested build from ${sameLength[0]?.lineage} outside its metadata trailer, and that trailer's bytes differ from the attested ones`,
+      observed.maskedByteCount === 0
+        ? `the deployed code is identical to the attested build from ${sameLength[0]?.lineage} outside its metadata trailer, and that trailer's bytes differ from the attested ones`
+        : `the deployed code is identical to the attested build from ${sameLength[0]?.lineage} where the normalised comparison looks, but its exact bytes differ: the difference is in the metadata trailer, in the ${observed.maskedByteCount} bytes holding immutables, or in both`,
       observed.maskedByteCount
     )
 

--- a/script/deploy/codehash/attested-set.ts
+++ b/script/deploy/codehash/attested-set.ts
@@ -14,11 +14,15 @@ export interface IAttestedBuild {
   solcVersion: string
   /** keccak of the runtime code after trailer-stripping and immutable masking. */
   maskedHash: string
+  /** Length of the code as deployed, before anything was stripped or masked. */
+  rawByteLength: number
 }
 
 /** What was actually found at the address, normalised the same way. */
 export interface IObservedCode {
   maskedHash: string
+  /** Length of the code as deployed, before anything was stripped or masked. */
+  rawByteLength: number
   /**
    * Decoded from the deployed code's own trailer, so chosen by whoever deployed
    * it. Absent when no version can be read.
@@ -70,6 +74,17 @@ const blocked = (
  * signers learn to click through. MISMATCH is a statement about the code;
  * UNVERIFIABLE is a statement about our knowledge. Both block.
  *
+ * A match requires the normalised hash AND the deployed length: the hash alone
+ * leaves the trailer's length word free, and that word decides how much is
+ * removed before hashing, so appending a payload and a length word covering it
+ * normalises to whatever prefix the appender likes.
+ *
+ * What both together still allow, measured on a 1440-byte facet with a 53-byte
+ * trailer: 45 bytes of arbitrary content inside the trailer region, where an
+ * honest build carries a 34-byte digest. It sits past the code's terminating
+ * INVALID and is not reachable, and removing this last latitude means comparing
+ * raw bytes, which no rebuild reproduces. Stated rather than hidden.
+ *
  * Known limitation, and the reason `scope` exists: with an open set, the only
  * thing distinguishing "we never built that toolchain" from "this is not our
  * code" is the compiler version in the deployed trailer, which the proposer
@@ -87,11 +102,15 @@ export const compareToAttestedSet = (
   scope: ILineageScope
 ): ICodehashComparison => {
   const target = normalizeHash(observed.maskedHash)
-  const matchedLineages = attested
-    .filter((build) => normalizeHash(build.maskedHash) === target)
-    .map((build) => build.lineage)
+  const sameCode = attested.filter(
+    (build) => normalizeHash(build.maskedHash) === target
+  )
+  const sameCodeAndLength = sameCode.filter(
+    (build) => build.rawByteLength === observed.rawByteLength
+  )
 
-  if (matchedLineages.length > 0)
+  if (sameCodeAndLength.length > 0) {
+    const matchedLineages = sameCodeAndLength.map((build) => build.lineage)
     return {
       verdict: 'MATCH',
       matchedLineages,
@@ -100,6 +119,25 @@ export const compareToAttestedSet = (
       )}`,
       blocksSigning: false,
     }
+  }
+
+  // Normalising to an attested build is not the same as being one. The trailer's
+  // length word says how many bytes come off before hashing, and it is part of
+  // the deployed code, so appending a payload and a length word covering it
+  // normalises to whatever prefix the appender likes.
+  if (sameCode.length > 0) {
+    const attestedLength = sameCode[0]?.rawByteLength ?? 0
+    return blocked(
+      'MISMATCH',
+      `the deployed code normalises to the attested build from ${
+        sameCode[0]?.lineage
+      } but is ${
+        observed.rawByteLength
+      } bytes where that build is ${attestedLength}, so ${Math.abs(
+        observed.rawByteLength - attestedLength
+      )} bytes of it are not accounted for`
+    )
+  }
 
   if (attested.length === 0)
     return blocked(

--- a/script/deploy/codehash/attested-set.ts
+++ b/script/deploy/codehash/attested-set.ts
@@ -16,6 +16,11 @@ export interface IAttestedBuild {
   maskedHash: string
   /** Length of the code as deployed, before anything was stripped or masked. */
   rawByteLength: number
+  /**
+   * keccak of the exact deployed bytes, or undefined to compare on the
+   * normalised form alone. Pass it when the attestation pins exact bytes.
+   */
+  rawHash: string | undefined
 }
 
 /** What was actually found at the address, normalised the same way. */
@@ -23,6 +28,14 @@ export interface IObservedCode {
   maskedHash: string
   /** Length of the code as deployed, before anything was stripped or masked. */
   rawByteLength: number
+  /** keccak of the exact deployed bytes. */
+  rawHash: string
+  /**
+   * How many bytes were excluded from `maskedHash` as immutables. A MATCH says
+   * nothing about them, so a caller that has not run layer 2 must not render an
+   * unqualified green.
+   */
+  maskedByteCount: number
   /**
    * Decoded from the deployed code's own trailer, so chosen by whoever deployed
    * it. Absent when no version can be read.
@@ -50,6 +63,11 @@ export interface ICodehashComparison {
   matchedLineages: string[]
   /** One line a signer can act on. */
   reason: string
+  /**
+   * Bytes the comparison did not look at, because they hold immutables. Nonzero
+   * means this verdict is incomplete until layer 2 has checked their values.
+   */
+  excludedByteCount: number
   /** True for everything but MATCH. Render the verdict, never this flag. */
   blocksSigning: boolean
 }
@@ -59,11 +77,13 @@ const normalizeHash = (hash: string): string =>
 
 const blocked = (
   verdict: 'MISMATCH' | 'UNVERIFIABLE',
-  reason: string
+  reason: string,
+  excludedByteCount: number
 ): ICodehashComparison => ({
   verdict,
   matchedLineages: [],
   reason,
+  excludedByteCount,
   blocksSigning: true,
 })
 
@@ -80,10 +100,17 @@ const blocked = (
  * normalises to whatever prefix the appender likes.
  *
  * What both together still allow, measured on a 1440-byte facet with a 53-byte
- * trailer: 45 bytes of arbitrary content inside the trailer region, where an
- * honest build carries a 34-byte digest. It sits past the code's terminating
- * INVALID and is not reachable, and removing this last latitude means comparing
- * raw bytes, which no rebuild reproduces. Stated rather than hidden.
+ * trailer: 47 bytes of arbitrary content inside the trailer region, where an
+ * honest build carries a 34-byte digest. It is unreachable because `src/` holds
+ * no internal function pointers, so no dynamic jump can be steered into it —
+ * NOT because it follows the code's terminating INVALID, which two artifacts in
+ * the fleet do not have (their code ends in EIP-712 type-string data).
+ *
+ * Pass `rawHash` to close that window: an attestation that pins the exact
+ * deployed bytes leaves nothing free. The cost is that metadata-level drift
+ * between the deployed source and the attested one — a comment, a file path —
+ * then reads as a MISMATCH, which is the reason stripping exists. The caller
+ * states which it wants; this module does not choose.
  *
  * Known limitation, and the reason `scope` exists: with an open set, the only
  * thing distinguishing "we never built that toolchain" from "this is not our
@@ -105,21 +132,43 @@ export const compareToAttestedSet = (
   const sameCode = attested.filter(
     (build) => normalizeHash(build.maskedHash) === target
   )
-  const sameCodeAndLength = sameCode.filter(
+  const sameLength = sameCode.filter(
     (build) => build.rawByteLength === observed.rawByteLength
   )
+  const exact = sameLength.filter(
+    (build) =>
+      build.rawHash === undefined ||
+      normalizeHash(build.rawHash) === normalizeHash(observed.rawHash)
+  )
 
-  if (sameCodeAndLength.length > 0) {
-    const matchedLineages = sameCodeAndLength.map((build) => build.lineage)
+  if (exact.length > 0) {
+    const matchedLineages = exact.map((build) => build.lineage)
     return {
       verdict: 'MATCH',
       matchedLineages,
-      reason: `code matches the attested build from ${matchedLineages.join(
-        ' and '
-      )}`,
+      reason:
+        observed.maskedByteCount === 0
+          ? `code matches the attested build from ${matchedLineages.join(
+              ' and '
+            )}`
+          : `code matches the attested build from ${matchedLineages.join(
+              ' and '
+            )} outside its immutables; the ${
+              observed.maskedByteCount
+            } bytes holding those were not compared and their values still have to be checked`,
+      excludedByteCount: observed.maskedByteCount,
       blocksSigning: false,
     }
   }
+
+  // Only reachable for an attestation that pins exact bytes: the code agrees
+  // everywhere the comparison looks, and the bytes it does not look at do not.
+  if (sameLength.length > 0)
+    return blocked(
+      'MISMATCH',
+      `the deployed code is identical to the attested build from ${sameLength[0]?.lineage} outside its metadata trailer, and that trailer's bytes differ from the attested ones`,
+      observed.maskedByteCount
+    )
 
   // Normalising to an attested build is not the same as being one. The trailer's
   // length word says how many bytes come off before hashing, and it is part of
@@ -135,14 +184,16 @@ export const compareToAttestedSet = (
         observed.rawByteLength
       } bytes where that build is ${attestedLength}, so ${Math.abs(
         observed.rawByteLength - attestedLength
-      )} bytes of it are not accounted for`
+      )} bytes of it are not accounted for`,
+      observed.maskedByteCount
     )
   }
 
   if (attested.length === 0)
     return blocked(
       'UNVERIFIABLE',
-      'no attested build of main is available for this contract, so nothing can be compared'
+      'no attested build of main is available for this contract, so nothing can be compared',
+      observed.maskedByteCount
     )
 
   // With the legitimate set complete, non-membership settles it on its own and
@@ -150,13 +201,15 @@ export const compareToAttestedSet = (
   if (scope.isClosedSet)
     return blocked(
       'MISMATCH',
-      `the deployed code matches none of the ${attested.length} builds this contract can legitimately have, so it is not a build of main`
+      `the deployed code matches none of the ${attested.length} builds this contract can legitimately have, so it is not a build of main`,
+      observed.maskedByteCount
     )
 
   if (!observed.solcVersion)
     return blocked(
       'UNVERIFIABLE',
-      'the deployed code carries no readable compiler version, and the set of legitimate builds is open, so its lineage cannot be established'
+      'the deployed code carries no readable compiler version, and the set of legitimate builds is open, so its lineage cannot be established',
+      observed.maskedByteCount
     )
 
   const builtVersions = new Set(attested.map((build) => build.solcVersion))
@@ -167,7 +220,8 @@ export const compareToAttestedSet = (
         observed.solcVersion
       }, which no attested build used (${[...builtVersions]
         .sort()
-        .join(', ')}), and the set of legitimate builds is open`
+        .join(', ')}), and the set of legitimate builds is open`,
+      observed.maskedByteCount
     )
 
   return blocked(
@@ -176,6 +230,7 @@ export const compareToAttestedSet = (
       observed.solcVersion
     } one it reports (${attested.length} build${
       attested.length === 1 ? '' : 's'
-    } compared)`
+    } compared)`,
+    observed.maskedByteCount
   )
 }

--- a/script/deploy/codehash/bytecode-trailer.test.ts
+++ b/script/deploy/codehash/bytecode-trailer.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Fixtures are real bytes, not synthetic ones, and they are EMBEDDED rather than
+ * read from `out/` — CI has no build artifacts, so a test that reads them either
+ * fails there or passes vacuously.
+ *
+ * Provenance: the tail of `out/AccessManagerFacet.sol/AccessManagerFacet.json`
+ * `deployedBytecode.object` at `ce1b2760c`, solc 0.8.29, 1423 bytes total,
+ * 51-byte CBOR trailer.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { readMetadataTrailer, stripMetadataTrailer } from './bytecode-trailer'
+
+/** Real tail: 7 bytes of code, then a 51-byte CBOR trailer, then its length. */
+const REAL_TAIL =
+  '0x925092509256fea2646970667358221220d03ac5dc4a08882370fe06263f9bcf6dee1812146c63a9d19ed384af9919e81e64736f6c634300081d0033'
+
+/** The same, with the trailing length word claiming more than exists. */
+const OVERLONG_LENGTH = `${REAL_TAIL.slice(0, -4)}ffff`
+
+describe('readMetadataTrailer', () => {
+  it('reads the length, the CBOR blob and the compiler from a real trailer', () => {
+    const trailer = readMetadataTrailer(REAL_TAIL)
+
+    expect(trailer.present).toBe(true)
+    if (!trailer.present) return
+    expect(trailer.byteLength).toBe(51)
+    // The whole trailer plus its own 2-byte length word.
+    expect(trailer.totalStrippedBytes).toBe(53)
+    // Constraint from the fleet sweep: read the toolchain from the trailer, not
+    // from the deployment record, which can disagree with what was deployed.
+    expect(trailer.solcVersion).toBe('0.8.29')
+  })
+
+  it('reports absence rather than guessing when there is no trailer', () => {
+    // A length word of 0 is not a zero-length trailer; it means the bytes are
+    // not a solc metadata trailer at all.
+    expect(readMetadataTrailer('0x60806040520000').present).toBe(false)
+  })
+
+  it('refuses a length word claiming more bytes than exist', () => {
+    // Stripping on this would cut into real code and silently change the hash
+    // the whole gate compares.
+    const trailer = readMetadataTrailer(OVERLONG_LENGTH)
+
+    expect(trailer.present).toBe(false)
+    if (!trailer.present) expect(trailer.reason).toMatch(/longer than/)
+  })
+
+  it('refuses bytes whose blob does not start with a CBOR map header', () => {
+    // 0x60 is PUSH1, not a CBOR map. Solc's trailer always opens 0xa1-0xbf.
+    // Without this, any contract whose last two bytes happen to look like a
+    // plausible length gets its tail amputated.
+    const notCbor = `0x${'60'.repeat(20)}0004`
+    const trailer = readMetadataTrailer(notCbor)
+
+    expect(trailer.present).toBe(false)
+    if (!trailer.present) expect(trailer.reason).toMatch(/CBOR map/)
+  })
+
+  it('reports no compiler rather than a wrong one when the key is absent', () => {
+    // A trailer without the solc key is legitimate. Returning undefined lets the
+    // caller decide; inventing a version would be compared against as fact.
+    const noSolc = '0xa1646970667358221220' + 'aa'.repeat(34) + '000b'
+    const trailer = readMetadataTrailer(noSolc)
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+  })
+
+  // The REASON is asserted, not just the refusal. Several of these inputs are
+  // caught by more than one guard, so `present === false` alone passes even with
+  // the specific guard removed.
+  it.each([
+    ['not hex', '0xzz', /not hex/],
+    ['odd-length hex', '0xabc', /whole bytes/],
+    ['empty', '0x', /empty/],
+    ['shorter than a length word', '0xab', /shorter than a length word/],
+  ])('refuses %s input, and says why', (_label, input, reason) => {
+    const trailer = readMetadataTrailer(input)
+
+    expect(trailer.present).toBe(false)
+    if (!trailer.present) expect(trailer.reason).toMatch(reason)
+  })
+})
+
+describe('stripMetadataTrailer', () => {
+  it('removes exactly the trailer and its length word', () => {
+    const { code, stripped } = stripMetadataTrailer(REAL_TAIL)
+
+    expect(stripped).toBe(true)
+    // 60 bytes in, 53 stripped, 7 left.
+    expect(code).toBe('0x92509250925' + '6fe')
+    expect((code.length - 2) / 2).toBe(7)
+  })
+
+  it('returns the input unchanged when there is no trailer to strip', () => {
+    const input = '0x60806040520000'
+
+    const { code, stripped } = stripMetadataTrailer(input)
+
+    expect(stripped).toBe(false)
+    expect(code).toBe(input)
+  })
+
+  it('leaves the code alone when the length word overclaims', () => {
+    // Fail closed: an unstrippable trailer must not become a truncated code.
+    const { code, stripped } = stripMetadataTrailer(OVERLONG_LENGTH)
+
+    expect(stripped).toBe(false)
+    expect(code).toBe(OVERLONG_LENGTH)
+  })
+
+  it('is idempotent — stripping twice removes only one trailer', () => {
+    // The remaining code must not look like a trailer to a second pass, or a
+    // caller that normalises defensively would eat real bytes.
+    const once = stripMetadataTrailer(REAL_TAIL).code
+
+    expect(stripMetadataTrailer(once).code).toBe(once)
+  })
+})

--- a/script/deploy/codehash/bytecode-trailer.test.ts
+++ b/script/deploy/codehash/bytecode-trailer.test.ts
@@ -125,3 +125,67 @@ describe('stripMetadataTrailer', () => {
     expect(stripMetadataTrailer(once).code).toBe(once)
   })
 })
+
+/**
+ * One source, two lineages. Both are the tail of `AccessManagerFacet`'s
+ * `deployedBytecode.object`: 96 code bytes, then a 51-byte trailer, then its
+ * length word.
+ *
+ * - CANCUN_TAIL: `out/` at 67922f138, default profile, solc 0.8.29 / cancun.
+ * - LONDON_TAIL: `out-floor/` at 67922f138, `FOUNDRY_PROFILE=solc_floor`, solc
+ *   0.8.17 / london — the floor every `src/` file pins, built in CI by
+ *   `solc-floor-build.yml`.
+ *
+ * The code differs because 0.8.29 emits PUSH0 (`5f`) where 0.8.17 has to spell
+ * out `6000`; a lineage difference is not a cosmetic one.
+ */
+const CANCUN_TAIL =
+  '0x5b9150610508602084016104bd565b90509250929050565b5f5f5f60608486031215610523575f5ffd5b61052c84610489565b925061053a602085016104bd565b91506040840135801515811461054e575f5ffd5b80915050925092509256fea2646970667358221220d03ac5dc4a08882370fe06263f9bcf6dee1812146c63a9d19ed384af9919e81e64736f6c634300081d0033'
+
+const LONDON_TAIL =
+  '0x0515602084016104c7565b90509250929050565b60008060006060848603121561053357600080fd5b61053c84610492565b925061054a602085016104c7565b91506040840135801515811461055f57600080fd5b80915050925092509256fea26469706673582212205bfef31b47d1e8650e0c547fe943a009dbb2467002129adbfe64624c618a0bf164736f6c63430008110033'
+
+describe('across build lineages', () => {
+  it('reads the compiler from the london lineage too, not just the default one', () => {
+    const london = readMetadataTrailer(LONDON_TAIL)
+
+    expect(london.present).toBe(true)
+    if (!london.present) return
+    // 0x11 = 17, against 0x1d = 29 in the cancun fixture: a reader that
+    // mis-slices the version triple cannot satisfy both.
+    expect(london.solcVersion).toBe('0.8.17')
+    expect(london.byteLength).toBe(51)
+  })
+
+  it('distinguishes lineages by the decoded version, not by trailer size', () => {
+    const cancun = readMetadataTrailer(CANCUN_TAIL)
+    const london = readMetadataTrailer(LONDON_TAIL)
+
+    expect([cancun.present, london.present]).toEqual([true, true])
+    if (!cancun.present || !london.present) return
+    expect(cancun.solcVersion).toBe('0.8.29')
+    expect(london.solcVersion).toBe('0.8.17')
+    // Both are 51-byte `a2` maps of ipfs + solc, so size carries no lineage
+    // information at all.
+    expect(london.totalStrippedBytes).toBe(cancun.totalStrippedBytes)
+  })
+
+  it('strips both lineages but does not reconcile them', () => {
+    const cancun = stripMetadataTrailer(CANCUN_TAIL)
+    const london = stripMetadataTrailer(LONDON_TAIL)
+
+    // Both really stripped — without this the inequality below would also hold
+    // for two inputs the stripper never touched.
+    expect([cancun.stripped, london.stripped]).toEqual([true, true])
+    expect(cancun.code.length).toBe(CANCUN_TAIL.length - 53 * 2)
+    expect(london.code.length).toBe(LONDON_TAIL.length - 53 * 2)
+
+    // The measurement WP-2.1 exists to act on: stripping normalises a rebuild
+    // of ONE lineage, and leaves two lineages of one source as far apart as
+    // before. Whole artifacts: 1370 bytes hashing to 0x9b3646… on cancun
+    // against 1387 and 0x632dab… on london. A sign-time gate therefore has to
+    // compare against a SET of expected hashes, one per lineage a network can
+    // legitimately have been built from — never a single expected value.
+    expect(cancun.code).not.toBe(london.code)
+  })
+})

--- a/script/deploy/codehash/bytecode-trailer.test.ts
+++ b/script/deploy/codehash/bytecode-trailer.test.ts
@@ -33,8 +33,8 @@ describe('readMetadataTrailer', () => {
     expect(trailer.byteLength).toBe(51)
     // The whole trailer plus its own 2-byte length word.
     expect(trailer.totalStrippedBytes).toBe(53)
-    // Constraint from the fleet sweep: read the toolchain from the trailer, not
-    // from the deployment record, which can disagree with what was deployed.
+    // Read the toolchain from the trailer, not from the deployment record,
+    // which can disagree with what was deployed.
     expect(trailer.solcVersion).toBe('0.8.29')
   })
 
@@ -54,7 +54,7 @@ describe('readMetadataTrailer', () => {
   })
 
   it('refuses bytes whose blob does not start with a CBOR map header', () => {
-    // 0x60 is PUSH1, not a CBOR map. Solc's trailer always opens 0xa1-0xbf.
+    // 0x60 is PUSH1, not a CBOR map. Solc opens its map 0xa1-0xaf.
     // Without this, any contract whose last two bytes happen to look like a
     // plausible length gets its tail amputated.
     const notCbor = `0x${'60'.repeat(20)}0004`
@@ -132,9 +132,10 @@ describe('stripMetadataTrailer', () => {
  * length word.
  *
  * - CANCUN_TAIL: `out/` at 67922f138, default profile, solc 0.8.29 / cancun.
- * - LONDON_TAIL: `out-floor/` at 67922f138, `FOUNDRY_PROFILE=solc_floor`, solc
- *   0.8.17 / london — the floor every `src/` file pins, built in CI by
- *   `solc-floor-build.yml`.
+ * - LONDON_TAIL: at 67922f138, `FOUNDRY_PROFILE=solc_floor forge build --out
+ *   out-floor --contracts src/Facets/AccessManagerFacet.sol` — solc 0.8.17 /
+ *   london, the floor every `src/` file pins, built in CI by
+ *   `solc-floor-build.yml`. The profile does not redirect `out` itself.
  *
  * The code differs because 0.8.29 emits PUSH0 (`5f`) where 0.8.17 has to spell
  * out `6000`; a lineage difference is not a cosmetic one.
@@ -180,12 +181,91 @@ describe('across build lineages', () => {
     expect(cancun.code.length).toBe(CANCUN_TAIL.length - 53 * 2)
     expect(london.code.length).toBe(LONDON_TAIL.length - 53 * 2)
 
-    // The measurement WP-2.1 exists to act on: stripping normalises a rebuild
-    // of ONE lineage, and leaves two lineages of one source as far apart as
-    // before. Whole artifacts: 1370 bytes hashing to 0x9b3646… on cancun
+    // Stripping normalises a rebuild of ONE lineage and leaves two lineages of
+    // one source as far apart as before. Whole artifacts: 1370 bytes hashing to 0x9b3646… on cancun
     // against 1387 and 0x632dab… on london. A sign-time gate therefore has to
     // compare against a SET of expected hashes, one per lineage a network can
     // legitimately have been built from — never a single expected value.
     expect(cancun.code).not.toBe(london.code)
+  })
+})
+
+describe('readMetadataTrailer, against a trailer chosen by the deployer', () => {
+  /** Assembles `code || cbor || lengthWord` from a CBOR blob's hex. */
+  const withTrailer = (cbor: string): string => {
+    const declared = (cbor.length / 2).toString(16).padStart(4, '0')
+    return `0x${'60'.repeat(8)}${cbor}${declared}`
+  }
+
+  it('reports no version when the solc key sits at an odd hex offset', () => {
+    // `indexOf` runs over hex characters, so this blob contains the key's
+    // characters spanning two bytes' nibbles. Reading it yields solc
+    // "237.234.219", which would be shown to a signer as fact.
+    const trailer = readMetadataTrailer(
+      withTrailer('a1164736f6c6343edeadbeef00')
+    )
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+  })
+
+  it('reports no version when a second solc key makes the real one ambiguous', () => {
+    // A planted key ahead of the genuine one wins on first-match.
+    const trailer = readMetadataTrailer(
+      withTrailer('a264736f6c634300080a64736f6c634300081d')
+    )
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+  })
+
+  it.each([
+    ['a major version solc has never released', 'a164736f6c6343ff0102'],
+    ['a minor beyond any release', 'a164736f6c634300ff02'],
+    ['a patch beyond any release', 'a164736f6c63430008ff'],
+  ])('reports no version for %s', (_label, cbor) => {
+    const trailer = readMetadataTrailer(withTrailer(cbor))
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+  })
+
+  it('still reads a genuine key at an even offset', () => {
+    // The positive control: without it, every assertion above is satisfied by a
+    // reader that has simply stopped reading versions.
+    const trailer = readMetadataTrailer(withTrailer('a164736f6c634300081d'))
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBe('0.8.29')
+  })
+
+  it.each([
+    ['b0', /CBOR map/],
+    ['b8', /CBOR map/],
+    ['bf', /CBOR map/],
+  ])(
+    'refuses a blob opening 0x%s, which solc does not emit',
+    (header, reason) => {
+      const trailer = readMetadataTrailer(
+        withTrailer(`${header}${'aa'.repeat(9)}`)
+      )
+
+      expect(trailer.present).toBe(false)
+      if (!trailer.present) expect(trailer.reason).toMatch(reason)
+    }
+  )
+
+  it('refuses a length word that would leave no code behind', () => {
+    // Stripping this returns `0x`, which hashes to a value that is nobody's
+    // contract — and would be compared as though it were the deployed code.
+    const cbor = `a1${'aa'.repeat(9)}`
+    const trailer = readMetadataTrailer(`0x${cbor}000a`)
+
+    expect(trailer.present).toBe(false)
+    if (!trailer.present) expect(trailer.reason).toMatch(/leave no code/)
+  })
+
+  it('accepts an uppercase 0X prefix', () => {
+    expect(readMetadataTrailer(`0X${REAL_TAIL.slice(2)}`).present).toBe(true)
   })
 })

--- a/script/deploy/codehash/bytecode-trailer.test.ts
+++ b/script/deploy/codehash/bytecode-trailer.test.ts
@@ -234,6 +234,21 @@ describe('readMetadataTrailer, against a trailer chosen by the deployer', () => 
     if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
   })
 
+  it.each([
+    ['two bytes, which would render as 0.8.NaN', 'a164736f6c63420008'],
+    [
+      'four bytes, which would render as 0.8.29 and hide one',
+      'a164736f6c634400081d00',
+    ],
+  ])('reports no version when the solc value is %s', (_label, cbor) => {
+    // The map decodes, so the value's width is the only thing left saying this is
+    // a release triple.
+    const trailer = readMetadataTrailer(withTrailer(cbor))
+
+    expect(trailer.present).toBe(true)
+    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+  })
+
   it('still reads a genuine key at an even offset', () => {
     // The positive control: without it, every assertion above is satisfied by a
     // reader that has simply stopped reading versions.

--- a/script/deploy/codehash/bytecode-trailer.test.ts
+++ b/script/deploy/codehash/bytecode-trailer.test.ts
@@ -67,7 +67,8 @@ describe('readMetadataTrailer', () => {
   it('reports no compiler rather than a wrong one when the key is absent', () => {
     // A trailer without the solc key is legitimate. Returning undefined lets the
     // caller decide; inventing a version would be compared against as fact.
-    const noSolc = '0xa1646970667358221220' + 'aa'.repeat(34) + '000b'
+    // One entry: text(4) 'ipfs' then bytes(34), so 42 bytes of map.
+    const noSolc = `0x${'60'.repeat(8)}a164697066735822${'aa'.repeat(34)}002a`
     const trailer = readMetadataTrailer(noSolc)
 
     expect(trailer.present).toBe(true)
@@ -197,26 +198,29 @@ describe('readMetadataTrailer, against a trailer chosen by the deployer', () => 
     return `0x${'60'.repeat(8)}${cbor}${declared}`
   }
 
-  it('reports no version when the solc key sits at an odd hex offset', () => {
-    // `indexOf` runs over hex characters, so this blob contains the key's
-    // characters spanning two bytes' nibbles. Reading it yields solc
-    // "237.234.219", which would be shown to a signer as fact.
+  it('refuses a blob carrying the solc key at an offset no map reaches', () => {
+    // Searching for the key's characters rather than decoding the map read solc
+    // "237.234.219" out of two bytes' nibbles here, and reported it to a signer
+    // as fact. Decoding refuses: the map's first key is not a text string.
     const trailer = readMetadataTrailer(
       withTrailer('a1164736f6c6343edeadbeef00')
     )
 
-    expect(trailer.present).toBe(true)
-    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+    expect(trailer.present).toBe(false)
+    if (!trailer.present)
+      expect(trailer.reason).toMatch(/key is not a text string/)
   })
 
-  it('reports no version when a second solc key makes the real one ambiguous', () => {
-    // A planted key ahead of the genuine one wins on first-match.
+  it('refuses a map that repeats the solc key', () => {
+    // A planted key ahead of the genuine one won on first-match. Two entries
+    // under one key leave no way to say which the map means, so neither is read.
     const trailer = readMetadataTrailer(
       withTrailer('a264736f6c634300080a64736f6c634300081d')
     )
 
-    expect(trailer.present).toBe(true)
-    if (trailer.present) expect(trailer.solcVersion).toBeUndefined()
+    expect(trailer.present).toBe(false)
+    if (!trailer.present)
+      expect(trailer.reason).toMatch(/repeats the key 'solc'/)
   })
 
   it.each([

--- a/script/deploy/codehash/bytecode-trailer.ts
+++ b/script/deploy/codehash/bytecode-trailer.ts
@@ -6,14 +6,12 @@
  * zksolc trailer is a different format and is not handled here.
  */
 
+import { decodeCborMap } from './cbor-map'
 import { frameFault, strip0x } from './hex'
 
-/** solc opens its CBOR map with a major-type-5 header of 1-15 entries. */
-const CBOR_MAP_MIN = 0xa1
-const CBOR_MAP_MAX = 0xaf
-
-/** `text(4) "solc"` then `bytes(3)`, which is how solc encodes a release triple. */
-const SOLC_KEY = '64736f6c6343'
+/** The key solc writes its version under, and the width of a release triple. */
+const SOLC_KEY = 'solc'
+const VERSION_BYTES = 3
 
 /** The trailer's own big-endian length word. */
 const LENGTH_WORD_BYTES = 2
@@ -44,31 +42,23 @@ const absent = (reason: string): IMetadataTrailerAbsent => ({
 })
 
 /**
- * Reads the compiler version out of a trailer's CBOR.
+ * Turns solc's three-byte version value into a release string.
  *
- * Returns undefined for anything it cannot read unambiguously. The bytes are
- * part of the deployed code and so are chosen by whoever deployed it: a version
- * this reports is shown to a signer as fact, so a planted or nonsensical one
- * must come back as "no version" rather than as a number.
+ * Returns undefined for anything it cannot read as a release. The bytes are part
+ * of the deployed code and so are chosen by whoever deployed it: a version this
+ * reports is shown to a signer as fact, so an implausible one must come back as
+ * "no version" rather than as a number.
  *
- * @param cbor - The trailer's CBOR, as hex without `0x`.
- * @returns The version, or undefined when none can be read.
+ * @param value - The decoded value of the map's `solc` key, as hex.
+ * @returns The version, or undefined when the value is not a release triple.
  */
-const readSolcVersion = (cbor: string): string | undefined => {
-  const at = cbor.indexOf(SOLC_KEY)
-  if (at === -1) return undefined
-  // The search runs over hex characters, so a match at an odd index spans the
-  // second half of one byte and the first half of the next — not a key.
-  if (at % 2 !== 0) return undefined
-  // A second occurrence leaves no way to tell which one the map's key is.
-  if (cbor.indexOf(SOLC_KEY, at + 1) !== -1) return undefined
+const readSolcVersion = (value: string | undefined): string | undefined => {
+  if (value === undefined || value.length !== VERSION_BYTES * 2)
+    return undefined
 
-  const triple = cbor.slice(at + SOLC_KEY.length, at + SOLC_KEY.length + 6)
-  if (triple.length < 6) return undefined
-
-  const major = parseInt(triple.slice(0, 2), 16)
-  const minor = parseInt(triple.slice(2, 4), 16)
-  const patch = parseInt(triple.slice(4, 6), 16)
+  const major = parseInt(value.slice(0, 2), 16)
+  const minor = parseInt(value.slice(2, 4), 16)
+  const patch = parseInt(value.slice(4, 6), 16)
   if (
     major !== 0 ||
     minor > MAX_PLAUSIBLE_VERSION_PART ||
@@ -115,13 +105,10 @@ export const readMetadataTrailer = (runtimeHex: string): MetadataTrailer => {
     )
 
   const cbor = body.slice(-(totalStrippedBytes * 2), -4)
-  const header = parseInt(cbor.slice(0, 2), 16)
-  if (header < CBOR_MAP_MIN || header > CBOR_MAP_MAX)
-    return absent(
-      `blob opens 0x${cbor.slice(0, 2)}, which is not a CBOR map header`
-    )
+  const decoded = decodeCborMap(cbor.toLowerCase())
+  if (!decoded.ok) return absent(decoded.reason)
 
-  const solcVersion = readSolcVersion(cbor.toLowerCase())
+  const solcVersion = readSolcVersion(decoded.entries[SOLC_KEY])
 
   return {
     present: true,

--- a/script/deploy/codehash/bytecode-trailer.ts
+++ b/script/deploy/codehash/bytecode-trailer.ts
@@ -1,0 +1,128 @@
+/**
+ * Reads and strips the solc metadata trailer from runtime bytecode.
+ *
+ * Two contracts built from identical source differ in these bytes whenever a
+ * comment or a file path changed, so the trailer has to come off before any hash
+ * comparison. It also carries the compiler version, which the fleet sweep found
+ * is the value to trust: a deployment record's `solcVersion` can disagree with
+ * what was actually deployed, and the trailer cannot.
+ *
+ * Every failure path returns "no trailer" rather than a best guess. Stripping the
+ * wrong number of bytes silently changes the hash the sign-time gate compares,
+ * which is the one outcome worse than refusing to verify.
+ *
+ * zkEVM's zksolc trailer is a different format and is not handled here.
+ */
+
+/** solc opens its CBOR map with a major-type-5 header, 1-15 entries. */
+const CBOR_MAP_MIN = 0xa1
+const CBOR_MAP_MAX = 0xbf
+
+/** `text(4) "solc"` then `bytes(3)`, which is how solc encodes a release triple. */
+const SOLC_KEY = '64736f6c6343'
+
+/** The trailer's own big-endian length word. */
+const LENGTH_WORD_BYTES = 2
+
+export interface IMetadataTrailerFound {
+  present: true
+  /** Bytes of CBOR, excluding the length word. */
+  byteLength: number
+  /** What a strip removes: the CBOR plus its length word. */
+  totalStrippedBytes: number
+  /** Undefined when the trailer carries no solc key — never a guess. */
+  solcVersion?: string
+}
+
+export interface IMetadataTrailerAbsent {
+  present: false
+  reason: string
+}
+
+export type MetadataTrailer = IMetadataTrailerFound | IMetadataTrailerAbsent
+
+const absent = (reason: string): IMetadataTrailerAbsent => ({
+  present: false,
+  reason,
+})
+
+/**
+ * @param bytes - The trailer's CBOR, as lowercase hex without `0x`.
+ * @returns The compiler version, or undefined when the key is absent.
+ */
+const readSolcVersion = (bytes: string): string | undefined => {
+  const at = bytes.indexOf(SOLC_KEY)
+  if (at === -1) return undefined
+
+  const triple = bytes.slice(at + SOLC_KEY.length, at + SOLC_KEY.length + 6)
+  if (triple.length < 6) return undefined
+
+  const [major, minor, patch] = [0, 2, 4].map((i) =>
+    parseInt(triple.slice(i, i + 2), 16)
+  )
+  return `${major}.${minor}.${patch}`
+}
+
+/**
+ * Inspects the tail of runtime bytecode for a solc metadata trailer.
+ *
+ * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
+ * @returns What is there, or why nothing can be read.
+ */
+export const readMetadataTrailer = (runtimeHex: string): MetadataTrailer => {
+  const body = runtimeHex.startsWith('0x') ? runtimeHex.slice(2) : runtimeHex
+  if (body.length === 0) return absent('bytecode is empty')
+  if (body.length % 2 !== 0) return absent('bytecode is not whole bytes')
+  if (!/^[0-9a-f]*$/i.test(body)) return absent('bytecode is not hex')
+
+  const totalBytes = body.length / 2
+  if (totalBytes < LENGTH_WORD_BYTES)
+    return absent('bytecode is shorter than a length word')
+
+  const declared = parseInt(body.slice(-4), 16)
+  if (declared === 0)
+    return absent('length word is zero, so there is no trailer')
+
+  const totalStrippedBytes = declared + LENGTH_WORD_BYTES
+  if (totalStrippedBytes > totalBytes)
+    return absent(
+      `length word claims ${declared} bytes, longer than the ${
+        totalBytes - LENGTH_WORD_BYTES
+      } available`
+    )
+
+  const cbor = body.slice(-(totalStrippedBytes * 2), -4)
+  const header = parseInt(cbor.slice(0, 2), 16)
+  if (header < CBOR_MAP_MIN || header > CBOR_MAP_MAX)
+    return absent(
+      `blob opens 0x${cbor.slice(0, 2)}, which is not a CBOR map header`
+    )
+
+  const solcVersion = readSolcVersion(cbor.toLowerCase())
+
+  return {
+    present: true,
+    byteLength: declared,
+    totalStrippedBytes,
+    ...(solcVersion ? { solcVersion } : {}),
+  }
+}
+
+/**
+ * Removes the metadata trailer, or returns the input untouched.
+ *
+ * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
+ * @returns The code to hash, and whether anything was removed.
+ */
+export const stripMetadataTrailer = (
+  runtimeHex: string
+): { code: string; stripped: boolean } => {
+  const trailer = readMetadataTrailer(runtimeHex)
+  if (!trailer.present) return { code: runtimeHex, stripped: false }
+
+  const body = runtimeHex.startsWith('0x') ? runtimeHex.slice(2) : runtimeHex
+  return {
+    code: `0x${body.slice(0, body.length - trailer.totalStrippedBytes * 2)}`,
+    stripped: true,
+  }
+}

--- a/script/deploy/codehash/bytecode-trailer.ts
+++ b/script/deploy/codehash/bytecode-trailer.ts
@@ -1,22 +1,16 @@
 /**
- * Reads and strips the solc metadata trailer from runtime bytecode.
+ * Reads and strips the solc CBOR metadata trailer from runtime bytecode.
  *
- * Two contracts built from identical source differ in these bytes whenever a
- * comment or a file path changed, so the trailer has to come off before any hash
- * comparison. It also carries the compiler version, which the fleet sweep found
- * is the value to trust: a deployment record's `solcVersion` can disagree with
- * what was actually deployed, and the trailer cannot.
- *
- * Every failure path returns "no trailer" rather than a best guess. Stripping the
- * wrong number of bytes silently changes the hash the sign-time gate compares,
- * which is the one outcome worse than refusing to verify.
- *
- * zkEVM's zksolc trailer is a different format and is not handled here.
+ * Import this before hashing deployed code for comparison: two builds of one
+ * source differ in these bytes whenever a comment or a file path changed. The
+ * zksolc trailer is a different format and is not handled here.
  */
 
-/** solc opens its CBOR map with a major-type-5 header, 1-15 entries. */
+import { frameFault, strip0x } from './hex'
+
+/** solc opens its CBOR map with a major-type-5 header of 1-15 entries. */
 const CBOR_MAP_MIN = 0xa1
-const CBOR_MAP_MAX = 0xbf
+const CBOR_MAP_MAX = 0xaf
 
 /** `text(4) "solc"` then `bytes(3)`, which is how solc encodes a release triple. */
 const SOLC_KEY = '64736f6c6343'
@@ -24,13 +18,16 @@ const SOLC_KEY = '64736f6c6343'
 /** The trailer's own big-endian length word. */
 const LENGTH_WORD_BYTES = 2
 
+/** solc is still on 0.x, and no released minor or patch is near this. */
+const MAX_PLAUSIBLE_VERSION_PART = 99
+
 export interface IMetadataTrailerFound {
   present: true
   /** Bytes of CBOR, excluding the length word. */
   byteLength: number
   /** What a strip removes: the CBOR plus its length word. */
   totalStrippedBytes: number
-  /** Undefined when the trailer carries no solc key — never a guess. */
+  /** Undefined when no version can be read, which is never a guess. */
   solcVersion?: string
 }
 
@@ -47,34 +44,56 @@ const absent = (reason: string): IMetadataTrailerAbsent => ({
 })
 
 /**
- * @param bytes - The trailer's CBOR, as lowercase hex without `0x`.
- * @returns The compiler version, or undefined when the key is absent.
+ * Reads the compiler version out of a trailer's CBOR.
+ *
+ * Returns undefined for anything it cannot read unambiguously. The bytes are
+ * part of the deployed code and so are chosen by whoever deployed it: a version
+ * this reports is shown to a signer as fact, so a planted or nonsensical one
+ * must come back as "no version" rather than as a number.
+ *
+ * @param cbor - The trailer's CBOR, as hex without `0x`.
+ * @returns The version, or undefined when none can be read.
  */
-const readSolcVersion = (bytes: string): string | undefined => {
-  const at = bytes.indexOf(SOLC_KEY)
+const readSolcVersion = (cbor: string): string | undefined => {
+  const at = cbor.indexOf(SOLC_KEY)
   if (at === -1) return undefined
+  // The search runs over hex characters, so a match at an odd index spans the
+  // second half of one byte and the first half of the next — not a key.
+  if (at % 2 !== 0) return undefined
+  // A second occurrence leaves no way to tell which one the map's key is.
+  if (cbor.indexOf(SOLC_KEY, at + 1) !== -1) return undefined
 
-  const triple = bytes.slice(at + SOLC_KEY.length, at + SOLC_KEY.length + 6)
+  const triple = cbor.slice(at + SOLC_KEY.length, at + SOLC_KEY.length + 6)
   if (triple.length < 6) return undefined
 
-  const [major, minor, patch] = [0, 2, 4].map((i) =>
-    parseInt(triple.slice(i, i + 2), 16)
+  const major = parseInt(triple.slice(0, 2), 16)
+  const minor = parseInt(triple.slice(2, 4), 16)
+  const patch = parseInt(triple.slice(4, 6), 16)
+  if (
+    major !== 0 ||
+    minor > MAX_PLAUSIBLE_VERSION_PART ||
+    patch > MAX_PLAUSIBLE_VERSION_PART
   )
+    return undefined
+
   return `${major}.${minor}.${patch}`
 }
 
 /**
  * Inspects the tail of runtime bytecode for a solc metadata trailer.
  *
+ * Every path that cannot read a trailer reports absence rather than a best
+ * guess: stripping the wrong number of bytes changes the hash the sign-time
+ * comparison is made on, without anything looking wrong.
+ *
  * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
  * @returns What is there, or why nothing can be read.
  */
 export const readMetadataTrailer = (runtimeHex: string): MetadataTrailer => {
-  const body = runtimeHex.startsWith('0x') ? runtimeHex.slice(2) : runtimeHex
-  if (body.length === 0) return absent('bytecode is empty')
-  if (body.length % 2 !== 0) return absent('bytecode is not whole bytes')
-  if (!/^[0-9a-f]*$/i.test(body)) return absent('bytecode is not hex')
+  const fault = frameFault(runtimeHex, 'bytecode')
+  if (fault) return absent(fault)
 
+  const body = strip0x(runtimeHex)
   const totalBytes = body.length / 2
   if (totalBytes < LENGTH_WORD_BYTES)
     return absent('bytecode is shorter than a length word')
@@ -89,6 +108,10 @@ export const readMetadataTrailer = (runtimeHex: string): MetadataTrailer => {
       `length word claims ${declared} bytes, longer than the ${
         totalBytes - LENGTH_WORD_BYTES
       } available`
+    )
+  if (totalStrippedBytes === totalBytes)
+    return absent(
+      `length word claims ${declared} bytes, which would leave no code at all`
     )
 
   const cbor = body.slice(-(totalStrippedBytes * 2), -4)
@@ -120,7 +143,7 @@ export const stripMetadataTrailer = (
   const trailer = readMetadataTrailer(runtimeHex)
   if (!trailer.present) return { code: runtimeHex, stripped: false }
 
-  const body = runtimeHex.startsWith('0x') ? runtimeHex.slice(2) : runtimeHex
+  const body = strip0x(runtimeHex)
   return {
     code: `0x${body.slice(0, body.length - trailer.totalStrippedBytes * 2)}`,
     stripped: true,

--- a/script/deploy/codehash/cbor-map.test.ts
+++ b/script/deploy/codehash/cbor-map.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Fixtures are assembled by hand from the CBOR encoding, and the positive one is
+ * the real trailer of `out/AccessManagerFacet.sol/AccessManagerFacet.json`.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { decodeCborMap } from './cbor-map'
+
+/** The real thing: `{ ipfs: h'…', solc: h'00081d' }`, 51 bytes. */
+const REAL_TRAILER =
+  'a2646970667358221220d03ac5dc4a08882370fe06263f9bcf6dee1812146c63a9d19ed384af9919e81e64736f6c634300081d'
+
+describe('decodeCborMap', () => {
+  it('decodes a real solc trailer into its entries', () => {
+    const result = decodeCborMap(REAL_TRAILER)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(Object.keys(result.entries).sort()).toEqual(['ipfs', 'solc'])
+    expect(result.entries['solc']).toBe('00081d')
+    expect(result.entries['ipfs']).toHaveLength(68)
+  })
+
+  it('decodes the boolean value solc writes for experimental builds', () => {
+    // `{ solc: h'00081d', experimental: true }`
+    const result = decodeCborMap(
+      'a264736f6c634300081d6c6578706572696d656e74616cf5'
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.entries['experimental']).toBe('true')
+  })
+
+  it('refuses a map header that promises more entries than the bytes hold', () => {
+    // The case a first-byte range check cannot see: `a1` with nothing after it
+    // decodes as "a map" under a range check, and 3 of 4 bytes get stripped off
+    // a contract that has no trailer at all.
+    const result = decodeCborMap('a1')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/ends before its keys do/)
+  })
+
+  it('refuses bytes left over after the map decodes', () => {
+    // A trailing byte means the declared length and the structure disagree, so
+    // the number of bytes to strip would be a guess.
+    const result = decodeCborMap(`${REAL_TRAILER}ff`)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/decodes in 51 of 52 bytes/)
+  })
+
+  it.each([
+    ['an empty blob', '', /empty/],
+    ['a text string', '6449504653', /not a CBOR map header/],
+    ['an array', '82616101', /not a CBOR map header/],
+    [
+      'an indefinite-length map',
+      'bf64736f6c634300081dff',
+      /not a CBOR map header/,
+    ],
+    ['a non-text key', 'a1164736f6c6343000000', /key is not a text string/],
+    ['a nested map as a value', 'a164736f6c63a0', /not a value solc emits/],
+    ['a key running past the end', 'a16f736f6c63', /runs past the blob/],
+    [
+      'a value running past the end',
+      'a164736f6c635822aa',
+      /runs past the blob/,
+    ],
+  ])('refuses %s', (_label, hex, reason) => {
+    const result = decodeCborMap(hex)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(reason)
+  })
+
+  it('refuses a repeated key rather than picking an entry', () => {
+    const result = decodeCborMap('a264736f6c634300080a64736f6c634300081d')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/repeats the key 'solc'/)
+  })
+
+  it('decodes an empty map, which is well-formed but carries nothing', () => {
+    const result = decodeCborMap('a0')
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.entries).toEqual({})
+  })
+})

--- a/script/deploy/codehash/cbor-map.test.ts
+++ b/script/deploy/codehash/cbor-map.test.ts
@@ -66,7 +66,7 @@ describe('decodeCborMap', () => {
       'bf64736f6c634300081dff',
       /not a CBOR map header/,
     ],
-    ['a non-text key', 'a1164736f6c6343000000', /key is not a text string/],
+    ['a non-text key', 'a116', /key is not a text string/],
     ['a nested map as a value', 'a164736f6c63a0', /not a value solc emits/],
     ['a key running past the end', 'a16f736f6c63', /runs past the blob/],
     [
@@ -88,10 +88,34 @@ describe('decodeCborMap', () => {
     if (!result.ok) expect(result.reason).toMatch(/repeats the key 'solc'/)
   })
 
-  it('decodes an empty map, which is well-formed but carries nothing', () => {
+  it('refuses a zero-entry map, which is well-formed CBOR solc never emits', () => {
+    // Admitting it widens what counts as a trailer for nothing in return: an
+    // `a0` before a plausible length word would strip bytes off a contract that
+    // has no trailer.
     const result = decodeCborMap('a0')
 
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/not a CBOR map header/)
+  })
+
+  it.each([
+    ['non-hex characters', 'a16161' + 'zz'],
+    ['an odd number of nibbles', 'a1616144deadbee'],
+  ])('refuses a blob with %s instead of reading zero bytes', (_label, hex) => {
+    // `parseInt('zz', 16)` is NaN, and a NaN in a Uint8Array becomes 0x00, so
+    // nonsense decoded into real-looking entries.
+    const result = decodeCborMap(hex)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/whole bytes of hex/)
+  })
+
+  it('reads a key that shadows an Object prototype member', () => {
+    // `key in entries` was true for inherited names, so a first-and-only
+    // `toString` key was refused as a repeat.
+    const result = decodeCborMap('a168746f537472696e6743000811')
+
     expect(result.ok).toBe(true)
-    if (result.ok) expect(result.entries).toEqual({})
+    if (result.ok) expect(result.entries['toString']).toBe('000811')
   })
 })

--- a/script/deploy/codehash/cbor-map.ts
+++ b/script/deploy/codehash/cbor-map.ts
@@ -8,8 +8,8 @@
  * refuses everything else instead of implementing CBOR.
  */
 
-/** Major type 5, entry count in the low 5 bits. Solc emits two or three keys. */
-const MAP_HEADER_MIN = 0xa0
+/** Major type 5, entry count in the low 5 bits. Solc emits one to three keys. */
+const MAP_HEADER_MIN = 0xa1
 const MAP_HEADER_MAX = 0xb7
 
 const MAJOR_BYTE_STRING = 2
@@ -85,6 +85,9 @@ const readLength = (info: number, reader: Reader): number | undefined => {
 export const decodeCborMap = (
   hex: string
 ): ICborMapDecoded | ICborMapRefused => {
+  if (!/^([0-9a-f]{2})*$/i.test(hex))
+    return { ok: false, reason: 'the blob is not whole bytes of hex' }
+
   const bytes = new Uint8Array(
     (hex.match(/../g) ?? []).map((pair) => parseInt(pair, 16))
   )
@@ -100,8 +103,11 @@ export const decodeCborMap = (
         .padStart(2, '0')}, which is not a CBOR map header`,
     }
 
-  const count = header - MAP_HEADER_MIN
-  const entries: Record<string, string> = {}
+  const count = header - 0xa0
+  const entries: Record<string, string> = Object.create(null) as Record<
+    string,
+    string
+  >
 
   for (let i = 0; i < count; i++) {
     const keyHeader = reader.byte()
@@ -118,7 +124,7 @@ export const decodeCborMap = (
     const key = new TextDecoder().decode(keyBytes)
 
     // A duplicate key leaves no way to say which entry the map means.
-    if (key in entries)
+    if (Object.prototype.hasOwnProperty.call(entries, key))
       return { ok: false, reason: `the CBOR map repeats the key '${key}'` }
 
     const valueHeader = reader.byte()

--- a/script/deploy/codehash/cbor-map.ts
+++ b/script/deploy/codehash/cbor-map.ts
@@ -1,0 +1,169 @@
+/**
+ * Decodes the flat CBOR map solc appends to runtime bytecode.
+ *
+ * Import this from the trailer reader rather than pattern-matching the bytes: a
+ * blob is only a trailer if it decodes completely, and a key's value is only
+ * that key's value if the map's structure says so. Deliberately narrow — it
+ * covers what solc emits (text keys; byte-string, text or boolean values) and
+ * refuses everything else instead of implementing CBOR.
+ */
+
+/** Major type 5, entry count in the low 5 bits. Solc emits two or three keys. */
+const MAP_HEADER_MIN = 0xa0
+const MAP_HEADER_MAX = 0xb7
+
+const MAJOR_BYTE_STRING = 2
+const MAJOR_TEXT_STRING = 3
+const MAJOR_SIMPLE = 7
+
+/** Low-5-bit values above this encode the length in following bytes. */
+const MAX_INLINE_LENGTH = 23
+const LENGTH_IN_ONE_BYTE = 24
+const LENGTH_IN_TWO_BYTES = 25
+
+const SIMPLE_FALSE = 20
+const SIMPLE_TRUE = 21
+
+export interface ICborMapDecoded {
+  ok: true
+  /** Values as hex without `0x`; booleans as `true`/`false`. */
+  entries: Record<string, string>
+}
+
+export interface ICborMapRefused {
+  ok: false
+  reason: string
+}
+
+class Reader {
+  private at = 0
+
+  public constructor(private readonly bytes: Uint8Array) {}
+
+  public done(): boolean {
+    return this.at >= this.bytes.length
+  }
+
+  public consumed(): number {
+    return this.at
+  }
+
+  public byte(): number | undefined {
+    return this.bytes[this.at++]
+  }
+
+  public slice(length: number): Uint8Array | undefined {
+    if (this.at + length > this.bytes.length) return undefined
+    const out = this.bytes.slice(this.at, this.at + length)
+    this.at += length
+    return out
+  }
+}
+
+const toHex = (bytes: Uint8Array): string =>
+  [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+
+/** Reads a byte- or text-string length, following the CBOR length encoding. */
+const readLength = (info: number, reader: Reader): number | undefined => {
+  if (info <= MAX_INLINE_LENGTH) return info
+  if (info === LENGTH_IN_ONE_BYTE) return reader.byte()
+  if (info === LENGTH_IN_TWO_BYTES) {
+    const high = reader.byte()
+    const low = reader.byte()
+    if (high === undefined || low === undefined) return undefined
+    return (high << 8) | low
+  }
+  return undefined
+}
+
+/**
+ * Decodes a complete flat CBOR map.
+ *
+ * @param hex - The blob, as hex without `0x`.
+ * @returns The map's entries, or why the bytes are not one.
+ */
+export const decodeCborMap = (
+  hex: string
+): ICborMapDecoded | ICborMapRefused => {
+  const bytes = new Uint8Array(
+    (hex.match(/../g) ?? []).map((pair) => parseInt(pair, 16))
+  )
+  const reader = new Reader(bytes)
+
+  const header = reader.byte()
+  if (header === undefined) return { ok: false, reason: 'the blob is empty' }
+  if (header < MAP_HEADER_MIN || header > MAP_HEADER_MAX)
+    return {
+      ok: false,
+      reason: `the blob opens 0x${header
+        .toString(16)
+        .padStart(2, '0')}, which is not a CBOR map header`,
+    }
+
+  const count = header - MAP_HEADER_MIN
+  const entries: Record<string, string> = {}
+
+  for (let i = 0; i < count; i++) {
+    const keyHeader = reader.byte()
+    if (keyHeader === undefined)
+      return { ok: false, reason: 'the CBOR map ends before its keys do' }
+    if (keyHeader >> 5 !== MAJOR_TEXT_STRING)
+      return { ok: false, reason: 'a CBOR map key is not a text string' }
+    const keyLength = readLength(keyHeader & 0x1f, reader)
+    if (keyLength === undefined)
+      return { ok: false, reason: 'a CBOR map key has no readable length' }
+    const keyBytes = reader.slice(keyLength)
+    if (!keyBytes)
+      return { ok: false, reason: 'a CBOR map key runs past the blob' }
+    const key = new TextDecoder().decode(keyBytes)
+
+    // A duplicate key leaves no way to say which entry the map means.
+    if (key in entries)
+      return { ok: false, reason: `the CBOR map repeats the key '${key}'` }
+
+    const valueHeader = reader.byte()
+    if (valueHeader === undefined)
+      return { ok: false, reason: `the value for '${key}' is missing` }
+    const major = valueHeader >> 5
+    const info = valueHeader & 0x1f
+
+    if (major === MAJOR_SIMPLE) {
+      if (info !== SIMPLE_TRUE && info !== SIMPLE_FALSE)
+        return {
+          ok: false,
+          reason: `the value for '${key}' is not a value solc emits`,
+        }
+      entries[key] = info === SIMPLE_TRUE ? 'true' : 'false'
+      continue
+    }
+
+    if (major !== MAJOR_BYTE_STRING && major !== MAJOR_TEXT_STRING)
+      return {
+        ok: false,
+        reason: `the value for '${key}' is not a value solc emits`,
+      }
+
+    const valueLength = readLength(info, reader)
+    if (valueLength === undefined)
+      return {
+        ok: false,
+        reason: `the value for '${key}' has no readable length`,
+      }
+    const valueBytes = reader.slice(valueLength)
+    if (!valueBytes)
+      return { ok: false, reason: `the value for '${key}' runs past the blob` }
+    entries[key] = toHex(valueBytes)
+  }
+
+  // The declared length and the structure have to agree, or the blob is not a
+  // trailer and the byte count taken off the code would be a guess.
+  if (!reader.done())
+    return {
+      ok: false,
+      reason: `the CBOR map decodes in ${reader.consumed()} of ${
+        bytes.length
+      } bytes`,
+    }
+
+  return { ok: true, entries }
+}

--- a/script/deploy/codehash/hex.test.ts
+++ b/script/deploy/codehash/hex.test.ts
@@ -1,0 +1,50 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { frameFault, strip0x } from './hex'
+
+describe('frameFault', () => {
+  it('accepts real bytecode with and without a prefix', () => {
+    expect(frameFault('0xdeadbeef', 'bytecode')).toBeUndefined()
+    expect(frameFault('deadbeef', 'bytecode')).toBeUndefined()
+    expect(frameFault('0xDEADBEEF', 'bytecode')).toBeUndefined()
+  })
+
+  it('names the caller in the message so a shared guard still reads locally', () => {
+    expect(frameFault('', 'bytecode')).toBe('bytecode is empty')
+    expect(frameFault('0xabc', 'runtime code')).toBe(
+      'runtime code is not whole bytes'
+    )
+  })
+
+  it('refuses half a byte, because masking it would misalign every offset', () => {
+    expect(frameFault('0xabc', 'bytecode')).toBe('bytecode is not whole bytes')
+  })
+
+  it('refuses non-hex rather than letting it reach a hash or a value', () => {
+    expect(frameFault(`0x${'zz'.repeat(4)}`, 'bytecode')).toBe(
+      'bytecode is not hex'
+    )
+  })
+
+  it('refuses an input that is only a prefix', () => {
+    expect(frameFault('0x', 'bytecode')).toBe('bytecode is empty')
+  })
+})
+
+describe('strip0x', () => {
+  it('removes either case of prefix and leaves bare hex alone', () => {
+    expect(strip0x('0xabcd')).toBe('abcd')
+    expect(strip0x('0Xabcd')).toBe('abcd')
+    expect(strip0x('abcd')).toBe('abcd')
+  })
+
+  it('does not mistake leading hex digits for a prefix', () => {
+    // `0` and `x` only pair up at the very start; `a0x…` is data.
+    expect(strip0x('a0xbc')).toBe('a0xbc')
+  })
+})

--- a/script/deploy/codehash/hex.ts
+++ b/script/deploy/codehash/hex.ts
@@ -1,0 +1,26 @@
+/**
+ * Framing checks for bytecode hex, shared by the codehash modules.
+ *
+ * Import this rather than re-deriving the checks: a module that masks or hashes
+ * unvalidated hex produces a plausible-looking result from nonsense input, and
+ * the two modules disagreeing about what counts as valid is the same bug twice.
+ */
+
+/** Accepts either case of prefix; no real toolchain emits `0X`, but refusing it is not a safety property. */
+export const strip0x = (hex: string): string =>
+  /^0x/i.test(hex) ? hex.slice(2) : hex
+
+/**
+ * Checks the string is a non-empty, whole-byte, hexadecimal sequence.
+ *
+ * @param hex - Candidate bytecode, with or without a `0x` prefix.
+ * @param noun - How to name the input in the message, e.g. `bytecode`.
+ * @returns Why the string is unusable, or undefined when it is fine.
+ */
+export const frameFault = (hex: string, noun: string): string | undefined => {
+  const body = strip0x(hex)
+  if (body.length === 0) return `${noun} is empty`
+  if (body.length % 2 !== 0) return `${noun} is not whole bytes`
+  if (!/^[0-9a-f]*$/i.test(body)) return `${noun} is not hex`
+  return undefined
+}

--- a/script/deploy/codehash/immutable-offsets.test.ts
+++ b/script/deploy/codehash/immutable-offsets.test.ts
@@ -4,9 +4,11 @@
  * byte offsets into the runtime code. Measured against
  * `out/AcrossFacet.sol/AcrossFacet.json`, which carries 2 astIds over 4 copies.
  *
- * A repo-wide pass over all 42 artifacts that carry references is the realism
- * evidence; these cases pin the behaviour a single artifact cannot show, notably
- * the failure paths.
+ * A repo-wide pass over the artifacts carrying references shows their offsets are
+ * real and in range, and nothing more: the slots hold all-zero placeholders until
+ * construction, so masking one is a no-op and a hash over it is unchanged. The
+ * fixture below holds non-zero bytes at the referenced offsets, which is the only
+ * way to observe masking at all.
  */
 
 import {
@@ -15,6 +17,7 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
+import { keccak256 } from 'viem'
 
 import { maskImmutables, readImmutableCopies } from './immutable-offsets'
 
@@ -45,9 +48,8 @@ describe('maskImmutables', () => {
     expect(body.slice(64, 128)).toBe('00'.repeat(32))
     expect(body.slice(128, 192)).toBe('00'.repeat(32))
     expect(body.slice(192, 256)).toBe('00'.repeat(32))
-    // Unmasked bytes are original. The last immutable covers bytes 96-127, i.e.
-    // the end of this 128-byte fixture, so the only untouched regions are the
-    // head and the gap at byte 95 — there is no tail to check.
+    // The three occurrences are contiguous over bytes 32-127, i.e. to the end of
+    // this fixture, so the head is the only region left to prove untouched.
     expect(body.slice(0, 2)).toBe('00')
     expect(body.slice(2, 4)).toBe('01')
     expect(body.slice(62, 64)).toBe('1f')
@@ -103,7 +105,7 @@ describe('maskImmutables', () => {
 
 describe('readImmutableCopies', () => {
   it('reads each value once when every copy agrees', () => {
-    const agreeing = maskImmutables(CODE, {}).ok ? CODE : CODE
+    const agreeing = CODE
     // Write the same value at both of astId 8938's offsets.
     const value = 'ab'.repeat(32)
     const body = agreeing.slice(2).split('')
@@ -119,8 +121,8 @@ describe('readImmutableCopies', () => {
   })
 
   it('refuses when two copies of one immutable disagree', () => {
-    // The spike requires every copy to agree. Picking one silently would report
-    // a value the contract does not uniformly hold.
+    // Picking one silently would report a value the contract does not uniformly
+    // hold.
     const result = readImmutableCopies(CODE, REFS)
 
     expect(result.ok).toBe(false)
@@ -134,5 +136,92 @@ describe('readImmutableCopies', () => {
     expect(
       readImmutableCopies(CODE, { '1': [{ start: 120, length: 32 }] }).ok
     ).toBe(false)
+  })
+})
+
+describe('against the shapes real artifacts and callers produce', () => {
+  it('treats an absent reference set as a contract with no immutables', () => {
+    // Foundry omits `immutableReferences` rather than emitting `{}`, and most
+    // artifacts in the repo have no immutables at all, so this is the common
+    // case reaching the module — not an edge one.
+    const masked = maskImmutables(CODE, undefined)
+    const read = readImmutableCopies(CODE, undefined)
+
+    expect(masked.ok).toBe(true)
+    if (masked.ok) expect(masked.code).toBe(CODE)
+    expect(read.ok).toBe(true)
+    if (read.ok) expect(read.values).toEqual({})
+  })
+
+  it.each([
+    ['non-hex code', `0x${'zz'.repeat(64)}`, /not hex/],
+    ['half a byte', `0x${'ab'.repeat(63)}c`, /whole bytes/],
+    ['no code at all', '0x', /empty/],
+  ])('refuses %s rather than masking it', (_label, code, reason) => {
+    const masked = maskImmutables(code, REFS)
+    const read = readImmutableCopies(code, REFS)
+
+    expect([masked.ok, read.ok]).toEqual([false, false])
+    if (!masked.ok) expect(masked.reason).toMatch(reason)
+    if (!read.ok) expect(read.reason).toMatch(reason)
+  })
+
+  it('refuses an immutable that lists no occurrences', () => {
+    // It would otherwise be dropped from the read result rather than compared,
+    // and an expectation with nothing to compare against passes by default.
+    const result = readImmutableCopies(CODE, { ...REFS, '9001': [] })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/no occurrences/)
+  })
+
+  it('says an occurrence is duplicated rather than naming one astId twice', () => {
+    const result = maskImmutables(CODE, {
+      '8938': [
+        { start: 32, length: 32 },
+        { start: 32, length: 32 },
+      ],
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/more than once/)
+  })
+})
+
+describe('the property layer 1 depends on', () => {
+  it('changes the hash it is asked to normalise', () => {
+    // Without this, a `maskImmutables` that returned its input unchanged would
+    // satisfy every other test in this file, and two deployments differing only
+    // in their immutables would compare as different code.
+    const masked = maskImmutables(CODE, REFS)
+
+    expect(masked.ok).toBe(true)
+    if (!masked.ok) return
+    expect(keccak256(masked.code as `0x${string}`)).not.toBe(
+      keccak256(CODE as `0x${string}`)
+    )
+  })
+
+  it('gives two deployments differing only in immutables the same hash', () => {
+    const write = (value: string): string => {
+      let hex = CODE.slice(2)
+      for (const { start, length } of REFS['8938'])
+        hex =
+          hex.slice(0, start * 2) +
+          value.repeat(length) +
+          hex.slice((start + length) * 2)
+      return `0x${hex}`
+    }
+    const first = maskImmutables(write('ab'), REFS)
+    const second = maskImmutables(write('cd'), REFS)
+
+    expect([first.ok, second.ok]).toEqual([true, true])
+    if (!first.ok || !second.ok) return
+    // The inputs really did differ, so the equality below is not two identical
+    // strings agreeing with each other.
+    expect(write('ab')).not.toBe(write('cd'))
+    expect(keccak256(first.code as `0x${string}`)).toBe(
+      keccak256(second.code as `0x${string}`)
+    )
   })
 })

--- a/script/deploy/codehash/immutable-offsets.test.ts
+++ b/script/deploy/codehash/immutable-offsets.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Offsets and lengths use the shape Foundry emits in
+ * `deployedBytecode.immutableReferences`: `{ [astId]: [{ start, length }] }`,
+ * byte offsets into the runtime code. Measured against
+ * `out/AcrossFacet.sol/AcrossFacet.json`, which carries 2 astIds over 4 copies.
+ *
+ * A repo-wide pass over all 42 artifacts that carry references is the realism
+ * evidence; these cases pin the behaviour a single artifact cannot show, notably
+ * the failure paths.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { maskImmutables, readImmutableCopies } from './immutable-offsets'
+
+/** 128 bytes of distinguishable filler. */
+const CODE = `0x${Array.from({ length: 128 }, (_, i) =>
+  i.toString(16).padStart(2, '0')
+).join('')}`
+
+/** Two immutables, the first with two copies — the shape that can disagree. */
+const REFS = {
+  '8938': [
+    { start: 32, length: 32 },
+    { start: 64, length: 32 },
+  ],
+  '8941': [{ start: 96, length: 32 }],
+}
+
+describe('maskImmutables', () => {
+  it('zeroes every occurrence and leaves the rest untouched', () => {
+    const result = maskImmutables(CODE, REFS)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // Same length: masking must not shift a single byte, or every offset after
+    // it means something else.
+    expect(result.code.length).toBe(CODE.length)
+    const body = result.code.slice(2)
+    expect(body.slice(64, 128)).toBe('00'.repeat(32))
+    expect(body.slice(128, 192)).toBe('00'.repeat(32))
+    expect(body.slice(192, 256)).toBe('00'.repeat(32))
+    // Unmasked bytes are original. The last immutable covers bytes 96-127, i.e.
+    // the end of this 128-byte fixture, so the only untouched regions are the
+    // head and the gap at byte 95 — there is no tail to check.
+    expect(body.slice(0, 2)).toBe('00')
+    expect(body.slice(2, 4)).toBe('01')
+    expect(body.slice(62, 64)).toBe('1f')
+  })
+
+  it('is unchanged by masking twice', () => {
+    const once = maskImmutables(CODE, REFS)
+    expect(once.ok).toBe(true)
+    if (!once.ok) return
+
+    const twice = maskImmutables(once.code, REFS)
+    expect(twice.ok).toBe(true)
+    if (twice.ok) expect(twice.code).toBe(once.code)
+  })
+
+  it('returns the code untouched when there are no references', () => {
+    const result = maskImmutables(CODE, {})
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.code).toBe(CODE)
+  })
+
+  it('refuses an occurrence that runs past the end of the code', () => {
+    // Masking on this would either throw or silently mask nothing, and a hash
+    // over partly-masked code is compared as though it were normalised.
+    const result = maskImmutables(CODE, { '1': [{ start: 120, length: 32 }] })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/past the end/)
+  })
+
+  it.each([
+    ['a negative start', { start: -1, length: 32 }],
+    ['a zero length', { start: 32, length: 0 }],
+    ['a negative length', { start: 32, length: -32 }],
+    ['a fractional start', { start: 32.5, length: 32 }],
+  ])('refuses %s', (_label, occurrence) => {
+    expect(maskImmutables(CODE, { '1': [occurrence] }).ok).toBe(false)
+  })
+
+  it('refuses overlapping occurrences', () => {
+    // Overlap means one of the two offsets is wrong, and masking both would
+    // hide that rather than surface it.
+    const result = maskImmutables(CODE, {
+      '1': [{ start: 32, length: 32 }],
+      '2': [{ start: 48, length: 32 }],
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toMatch(/overlap/)
+  })
+})
+
+describe('readImmutableCopies', () => {
+  it('reads each value once when every copy agrees', () => {
+    const agreeing = maskImmutables(CODE, {}).ok ? CODE : CODE
+    // Write the same value at both of astId 8938's offsets.
+    const value = 'ab'.repeat(32)
+    const body = agreeing.slice(2).split('')
+    for (const start of [32, 64]) body.splice(start * 2, 64, ...value.split(''))
+    const code = `0x${body.join('')}`
+
+    const result = readImmutableCopies(code, REFS)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.values['8938']).toBe(`0x${value}`)
+    expect(Object.keys(result.values)).toHaveLength(2)
+  })
+
+  it('refuses when two copies of one immutable disagree', () => {
+    // The spike requires every copy to agree. Picking one silently would report
+    // a value the contract does not uniformly hold.
+    const result = readImmutableCopies(CODE, REFS)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toMatch(/disagree/)
+      expect(result.reason).toContain('8938')
+    }
+  })
+
+  it('refuses an occurrence past the end rather than reading short', () => {
+    expect(
+      readImmutableCopies(CODE, { '1': [{ start: 120, length: 32 }] }).ok
+    ).toBe(false)
+  })
+})

--- a/script/deploy/codehash/immutable-offsets.ts
+++ b/script/deploy/codehash/immutable-offsets.ts
@@ -1,0 +1,141 @@
+/**
+ * Masks and reads a contract's immutables in its runtime bytecode.
+ *
+ * Immutables are written into the code at construction, so two deployments of
+ * identical source differ at exactly these offsets. Layer 1 of the codehash
+ * check compares code with them masked; layer 2 reads their values and checks
+ * each against a declared expectation.
+ *
+ * Every failure path refuses. A hash over partly-masked code is compared as
+ * though it were normalised, and a value read from an out-of-range offset is
+ * compared against an expectation as though it came from the chain.
+ *
+ * zkEVM does not use offsets — its immutables live in `ImmutableSimulator` and
+ * are read by ordinal — so this applies to the EVM and Tron lineages only.
+ */
+
+/** Foundry's shape: byte offsets into the runtime code, keyed by AST id. */
+export interface IImmutableOccurrence {
+  start: number
+  length: number
+}
+
+export type ImmutableReferences = Record<string, IImmutableOccurrence[]>
+
+export interface IMaskResult {
+  ok: true
+  /** Same length as the input; only the occurrences are zeroed. */
+  code: string
+}
+
+export interface IReadResult {
+  ok: true
+  /** One value per AST id, `0x`-prefixed, once every copy has agreed. */
+  values: Record<string, string>
+}
+
+export interface IRefused {
+  ok: false
+  reason: string
+}
+
+const refused = (reason: string): IRefused => ({ ok: false, reason })
+
+const body = (hex: string): string =>
+  hex.startsWith('0x') ? hex.slice(2) : hex
+
+/**
+ * Checks the occurrences describe real, non-overlapping ranges.
+ *
+ * @param refs - Foundry's `immutableReferences`.
+ * @param totalBytes - Length of the runtime code.
+ * @returns Why the set is unusable, or undefined when it is fine.
+ */
+const findFault = (
+  refs: ImmutableReferences,
+  totalBytes: number
+): string | undefined => {
+  const ranges: { start: number; end: number; astId: string }[] = []
+
+  for (const [astId, occurrences] of Object.entries(refs))
+    for (const { start, length } of occurrences) {
+      if (!Number.isInteger(start) || start < 0)
+        return `astId ${astId} has start ${start}, which is not a byte offset`
+      if (!Number.isInteger(length) || length <= 0)
+        return `astId ${astId} has length ${length}, which is not a byte count`
+      if (start + length > totalBytes)
+        return `astId ${astId} at ${start}+${length} runs past the end of ${totalBytes} bytes`
+      ranges.push({ start, end: start + length, astId })
+    }
+
+  ranges.sort((a, b) => a.start - b.start)
+  for (let i = 1; i < ranges.length; i++) {
+    const previous = ranges[i - 1]
+    const current = ranges[i]
+    if (previous && current && current.start < previous.end)
+      return `astId ${previous.astId} and astId ${current.astId} overlap at byte ${current.start}`
+  }
+
+  return undefined
+}
+
+/**
+ * Zeroes every immutable occurrence, leaving the code the same length.
+ *
+ * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
+ * @param refs - Foundry's `immutableReferences`.
+ * @returns The masked code, or why it was refused.
+ */
+export const maskImmutables = (
+  runtimeHex: string,
+  refs: ImmutableReferences
+): IMaskResult | IRefused => {
+  const hex = body(runtimeHex)
+  const fault = findFault(refs, hex.length / 2)
+  if (fault) return refused(fault)
+
+  const chars = hex.split('')
+  for (const occurrences of Object.values(refs))
+    for (const { start, length } of occurrences)
+      chars.splice(start * 2, length * 2, ...'0'.repeat(length * 2).split(''))
+
+  return { ok: true, code: `0x${chars.join('')}` }
+}
+
+/**
+ * Reads each immutable's value, requiring every copy to agree.
+ *
+ * A disagreement means the deployed code does not uniformly hold the value, so
+ * there is no single value to check against an expectation. Picking one would
+ * report something the contract does not hold.
+ *
+ * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
+ * @param refs - Foundry's `immutableReferences`.
+ * @returns One value per AST id, or why it was refused.
+ */
+export const readImmutableCopies = (
+  runtimeHex: string,
+  refs: ImmutableReferences
+): IReadResult | IRefused => {
+  const hex = body(runtimeHex)
+  const fault = findFault(refs, hex.length / 2)
+  if (fault) return refused(fault)
+
+  const values: Record<string, string> = {}
+
+  for (const [astId, occurrences] of Object.entries(refs)) {
+    const seen = new Set(
+      occurrences.map(({ start, length }) =>
+        hex.slice(start * 2, (start + length) * 2).toLowerCase()
+      )
+    )
+    if (seen.size > 1)
+      return refused(
+        `astId ${astId} has ${seen.size} differing values across ${occurrences.length} copies, so they disagree`
+      )
+    const [only] = [...seen]
+    if (only !== undefined) values[astId] = `0x${only}`
+  }
+
+  return { ok: true, values }
+}

--- a/script/deploy/codehash/immutable-offsets.ts
+++ b/script/deploy/codehash/immutable-offsets.ts
@@ -1,18 +1,12 @@
 /**
  * Masks and reads a contract's immutables in its runtime bytecode.
  *
- * Immutables are written into the code at construction, so two deployments of
- * identical source differ at exactly these offsets. Layer 1 of the codehash
- * check compares code with them masked; layer 2 reads their values and checks
- * each against a declared expectation.
- *
- * Every failure path refuses. A hash over partly-masked code is compared as
- * though it were normalised, and a value read from an out-of-range offset is
- * compared against an expectation as though it came from the chain.
- *
- * zkEVM does not use offsets — its immutables live in `ImmutableSimulator` and
- * are read by ordinal — so this applies to the EVM and Tron lineages only.
+ * Import this to normalise code before hashing it, or to read immutable values
+ * for checking against a declared expectation. Offsets are an EVM and Tron
+ * concept: zkEVM keeps immutables in `ImmutableSimulator`, read by ordinal.
  */
+
+import { frameFault, strip0x } from './hex'
 
 /** Foundry's shape: byte offsets into the runtime code, keyed by AST id. */
 export interface IImmutableOccurrence {
@@ -30,7 +24,7 @@ export interface IMaskResult {
 
 export interface IReadResult {
   ok: true
-  /** One value per AST id, `0x`-prefixed, once every copy has agreed. */
+  /** One value per AST id in `refs`, `0x`-prefixed, once every copy agreed. */
   values: Record<string, string>
 }
 
@@ -41,8 +35,12 @@ export interface IRefused {
 
 const refused = (reason: string): IRefused => ({ ok: false, reason })
 
-const body = (hex: string): string =>
-  hex.startsWith('0x') ? hex.slice(2) : hex
+/**
+ * Foundry omits `immutableReferences` entirely for a contract that has none, so
+ * the majority of real artifacts hand this module `undefined`.
+ */
+const present = (refs: ImmutableReferences | undefined): ImmutableReferences =>
+  refs ?? {}
 
 /**
  * Checks the occurrences describe real, non-overlapping ranges.
@@ -57,7 +55,12 @@ const findFault = (
 ): string | undefined => {
   const ranges: { start: number; end: number; astId: string }[] = []
 
-  for (const [astId, occurrences] of Object.entries(refs))
+  for (const [astId, occurrences] of Object.entries(refs)) {
+    // An immutable with no occurrences would be dropped from the read result
+    // rather than compared, so layer 2 would pass it by default.
+    if (occurrences.length === 0)
+      return `astId ${astId} lists no occurrences, so it has no value to check`
+
     for (const { start, length } of occurrences) {
       if (!Number.isInteger(start) || start < 0)
         return `astId ${astId} has start ${start}, which is not a byte offset`
@@ -67,13 +70,16 @@ const findFault = (
         return `astId ${astId} at ${start}+${length} runs past the end of ${totalBytes} bytes`
       ranges.push({ start, end: start + length, astId })
     }
+  }
 
   ranges.sort((a, b) => a.start - b.start)
   for (let i = 1; i < ranges.length; i++) {
     const previous = ranges[i - 1]
     const current = ranges[i]
     if (previous && current && current.start < previous.end)
-      return `astId ${previous.astId} and astId ${current.astId} overlap at byte ${current.start}`
+      return previous.astId === current.astId
+        ? `astId ${current.astId} lists an occurrence at byte ${current.start} more than once`
+        : `astId ${previous.astId} and astId ${current.astId} overlap at byte ${current.start}`
   }
 
   return undefined
@@ -83,23 +89,30 @@ const findFault = (
  * Zeroes every immutable occurrence, leaving the code the same length.
  *
  * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
- * @param refs - Foundry's `immutableReferences`.
+ * @param refs - Foundry's `immutableReferences`, or undefined when it has none.
  * @returns The masked code, or why it was refused.
  */
 export const maskImmutables = (
   runtimeHex: string,
-  refs: ImmutableReferences
+  refs: ImmutableReferences | undefined
 ): IMaskResult | IRefused => {
-  const hex = body(runtimeHex)
-  const fault = findFault(refs, hex.length / 2)
+  const frame = frameFault(runtimeHex, 'bytecode')
+  if (frame) return refused(frame)
+
+  const hex = strip0x(runtimeHex)
+  const known = present(refs)
+  const fault = findFault(known, hex.length / 2)
   if (fault) return refused(fault)
 
-  const chars = hex.split('')
-  for (const occurrences of Object.values(refs))
+  let masked = hex
+  for (const occurrences of Object.values(known))
     for (const { start, length } of occurrences)
-      chars.splice(start * 2, length * 2, ...'0'.repeat(length * 2).split(''))
+      masked =
+        masked.slice(0, start * 2) +
+        '0'.repeat(length * 2) +
+        masked.slice((start + length) * 2)
 
-  return { ok: true, code: `0x${chars.join('')}` }
+  return { ok: true, code: `0x${masked}` }
 }
 
 /**
@@ -110,20 +123,24 @@ export const maskImmutables = (
  * report something the contract does not hold.
  *
  * @param runtimeHex - Runtime bytecode, `0x`-prefixed.
- * @param refs - Foundry's `immutableReferences`.
+ * @param refs - Foundry's `immutableReferences`, or undefined when it has none.
  * @returns One value per AST id, or why it was refused.
  */
 export const readImmutableCopies = (
   runtimeHex: string,
-  refs: ImmutableReferences
+  refs: ImmutableReferences | undefined
 ): IReadResult | IRefused => {
-  const hex = body(runtimeHex)
-  const fault = findFault(refs, hex.length / 2)
+  const frame = frameFault(runtimeHex, 'bytecode')
+  if (frame) return refused(frame)
+
+  const hex = strip0x(runtimeHex)
+  const known = present(refs)
+  const fault = findFault(known, hex.length / 2)
   if (fault) return refused(fault)
 
   const values: Record<string, string> = {}
 
-  for (const [astId, occurrences] of Object.entries(refs)) {
+  for (const [astId, occurrences] of Object.entries(known)) {
     const seen = new Set(
       occurrences.map(({ start, length }) =>
         hex.slice(start * 2, (start + length) * 2).toLowerCase()
@@ -134,7 +151,9 @@ export const readImmutableCopies = (
         `astId ${astId} has ${seen.size} differing values across ${occurrences.length} copies, so they disagree`
       )
     const [only] = [...seen]
-    if (only !== undefined) values[astId] = `0x${only}`
+    if (only === undefined)
+      return refused(`astId ${astId} yielded no value to read`)
+    values[astId] = `0x${only}`
   }
 
   return { ok: true, values }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Part of [EXSC-906](https://linear.app/lifi-linear/issue/EXSC-906/wp-21-verifycodehash-primitive-sign-time-gate) (ref EXSC-906) — the pure primitives only. Deliberately does not close the ticket: the `confirm-safe-tx.ts` wiring, the zksolc trailer and layer-2's immutable decode are still to come.

# Why did I implement it this way?

Five modules, no call sites yet. Nothing in the repo imports them, so this PR cannot change any behaviour — the wiring lands once [#2297](https://github.com/lifinance/contracts/pull/2297) (same funnel, `confirm-safe-tx.ts`) is merged, which is the sequencing the ticket asks for.

| Module | What it does |
|---|---|
| `hex.ts` | The framing checks both other modules need — non-empty, whole-byte, hexadecimal. Shared so the two cannot drift. |
| `cbor-map.ts` | Decodes the flat CBOR map solc appends. Narrow on purpose: text keys, byte-string/text/boolean values, and it must consume the declared length exactly. |
| `bytecode-trailer.ts` | Reads and strips the trailer. The compiler comes from the code's own trailer, because the fleet sweep found a record's `solcVersion` can disagree with what was deployed. |
| `immutable-offsets.ts` | Masks immutables from Foundry's `immutableReferences`, and reads their values only when every copy agrees. |
| `attested-set.ts` | Layer 1: set membership against attested builds, never equality against one record- or network-derived profile (adversarial E1). |

Every failure path refuses rather than guessing. Stripping the wrong number of bytes changes the hash the whole comparison is made on, with nothing looking wrong.

## The three verdicts, and the parameter that makes them honest

| Verdict | When | Blocks |
|---|---|---|
| MATCH | the hash is one we built | no |
| MISMATCH | it is not, and the disagreement is evidence about the code | yes |
| UNVERIFIABLE | we cannot tell — nothing attested, or an open lineage set with no readable version | yes |

The first version of this graded a non-match as UNVERIFIABLE whenever the compiler version was not one we had built. **That version came out of the deployed code's own metadata trailer, which whoever proposes the cut writes** — so a real tamper could be moved from RED to GREY by rewriting three bytes, no executable code touched. Both still block, but the whole reason for three buckets is that a GREY is treated more leniently downstream, and GREY is already routine (every zkEVM deployment lands there while the zksolc trailer is unparsed).

So `compareToAttestedSet` now takes a required `scope`. With the legitimate toolchains fully enumerated, non-membership settles the verdict on its own and the trailer is never consulted; only an open set falls back to reasoning about the reported version. No default value — the caller has to say which it is, so `tsc` names every site.

## What a normalised hash does not pin

A match needs the normalised hash **and** the deployed length. The masked hash is taken over the code with the trailer removed, and how much gets removed comes from the trailer's own length word — part of the deployed code. Appending a payload plus a length word covering it leaves the stripped prefix untouched, so the hash matches by construction:

```text
honest: 1440 bytes, masked 0x632dab2dd5d9…

payload    4 bytes -> deployed 1399 bytes   masked hash equal: true   MISMATCH  (41 bytes unaccounted)
payload  100 bytes -> deployed 1495 bytes   masked hash equal: true   MISMATCH  (55 bytes unaccounted)
payload 3000 bytes -> deployed 4395 bytes   masked hash equal: true   MISMATCH  (2955 bytes unaccounted)
control, the honest build itself                                      MATCH
```

Each of those was MATCH — "code matches the attested build" — until `914a837`. `IAttestedBuild` and `IObservedCode` now carry `rawByteLength`, and a hash match with a differing length is MISMATCH under either scope: that is positive evidence of a difference, not absent knowledge.

**Two things a MATCH still does not cover**, both stated in the module rather than left to be found:

*The trailer window.* Hold the length equal and a tamperer keeps 47 bytes of arbitrary content inside the 53-byte trailer region, where an honest build carries a 34-byte digest. It is unreachable because `src/` has no internal function pointers, so nothing can jump into it — not, as I first wrote, because it follows the terminating INVALID: two artifacts in the fleet end in EIP-712 type-string data instead. Pass `IAttestedBuild.rawHash` to close it; the caller decides, because pinning exact bytes makes metadata-level drift between the deployed and attested source read as MISMATCH, which is the reason stripping exists.

*The masked immutables, which are the bigger channel.* Layer 1 hashes the code with immutables masked out, so a deployment whose immutables hold attacker-chosen call targets matches an honest build. On `ReceiverStargateV2` that is 480 bytes of 7390:

```text
honest deployment      deployed bytes differ: false   MATCH  excluded=480
immutables replaced    deployed bytes differ: true    MATCH  excluded=480
  code matches the attested build from upstream london outside its immutables;
  the 480 bytes holding those were not compared and their values still have to be checked
```

Checking those values is layer 2's job and nothing is wired yet — but the result used to carry no sign that bytes had been excluded, so a layer-1-only caller would render a green it had not earned. `ICodehashComparison.excludedByteCount` and that reason wording exist so it cannot.

**One open question for the wiring PR, not settled here:** how `isClosedSet` is derived. `config/networks.json` carries `targetEvmVersion` and `isZkEVM`, which is the obvious source, but the deploy log is not a corroborator today — 1 of 3765 entries carries `SOLC_VERSION`. Raised on EXSC-883 as D19.

## Evidence

**A second real lineage, not a synthetic one.** `FOUNDRY_PROFILE=solc_floor` (solc 0.8.17 / london, built in CI by `solc-floor-build.yml`) gives a genuine second build of one source:

```text
floor   (0.8.17 / london)   1440 raw → 1387 stripped   masked 0x632dab2dd5d9…
default (0.8.29 / cancun)   1423 raw → 1370 stripped   masked 0x9b36461a7235…
```

Identical source, both trailers 51-byte `a2` maps, different code — 0.8.29 emits PUSH0 where 0.8.17 spells out `6000`. That is what layer 1 turns on: stripping normalises a rebuild of **one** lineage and does not reconcile two, so a single expected hash turns honest builds red. Before these fixtures existed, a version hardcoded to `0.8.29` passed the whole suite.

**Fleet-wide, against a full `solc_floor` build** — 191 artifacts, 92 with runtime code (the count includes `lib/` dependencies, not only `src/`):

```text
trailer decoded            : 92 of 92      versions read: {"0.8.17": 92}
trailer byteLength         : 51 for all 92
immutableReferences absent : 50   non-empty: 42
maskImmutables ok          : 92      readImmutableCopies ok: 92
refusals                   : none in any of the three
```

The 50 with no `immutableReferences` key are the shape that made the natural call throw a `TypeError` before this PR — the majority of the fleet, not an edge case.

**Falsification, on real artifacts.** One code byte of a real build flipped, then the trailer varied. The masked hash is identical in all four tamper rows; only the grading differed before the `scope` fix:

```text
tamper changed the hash: true
trailer rewrite kept the code identical: true

CLOSED set
  1. honest deployment                        MATCH
  2. one code byte flipped, trailer honest    MISMATCH     (blocks)
  3. same tamper, trailer version rewritten   MISMATCH     (blocks)   <- was UNVERIFIABLE
  4. same tamper, trailer removed entirely    MISMATCH     (blocks)   <- was UNVERIFIABLE
OPEN set
  5. same tamper, unattested version reported UNVERIFIABLE (blocks)   <- honest: we may not have built it
```

And the benign direction, which must stay silent: a comment added to the source and rebuilt gives `raw hashes differ: true`, `masked hashes equal: true`, verdict MATCH.

**Mutation testing.** 27 mutations across the five modules; all die. Worth naming three: comparing only `attested[0]` kills three tests; dropping the empty-attested-set branch leaves the verdict right while degrading the signer's message to "no attested build used ()", so that test asserts the message; and dropping the version-width check leaves a signer told the code was built with **solc 0.8.NaN**, which nothing covered until the mutation found it.

Three review rounds ran on this branch, and each found a defect inside the previous round's fix: the attacker-controlled GREY/RED downgrade, then tampered code reaching MATCH through the length word, then the unqualified MATCH over masked immutables. Mutation testing found none of them. They are *absent* guards, and there is nothing to mutate. All three came from adversarial passes over what the input can lie about.

`bun test script/` — 1635 pass, 0 fail, run with `.env` moved aside so the suite sees what CI sees.

## Alternatives considered: `forge verify-bytecode`

Raised in review: foundry ships a bytecode verifier, so why hand-roll the primitives? Evaluated
against `forge 1.7.1` and production RPCs/explorers on 2026-09-02. It cannot do this job, for
reasons specific to how we deploy:

- **It cannot check runtime bytecode for any LI.FI contract, on any network.** `utils.rs::deploy_contract`
  bails unless the creation tx's `to` is the canonical CREATE2 deployer `0x4e59b448…`. Every LI.FI
  contract is deployed through our own CREATE3Factory, so the runtime step aborts with *"Transaction
  `to` address is not the default create2 deployer"* — 0 of 66 production networks. Runtime code is
  the only thing a `diamondCut` signer cares about.
- **It exits 0 when the bytecode does not match.** Every path in `bytecode.rs::run` returns `Ok(())`;
  the verdict lives in stdout only. Verified by rebuilding a facet with an extra function and
  re-running against the real deployed address: "Creation code did not match", exit code 0, same
  under `--json`.
- **The one comparison reachable for us ignores immutables.** Provided `--constructor-args` are
  discarded and re-derived from the tail of the onchain creation code, then stripped by length before
  comparing. Mainnet `FeeCollector` (real owner `0xC06ebbeF…264B`) run with
  `--constructor-args 0x…dEaD` still reports "matched".
- **Its trailer strip is steerable, and it has no length pin.** `find_metadata_start` trusts the
  trailing two-byte length word with only a parses-as-CBOR check — the same defect this PR's third
  round removed. Compiled that function verbatim and ran it on real deployed `AllBridgeFacet` runtime
  code: appending 32, 64, 512 or 4096 arbitrary bytes behind a CBOR byte-string header all normalise
  to the identical 9179-byte prefix, so it prints "matched with status partial". `partial` — not
  `full` — is our normal case, so this is the path we would live on.

Reachability, for completeness: because our deployments are neither direct-`CREATE` nor
canonical-CREATE2, even the creation-code half needs `trace_transaction`, which only 22 of our 66
production RPCs serve. Of those 22, 8 produced a verdict; the rest failed on unverified explorer
sources (`gnosis` is in `DO_NOT_VERIFY_IN_THESE_NETWORKS` by policy), explorer deserialisation
errors, or our own Etherscan plan.

Worth taking forward, and the one good idea in it: replay the constructor to reconstruct expected
immutables and compare all bytes exactly, rather than masking their offsets and deferring the values
to layer 2 — but with the args from our own record and config, never from the chain, which is the
proposer-controlled input foundry uses. Filed as [EXSC-924](https://linear.app/lifi-linear/issue/EXSC-924/wp-23-reconstruct-immutables-by-constructor-replay-instead) (WP-2.3), not this PR.

## Not in this PR

The zksolc trailer (a third format), layer-2 immutable decode by declared type, lineage resolution including fetch-by-SHA, and the `confirm-safe-tx.ts` gate with its per-`FacetCut`-element classification and the `_init == address(0)` rule. `docs/MultisigSigningProcess.md` §9 still lists bytecode attestation as planned, correctly — the PR that wires this in owns that update.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation — none: no behaviour is reachable yet, so there is nothing user-visible to document

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

