### PR TITLE
fix(tron): record the constructor arguments a contract was deployed with (EXSC-907)

### DIFF
--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -10,7 +10,7 @@ import {
   sanitizeProvenanceText,
 } from '../shared/git-provenance'
 
-import { MAX_PROPOSAL_REASON_LENGTH } from './safe-utils'
+import { MAX_PROPOSAL_REASON_LENGTH } from './proposal-intent'
 
 /** How many networks are named individually before the card switches to a count. */
 const NAMED_NETWORK_LIMIT = 4

--- a/script/deploy/tron/constructor-args.test.ts
+++ b/script/deploy/tron/constructor-args.test.ts
@@ -1,0 +1,245 @@
+/**
+ * ABI fixtures are trimmed copies of real artifact shapes: `ERC20Proxy` and
+ * `ReceiverStargateV2` as they appear in `out/<name>.sol/<name>.json`, and a
+ * facet with no constructor. They are EMBEDDED because CI has no build
+ * artifacts, so a test that reads `out/` either fails there or passes vacuously.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  assertRecordedArgsMatchAbi,
+  constructorInputTypes,
+  encodeConstructorArgs,
+} from './constructor-args'
+
+/** Two addresses, the shape recorded as `'0x'` on every Tron deployment. */
+const ERC20_PROXY_ABI = [
+  {
+    type: 'constructor',
+    inputs: [
+      { name: '_owner', type: 'address', internalType: 'address' },
+      { name: '_executor', type: 'address', internalType: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  { type: 'function', name: 'owner', inputs: [], outputs: [] },
+]
+
+/** Four addresses and a uint256 — the case type-guessing gets wrong. */
+const RECEIVER_STARGATE_V2_ABI = [
+  {
+    type: 'constructor',
+    inputs: [
+      { name: '_owner', type: 'address', internalType: 'address' },
+      { name: '_executor', type: 'address', internalType: 'address' },
+      { name: '_tokenMessaging', type: 'address', internalType: 'address' },
+      { name: '_endpointV2', type: 'address', internalType: 'address' },
+      { name: '_recoverGas', type: 'uint256', internalType: 'uint256' },
+    ],
+    stateMutability: 'nonpayable',
+  },
+]
+
+/** A facet: no constructor entry at all, which is not the same as an empty one. */
+const FACET_ABI = [{ type: 'function', name: 'doSomething', inputs: [] }]
+
+const ADDRESS = '0x1111111111111111111111111111111111111111'
+
+describe('constructorInputTypes', () => {
+  it('reads the declared types rather than inferring them from values', () => {
+    expect(constructorInputTypes(ERC20_PROXY_ABI)).toEqual([
+      'address',
+      'address',
+    ])
+    expect(constructorInputTypes(RECEIVER_STARGATE_V2_ABI)).toEqual([
+      'address',
+      'address',
+      'address',
+      'address',
+      'uint256',
+    ])
+  })
+
+  it('returns nothing for a contract with no constructor', () => {
+    expect(constructorInputTypes(FACET_ABI)).toEqual([])
+  })
+
+  it('expands a tuple into its canonical form', () => {
+    // A guessed type can never produce this, so it is the clearest signal that
+    // types come from the ABI.
+    const abi = [
+      {
+        type: 'constructor',
+        inputs: [
+          {
+            name: '_config',
+            type: 'tuple',
+            components: [
+              { name: 'token', type: 'address' },
+              { name: 'amount', type: 'uint128' },
+            ],
+          },
+          { name: '_ids', type: 'uint32[]' },
+        ],
+      },
+    ]
+
+    expect(constructorInputTypes(abi)).toEqual([
+      '(address,uint128)',
+      'uint32[]',
+    ])
+  })
+
+  it('refuses an ABI it cannot read instead of assuming no arguments', () => {
+    // Returning [] here would let a malformed artifact record "no constructor
+    // args" for a contract that has them — the exact defect being fixed.
+    for (const bad of [undefined, null, {}, 'abi', 42])
+      expect(() => constructorInputTypes(bad)).toThrow(/no readable ABI/i)
+  })
+
+  it('refuses a constructor whose inputs are not a list', () => {
+    expect(() =>
+      constructorInputTypes([{ type: 'constructor', inputs: 'address' }])
+    ).toThrow(/inputs/i)
+  })
+
+  it('refuses an input with no type', () => {
+    expect(() =>
+      constructorInputTypes([
+        { type: 'constructor', inputs: [{ name: '_owner' }] },
+      ])
+    ).toThrow(/type/i)
+  })
+})
+
+describe('assertRecordedArgsMatchAbi', () => {
+  it.each(['0x', '', '0X'])(
+    'refuses %p as the record for a contract that takes arguments',
+    (recorded) => {
+      // The live defect: seven Tron periphery contracts are deployed with real
+      // arguments and recorded with this literal, so a verifier rebuilding from
+      // the record computes creation code for a different deployment.
+      expect(() =>
+        assertRecordedArgsMatchAbi('ERC20Proxy', recorded, [
+          'address',
+          'address',
+        ])
+      ).toThrow(/ERC20Proxy takes 2 constructor arguments/)
+    }
+  )
+
+  it('accepts a record that carries encoded arguments', () => {
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', `0x${'11'.repeat(64)}`, [
+        'address',
+        'address',
+      ])
+    ).not.toThrow()
+  })
+
+  it.each(['0x', ''])(
+    'accepts %p for a contract that takes none',
+    (recorded) => {
+      expect(() =>
+        assertRecordedArgsMatchAbi('AccessManagerFacet', recorded, [])
+      ).not.toThrow()
+    }
+  )
+
+  it('refuses a record carrying arguments a contract cannot take', () => {
+    // The mirror case: a record that claims more than the contract's ABI allows
+    // is equally unverifiable, and it means someone recorded the wrong contract.
+    expect(() =>
+      assertRecordedArgsMatchAbi(
+        'AccessManagerFacet',
+        `0x${'11'.repeat(32)}`,
+        []
+      )
+    ).toThrow(/takes no constructor arguments/)
+  })
+})
+
+describe('encodeConstructorArgs', () => {
+  /** Stands in for TronWeb's encoder; records what types it was handed. */
+  const spyEncoder = () => {
+    const seen: { types: string[]; values: readonly unknown[] }[] = []
+    const encode = (types: string[], values: readonly unknown[]): string => {
+      seen.push({ types, values })
+      return `0x${'ab'.repeat(32)}`
+    }
+    return { seen, encode }
+  }
+
+  it('hands the encoder the declared types, not guessed ones', () => {
+    const { seen, encode } = spyEncoder()
+    // A gas value read from config arrives as a string. Guessing from the value
+    // types it `string`, which ABI-encodes as dynamic bytes at a wholly
+    // different offset; the ABI says `uint256`.
+    encodeConstructorArgs(
+      encode,
+      [ADDRESS, ADDRESS, ADDRESS, ADDRESS, '100000'],
+      constructorInputTypes(RECEIVER_STARGATE_V2_ABI),
+      'ReceiverStargateV2'
+    )
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.types).toEqual([
+      'address',
+      'address',
+      'address',
+      'address',
+      'uint256',
+    ])
+  })
+
+  it('returns 0x without calling the encoder when there are no arguments', () => {
+    const { seen, encode } = spyEncoder()
+
+    expect(encodeConstructorArgs(encode, [], [], 'AccessManagerFacet')).toBe(
+      '0x'
+    )
+    expect(seen).toHaveLength(0)
+  })
+
+  it('refuses when the argument count does not match the ABI', () => {
+    const { encode } = spyEncoder()
+
+    expect(() =>
+      encodeConstructorArgs(
+        encode,
+        [ADDRESS],
+        ['address', 'address'],
+        'ERC20Proxy'
+      )
+    ).toThrow(/ERC20Proxy expects 2 constructor arguments, got 1/)
+  })
+
+  it('propagates an encoder failure instead of substituting its own bytes', () => {
+    // The previous implementation caught this and concatenated raw hex and UTF-8
+    // bytes, which is not ABI encoding — and wrote it to the record as if it
+    // were. A failed deploy is recoverable; a wrong record is not.
+    const failing = () => {
+      throw new Error('unsupported type')
+    }
+
+    expect(() =>
+      encodeConstructorArgs(failing, [ADDRESS], ['address'], 'ERC20Proxy')
+    ).toThrow(/ERC20Proxy.*unsupported type/)
+  })
+
+  it('refuses an encoder result that is not hex', () => {
+    // Whatever the encoder returns goes straight onto the record, so a
+    // non-answer must not be stored as one.
+    const bogus = () => 'not-hex'
+
+    expect(() =>
+      encodeConstructorArgs(bogus, [ADDRESS], ['address'], 'ERC20Proxy')
+    ).toThrow(/did not return hex/i)
+  })
+})

