### PR TITLE
chore(whitelist): allow Nexroute post-hook wrapper on Robinhood (EXSC-910)

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -4773,6 +4773,14 @@
               "0xf8989325": ""
             }
           }
+        ],
+        "robinhood": [
+          {
+            "address": "0xCC89feed31b3e59F8e345Feb15c3b58956A88599",
+            "functions": {
+              "0xf8989325": ""
+            }
+          }
         ]
       }
     },


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-910

# Why did I implement it this way?

Whitelists Nexroute's post-hook wrapper contract (`0xCC89feed31b3e59F8e345Feb15c3b58956A88599`) on **Robinhood chain** (chainId 4663) so it can be called as a post-hook step in `swapData`. This is the Robinhood counterpart of #2030 (BSC, EXSC-495) and follows that PR exactly.

Requested by Nexroute/Jumper: the current Jumper POC routes via the swap's `to` address and therefore only works for native-token swaps. Whitelisting the wrapper in the diamond is what unblocks the general ERC-20 case; the remaining calldata plumbing is on their side.

The address is added under the existing `Nexroute` DEX entry's `contracts` map (new `robinhood` key, alphabetically after `bsc`) rather than as a new DEX, since it belongs to the same integration.

The selector `0xf8989325` is listed with an empty value. `script/tasks/diamondSyncWhitelist.sh` builds the on-chain `(address, selector)` allowlist pairs from the **keys** of the `functions` map, so an empty value is sufficient — and per EXSC-495 the partner asked that the raw function name not be committed to this repo. Keeping the selector key (rather than an empty `functions: {}`) keeps the grant granular; an empty map would fall back to the `0xffffffff` approve-to-only selector, which whitelists the contract for any call.

**Verification of the address before whitelisting it:**

- valid EIP-55 checksum
- 2744 bytes of code on chainId 4663
- deployed bytecode contains `0xf8989325`, `0x110be9b7` and `0x01681a62`, matching the three external functions of the source the partner supplied (`backrun`, `_backrun`, `sweep`)
- `0xf8989325` is the same selector already whitelisted for this integration's BSC wrapper in #2030

Architecture/security review of the backrun-as-post-hook pattern was done under EXSC-340.

Config-only change; no contract or script logic modified.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
