### PR TITLE
fix(drain): resolve out/ from the repo root and compile before declaring a facet unverifiable (EXSC-912)

### DIFF
--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -483,9 +483,13 @@ a deliberate future option, not part of v1.
    - `stillExpected` → keep queued + alert (the address points at a facet target
      state still expects — a wrong snapshot must never remove a live facet).
    - `unverifiable` → keep queued + alert (no target-state entry, or the selector
-     unions are still unavailable after the engine's one-shot `forge build`; the
-     propose paths that drain — whitelist sync, propose-only rollout — never
-     compile on their own, and a per-session worktree starts without `out/`).
+     unions could not be built from `out/`). **Superseding #2157's "tell a human to
+     run `forge build`" remedy (EXSC-912):** the engine now compiles once itself and
+     re-reads before it concludes, because the propose paths that drain — whitelist
+     sync, propose-only rollout — never compile on their own and a per-session
+     worktree starts without `out/`, so the remedy was being handed to an operator
+     for a condition no operator had caused. The build is skipped when there is no
+     target-state entry, since every address is `unverifiable` either way.
    - `removals` → proceed, but refuse (`nameMismatch`, keep queued + alert) any
      removal whose engine-resolved deploy-log name disagrees with the task's
      `facetName`, and skip (`duplicateAddresses`) any address already carried by
@@ -734,7 +738,8 @@ All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
   whose loupe-resolved deploy-log name disagrees with its parked `facetName`, one
   whose address target state still expects (`stillExpected`), one whose removability
   cannot be verified (`unverifiable` — a build gap, not a cancellation: the engine
-  compiles once and re-reads before it concludes), and a legacy row whose stored
+  compiles once and re-reads before concluding, and a build that still does not
+  produce the artifacts leaves the task queued), and a legacy row whose stored
   address is not a valid EVM address.
   The wrong-snapshot alerts name the `cancel-parked-task.ts` command that retires
   the task.

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -483,7 +483,9 @@ a deliberate future option, not part of v1.
    - `stillExpected` → keep queued + alert (the address points at a facet target
      state still expects — a wrong snapshot must never remove a live facet).
    - `unverifiable` → keep queued + alert (no target-state entry, or the selector
-     unions are unavailable — run `forge build`).
+     unions are still unavailable after the engine's one-shot `forge build`; the
+     propose paths that drain — whitelist sync, propose-only rollout — never
+     compile on their own, and a per-session worktree starts without `out/`).
    - `removals` → proceed, but refuse (`nameMismatch`, keep queued + alert) any
      removal whose engine-resolved deploy-log name disagrees with the task's
      `facetName`, and skip (`duplicateAddresses`) any address already carried by
@@ -731,8 +733,9 @@ All six transitions ship as helpers in `parked-tasks.ts` (#2051, Fact 15):
 - **No contradiction is removed.** The drain refuses (keeps queued + alerts) a task
   whose loupe-resolved deploy-log name disagrees with its parked `facetName`, one
   whose address target state still expects (`stillExpected`), one whose removability
-  cannot be verified (`unverifiable` — the remedy there is `forge build`, not a
-  cancellation), and a legacy row whose stored address is not a valid EVM address.
+  cannot be verified (`unverifiable` — a build gap, not a cancellation: the engine
+  compiles once and re-reads before it concludes), and a legacy row whose stored
+  address is not a valid EVM address.
   The wrong-snapshot alerts name the `cancel-parked-task.ts` command that retires
   the task.
 

--- a/script/deploy/safe/diamondRemovalDiff.test.ts
+++ b/script/deploy/safe/diamondRemovalDiff.test.ts
@@ -22,6 +22,7 @@ import {
   getFacetSourceNames,
   getProtectedNames,
   getSourceContractNames,
+  tryCollectFacetSelectorUnion,
   HARDCODED_PROTECTED_FACETS,
   mapLoupeResult,
   resolveAddressToName,
@@ -135,6 +136,55 @@ describe('collectActiveSelectors', () => {
 
   it('returns empty for no names', () => {
     expect(collectActiveSelectors([], () => []).size).toBe(0)
+  })
+})
+
+describe('tryCollectFacetSelectorUnion', () => {
+  it('compiles and re-reads when an artifact is missing', () => {
+    let built = false
+    let reads = 0
+    const union = tryCollectFacetSelectorUnion(['A'], {
+      getFacetNames: () => new Set(['A']),
+      getActiveSelectors: () => {
+        reads++
+        if (!built) throw new Error('Contract JSON not found')
+        return new Set([sel(0xaa)])
+      },
+      ensureArtifacts: () => {
+        built = true
+        return true
+      },
+    })
+    expect(reads).toBe(2)
+    expect(union).toEqual(new Set([sel(0xaa)]))
+  })
+
+  it('stays unavailable when the build cannot produce the artifact', () => {
+    let reads = 0
+    const union = tryCollectFacetSelectorUnion(['A'], {
+      getFacetNames: () => new Set(['A']),
+      getActiveSelectors: () => {
+        reads++
+        throw new Error('Contract JSON not found')
+      },
+      ensureArtifacts: () => false,
+    })
+    expect(union).toBeUndefined()
+    expect(reads).toBe(1)
+  })
+
+  it('does not compile when the union reads on the first try', () => {
+    let builds = 0
+    const union = tryCollectFacetSelectorUnion(['A'], {
+      getFacetNames: () => new Set(['A']),
+      getActiveSelectors: () => new Set([sel(0xaa)]),
+      ensureArtifacts: () => {
+        builds++
+        return true
+      },
+    })
+    expect(union).toEqual(new Set([sel(0xaa)]))
+    expect(builds).toBe(0)
   })
 })
 
@@ -804,6 +854,29 @@ describe('computeFacetRemovalsByAddress', () => {
     })
     expect(r.removals).toHaveLength(0)
     expect(r.unverifiable).toEqual([addr(9)])
+  })
+
+  it('removes an address that was unverifiable only because nothing was compiled', async () => {
+    let built = false
+    const r = await computeFacetRemovalsByAddress('net', PROD, [addr(9)], {
+      getDiamondAddress: async () => addr(0xd),
+      getOnChainFacets: async () => [{ address: addr(9), selectors: [sel(9)] }],
+      getAddressToName: async () => ({}),
+      getExpectedNames: () => new Set(['LiveFacet']),
+      getFacetNames: () => new Set(['LiveFacet']),
+      getActiveSelectors: () => {
+        if (!built) throw new Error('Contract JSON not found')
+        return new Set([sel(0xc)])
+      },
+      ensureArtifacts: () => {
+        built = true
+        return true
+      },
+    })
+    expect(r.unverifiable).toHaveLength(0)
+    expect(r.removals).toEqual([
+      { name: undefined, address: addr(9), selectors: [sel(9)] },
+    ])
   })
 })
 