--- a/script/deploy/tron/constructor-args.test.ts
+++ b/script/deploy/tron/constructor-args.test.ts
@@ -243,3 +243,76 @@ describe('encodeConstructorArgs', () => {
     ).toThrow(/did not return hex/i)
   })
 })
+
+describe('cases mutation testing found uncovered', () => {
+  it('keeps a tuple array suffix, which changes the encoding', () => {
+    // `(a,b)` and `(a,b)[]` encode differently; dropping the suffix produces hex
+    // that still looks plausible.
+    const abi = [
+      {
+        type: 'constructor',
+        inputs: [
+          {
+            type: 'tuple[2][]',
+            components: [
+              { name: 'token', type: 'address' },
+              { name: 'amount', type: 'uint128' },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(constructorInputTypes(abi)).toEqual(['(address,uint128)[2][]'])
+  })
+
+  it('refuses a tuple with no components rather than emitting the word tuple', () => {
+    expect(() =>
+      constructorInputTypes([
+        { type: 'constructor', inputs: [{ name: '_c', type: 'tuple' }] },
+      ])
+    ).toThrow(/components/i)
+  })
+
+  it('refuses an encoder result that is prefixed but not hex', () => {
+    // `startsWith('0x')` accepts this; the digits still have to be hex.
+    const bogus = () => '0xZZZZ'
+
+    expect(() =>
+      encodeConstructorArgs(bogus, ['0x00'], ['address'], 'ERC20Proxy')
+    ).toThrow(/did not return hex/i)
+  })
+
+  it('treats a padded record as empty, since a record is read not parsed', () => {
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', '  0x  ', ['address'])
+    ).toThrow(/takes 1 constructor arguments/)
+  })
+})
+
+describe('a record that is neither empty nor usable', () => {
+  it('refuses arguments that are not hex', () => {
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', 'not-hex', ['address'])
+    ).toThrow(/not hex/i)
+  })
+
+  it('refuses a record holding fewer words than the constructor takes', () => {
+    // Half an address word: enough to look like data, not enough to be it.
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', `0x${'11'.repeat(16)}`, [
+        'address',
+        'address',
+      ])
+    ).toThrow(/only 0 words/)
+  })
+
+  it('accepts a record with one word per static argument', () => {
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', `0x${'11'.repeat(64)}`, [
+        'address',
+        'address',
+      ])
+    ).not.toThrow()
+  })
+})

--- a/script/deploy/tron/constructor-args.test.ts
+++ b/script/deploy/tron/constructor-args.test.ts
@@ -316,3 +316,35 @@ describe('a record that is neither empty nor usable', () => {
     ).not.toThrow()
   })
 })
+
+describe('an encoded value has to be whole bytes', () => {
+  it.each(['0x0', '0x123', `0x${'11'.repeat(31)}1`])(
+    'refuses %p as an encoder result',
+    (odd) => {
+      // Half a byte is not a value a constructor received, and the record is
+      // read as bytes downstream.
+      expect(() =>
+        encodeConstructorArgs(() => odd, ['0x00'], ['address'], 'ERC20Proxy')
+      ).toThrow(/did not return hex/i)
+    }
+  )
+
+  it('refuses an odd-length record for a contract that takes arguments', () => {
+    expect(() =>
+      assertRecordedArgsMatchAbi('ERC20Proxy', '0x123', ['address'])
+    ).toThrow(/not hex/i)
+  })
+
+  it('still accepts a whole-byte encoder result', () => {
+    // The control: without it, a stricter isHex that rejected everything would
+    // satisfy every assertion above.
+    expect(
+      encodeConstructorArgs(
+        () => `0x${'11'.repeat(32)}`,
+        ['0x00'],
+        ['address'],
+        'ERC20Proxy'
+      )
+    ).toBe(`0x${'11'.repeat(32)}`)
+  })
+})

