### PR TITLE
fix(scripts): end generated config JSON with a newline (EXSC-913)

### DIFF
--- a/script/deploy/safe/deploy-safe.ts
+++ b/script/deploy/safe/deploy-safe.ts
@@ -576,7 +576,7 @@ const main = defineCommand({
         }
         writeFileSync(
           join(__dirname, '../../../config/networks.json'),
-          JSON.stringify(networks, null, 2),
+          `${JSON.stringify(networks, null, 2)}\n`,
           'utf8'
         )
         consola.success(`✔ networks.json updated with Safe @ ${safeAddress}`)

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -648,7 +648,7 @@ async function run(options: {
   delete networkEntry.safeProxyFactoryAddress
   fs.writeFileSync(
     networksPath,
-    JSON.stringify(networksContent, null, 2),
+    `${JSON.stringify(networksContent, null, 2)}\n`,
     'utf8'
   )
   consola.success(

--- a/script/tasks/updateWhitelistPeriphery.test.ts
+++ b/script/tasks/updateWhitelistPeriphery.test.ts
@@ -87,6 +87,28 @@ describe('updateWhitelistPeriphery network scoping', () => {
     }
   }, 180_000)
 
+  it('writes whitelist.json with exactly one trailing newline', () => {
+    const committed = readFileSync(WHITELIST_PATH, 'utf8')
+    try {
+      execFileSync(
+        'bunx',
+        ['tsx', 'script/tasks/updateWhitelistPeriphery.ts'],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        }
+      )
+      const generated = readFileSync(WHITELIST_PATH, 'utf8')
+      // prettier owns config/ and always ends a file with one newline; a generator that
+      // disagrees makes the file flip-flop between every sync run and every format run
+      expect(generated.endsWith('\n')).toBe(true)
+      expect(generated.endsWith('\n\n')).toBe(false)
+    } finally {
+      writeFileSync(WHITELIST_PATH, committed)
+    }
+  }, 180_000)
+
   it('leaves unscoped contracts on every network they are deployed to', () => {
     const generated = networksPerContract()
     const eligible = Object.keys(

--- a/script/tasks/updateWhitelistPeriphery.ts
+++ b/script/tasks/updateWhitelistPeriphery.ts
@@ -599,7 +599,7 @@ const main = defineCommand({
         )
         fs.writeFileSync(
           tempProductionPath,
-          JSON.stringify(whitelistData, null, 2)
+          `${JSON.stringify(whitelistData, null, 2)}\n`
         )
 
         // Validate the temporary production file
@@ -644,7 +644,7 @@ const main = defineCommand({
         )
         fs.writeFileSync(
           tempStagingPath,
-          JSON.stringify(whitelistStagingData, null, 2)
+          `${JSON.stringify(whitelistStagingData, null, 2)}\n`
         )
 
         // Validate the temporary staging file


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-913

# Why did I implement it this way?

`config/whitelist.json` and `config/networks.json` have been flip-flopping between "removing a newline" and "adding a newline" — a spurious ` M config/whitelist.json` shows up after routine work and occasionally rides along into an unrelated PR.

Two tools disagree about the file's canonical form, and neither runs on the other's schedule:

- **Strippers** — the generators write via `JSON.stringify(data, null, 2)`, which emits no trailing newline: `updateWhitelistPeriphery.ts` (→ `config/whitelist.json`, `config/whitelist.staging.json`), `deploy-safe.ts` and `deploy-safe-tron.ts` (→ `config/networks.json`).
- **Restorer** — prettier covers `config/` (`.prettierignore` excludes `deployments/`, not `config/`) and always ends a file with exactly one newline. `bun format:fix`, an editor with `insertFinalNewline`, or anyone running prettier puts it back.

`script/tasks/diamondSyncWhitelist.sh:16` runs `updateWhitelistPeriphery.ts` on **every** whitelist sync, so even a DEX-only sync that changes no periphery data rewrites the file and dirties the tree.

Fixing the generators rather than adding `config/whitelist.json` to `.prettierignore`, because prettier's form is already the committed form: prettier agrees with the file on `main` byte-for-byte, and `JSON.stringify(…, null, 2)` reproduces it exactly except for the final `\n`. The newline is the only disagreement, so making the generators emit it removes the conflict without changing what the files look like. This is also the idiom already used elsewhere in the repo (`selector-registry.ts:339`, `list-parked-tasks.ts:141`).

The regression test asserts exactly one trailing newline. It was verified to fail against the unfixed generator (`expect(generated.endsWith('\n')).toBe(true)` → received `false`) and pass with the fix, so it is not a test that passes vacuously.

`deployments/**` writers (`updateDiamondLog.ts`, `deployment-logger.ts`) share the pattern, but `deployments/` is prettier-ignored so nothing fights back there — deliberately left alone, noted on the ticket.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