--- a/script/deploy/safe/diamondRemovalDiff.test.ts
+++ b/script/deploy/safe/diamondRemovalDiff.test.ts
@@ -29,6 +29,7 @@ import {
   resolveAddressToName,
   resolveDiamondAddress,
   revalidateRemovalsOnChain,
+  type IAddressRemovalResult,
   type IFacetRemoval,
   type IOnChainFacet,
   type IRemovalDiffIO,
@@ -880,27 +881,57 @@ describe('computeFacetRemovalsByAddress', () => {
     expect(r.unverifiable).toEqual([addr(9)])
   })
 
-  it('removes an address that was unverifiable only because nothing was compiled', async () => {
-    let built = false
-    const r = await computeFacetRemovalsByAddress('net', PROD, [addr(9)], {
+  /**
+   * The EXSC-912 shape: a superseded facet co-registered alongside its successor
+   * (EXSC-750), so the deploy log names only the successor and the doomed address
+   * resolves by selector alone — against a union no artifact was there to build.
+   *
+   * @param rebuiltSelectors - The union once the build has run.
+   */
+  const uncompiledIncident = async (
+    rebuiltSelectors: Set<`0x${string}`>
+  ): Promise<{ result: IAddressRemovalResult; builds: number }> => {
+    let builds = 0
+    const result = await computeFacetRemovalsByAddress('net', PROD, [addr(9)], {
       getDiamondAddress: async () => addr(0xd),
-      getOnChainFacets: async () => [{ address: addr(9), selectors: [sel(9)] }],
-      getAddressToName: async () => ({}),
-      getExpectedNames: () => new Set(['LiveFacet']),
-      getFacetNames: () => new Set(['LiveFacet']),
-      getActiveSelectors: () => {
-        if (!built) throw new Error('Contract JSON not found')
-        return new Set([sel(0xc)])
+      getOnChainFacets: async () => [
+        { address: addr(9), selectors: [sel(9)] },
+        { address: addr(0x42), selectors: [sel(0xc)] },
+      ],
+      getAddressToName: async () => ({ [addr(0x42)]: 'SymbiosisFacet' }),
+      getExpectedNames: () => new Set(['SymbiosisFacet']),
+      getFacetNames: () => new Set(['SymbiosisFacet']),
+      getActiveSelectors: (names) => {
+        // The protected union reads no artifact here (no protected name is a
+        // facet in this fixture), so only the target-state union hits the gap.
+        if (names.length === 0) return new Set<string>()
+        if (builds === 0) throw new Error('Contract JSON not found')
+        return rebuiltSelectors
       },
       ensureArtifacts: () => {
-        built = true
+        builds++
         return true
       },
     })
-    expect(r.unverifiable).toHaveLength(0)
-    expect(r.removals).toEqual([
+    return { result, builds }
+  }
+
+  it('removes the superseded address once the build supplies the union', async () => {
+    const { result, builds } = await uncompiledIncident(new Set([sel(0xc)]))
+    expect(builds).toBe(1)
+    expect(result.unverifiable).toHaveLength(0)
+    expect(result.removals).toEqual([
       { name: undefined, address: addr(9), selectors: [sel(9)] },
     ])
+  })
+
+  it('holds the same address back when the rebuilt union claims its selector', async () => {
+    // The build's own output decides the verdict — not merely whether one exists.
+    const { result } = await uncompiledIncident(new Set([sel(9)]))
+    expect(result.removals).toHaveLength(0)
+    expect(result.unverifiable).toHaveLength(0)
+    expect(result.stillExpected).toHaveLength(1)
+    expect(result.stillExpected[0]?.address).toBe(addr(9))
   })
 })
 

--- a/script/deploy/safe/diamondRemovalDiff.test.ts
+++ b/script/deploy/safe/diamondRemovalDiff.test.ts
@@ -405,6 +405,29 @@ describe('computeFacetRemovalDiff', () => {
     )
   })
 
+  it('restates the failure when the build ran and the union is still missing', async () => {
+    let builds = 0
+    const io: Partial<IRemovalDiffIO> = {
+      getDiamondAddress: async () => addr(0xd),
+      getOnChainFacets: async () => [{ address: addr(1), selectors: [sel(1)] }],
+      getAddressToName: async () => ({ [addr(1)]: 'SomeFacet' }),
+      getExpectedNames: () => new Set(['GasZipFacet']),
+      getFacetNames: () => new Set(['GasZipFacet']),
+      getActiveSelectors: () => {
+        throw new Error('Cannot read selectors for active facet "GasZipFacet"')
+      },
+      ensureArtifacts: () => {
+        builds++
+        return true
+      },
+    }
+    await expectRejects(
+      computeFacetRemovalDiff('mainnet', PROD, io),
+      /still unavailable after `forge build`.*GasZipFacet/
+    )
+    expect(builds).toBe(1)
+  })
+
   it('scopes active-selectors to real facets — periphery names never hold back selectors', async () => {
     let activeNamesSeen: string[] = []
     const io: Partial<IRemovalDiffIO> = {

--- a/script/deploy/safe/diamondRemovalDiff.test.ts
+++ b/script/deploy/safe/diamondRemovalDiff.test.ts
@@ -22,6 +22,7 @@ import {
   getFacetSourceNames,
   getProtectedNames,
   getSourceContractNames,
+  createArtifactBuilder,
   tryCollectFacetSelectorUnion,
   HARDCODED_PROTECTED_FACETS,
   mapLoupeResult,
@@ -136,6 +137,29 @@ describe('collectActiveSelectors', () => {
 
   it('returns empty for no names', () => {
     expect(collectActiveSelectors([], () => []).size).toBe(0)
+  })
+})
+
+describe('createArtifactBuilder', () => {
+  it('reports availability after a successful build and does not build twice', () => {
+    let runs = 0
+    const ensure = createArtifactBuilder(() => {
+      runs++
+    })
+    expect(ensure()).toBe(true)
+    expect(ensure()).toBe(true)
+    expect(runs).toBe(1)
+  })
+
+  it('reports unavailable when the build throws, and does not retry it', () => {
+    let runs = 0
+    const ensure = createArtifactBuilder(() => {
+      runs++
+      throw new Error('forge: command not found')
+    })
+    expect(ensure()).toBe(false)
+    expect(ensure()).toBe(false)
+    expect(runs).toBe(1)
   })
 })
 

--- a/script/deploy/safe/diamondRemovalDiff.ts
+++ b/script/deploy/safe/diamondRemovalDiff.ts
@@ -786,7 +786,18 @@ function collectSelectorsBuildingIfNeeded(
     return io.getActiveSelectors(names)
   } catch (error) {
     if (!io.ensureArtifacts?.()) throw error
-    return io.getActiveSelectors(names)
+    try {
+      return io.getActiveSelectors(names)
+    } catch (afterBuild) {
+      // The inner error still prescribes `forge build`, which just ran — restate
+      // it so a caller that surfaces this message does not send the operator
+      // after a build that already happened.
+      throw new Error(
+        `Selector union still unavailable after \`forge build\`: ${
+          afterBuild instanceof Error ? afterBuild.message : String(afterBuild)
+        }`
+      )
+    }
   }
 }
 

--- a/script/deploy/safe/diamondRemovalDiff.ts
+++ b/script/deploy/safe/diamondRemovalDiff.ts
@@ -795,7 +795,8 @@ function collectSelectorsBuildingIfNeeded(
       throw new Error(
         `Selector union still unavailable after \`forge build\`: ${
           afterBuild instanceof Error ? afterBuild.message : String(afterBuild)
-        }`
+        }`,
+        { cause: afterBuild }
       )
     }
   }
@@ -823,7 +824,15 @@ export function tryCollectFacetSelectorUnion(
       [...names].filter((name) => facetNames.has(name)),
       io
     )
-  } catch {
+  } catch (error) {
+    // Callers turn `undefined` into a per-facet "cannot verify" alert that cannot
+    // say WHICH artifact was missing — the only place that knows is here, so log
+    // it rather than let the diagnosis die with the swallowed error.
+    consola.warn(
+      `Selector union unavailable: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
     return undefined
   }
 }

--- a/script/deploy/safe/diamondRemovalDiff.ts
+++ b/script/deploy/safe/diamondRemovalDiff.ts
@@ -51,45 +51,84 @@ const SRC_ROOT = path.resolve(MODULE_DIR, '../../../src')
 const FACETS_ROOT = path.resolve(SRC_ROOT, 'Facets')
 /** Repo root, so the build below runs against this checkout regardless of cwd. */
 const REPO_ROOT = path.resolve(MODULE_DIR, '../../..')
-/** Generous enough for a cold build of the whole source tree. */
-const FORGE_BUILD_TIMEOUT_MS = 15 * 60 * 1000
-/** A warning-heavy build overruns the 1 MB default, which surfaces as a build failure. */
-const FORGE_BUILD_MAX_BUFFER = 64 * 1024 * 1024
+const FORGE_BUILD_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
+const FORGE_BUILD_MAX_BUFFER = 64 * 1024 * 1024 // 64 MB — a warning-heavy build overruns the 1 MB default, which would surface as a build failure
 
-let artifactsAvailable: boolean | undefined
 /**
- * Compiles the contracts when a selector union came back unavailable, so a
- * checkout that was simply never built does not read as "removability cannot be
- * verified". Some propose paths that drain the parked queue — a whitelist sync,
- * a periphery-only rollout — never compile on their own, and per-session
- * worktrees start without `out/`.
- *
- * Attempted at most once per process; a failed build keeps the fail-closed
- * behaviour rather than turning a build problem into a removal.
+ * The argument set `reconcileParkedTasks.yml` already uses to produce these very
+ * selector-union artifacts: only facet ABIs matter here, and skipping tests and
+ * scripts is the difference between a build that fits inside a scheduled job and
+ * one that times it out.
  */
-function buildArtifactsOnce(): boolean {
-  if (artifactsAvailable !== undefined) return artifactsAvailable
-  consola.info(
-    'Compiled artifacts unavailable — running `forge build` so facet removability can be verified'
-  )
-  try {
-    execFileSync('forge', ['build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: FORGE_BUILD_TIMEOUT_MS,
-      maxBuffer: FORGE_BUILD_MAX_BUFFER,
-    })
-    artifactsAvailable = true
-  } catch (error) {
-    consola.warn(
-      `\`forge build\` failed — facet removability stays unverifiable: ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    )
-    artifactsAvailable = false
-  }
-  return artifactsAvailable
+const FORGE_BUILD_ARGS = [
+  'build',
+  '--skip',
+  'script',
+  '--skip',
+  'test',
+  '--skip',
+  'Base',
+  '--skip',
+  'Test',
+  '--skip',
+  '*.t.sol',
+]
+
+function runForgeBuild(): void {
+  execFileSync('forge', FORGE_BUILD_ARGS, {
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+    timeout: FORGE_BUILD_TIMEOUT_MS,
+    maxBuffer: FORGE_BUILD_MAX_BUFFER,
+    // Artifacts are read from `<repo>/out`, but forge writes to `out/<profile>`
+    // under a non-default FOUNDRY_PROFILE — and `helperFunctions.sh` exports
+    // `zksync` without unsetting it, so a propose script can inherit one.
+    env: { ...process.env, FOUNDRY_PROFILE: 'default' },
+  })
 }
+
+/**
+ * Builds an `ensureArtifacts` implementation: compiles when a selector union came
+ * back unavailable, so a checkout that was simply never built does not read as
+ * "removability cannot be verified". Some propose paths that drain the parked
+ * queue — a whitelist sync, a periphery-only rollout — never compile on their
+ * own, and per-session worktrees start without `out/`.
+ *
+ * The returned function attempts the build at most once; a failed build keeps the
+ * fail-closed behaviour rather than turning a build problem into a removal.
+ *
+ * @param run - Runs the build; defaults to `forge build` in this checkout.
+ * @returns Whether artifacts are available, memoized per instance.
+ */
+export function createArtifactBuilder(
+  run: () => void = runForgeBuild
+): () => boolean {
+  let available: boolean | undefined
+  return () => {
+    if (available !== undefined) return available
+    consola.info(
+      'Compiled artifacts unavailable — running `forge build` so facet removability can be verified'
+    )
+    try {
+      run()
+      // The selector memo assumes `out/` never moves under it; a build that just
+      // rewrote it makes every earlier hit stale, and a stale union can hold back
+      // the wrong selectors.
+      selectorsByContractCache.clear()
+      available = true
+    } catch (error) {
+      consola.warn(
+        `\`forge build\` failed — facet removability stays unverifiable: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+      available = false
+    }
+    return available
+  }
+}
+
+const buildArtifactsOnce = createArtifactBuilder()
 
 /**
  * Diamond-machinery facets that permanently brick the diamond if removed. They
@@ -1041,7 +1080,12 @@ export async function computeFacetRemovalsByAddress(
     addressToName,
     protectedNames,
     expectedNames,
-    protectedSelectors: tryCollectFacetSelectorUnion(protectedNames, resolved),
+    // Both unions are skipped without target state: every address is unverifiable
+    // either way, and collecting them would spend a full build on an outcome that
+    // is already fixed — which most networks' staging environment would hit.
+    protectedSelectors: expectedNames
+      ? tryCollectFacetSelectorUnion(protectedNames, resolved)
+      : undefined,
     activeSelectors: expectedNames
       ? tryCollectFacetSelectorUnion(expectedNames, resolved)
       : undefined,

--- a/script/deploy/safe/diamondRemovalDiff.ts
+++ b/script/deploy/safe/diamondRemovalDiff.ts
@@ -15,10 +15,12 @@
  * injectable via the `io` parameter.
  */
 
+import { execFileSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 
+import { consola } from 'consola'
 import {
   createPublicClient,
   decodeFunctionData,
@@ -47,6 +49,47 @@ const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url))
 const SRC_ROOT = path.resolve(MODULE_DIR, '../../../src')
 /** Repo `src/Facets/` root — where every active facet's source lives. */
 const FACETS_ROOT = path.resolve(SRC_ROOT, 'Facets')
+/** Repo root, so the build below runs against this checkout regardless of cwd. */
+const REPO_ROOT = path.resolve(MODULE_DIR, '../../..')
+/** Generous enough for a cold build of the whole source tree. */
+const FORGE_BUILD_TIMEOUT_MS = 15 * 60 * 1000
+/** A warning-heavy build overruns the 1 MB default, which surfaces as a build failure. */
+const FORGE_BUILD_MAX_BUFFER = 64 * 1024 * 1024
+
+let artifactsAvailable: boolean | undefined
+/**
+ * Compiles the contracts when a selector union came back unavailable, so a
+ * checkout that was simply never built does not read as "removability cannot be
+ * verified". Some propose paths that drain the parked queue — a whitelist sync,
+ * a periphery-only rollout — never compile on their own, and per-session
+ * worktrees start without `out/`.
+ *
+ * Attempted at most once per process; a failed build keeps the fail-closed
+ * behaviour rather than turning a build problem into a removal.
+ */
+function buildArtifactsOnce(): boolean {
+  if (artifactsAvailable !== undefined) return artifactsAvailable
+  consola.info(
+    'Compiled artifacts unavailable — running `forge build` so facet removability can be verified'
+  )
+  try {
+    execFileSync('forge', ['build'], {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+      timeout: FORGE_BUILD_TIMEOUT_MS,
+      maxBuffer: FORGE_BUILD_MAX_BUFFER,
+    })
+    artifactsAvailable = true
+  } catch (error) {
+    consola.warn(
+      `\`forge build\` failed — facet removability stays unverifiable: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+    artifactsAvailable = false
+  }
+  return artifactsAvailable
+}
 
 /**
  * Diamond-machinery facets that permanently brick the diamond if removed. They
@@ -137,6 +180,12 @@ export interface IRemovalDiffIO {
   getSourceNames: () => Set<string>
   /** Set of contract names whose `.sol` source lives under `src/Facets/` (real facets only). */
   getFacetNames: () => Set<string>
+  /**
+   * Compiles the contracts so the artifact-backed selector unions can be built.
+   * Returns whether artifacts are available afterwards; called at most once per
+   * process, and only when a union came back unavailable.
+   */
+  ensureArtifacts: () => boolean
 }
 
 const lower = (s: string): string => s.toLowerCase()
@@ -453,6 +502,7 @@ const defaultIO: IRemovalDiffIO = {
   getActiveSelectors: collectActiveSelectors,
   getSourceNames: cachedSourceContractNames,
   getFacetNames: cachedFacetSourceNames,
+  ensureArtifacts: buildArtifactsOnce,
 }
 
 /**
@@ -515,7 +565,10 @@ export async function computeFacetRemovalDiff(
   // selectors to be wrongly held back instead of removed.
   const facetNames = resolved.getFacetNames()
   const activeFacetNames = [...expectedNames].filter((n) => facetNames.has(n))
-  const activeSelectors = resolved.getActiveSelectors(activeFacetNames)
+  const activeSelectors = collectSelectorsBuildingIfNeeded(
+    activeFacetNames,
+    resolved
+  )
   const sourceNames = resolved.getSourceNames()
 
   return diffFacets({
@@ -669,12 +722,42 @@ export function diffNamedFacets(params: {
   return result
 }
 
+/** I/O subset every selector-union collector needs. */
+type ISelectorUnionIO = Pick<
+  IRemovalDiffIO,
+  'getActiveSelectors' | 'getFacetNames'
+> &
+  Partial<Pick<IRemovalDiffIO, 'ensureArtifacts'>>
+
+/**
+ * `getActiveSelectors`, retried once after compiling. A missing artifact is
+ * ambiguous — a deprecated contract, or a checkout nobody built — and only the
+ * second reading is an answer about removability, so build before concluding.
+ * Rethrows when the build is unavailable or fails, preserving the fail-closed
+ * contract of every caller.
+ *
+ * @param names - Facet names to collect selectors for.
+ * @param io - I/O providing selector collection and the build escape hatch.
+ */
+function collectSelectorsBuildingIfNeeded(
+  names: string[],
+  io: ISelectorUnionIO
+): Set<string> {
+  try {
+    return io.getActiveSelectors(names)
+  } catch (error) {
+    if (!io.ensureArtifacts?.()) throw error
+    return io.getActiveSelectors(names)
+  }
+}
+
 /**
  * Selector union owned by the given contract names, scoped to real facets (a
  * target-state `LiFiDiamond` block also lists periphery, whose ABIs are not
  * diamond-routed and would cause false selector matches). Returns `undefined`
- * when the union cannot be built (a missing artifact), which every caller must
- * treat as "cannot verify" — never as "nothing matched".
+ * when the union cannot be built (a missing artifact that a build did not
+ * produce), which every caller must treat as "cannot verify" — never as
+ * "nothing matched".
  *
  * @param names - Contract names to collect selectors for (non-facets are filtered out).
  * @param io - I/O providing facet names + selector collection; defaults hit real files.
@@ -682,12 +765,13 @@ export function diffNamedFacets(params: {
  */
 export function tryCollectFacetSelectorUnion(
   names: Iterable<string>,
-  io: Pick<IRemovalDiffIO, 'getActiveSelectors' | 'getFacetNames'> = defaultIO
+  io: ISelectorUnionIO = defaultIO
 ): Set<string> | undefined {
   try {
     const facetNames = io.getFacetNames()
-    return io.getActiveSelectors(
-      [...names].filter((name) => facetNames.has(name))
+    return collectSelectorsBuildingIfNeeded(
+      [...names].filter((name) => facetNames.has(name)),
+      io
     )
   } catch {
     return undefined

--- a/script/deploy/safe/drain-parked-tasks.ts
+++ b/script/deploy/safe/drain-parked-tasks.ts
@@ -311,7 +311,7 @@ export async function prepareDrainNetwork(
       } else if (unverifiableAddresses.has(address)) {
         outcome.unverifiable.push(name)
         deps.alert(
-          `[${network}] ${name} (${task.facetAddress}): cannot verify removability — the network has no target-state entry, or the selector unions are unavailable (run \`forge build\`) — leaving it queued. Origin PR: ${task.prUrl}`
+          `[${network}] ${name} (${task.facetAddress}): cannot verify removability — the network has no target-state entry, or the selector unions are unavailable (\`forge build\` was attempted and did not produce them) — leaving it queued. Origin PR: ${task.prUrl}`
         )
       }
     }

--- a/script/deploy/safe/drain-parked-tasks.ts
+++ b/script/deploy/safe/drain-parked-tasks.ts
@@ -311,7 +311,7 @@ export async function prepareDrainNetwork(
       } else if (unverifiableAddresses.has(address)) {
         outcome.unverifiable.push(name)
         deps.alert(
-          `[${network}] ${name} (${task.facetAddress}): cannot verify removability — the network has no target-state entry, or the selector unions are unavailable (\`forge build\` was attempted and did not produce them) — leaving it queued. Origin PR: ${task.prUrl}`
+          `[${network}] ${name} (${task.facetAddress}): cannot verify removability — the network has no target-state entry, or the selector unions could not be built from \`out/\` — leaving it queued. Origin PR: ${task.prUrl}`
         )
       }
     }

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -1067,7 +1067,7 @@ async function reconcileAll(
           const reason =
             refusalReason !== undefined
               ? `facet is routed again and the removal engine refuses it (${refusalReason}) — treated as a deliberate re-add, reopen withheld`
-              : `facet is routed again but removability cannot be verified (no target-state entry for ${network}:${environment}, or the selector unions are unavailable — run \`forge build\`) — reopen withheld`
+              : `facet is routed again but removability cannot be verified (no target-state entry for ${network}:${environment}, or the selector unions are unavailable after \`forge build\`) — reopen withheld`
           consola.warn(
             `[${network}:${environment}] ${task.facetName}: ${reason}`
           )

--- a/script/deploy/safe/reconcile-parked-tasks.ts
+++ b/script/deploy/safe/reconcile-parked-tasks.ts
@@ -1067,7 +1067,7 @@ async function reconcileAll(
           const reason =
             refusalReason !== undefined
               ? `facet is routed again and the removal engine refuses it (${refusalReason}) — treated as a deliberate re-add, reopen withheld`
-              : `facet is routed again but removability cannot be verified (no target-state entry for ${network}:${environment}, or the selector unions are unavailable after \`forge build\`) — reopen withheld`
+              : `facet is routed again but removability cannot be verified (no target-state entry for ${network}:${environment}, or the selector unions could not be built from \`out/\`) — reopen withheld`
           consola.warn(
             `[${network}:${environment}] ${task.facetName}: ${reason}`
           )

--- a/script/tasks/cleanUpProdDiamond.ts
+++ b/script/tasks/cleanUpProdDiamond.ts
@@ -852,7 +852,7 @@ function printAddressRemoval(result: IAddressRemovalResult): void {
 
   if (result.unverifiable.length > 0)
     consola.error(
-      `🛑 REFUSED (cannot verify removability — the network has no target-state entry, or the selector unions are unavailable after "forge build"): ${result.unverifiable.join(
+      `🛑 REFUSED (cannot verify removability — the network has no target-state entry, or the selector unions could not be built from out/): ${result.unverifiable.join(
         ', '
       )}`
     )

--- a/script/tasks/cleanUpProdDiamond.ts
+++ b/script/tasks/cleanUpProdDiamond.ts
@@ -852,7 +852,7 @@ function printAddressRemoval(result: IAddressRemovalResult): void {
 
   if (result.unverifiable.length > 0)
     consola.error(
-      `🛑 REFUSED (cannot verify removability — the network has no target-state entry, or the selector unions are unavailable; run "forge build" and retry): ${result.unverifiable.join(
+      `🛑 REFUSED (cannot verify removability — the network has no target-state entry, or the selector unions are unavailable after "forge build"): ${result.unverifiable.join(
         ', '
       )}`
     )

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -75,6 +75,17 @@ const FOUNDRY_TOML_PATH = resolve(
   '../../foundry.toml'
 )
 
+/**
+ * Foundry's build output, resolved from this module rather than `process.cwd()`.
+ * A cwd-relative lookup makes every artifact reader report "not built" whenever
+ * the caller was launched from outside the repo root, which reads as a missing
+ * contract rather than a missing build.
+ */
+export const OUT_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../out'
+)
+
 function readFoundryProfileDefaultConfig(): IFoundryProfileDefaultConfig {
   const content = readFileSync(FOUNDRY_TOML_PATH, 'utf8')
 
@@ -474,7 +485,7 @@ export async function getFacetSelectors(
   facetName: string,
   excludeSelectors: string[] = []
 ): Promise<string[]> {
-  const base = resolve(process.cwd(), 'out')
+  const base = OUT_ROOT
   const artifactPath = resolve(base, `${facetName}.sol`, `${facetName}.json`)
   const relativePath = relative(base, artifactPath)
   if (relativePath.startsWith('..') || isAbsolute(relativePath))

--- a/script/utils/viemScriptHelpers.test.ts
+++ b/script/utils/viemScriptHelpers.test.ts
@@ -6,15 +6,19 @@
  * below pin behavior against real entries in those files.
  * If the network list changes, update the fixtures used here accordingly.
  */
+import { tmpdir } from 'os'
+
 // eslint-disable-next-line import/no-unresolved
 import { describe, expect, it } from 'bun:test'
 
 import networksConfig from '../../config/networks.json'
 import { EnvironmentEnum } from '../common/types'
 
+import { OUT_ROOT } from './utils'
 import {
   buildExplorerContractPageUrl,
   getDeployLogFile,
+  getFunctionSelectors,
   isTestnetNetwork,
 } from './viemScriptHelpers'
 
@@ -99,5 +103,22 @@ describe('getDeployLogFile path guard', () => {
   it('reads a real production deploy log', () => {
     const log = getDeployLogFile('mainnet', EnvironmentEnum.production)
     expect(log.LiFiDiamond).toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+})
+
+describe('getFunctionSelectors', () => {
+  it('looks the artifact up in the repo, not under the caller cwd', () => {
+    const originalCwd = process.cwd()
+    let message = ''
+    try {
+      process.chdir(tmpdir())
+      getFunctionSelectors('ThisContractDoesNotExist')
+    } catch (error) {
+      message = (error as Error).message
+    } finally {
+      process.chdir(originalCwd)
+    }
+    expect(message).toContain(OUT_ROOT)
+    expect(message).not.toContain(tmpdir())
   })
 })

--- a/script/utils/viemScriptHelpers.ts
+++ b/script/utils/viemScriptHelpers.ts
@@ -26,7 +26,7 @@ import {
 
 import { getDeployments } from './deploymentHelpers'
 import { normalizeAddressForNetwork } from './normalizeAddressStringForViem'
-import { getRPCEnvVarName } from './utils'
+import { getRPCEnvVarName, OUT_ROOT } from './utils'
 
 dotenv.config()
 
@@ -365,7 +365,7 @@ export function getFunctionSelectors(
   excludes: string[] = []
 ): `0x${string}`[] {
   // Build the file path to the contract's compiled JSON file
-  const base = path.resolve('out')
+  const base = OUT_ROOT
   const filePath = path.resolve(
     base,
     `${contractName}.sol`,


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-912](https://linear.app/lifi-linear/issue/EXSC-912/parked-task-drain-reports-cannot-verify-removability-in-an-uncompiled)

# Why did I implement it this way?

The deferred diamond-cleanup drain verifies removability by matching a parked facet's
on-chain selectors against two unions built from Foundry artifacts. Both unions land in
`out/`, which `getFunctionSelectors` resolved relative to `process.cwd()` — and nothing on
the drain's own path guarantees `out/` exists at all.

On 2026-09-02 the Robinhood whitelist sync (#2303) ran from a per-session worktree that had
never been built. Neither union could be assembled, so the queued SymbiosisFacet v1 removal
(#2108) failed closed as `unverifiable`, stayed queued, and re-alerted — while the facet was
perfectly removable. The propose paths that drain (whitelist sync, propose-only rollout)
never compile on their own, and every fresh worktree starts without `out/`, so this fires on
a build gap rather than on anything about the facet.

Two changes, addressing the two independent halves:

- **`out/` resolves from the repo root** (`OUT_ROOT` in `script/utils/utils.ts`), mirroring
  the existing `SRC_ROOT`/`FOUNDRY_TOML_PATH` idiom. `getFunctionSelectors` and
  `getFacetSelectors` are the two readers the removal engine depends on; a script launched
  from anywhere but the repo root previously read a non-existent `out/` and reported every
  contract as "not built". Four further cwd-relative readers exist and are left for a
  follow-up: `facetPeripheryCouplings.ts:238`, `safe-utils.ts:2578`,
  `tron/register-facets-to-diamond.ts:34`, `removeDuplicateEventsFromABI.ts:51`.
- **The removal engine compiles once before concluding.** When a selector union comes back
  unavailable, `collectSelectorsBuildingIfNeeded` runs `forge build` (at most once per
  process, injectable as `IRemovalDiffIO.ensureArtifacts`) and re-reads. A missing artifact
  is ambiguous — a deprecated contract, or a checkout nobody built — and only the second
  reading answers the removability question. A failed or unavailable build rethrows, so the
  fail-closed contract every caller depends on is unchanged: a build problem never becomes a
  removal.

Details worth a reviewer's eye: the build uses the same `--skip` set
`reconcileParkedTasks.yml` already uses for these artifacts (only facet ABIs matter, and the
scheduled job caps at 20 min); it forces `FOUNDRY_PROFILE=default`, because a profile
inherited from `helperFunctions.sh` would write to `out/<profile>` while the reader looks in
`out/`; `maxBuffer` is explicit because a warning-heavy build overruns the 1 MB default and
would surface as a build failure; and the selector memo is cleared after a successful build,
since it assumes `out/` never moves under it. The call is synchronous, so a fleet loop
cannot start two concurrent builds over the same `out/`.

This supersedes the remedy #2157 chose — leave the task queued and tell a human to run
`forge build`. That remedy assumed an operator could have prevented the condition, and none
could: the propose paths that drain never compile, and a fresh worktree never has `out/`.
`docs/DeferredDiamondCleanupQueue.md` records the change where it recorded the old rule, so
the design-of-record does not silently contradict the code.

The operator-facing alerts in `drain-parked-tasks.ts`, `reconcile-parked-tasks.ts` and
`cleanUpProdDiamond.ts` stay neutral about whether a build ran — `getFacetNames()` can fail
before the recovery is reached, and `cleanUpProdDiamond`'s interactive branch never builds at
all. Where a build demonstrably did run and the artifacts still did not appear, the error says
so explicitly.

Verified end-to-end against the real incident: in a worktree with no `out/`,
`computeFacetRemovalsByAddress('robinhood', production, [0x35970e…])` now builds and returns
the facet as a removal instead of `unverifiable`. Robinhood's queued task has since been
drained into a fresh nonce-28 proposal.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