--- a/script/deploy/tron/constructor-args.ts
+++ b/script/deploy/tron/constructor-args.ts
@@ -69,6 +69,7 @@ const canonicalType = (input: unknown, contractName: string): string => {
  * @param contractName - Named in every message; the caller always knows it.
  * @returns Canonical type strings in declaration order, empty when the contract
  * declares no constructor.
+ * @throws When the ABI, a constructor input, or a tuple components list cannot be read.
  */
 export const constructorInputTypes = (
   abi: unknown,
@@ -120,6 +121,19 @@ export const assertRecordedArgsMatchAbi = (
       } constructor arguments (${types.join(
         ', '
       )}) but the record says it has none. A verifier rebuilding creation code from this record would compute a different deployment.`
+    )
+
+  if (types.length > 0 && !isHex(recorded))
+    throw new Error(
+      `${contractName}'s recorded constructor arguments are not hex, so they are not what the constructor received.`
+    )
+
+  // Each static parameter occupies one 32-byte word, and a dynamic one occupies
+  // at least an offset word, so anything shorter is truncated.
+  const words = (recorded.trim().replace(/^0x/iu, '').length / 64) | 0
+  if (types.length > 0 && words < types.length)
+    throw new Error(
+      `${contractName} takes ${types.length} constructor arguments but the record holds only ${words} words of them.`
     )
 
   if (types.length === 0 && !empty)

--- a/script/deploy/tron/constructor-args.ts
+++ b/script/deploy/tron/constructor-args.ts
@@ -1,0 +1,182 @@
+/**
+ * Constructor arguments for a Tron deployment record.
+ *
+ * Import this wherever a deployment is recorded: the recorded arguments are what
+ * a verifier rebuilds creation code from, so a record claiming a contract took
+ * none when it took two describes a deployment that never happened.
+ */
+
+/** What a record holds when a contract genuinely takes no arguments. */
+const NO_ARGS = '0x'
+
+/** Both spellings appear in existing records; `''` predates the sentinel. */
+const isEmptyRecord = (recorded: string): boolean =>
+  recorded.trim() === '' || /^0x$/i.test(recorded.trim())
+
+const isHex = (value: string): boolean => /^0x[0-9a-f]*$/i.test(value.trim())
+
+interface IAbiParameter {
+  type: string
+  components?: readonly unknown[]
+}
+
+const asParameter = (input: unknown, contractName: string): IAbiParameter => {
+  if (typeof input !== 'object' || input === null)
+    throw new Error(
+      `${contractName}: a constructor input is not an object, so its type cannot be read`
+    )
+  const { type, components } = input as { type?: unknown; components?: unknown }
+  if (typeof type !== 'string' || type === '')
+    throw new Error(
+      `${contractName}: a constructor input has no type, so it cannot be encoded`
+    )
+  return {
+    type,
+    ...(Array.isArray(components) ? { components } : {}),
+  }
+}
+
+/**
+ * Renders one ABI parameter as its canonical type string.
+ *
+ * Tuples have to be expanded into `(a,b)` because an encoder given the literal
+ * word `tuple` has no idea what it is encoding.
+ */
+const canonicalType = (input: unknown, contractName: string): string => {
+  const { type, components } = asParameter(input, contractName)
+  if (!type.startsWith('tuple')) return type
+
+  if (!components)
+    throw new Error(
+      `${contractName}: a tuple constructor input has no components, so its type cannot be built`
+    )
+
+  const inner = components
+    .map((component) => canonicalType(component, contractName))
+    .join(',')
+  // Anything after `tuple` is array suffixes, e.g. `tuple[2][]`.
+  return `(${inner})${type.slice('tuple'.length)}`
+}
+
+/**
+ * Reads a constructor's parameter types out of a contract's ABI.
+ *
+ * Throws rather than returning an empty list when the ABI cannot be read: an
+ * empty list means "this contract takes no arguments", and letting a malformed
+ * artifact say that is how a record ends up claiming a deployment had none.
+ *
+ * @param abi - The `abi` array from a Forge artifact.
+ * @param contractName - Named in every message; the caller always knows it.
+ * @returns Canonical type strings in declaration order, empty when the contract
+ * declares no constructor.
+ */
+export const constructorInputTypes = (
+  abi: unknown,
+  contractName = 'contract'
+): string[] => {
+  if (!Array.isArray(abi))
+    throw new Error(
+      `${contractName}: the artifact holds no readable ABI, so its constructor cannot be read`
+    )
+
+  const constructor = abi.find(
+    (entry) =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      (entry as { type?: unknown }).type === 'constructor'
+  )
+  if (!constructor) return []
+
+  const { inputs } = constructor as { inputs?: unknown }
+  if (inputs === undefined) return []
+  if (!Array.isArray(inputs))
+    throw new Error(
+      `${contractName}: the constructor's inputs are not a list, so its types cannot be read`
+    )
+
+  return inputs.map((input) => canonicalType(input, contractName))
+}
+
+/**
+ * Checks a record's constructor arguments against what the contract can take.
+ *
+ * @param contractName - Contract the record is for.
+ * @param recorded - The string about to be written to the record.
+ * @param types - Declared constructor types, from {@link constructorInputTypes}.
+ * @throws When the record and the ABI disagree about whether there are
+ * arguments, in either direction.
+ */
+export const assertRecordedArgsMatchAbi = (
+  contractName: string,
+  recorded: string,
+  types: readonly string[]
+): void => {
+  const empty = isEmptyRecord(recorded)
+
+  if (types.length > 0 && empty)
+    throw new Error(
+      `${contractName} takes ${
+        types.length
+      } constructor arguments (${types.join(
+        ', '
+      )}) but the record says it has none. A verifier rebuilding creation code from this record would compute a different deployment.`
+    )
+
+  if (types.length === 0 && !empty)
+    throw new Error(
+      `${contractName} takes no constructor arguments, but the record carries ${
+        recorded.trim().length
+      } characters of them. Either the record is for a different contract or the arguments are wrong.`
+    )
+}
+
+/** Encodes ABI parameters. Tron's encoder accepts base58 addresses; viem's does not. */
+export type AbiParamEncoder = (
+  types: string[],
+  values: readonly unknown[]
+) => string
+
+/**
+ * Encodes constructor arguments using the contract's declared types.
+ *
+ * Every failure throws. Substituting a best-effort encoding writes bytes that
+ * are not what the constructor received, and nothing downstream can tell the
+ * difference — a failed deploy is recoverable, a wrong record is not.
+ *
+ * @param encoder - ABI encoder to call, e.g. TronWeb's.
+ * @param args - Values passed to the constructor, in declaration order.
+ * @param types - Declared types, from {@link constructorInputTypes}.
+ * @param contractName - Named in every message.
+ * @returns Hex-encoded arguments, or `0x` when the contract takes none.
+ */
+export const encodeConstructorArgs = (
+  encoder: AbiParamEncoder,
+  args: readonly unknown[],
+  types: readonly string[],
+  contractName: string
+): string => {
+  if (args.length !== types.length)
+    throw new Error(
+      `${contractName} expects ${types.length} constructor arguments, got ${args.length}`
+    )
+
+  if (types.length === 0) return NO_ARGS
+
+  let encoded: string
+  try {
+    encoded = encoder([...types], args)
+  } catch (error) {
+    throw new Error(
+      `${contractName}: encoding constructor arguments failed (${
+        error instanceof Error ? error.message : String(error)
+      })`
+    )
+  }
+
+  if (typeof encoded !== 'string' || !isHex(encoded))
+    throw new Error(
+      `${contractName}: the ABI encoder did not return hex, so there is nothing safe to record`
+    )
+
+  return encoded
+}

--- a/script/deploy/tron/constructor-args.ts
+++ b/script/deploy/tron/constructor-args.ts
@@ -13,7 +13,12 @@ const NO_ARGS = '0x'
 const isEmptyRecord = (recorded: string): boolean =>
   recorded.trim() === '' || /^0x$/i.test(recorded.trim())
 
-const isHex = (value: string): boolean => /^0x[0-9a-f]*$/i.test(value.trim())
+const isHex = (value: string): boolean => {
+  const normalized = value.trim()
+  // Whole bytes only: '0x0' is a nibble, and half a byte of a record is not a
+  // value the constructor could have received.
+  return /^0x[0-9a-f]*$/iu.test(normalized) && (normalized.length - 2) % 2 === 0
+}
 
 interface IAbiParameter {
   type: string

--- a/script/deploy/tron/constructor-args.ts
+++ b/script/deploy/tron/constructor-args.ts
@@ -106,6 +106,14 @@ export const constructorInputTypes = (
 /**
  * Checks a record's constructor arguments against what the contract can take.
  *
+ * Both current call sites feed this the string {@link encodeConstructorArgs}
+ * just produced from the same `types`, which already guarantees hex output and
+ * matching arity — so of the checks below, only the word-count one can still
+ * fire there, and only if the underlying ABI encoder itself returns fewer
+ * words than the types call for. The empty-vs-non-empty checks earn their keep
+ * against a `recorded` that did NOT come from a fresh encode, e.g. an existing
+ * deployment record being audited independently.
+ *
  * @param contractName - Contract the record is for.
  * @param recorded - The string about to be written to the record.
  * @param types - Declared constructor types, from {@link constructorInputTypes}.

--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -40,7 +40,11 @@ import { getContractVersion } from '../shared/getContractVersion'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
 import { getTronCorePeriphery } from './helpers/tronContractLists.js'
-import { getTronWallet, recordTronDeployment } from './tronUtils.js'
+import {
+  assertTronDeploymentRecordable,
+  getTronWallet,
+  recordTronDeployment,
+} from './tronUtils.js'
 
 const ERC20_PROXY_ABI = [
   {
@@ -397,6 +401,16 @@ async function deployAndRegisterPeripheryImpl(options: {
             )
             consola.info(`Version: ${version}`)
 
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'ERC20Proxy',
+
+              network
+            )
+
             const result = await deployer.deployContract(
               artifact,
               constructorArgs
@@ -497,6 +511,16 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Using ERC20Proxy: ${erc20ProxyAddress}`)
             consola.info(`Using refundWallet: ${refundWalletHex}`)
             consola.info(`Version: ${version}`)
+
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'Executor',
+
+              network
+            )
 
             const result = await deployer.deployContract(
               artifact,
@@ -612,6 +636,16 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Using feeCollectorOwner: ${feeCollectorOwnerHex}`)
             consola.info(`Version: ${version}`)
 
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'FeeCollector',
+
+              network
+            )
+
             const result = await deployer.deployContract(
               artifact,
               constructorArgs
@@ -708,6 +742,16 @@ async function deployAndRegisterPeripheryImpl(options: {
               `Using withdrawWallet as contract owner: ${withdrawWallet}`
             )
             consola.info(`Version: ${version}`)
+
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'FeeForwarder',
+
+              network
+            )
 
             const result = await deployer.deployContract(
               artifact,
@@ -871,6 +915,16 @@ async function deployAndRegisterPeripheryImpl(options: {
               consola.info(`Using refundWallet: ${refundWalletHex}`)
               consola.info(`Version: ${version}`)
 
+              assertTronDeploymentRecordable(
+                artifact,
+
+                constructorArgs,
+
+                'TokenWrapper',
+
+                network
+              )
+
               const result = await deployer.deployContract(
                 artifact,
                 constructorArgs
@@ -963,6 +1017,16 @@ async function deployAndRegisterPeripheryImpl(options: {
               ` Using owner: ${networkInfo.address} (hex: ${ownerHex})`
             )
             consola.info(`Version: ${version}`)
+
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'OutputValidator',
+
+              network
+            )
 
             const result = await deployer.deployContract(
               artifact,
@@ -1093,6 +1157,16 @@ async function deployAndRegisterPeripheryImpl(options: {
               `Using OIF output settler: ${outputSettlerTron} (hex: ${outputSettlerHex})`
             )
             consola.info(`Version: ${version}`)
+
+            assertTronDeploymentRecordable(
+              artifact,
+
+              constructorArgs,
+
+              'ReceiverOIF',
+
+              network
+            )
 
             const result = await deployer.deployContract(
               artifact,
@@ -1226,6 +1300,12 @@ async function deployAndRegisterPeripheryImpl(options: {
                   )
                   const version = await getContractVersion(
                     'LiFiTimelockController'
+                  )
+                  assertTronDeploymentRecordable(
+                    artifact,
+                    constructorArgs,
+                    'LiFiTimelockController',
+                    network
                   )
                   const result = await deployer.deployContract(
                     artifact,

--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -31,7 +31,6 @@ import {
   getContractAddress,
   getEnvironment,
   getNetworkConfig,
-  logDeployment,
   readJsonFile,
   saveContractAddress,
   updateDiamondJsonPeriphery,
@@ -41,7 +40,7 @@ import { getContractVersion } from '../shared/getContractVersion'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
 import { getTronCorePeriphery } from './helpers/tronContractLists.js'
-import { encodeConstructorArgs, getTronWallet } from './tronUtils.js'
+import { getTronWallet, recordTronDeployment } from './tronUtils.js'
 
 const ERC20_PROXY_ABI = [
   {
@@ -419,14 +418,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'ERC20Proxy',
+              await recordTronDeployment({
+                contractName: 'ERC20Proxy',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                '0x',
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'ERC20Proxy',
@@ -517,14 +517,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'Executor',
+              await recordTronDeployment({
+                contractName: 'Executor',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                '0x',
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'Executor',
@@ -632,14 +633,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'FeeCollector',
+              await recordTronDeployment({
+                contractName: 'FeeCollector',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                '0x',
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'FeeCollector',
@@ -728,14 +730,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'FeeForwarder',
+              await recordTronDeployment({
+                contractName: 'FeeForwarder',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                '0x',
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'FeeForwarder',
@@ -889,14 +892,15 @@ async function deployAndRegisterPeripheryImpl(options: {
               consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
               if (!dryRun) {
-                await logDeployment(
-                  'TokenWrapper',
+                await recordTronDeployment({
+                  contractName: 'TokenWrapper',
                   network,
-                  result.contractAddress,
+                  address: result.contractAddress,
                   version,
-                  '0x',
-                  false
-                )
+                  artifact,
+                  constructorArgs,
+                  verified: false,
+                })
                 await saveContractAddress(
                   network,
                   'TokenWrapper',
@@ -981,14 +985,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'OutputValidator',
+              await recordTronDeployment({
+                contractName: 'OutputValidator',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                '0x',
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'OutputValidator',
@@ -1110,14 +1115,15 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
-              await logDeployment(
-                'ReceiverOIF',
+              await recordTronDeployment({
+                contractName: 'ReceiverOIF',
                 network,
-                result.contractAddress,
+                address: result.contractAddress,
                 version,
-                await encodeConstructorArgs(constructorArgs),
-                false
-              )
+                artifact,
+                constructorArgs,
+                verified: false,
+              })
               await saveContractAddress(
                 network,
                 'ReceiverOIF',
@@ -1238,14 +1244,15 @@ async function deployAndRegisterPeripheryImpl(options: {
                     ` LiFiTimelockController deployed: ${result.contractAddress}`
                   )
                   if (!dryRun) {
-                    await logDeployment(
-                      'LiFiTimelockController',
+                    await recordTronDeployment({
+                      contractName: 'LiFiTimelockController',
                       network,
-                      result.contractAddress,
+                      address: result.contractAddress,
                       version,
-                      '0x',
-                      false
-                    )
+                      artifact,
+                      constructorArgs,
+                      verified: false,
+                    })
                     await saveContractAddress(
                       network,
                       'LiFiTimelockController',

--- a/script/deploy/tron/deploy-and-register-periphery.ts
+++ b/script/deploy/tron/deploy-and-register-periphery.ts
@@ -418,6 +418,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'ERC20Proxy',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'ERC20Proxy',
                 network,
@@ -427,11 +432,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'ERC20Proxy',
-                result.contractAddress
-              )
             }
           }
 
@@ -517,6 +517,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'Executor',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'Executor',
                 network,
@@ -526,11 +531,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'Executor',
-                result.contractAddress
-              )
             }
           }
 
@@ -633,6 +633,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'FeeCollector',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'FeeCollector',
                 network,
@@ -642,11 +647,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'FeeCollector',
-                result.contractAddress
-              )
             }
           }
 
@@ -730,6 +730,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'FeeForwarder',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'FeeForwarder',
                 network,
@@ -739,11 +744,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'FeeForwarder',
-                result.contractAddress
-              )
             }
           }
 
@@ -892,6 +892,11 @@ async function deployAndRegisterPeripheryImpl(options: {
               consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
               if (!dryRun) {
+                await saveContractAddress(
+                  network,
+                  'TokenWrapper',
+                  result.contractAddress
+                )
                 await recordTronDeployment({
                   contractName: 'TokenWrapper',
                   network,
@@ -901,11 +906,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                   constructorArgs,
                   verified: false,
                 })
-                await saveContractAddress(
-                  network,
-                  'TokenWrapper',
-                  result.contractAddress
-                )
               }
             }
 
@@ -985,6 +985,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'OutputValidator',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'OutputValidator',
                 network,
@@ -994,11 +999,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'OutputValidator',
-                result.contractAddress
-              )
             }
           }
 
@@ -1115,6 +1115,11 @@ async function deployAndRegisterPeripheryImpl(options: {
             consola.info(`Cost: ${result.actualCost.trxCost} TRX`)
 
             if (!dryRun) {
+              await saveContractAddress(
+                network,
+                'ReceiverOIF',
+                result.contractAddress
+              )
               await recordTronDeployment({
                 contractName: 'ReceiverOIF',
                 network,
@@ -1124,11 +1129,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                 constructorArgs,
                 verified: false,
               })
-              await saveContractAddress(
-                network,
-                'ReceiverOIF',
-                result.contractAddress
-              )
             }
           }
 
@@ -1244,6 +1244,11 @@ async function deployAndRegisterPeripheryImpl(options: {
                     ` LiFiTimelockController deployed: ${result.contractAddress}`
                   )
                   if (!dryRun) {
+                    await saveContractAddress(
+                      network,
+                      'LiFiTimelockController',
+                      result.contractAddress
+                    )
                     await recordTronDeployment({
                       contractName: 'LiFiTimelockController',
                       network,
@@ -1253,11 +1258,6 @@ async function deployAndRegisterPeripheryImpl(options: {
                       constructorArgs,
                       verified: false,
                     })
-                    await saveContractAddress(
-                      network,
-                      'LiFiTimelockController',
-                      result.contractAddress
-                    )
                   }
                 }
               }

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -200,6 +200,10 @@ export async function deployContractWithLogging(
 
     // Log deployment (skip in dry run)
     if (!dryRun) {
+      // The address is saved first: the contract is already on chain, and a
+      // recording failure that loses its address costs a duplicate deployment.
+      await saveContractAddress(network, contractName, result.contractAddress)
+
       await recordTronDeployment({
         contractName,
         network,
@@ -209,8 +213,6 @@ export async function deployContractWithLogging(
         constructorArgs,
         verified: false,
       })
-
-      await saveContractAddress(network, contractName, result.contractAddress)
     }
 
     return {
@@ -240,41 +242,17 @@ const tronAbiEncoder =
     )
 
 /**
- * Encodes constructor arguments using the types the contract's ABI declares.
- *
- * @param args - Values passed to the constructor, in declaration order.
- * @param abi - The `abi` array from the contract's Forge artifact.
- * @param contractName - Named in every error message.
- * @param network - Network whose TronWeb codec encodes the values.
- * @returns Hex-encoded arguments, or `0x` when the contract takes none.
- * @throws When the ABI is unreadable, the arity disagrees, or encoding fails —
- * a record holding the wrong arguments is worse than a deploy that stops.
- */
-export function encodeConstructorArgs(
-  args: readonly unknown[],
-  abi: unknown,
-  contractName: string,
-  network: SupportedChain
-): string {
-  return encodeWithTypes(
-    tronAbiEncoder(network),
-    args,
-    constructorInputTypes(abi, contractName),
-    contractName
-  )
-}
-
-/**
  * Records a Tron deployment with its constructor arguments encoded from the ABI.
  *
  * Use this rather than calling `logDeployment` directly: it is the only place
  * that decides what the `constructorArgs` field holds, so a call site cannot
- * record `'0x'` for a contract that was deployed with arguments — which is what
- * seven periphery contracts did, leaving records a verifier cannot rebuild
- * creation code from.
+ * hand the log a string of its own.
  *
  * @param params.artifact - The Forge artifact the contract was deployed from.
  * @param params.constructorArgs - Exactly the values passed to the constructor.
+ * @throws When the arguments cannot be encoded from the ABI. Callers must save
+ * the deployed address BEFORE calling this: the contract is already on chain by
+ * then, and losing its address costs a duplicate deployment.
  */
 export async function recordTronDeployment(params: {
   contractName: string

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -192,6 +192,13 @@ export async function deployContractWithLogging(
     if (constructorArgs.length > 0)
       consola.info(`Constructor arguments:`, constructorArgs)
 
+    assertTronDeploymentRecordable(
+      artifact,
+      constructorArgs,
+      contractName,
+      network
+    )
+
     const result = await deployer.deployContract(artifact, constructorArgs)
 
     consola.success(`${contractName} deployed to: ${result.contractAddress}`)
@@ -240,6 +247,37 @@ const tronAbiEncoder =
       types,
       values as any[]
     )
+
+/**
+ * Checks that a deployment will be recordable, before anything is broadcast.
+ *
+ * Call this immediately before deploying. Everything it checks is pure — the
+ * artifact's ABI and the values — so failing here costs nothing, while the same
+ * failure after `deployer.deployContract` leaves a contract on chain that
+ * cannot be recorded, and TRX already spent.
+ *
+ * @param artifact - The Forge artifact about to be deployed.
+ * @param constructorArgs - Exactly the values the constructor will receive.
+ * @param contractName - Named in every message.
+ * @param network - Network whose codec will encode the values.
+ * @throws When the ABI is unreadable, the arity disagrees, or the values cannot
+ * be encoded.
+ */
+export function assertTronDeploymentRecordable(
+  artifact: { abi?: unknown },
+  constructorArgs: readonly unknown[],
+  contractName: string,
+  network: SupportedChain
+): void {
+  const types = constructorInputTypes(artifact?.abi, contractName)
+  const encoded = encodeWithTypes(
+    tronAbiEncoder(network),
+    constructorArgs,
+    types,
+    contractName
+  )
+  assertRecordedArgsMatchAbi(contractName, encoded, types)
+}
 
 /**
  * Records a Tron deployment with its constructor arguments encoded from the ABI.

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -47,6 +47,7 @@ import {
   assertRecordedArgsMatchAbi,
   constructorInputTypes,
   encodeConstructorArgs as encodeWithTypes,
+  type AbiParamEncoder,
 } from './constructor-args'
 import type { IDiamondRegistrationResult } from './types'
 
@@ -229,6 +230,15 @@ export async function deployContractWithLogging(
 /**
  * Encode constructor arguments to hex
  */
+/** TronWeb's ABI encoder for one network; it accepts base58 addresses, viem's does not. */
+const tronAbiEncoder =
+  (network: SupportedChain): AbiParamEncoder =>
+  (types, values) =>
+    getTronWebCodecOnlyForNetwork(network).utils.abi.encodeParams(
+      types,
+      values as any[]
+    )
+
 /**
  * Encodes constructor arguments using the types the contract's ABI declares.
  *
@@ -240,15 +250,14 @@ export async function deployContractWithLogging(
  * @throws When the ABI is unreadable, the arity disagrees, or encoding fails —
  * a record holding the wrong arguments is worse than a deploy that stops.
  */
-export async function encodeConstructorArgs(
+export function encodeConstructorArgs(
   args: readonly unknown[],
   abi: unknown,
   contractName: string,
-  network: SupportedChain = 'tron'
-): Promise<string> {
-  const tronWeb = getTronWebCodecOnlyForNetwork(network)
+  network: SupportedChain
+): string {
   return encodeWithTypes(
-    (types, values) => tronWeb.utils.abi.encodeParams(types, values as any[]),
+    tronAbiEncoder(network),
     args,
     constructorInputTypes(abi, contractName),
     contractName
@@ -277,12 +286,14 @@ export async function recordTronDeployment(params: {
   verified: boolean
 }): Promise<void> {
   const { contractName, network, address, version, artifact } = params
+  // Parsed once: an encode and an assert reading the ABI separately could
+  // disagree about what the contract takes.
   const types = constructorInputTypes(artifact?.abi, contractName)
-  const encoded = await encodeConstructorArgs(
+  const encoded = encodeWithTypes(
+    tronAbiEncoder(network),
     params.constructorArgs,
-    artifact?.abi,
-    contractName,
-    network
+    types,
+    contractName
   )
   assertRecordedArgsMatchAbi(contractName, encoded, types)
 

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -43,6 +43,11 @@ import { getContractVersion } from '../shared/getContractVersion'
 import { isRateLimitError } from '../shared/rateLimit'
 
 import { DIAMOND_CUT_ENERGY_MULTIPLIER } from './constants'
+import {
+  assertRecordedArgsMatchAbi,
+  constructorInputTypes,
+  encodeConstructorArgs as encodeWithTypes,
+} from './constructor-args'
 import type { IDiamondRegistrationResult } from './types'
 
 /**
@@ -194,20 +199,15 @@ export async function deployContractWithLogging(
 
     // Log deployment (skip in dry run)
     if (!dryRun) {
-      // Encode constructor args
-      const constructorArgsHex =
-        constructorArgs.length > 0
-          ? await encodeConstructorArgs(constructorArgs)
-          : '0x'
-
-      await logDeployment(
+      await recordTronDeployment({
         contractName,
         network,
-        result.contractAddress,
+        address: result.contractAddress,
         version,
-        constructorArgsHex,
-        false
-      )
+        artifact,
+        constructorArgs,
+        verified: false,
+      })
 
       await saveContractAddress(network, contractName, result.contractAddress)
     }
@@ -229,49 +229,71 @@ export async function deployContractWithLogging(
 /**
  * Encode constructor arguments to hex
  */
-export async function encodeConstructorArgs(args: any[]): Promise<string> {
-  // Return empty hex for no arguments
-  if (args.length === 0) return '0x'
+/**
+ * Encodes constructor arguments using the types the contract's ABI declares.
+ *
+ * @param args - Values passed to the constructor, in declaration order.
+ * @param abi - The `abi` array from the contract's Forge artifact.
+ * @param contractName - Named in every error message.
+ * @param network - Network whose TronWeb codec encodes the values.
+ * @returns Hex-encoded arguments, or `0x` when the contract takes none.
+ * @throws When the ABI is unreadable, the arity disagrees, or encoding fails —
+ * a record holding the wrong arguments is worse than a deploy that stops.
+ */
+export async function encodeConstructorArgs(
+  args: readonly unknown[],
+  abi: unknown,
+  contractName: string,
+  network: SupportedChain = 'tron'
+): Promise<string> {
+  const tronWeb = getTronWebCodecOnlyForNetwork(network)
+  return encodeWithTypes(
+    (types, values) => tronWeb.utils.abi.encodeParams(types, values as any[]),
+    args,
+    constructorInputTypes(abi, contractName),
+    contractName
+  )
+}
 
-  try {
-    const tronWeb = getTronWebCodecOnlyForNetwork('tron')
+/**
+ * Records a Tron deployment with its constructor arguments encoded from the ABI.
+ *
+ * Use this rather than calling `logDeployment` directly: it is the only place
+ * that decides what the `constructorArgs` field holds, so a call site cannot
+ * record `'0x'` for a contract that was deployed with arguments — which is what
+ * seven periphery contracts did, leaving records a verifier cannot rebuild
+ * creation code from.
+ *
+ * @param params.artifact - The Forge artifact the contract was deployed from.
+ * @param params.constructorArgs - Exactly the values passed to the constructor.
+ */
+export async function recordTronDeployment(params: {
+  contractName: string
+  network: SupportedChain
+  address: string
+  version: string
+  artifact: { abi?: unknown }
+  constructorArgs: readonly unknown[]
+  verified: boolean
+}): Promise<void> {
+  const { contractName, network, address, version, artifact } = params
+  const types = constructorInputTypes(artifact?.abi, contractName)
+  const encoded = await encodeConstructorArgs(
+    params.constructorArgs,
+    artifact?.abi,
+    contractName,
+    network
+  )
+  assertRecordedArgsMatchAbi(contractName, encoded, types)
 
-    // Determine types based on argument values
-    const types: string[] = args.map((arg) => {
-      if (typeof arg === 'string') {
-        // Check if it's an address (starts with T or 0x)
-        if (arg.startsWith('T') || arg.startsWith('0x')) return 'address'
-
-        return 'string'
-      } else if (typeof arg === 'number' || typeof arg === 'bigint')
-        return 'uint256'
-      else if (typeof arg === 'boolean') return 'bool'
-      else if (Array.isArray(arg)) {
-        // For arrays, try to determine the element type
-        if (arg.length > 0 && typeof arg[0] === 'string') return 'string[]'
-
-        return 'uint256[]'
-      }
-      return 'bytes'
-    })
-
-    // Use TronWeb's ABI encoder
-    return tronWeb.utils.abi.encodeParams(types, args)
-  } catch (error) {
-    consola.warn('Failed to encode constructor args, using fallback:', error)
-    // Fallback to simple hex encoding
-    return (
-      '0x' +
-      args
-        .map((arg) => {
-          if (typeof arg === 'string' && arg.startsWith('0x'))
-            return arg.slice(2)
-
-          return Buffer.from(String(arg)).toString('hex')
-        })
-        .join('')
-    )
-  }
+  await logDeployment(
+    contractName,
+    network,
+    address,
+    version,
+    encoded,
+    params.verified
+  )
 }
 
 /**


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Part of [EXSC-907](https://linear.app/lifi-linear/issue/EXSC-907/wp-22-record-hardening) (ref EXSC-907) — the `constructorArgs` leg of WP-2.2. Deliberately does not close the ticket; the other four items are listed at the bottom with why each is separate.

# Why did I implement it this way?

## The defect

Seven Tron periphery contracts are deployed with real constructor arguments and recorded with the literal `'0x'`:

| Contract | Deployed with | Recorded as |
|---|---|---|
| `ERC20Proxy` | 2 addresses | `'0x'` |
| `Executor` | 2 addresses | `'0x'` |
| `FeeCollector` | 1 address | `'0x'` |
| `FeeForwarder` | 1 address | `'0x'` |
| `TokenWrapper` | 3 addresses | `'0x'` |
| `OutputValidator` | 1 address | `'0x'` |
| `LiFiTimelockController` | `uint256, address[], address[], address, address, address` | `'0x'` |

A record is what a verifier rebuilds creation code from, so each of these describes a deployment that did not happen. Constructor arguments are also what set immutables, so nothing downstream can check those either. This is the `constructorArgs "0x"` item in WP-2.2's scope, and it is live on real deployments rather than latent.

The eighth site did encode, but from types **guessed off JavaScript runtime values** — a string starting with `0x` or `T` became `address`, any other string `string`, a number `uint256`, anything else `bytes`. Every current call site passes hex addresses, so today the guess is right; a `uint256` gas value read from config as a string would encode as a dynamic string at a different offset. And on failure it caught the error and concatenated raw hex and UTF-8 bytes — not ABI encoding at all — then wrote that to the record as if it were.

## The fix

Types come from the contract's own ABI (`constructorInputTypes`), tuples expanded to `(address,uint128)` form. Every failure throws: an unreadable ABI, an arity mismatch, an encoder error, a non-hex result. A deploy that stops is recoverable; a record holding the wrong arguments is not, because nothing downstream can tell.

`recordTronDeployment` is now the only path from a Tron deployment to the log. That matters more than fixing seven call sites: the sites could pass a raw string, which is how one literal spread to seven places. They now pass the artifact and the values, and the funnel decides what gets recorded. `logDeployment` is no longer imported by the periphery script, so the old shape is gone rather than merely unused.

`assertRecordedArgsMatchAbi` then refuses either direction of disagreement — a record claiming none for a contract that takes some, and a record carrying arguments a contract cannot take (which means it is for a different contract).

## Evidence

**The guard against real ABIs.** All seven fire; genuine no-arg facets stay silent; and the same seven go silent once real arguments are recorded:

```text
MUST FIRE — real ABIs, recorded as '0x' by deploy-and-register-periphery.ts:
  ERC20Proxy               FIRES   ERC20Proxy takes 2 constructor arguments (address, address) but the record says it has none…
  Executor                 FIRES   Executor takes 2 constructor arguments (address, address)…
  FeeCollector             FIRES   FeeCollector takes 1 constructor arguments (address)…
  FeeForwarder             FIRES   FeeForwarder takes 1 constructor arguments (address)…
  TokenWrapper             FIRES   TokenWrapper takes 3 constructor arguments (address, address, address)…
  OutputValidator          FIRES   OutputValidator takes 1 constructor arguments (address)…
  LiFiTimelockController   FIRES   LiFiTimelockController takes 6 constructor arguments (uint256, address[], address[], address, address, address)…

MUST STAY SILENT — contracts that genuinely take no arguments:
  AccessManagerFacet       silent  (0 declared: none)
  PeripheryRegistryFacet   silent  (0 declared: none)

MUST STAY SILENT — the same contracts once real encoded args are recorded:
  ERC20Proxy               silent  (2 declared: address, address)
  Executor                 silent  (2 declared: address, address)
  FeeCollector             silent  (1 declared: address)
```

**Placement.** The periphery script no longer imports `logDeployment`, and `recordTronDeployment` takes an artifact and values, so there is no parameter a raw string could be passed through and a site left behind would be a TS2304. Correcting an earlier version of this description: I wrote that `tsc` named all eight sites when the encoder signature changed. It did not. Only one of the eight called the encoder; the other seven passed the literal to `logDeployment`, whose signature this PR does not touch. They were found by reading the file. The compiler guarantees completeness from here, not discovery.

**30 unit tests, 15 mutations, all dying.** Including: accepting a no-args record for a contract with arguments, dropping the mirror check, returning `[]` instead of throwing on an unreadable ABI, allowing an arity mismatch, accepting a non-hex encoder result, not expanding tuples, and treating only `''` as an empty record.

`bun test script/` — 1568 pass, 0 fail, run with `.env` moved aside so the suite sees what CI sees.

## What the review round changed

The gate found the ordering wrong, and it inverted this PR's own argument. `recordTronDeployment` throws on an ABI or arity problem, and it ran **before** `saveContractAddress` — so a throw left a contract deployed on chain with its address never written to `deployments/<network>.json`. `checkExistingDeployment` reads only that file, with no on-chain fallback, so the next run deploys a duplicate. "A failed deploy is recoverable" is not true of a deploy whose address is lost. All eight sites and `deployContractWithLogging` now save the address first and record second.

Three smaller things from the same round: the record check tested emptiness and nothing else, so `not-hex`, `0` and a truncated `0x11…` were all accepted for a contract taking two addresses (it now requires hex and at least one 32-byte word per declared argument); the `tronUtils` encoder had no callers left once the recorder called the pure helper directly and it asserted nothing, so it was a funnel bypass waiting for a caller, now deleted; and three comments recounted the defect, which belongs in this description rather than in the code.

**One behavioural change worth naming:** encoding now uses the target network's TronWeb codec rather than always mainnet's. ABI encoding is network-independent and both Tron networks share the address prefix, so no output differs — but it is a change.

**Adjacent, pre-existing, not fixed here:** `deploy-core-facets.ts` passes one argument to `LiFiDiamond` (which declares two) and none to `LiFiIntentEscrowFacetV2` (which declares one). Both already fail before any TRX is spent — the devkit checks arity at energy-estimation time — so this PR neither fixes nor worsens them. Worth its own ticket.

## Round two of review: the check moved before the broadcast

Reordering save-before-record removed the duplicate-deployment risk but left the real problem — a bad ABI or arity still failed *after* TRX was spent, leaving a contract on chain that could not be recorded. Everything the check needs is pure (the artifact's ABI and the values), so it belongs before the deploy, where failing costs nothing.

`assertTronDeploymentRecordable` now runs immediately before `deployer.deployContract` at all eight periphery sites and in `deployContractWithLogging`. Ordering verified at every site rather than asserted:

```text
404-440:   PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
515-549:   PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
639-675:   PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
746-782:   PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
918-954:   PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
1021-1057: PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
1161-1197: PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
1304-1332: PREFLIGHT -> DEPLOY -> SAVE -> RECORD  ok
```

What the preflight adds beyond the devkit: `TronContractDeployer` already checks arity at energy-estimation time, so an arity mismatch was stopped pre-broadcast. It does not cover an unreadable ABI, a non-hex encoder result, or the record-vs-ABI mirror check — those are what this closes. The save-before-record ordering stays as the backstop.

Also this round: `isHex` accepted odd-length payloads, so `0x0` passed both as an encoder result and as a record. Whole bytes are now required, with a whole-byte control case so a stricter version rejecting everything could not pass instead.

## Not in this PR

The other four WP-2.2 items, each separable:

- **`repo` field on `IDeploymentRecord`** and **the verifier's repo check** — worth landing together, since the field exists to be checked. The check also needs a decision first: WP-2.2's scope says "commit reachable from the declared repo's default branch", but F18/F25 and the D3 ruling establish that ancestry is meaningless under squash-merge (78 of 98 audit entries fail an ancestor test), which is why WP-0.3 was re-scoped to content equality. Presence-in-the-declared-repo is the check that survives that; I am not going to quietly implement an ancestry assertion the project already ruled against.
- **Refuse a dirty or unpushed tree** — `git-provenance.ts` already has `getScopedDirtyTree` (with F22's exclusions) and `isCommitOnRemote`, so this is a policy layer, not new plumbing. One catch to handle first: `isCommitOnRemote` reads local refs only, so a stale checkout reports `false` for a commit that is in fact pushed — fine for a recorded field, not fine as a refusal.
- **Store the verified codehash post-deploy** — needs the primitives in [#2301](https://github.com/lifinance/contracts/pull/2301), which is in review.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation — none: this corrects what a deployment record holds, with no user-visible behaviour change beyond a deploy now stopping rather than recording something false

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
