### PR TITLE
feat(healthcheck): whitelist invariant reads the timelock queue — queued syncs report as expected-pending (EXSC-918)

### DIFF
--- a/.agents/rules/601-healthcheck-invariants.md
+++ b/.agents/rules/601-healthcheck-invariants.md
@@ -95,7 +95,8 @@ invariant:
 - A rollout proposed **without** `--timelock` writes no row at all, and so is never downgraded.
 - Only whitelist **additions** are covered. A pair the diamond holds and config no longer
   declares (`Pair Array has N stale pairs`) reports as a hard error even while its removal
-  is queued — the removal side reads parked tasks, which carry no whitelist payloads.
+  is queued: that branch consults no intent source at all, and the parked-task queue the
+  other removal gate reads carries no whitelist payloads to consult.
 - **Tron** rolls out through `contracts-tron` and has no EVM queue row; it is skipped by branch.
 - A row is honoured only while it is plausibly still waiting. A never-scheduled or
   directly-cancelled operation is reported and skipped by the execution runner *without* a
@@ -111,10 +112,10 @@ Two boundaries are not negotiable:
   compensating write. Deploy logs stay a pure function of the loupe
   ([docs/DeploymentLogs.md](../../docs/DeploymentLogs.md)).
 - **An unreachable queue must never suppress a finding.** What decides the degradation is
-  what the check is *for*, not its severity — all three are error-severity.
+  what the check is *for*, not its severity — all four are error-severity.
   `no-stale-registered-facets` exists _only_ to police queue coverage, so without the queue
   every finding it could make is noise: it skips and reports the reduced coverage.
-  `facets-registered` and `periphery-registered` stand on an independent on-chain signal, so
-  they keep every error and add a warning naming the degraded coverage — a MongoDB blip
-  turning genuinely missing registrations green is far worse than a false alert during a
-  rollout.
+  `facets-registered`, `periphery-registered` and `whitelist-integrity` stand on an
+  independent on-chain signal, so they keep every error and add a warning naming the
+  degraded coverage — a MongoDB blip turning genuinely missing registrations green is far
+  worse than a false alert during a rollout.

--- a/.agents/rules/601-healthcheck-invariants.md
+++ b/.agents/rules/601-healthcheck-invariants.md
@@ -61,10 +61,10 @@ JSDoc on exports, `bunx eslint` + `bunx tsc-files --noEmit`).
 ## Intent-aware invariants, chain-only generators ([CONV:HEALTHCHECK-INTENT])
 
 Several invariants compare on-chain reality against a _desired_ state that a merged PR
-already records — `_targetState.json` for `facets-registered` and `periphery-registered`, a
-deleted source file for `no-stale-registered-facets`. Between that merge and the multisig
-operation acting on it the two legitimately disagree, and the remediation is "wait", not
-"fix".
+already records — `_targetState.json` for `facets-registered` and `periphery-registered`,
+`config/whitelist.json` for the whitelist pair checks, a deleted source file for
+`no-stale-registered-facets`. Between that merge and the multisig operation acting on it the
+two legitimately disagree, and the remediation is "wait", not "fix".
 
 Invariants may consult operator intent to resolve that window and report the finding as
 **expected-pending** instead of a failure:
@@ -76,8 +76,12 @@ Invariants may consult operator intent to resolve that window and report the fin
   sufficient: a facet needs a `diamondCut` record, because a registry entry routes no
   selectors, and a periphery contract needs a `registerPeripheryContract` record carrying
   **its own** registry name, because binding an address under one name leaves every other
-  name unset. Every record decoded for an address is kept, so a second call for the same
-  address cannot erase the first.
+  name unset. A whitelist pair needs a `setContractSelectorWhitelist` /
+  `batchSetContractSelectorWhitelist` record carrying **its own** selector, because
+  whitelisting is per contract *and* selector. Every record decoded for an address is kept,
+  so a second call for the same address cannot erase the first, and each consumer matches
+  the record's `kind` — a check keyed on the absence of a field silently widens the next
+  time a kind is added.
 - Removals read the parked-task queue (`script/deploy/safe/parked-tasks.ts`), and only while
   the task is **live** — a claim held with no Safe proposal past `STALE_PARKED_CLAIM_DAYS` is
   breakage, not progress, and covers nothing.
@@ -89,6 +93,9 @@ invariant:
   so the multisig **signing** window before it stays red. Only the timelock delay itself
   (plus execution lag) is covered.
 - A rollout proposed **without** `--timelock` writes no row at all, and so is never downgraded.
+- Only whitelist **additions** are covered. A pair the diamond holds and config no longer
+  declares (`Pair Array has N stale pairs`) reports as a hard error even while its removal
+  is queued — the removal side reads parked tasks, which carry no whitelist payloads.
 - **Tron** rolls out through `contracts-tron` and has no EVM queue row; it is skipped by branch.
 - A row is honoured only while it is plausibly still waiting. A never-scheduled or
   directly-cancelled operation is reported and skipped by the execution runner *without* a

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -876,7 +876,9 @@ describe('splitByPendingWhitelist', () => {
     expect(splitByPendingWhitelist([PAIR], new Map()).uncovered).toEqual([PAIR])
   })
 
-  // A cut or a registry entry for the same address whitelists nothing.
+  // A cut or a registry entry for the same address whitelists nothing. The record carries
+  // the matching selector on purpose: without it the selector comparison alone would
+  // reject the record and the `kind` guard would never be exercised.
   it('ignores queued records of another kind for the same address', () => {
     const split = splitByPendingWhitelist(
       [PAIR],
@@ -884,12 +886,27 @@ describe('splitByPendingWhitelist', () => {
         {
           kind: 'facet-cut',
           address: DEX.toLowerCase(),
+          selector: SELECTOR,
           operationId: OPERATION_ID,
           target: DIAMOND,
         },
       ])
     )
     expect(split.uncovered).toEqual([PAIR])
+  })
+
+  // Real batches repeat one contract under several selectors, so the matcher has to pick
+  // the right record out of many for the same address rather than trust the first.
+  it('finds the matching selector among several records for one contract', () => {
+    const records = ['0x11111111', '0x22222222', SELECTOR, '0x33333333'].map(
+      (selector) => whitelistRecord(selector as Hex)
+    )
+    expect(splitByPendingWhitelist([PAIR], coverage(records)).pending).toEqual([
+      PAIR,
+    ])
+    expect(
+      splitByPendingWhitelist([PAIR], coverage(records.slice(0, 2))).uncovered
+    ).toEqual([PAIR])
   })
 
   it('matches case-insensitively on the contract and selector', () => {
@@ -1011,6 +1028,31 @@ describe('checkWhitelistIntegrity expected-pending downgrade', () => {
     expect(reads).toBe(0)
     expect(errors).toEqual([])
     expect(warnings).toEqual([])
+  })
+
+  // Every chain with a multicall3 deployment takes the batched path, so the downgrade has
+  // to hold there and not only in the sequential fallback.
+  it('downgrades on the multicall path too', async () => {
+    const client = {
+      readContract: async () => [[], []],
+      multicall: async ({ contracts }: { contracts: unknown[] }) =>
+        contracts.map(() => ({ status: 'success', result: false })),
+      chain: { contracts: { multicall3: { address: DIAMOND } } },
+    } as unknown as PublicClient
+    const { errors, warnings } = await run(client, async () => queued(SELECTOR))
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+  })
+
+  it('errors on the multicall path when nothing is queued', async () => {
+    const client = {
+      readContract: async () => [[], []],
+      multicall: async ({ contracts }: { contracts: unknown[] }) =>
+        contracts.map(() => ({ status: 'success', result: false })),
+      chain: { contracts: { multicall3: { address: DIAMOND } } },
+    } as unknown as PublicClient
+    const { errors } = await run(client, async () => new Map())
+    expect(errors.some((e) => e.includes('Source of Truth FAILED'))).toBe(true)
   })
 
   it('resolves the queue once even though both steps consult it', async () => {
@@ -2889,6 +2931,35 @@ describe('periphery-registered scheduled-registration coverage', () => {
     await invariant('periphery-registered').run(ctx)
     expect(ctx.errors).toEqual([])
     expect(ctx.warnings).toEqual([])
+  })
+
+  // Locks the `kind` guard itself: this record carries the matching registry name, so the
+  // name comparison alone would accept it and only the kind check rejects it.
+  it('still errors when a record of another kind carries the matching name', async () => {
+    const ctx = makePeripheryCtx(
+      new Map([
+        [
+          'testnet1',
+          new Map([
+            [
+              EXECUTOR.toLowerCase(),
+              [
+                {
+                  kind: 'facet-cut' as const,
+                  address: EXECUTOR.toLowerCase(),
+                  peripheryName: 'Executor',
+                  operationId: OPERATION_ID,
+                  target: DIAMOND.toLowerCase(),
+                },
+              ],
+            ],
+          ]),
+        ],
+      ])
+    )
+    await invariant('periphery-registered').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('Executor')
   })
 
   // The registry is keyed by name: registering this address under a different name

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -4,7 +4,7 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
-import { getAddress, type Address, type Hex } from 'viem'
+import { getAddress, type Address, type Hex, type PublicClient } from 'viem'
 
 import globalConfig from '../../config/global.json'
 import networksConfig from '../../config/networks.json'
@@ -28,8 +28,11 @@ import {
   findDuplicateSelectors,
   getExemptCoreFacets,
   getExemptCorePeriphery,
+  checkWhitelistIntegrity,
   getExpectedPairs,
   getInvariantExclusion,
+  splitByPendingWhitelist,
+  type IWhitelistPair,
   isInvariantApplicable,
   runHealthCheckInvariants,
   type IHealthCheckContext,
@@ -824,6 +827,199 @@ describe('getExpectedPairs — periphery address resolution', () => {
     expect(pairs).toEqual([])
     expect(warns).toHaveLength(1)
     expect(warns[0]).toContain('reduced coverage')
+  })
+})
+
+describe('splitByPendingWhitelist', () => {
+  const DEX = '0x5555555555555555555555555555555555555555'
+  const DIAMOND = '0xd1a0000000000000000000000000000000000001'
+  const SELECTOR = '0xf8989325' as Hex
+  const OTHER_SELECTOR = '0x2646478b' as Hex
+  const OPERATION_ID = `0x${'ef'.repeat(32)}` as Hex
+  const PAIR: IWhitelistPair = { contract: DEX, selector: SELECTOR }
+
+  const coverage = (
+    records: IPendingRegistration[]
+  ): Map<string, IPendingRegistration[]> =>
+    new Map([[DEX.toLowerCase(), records]])
+
+  const whitelistRecord = (selector: Hex): IPendingRegistration => ({
+    kind: 'whitelist',
+    address: DEX.toLowerCase(),
+    selector,
+    operationId: OPERATION_ID,
+    target: DIAMOND,
+  })
+
+  it('treats a pair as pending when a queued operation whitelists exactly it', () => {
+    const split = splitByPendingWhitelist(
+      [PAIR],
+      coverage([whitelistRecord(SELECTOR)])
+    )
+    expect(split.pending).toEqual([PAIR])
+    expect(split.uncovered).toEqual([])
+  })
+
+  // Whitelisting is per contract AND selector, so another selector on the same contract
+  // leaves this pair unset — downgrading on the address alone would report a sync that
+  // is never coming.
+  it('keeps a pair uncovered when the queued operation grants another selector', () => {
+    const split = splitByPendingWhitelist(
+      [PAIR],
+      coverage([whitelistRecord(OTHER_SELECTOR)])
+    )
+    expect(split.pending).toEqual([])
+    expect(split.uncovered).toEqual([PAIR])
+  })
+
+  it('keeps a pair uncovered when nothing is queued for the contract', () => {
+    expect(splitByPendingWhitelist([PAIR], new Map()).uncovered).toEqual([PAIR])
+  })
+
+  // A cut or a registry entry for the same address whitelists nothing.
+  it('ignores queued records of another kind for the same address', () => {
+    const split = splitByPendingWhitelist(
+      [PAIR],
+      coverage([
+        {
+          kind: 'facet-cut',
+          address: DEX.toLowerCase(),
+          operationId: OPERATION_ID,
+          target: DIAMOND,
+        },
+      ])
+    )
+    expect(split.uncovered).toEqual([PAIR])
+  })
+
+  it('matches case-insensitively on the contract and selector', () => {
+    const split = splitByPendingWhitelist(
+      [{ contract: getAddress(DEX), selector: '0xF8989325' as Hex }],
+      coverage([whitelistRecord(SELECTOR)])
+    )
+    expect(split.pending).toHaveLength(1)
+  })
+
+  it('splits a mixed set, keeping each pair on its own evidence', () => {
+    const bare: IWhitelistPair = {
+      contract: '0x6666666666666666666666666666666666666666',
+      selector: SELECTOR,
+    }
+    const split = splitByPendingWhitelist(
+      [PAIR, bare],
+      coverage([whitelistRecord(SELECTOR)])
+    )
+    expect(split.pending).toEqual([PAIR])
+    expect(split.uncovered).toEqual([bare])
+  })
+})
+
+describe('checkWhitelistIntegrity expected-pending downgrade', () => {
+  const DEX = '0x5555555555555555555555555555555555555555'
+  const DIAMOND = '0xd1a0000000000000000000000000000000000001'
+  const SELECTOR = '0xf8989325' as Hex
+  const OPERATION_ID = `0x${'ef'.repeat(32)}` as Hex
+  const PAIR: IWhitelistPair = { contract: DEX, selector: SELECTOR }
+
+  /** A diamond that whitelists nothing: both the getter array and the per-pair read are empty. */
+  const emptyDiamond = () =>
+    ({
+      readContract: async ({ functionName }: { functionName: string }) =>
+        functionName === 'getAllContractSelectorPairs' ? [[], []] : false,
+    } as unknown as PublicClient)
+
+  /** A diamond that already holds `PAIR`. */
+  const syncedDiamond = () =>
+    ({
+      readContract: async ({ functionName }: { functionName: string }) =>
+        functionName === 'getAllContractSelectorPairs'
+          ? [[DEX], [[SELECTOR]]]
+          : true,
+    } as unknown as PublicClient)
+
+  const queued = (selector: Hex): Map<string, IPendingRegistration[]> =>
+    new Map([
+      [
+        DEX.toLowerCase(),
+        [
+          {
+            kind: 'whitelist' as const,
+            address: DEX.toLowerCase(),
+            selector,
+            operationId: OPERATION_ID,
+            target: DIAMOND,
+          },
+        ],
+      ],
+    ])
+
+  async function run(
+    publicClient: PublicClient,
+    resolvePendingWhitelist?: () => Promise<
+      Map<string, IPendingRegistration[]> | { unreachable: string }
+    >
+  ): Promise<{ errors: string[]; warnings: string[] }> {
+    const errors: string[] = []
+    const warnings: string[] = []
+    await checkWhitelistIntegrity(
+      'testnet1',
+      'production',
+      [PAIR],
+      (msg) => errors.push(msg),
+      DIAMOND,
+      {
+        evmContext: { publicClient },
+        logWarn: (msg) => warnings.push(msg),
+        resolvePendingWhitelist,
+      }
+    )
+    return { errors, warnings }
+  }
+
+  it('errors on both checks when nothing is queued', async () => {
+    const { errors } = await run(emptyDiamond(), async () => new Map())
+    expect(errors.some((e) => e.includes('Source of Truth FAILED'))).toBe(true)
+    expect(errors.some((e) => e.includes('Pair Array is missing'))).toBe(true)
+  })
+
+  it('reports nothing when a queued operation whitelists the missing pair', async () => {
+    const { errors, warnings } = await run(emptyDiamond(), async () =>
+      queued(SELECTOR)
+    )
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+  })
+
+  // The pair comparison stands on its own on-chain signal, so a queue it cannot read
+  // must cost coverage, never a finding.
+  it('keeps both errors and warns about coverage when the queue is unreachable', async () => {
+    const { errors, warnings } = await run(emptyDiamond(), async () => ({
+      unreachable: 'connect ECONNREFUSED',
+    }))
+    expect(errors.some((e) => e.includes('Source of Truth FAILED'))).toBe(true)
+    expect(errors.some((e) => e.includes('Pair Array is missing'))).toBe(true)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('Timelock queue unreachable')
+  })
+
+  it('never reads the queue for a synced network', async () => {
+    let reads = 0
+    const { errors, warnings } = await run(syncedDiamond(), async () => {
+      reads++
+      return new Map()
+    })
+    expect(reads).toBe(0)
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+  })
+
+  it('resolves the queue once even though both steps consult it', async () => {
+    let reads = 0
+    await run(emptyDiamond(), async () => {
+      reads++
+      return queued(SELECTOR)
+    })
+    expect(reads).toBe(1)
   })
 })
 
@@ -2446,6 +2642,7 @@ describe('facets-registered scheduled-registration coverage', () => {
             FACET_ADDRESS.toLowerCase(),
             [
               {
+                kind: 'facet-cut',
                 address: FACET_ADDRESS.toLowerCase(),
                 operationId: OPERATION_ID,
                 target: target.toLowerCase(),
@@ -2486,6 +2683,7 @@ describe('facets-registered scheduled-registration coverage', () => {
               '0xffff000000000000000000000000000000000099',
               [
                 {
+                  kind: 'facet-cut',
                   address: '0xffff000000000000000000000000000000000099',
                   operationId: OPERATION_ID,
                   target: DIAMOND.toLowerCase(),
@@ -2511,8 +2709,38 @@ describe('facets-registered scheduled-registration coverage', () => {
               FACET_ADDRESS.toLowerCase(),
               [
                 {
+                  kind: 'periphery',
                   address: FACET_ADDRESS.toLowerCase(),
                   peripheryName: 'SomeName',
+                  operationId: OPERATION_ID,
+                  target: DIAMOND.toLowerCase(),
+                },
+              ],
+            ],
+          ]),
+        ],
+      ])
+    )
+    await invariant('facets-registered').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain(EXPECTED_FACET)
+  })
+
+  // A whitelist entry grants a DEX call permission and routes no selectors, so it is no
+  // more evidence of a cut than a registry entry is.
+  it('still errors when the only queued record is a whitelist entry', async () => {
+    const ctx = makeMissingCtx(
+      new Map([
+        [
+          'testnet1',
+          new Map([
+            [
+              FACET_ADDRESS.toLowerCase(),
+              [
+                {
+                  kind: 'whitelist' as const,
+                  address: FACET_ADDRESS.toLowerCase(),
+                  selector: '0xf8989325' as Hex,
                   operationId: OPERATION_ID,
                   target: DIAMOND.toLowerCase(),
                 },
@@ -2537,6 +2765,7 @@ describe('facets-registered scheduled-registration coverage', () => {
               FACET_ADDRESS.toLowerCase(),
               [
                 {
+                  kind: 'facet-cut',
                   address: FACET_ADDRESS.toLowerCase(),
                   operationId: OPERATION_ID,
                   target: DIAMOND.toLowerCase(),
@@ -2636,6 +2865,7 @@ describe('periphery-registered scheduled-registration coverage', () => {
             EXECUTOR.toLowerCase(),
             [
               {
+                kind: 'periphery',
                 address: EXECUTOR.toLowerCase(),
                 peripheryName,
                 operationId: OPERATION_ID,

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -745,8 +745,15 @@ export interface IWhitelistPair {
  * granting another selector on the same contract leaves this pair unset — the same reason
  * the periphery caller has to match the registry name rather than the address alone.
  *
+ * Two preconditions the caller owns, because neither is checked here: `coverage` must
+ * already be scoped to this network's own diamond (`resolvePendingRegistrations` filters by
+ * `target`), and its keys are lowercased EVM addresses — a Tron base58 contract would be
+ * corrupted by the lookup's `toLowerCase()`, which is harmless only because Tron is gated
+ * out of the queue upstream and so always arrives with empty coverage.
+ *
  * @param missing - Pairs config expects that the diamond does not have.
- * @param coverage - Registered-address → queued registrations aimed at this diamond.
+ * @param coverage - Lowercased registered address → queued registrations aimed at this
+ * diamond.
  * @returns The missing pairs split by whether the queue covers them.
  */
 export function splitByPendingWhitelist(
@@ -771,6 +778,17 @@ export function splitByPendingWhitelist(
 
 /**
  * Check whitelist integrity by comparing config against on-chain state.
+ *
+ * Reports through `logError` rather than throwing, so one unsynced network never aborts a
+ * fleet sweep.
+ *
+ * @param network - Network id, used only in the remediation hint.
+ * @param environment - Deployment environment, used only in the remediation hint.
+ * @param expectedPairs - Pairs the whitelist config declares for this network.
+ * @param logError - Sink for findings; every call fails the invariant.
+ * @param diamondAddress - Diamond whose whitelist is read.
+ * @param context - On-chain clients plus the optional intent hooks; see the field comments.
+ * @returns Nothing — findings are reported through `logError`.
  */
 export async function checkWhitelistIntegrity(
   network: string,

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -727,18 +727,69 @@ export const getExpectedPairs = async (
   }
 }
 
+/** One contract/selector pair the whitelist config declares for a network. */
+export interface IWhitelistPair {
+  contract: string
+  selector: Hex
+}
+
+/**
+ * Splits config-declared pairs the diamond does not hold into the ones a queued timelock
+ * operation would whitelist and the ones genuinely missing. Pure.
+ *
+ * `config/whitelist.json` is merged before the Safe proposal syncing it executes, so
+ * between those two events config and chain legitimately disagree and the remediation is
+ * "wait", not "fix" ([CONV:HEALTHCHECK-INTENT]).
+ *
+ * Matching is exact on contract AND selector: whitelisting is per pair, so an operation
+ * granting another selector on the same contract leaves this pair unset — the same reason
+ * the periphery caller has to match the registry name rather than the address alone.
+ *
+ * @param missing - Pairs config expects that the diamond does not have.
+ * @param coverage - Registered-address → queued registrations aimed at this diamond.
+ * @returns The missing pairs split by whether the queue covers them.
+ */
+export function splitByPendingWhitelist(
+  missing: IWhitelistPair[],
+  coverage: Map<string, IPendingRegistration[]>
+): { pending: IWhitelistPair[]; uncovered: IWhitelistPair[] } {
+  const pending: IWhitelistPair[] = []
+  const uncovered: IWhitelistPair[] = []
+  for (const pair of missing) {
+    const covered = coverage
+      .get(pair.contract.toLowerCase())
+      ?.some(
+        (record) =>
+          record.kind === 'whitelist' &&
+          record.selector === pair.selector.toLowerCase()
+      )
+    if (covered) pending.push(pair)
+    else uncovered.push(pair)
+  }
+  return { pending, uncovered }
+}
+
 /**
  * Check whitelist integrity by comparing config against on-chain state.
  */
-async function checkWhitelistIntegrity(
+export async function checkWhitelistIntegrity(
   network: string,
   environment: string,
-  expectedPairs: Array<{ contract: string; selector: Hex }>,
+  expectedPairs: IWhitelistPair[],
   logError: (msg: string) => void,
   diamondAddress: string,
   context: {
     tronContext?: { tronRpcUrl: string; tronWeb: TronWeb }
     evmContext?: { publicClient: PublicClient }
+    /** Reports coverage lost when the queue cannot be read. */
+    logWarn?: (msg: string) => void
+    /**
+     * Queued whitelist intent for this diamond. Called at most once, and only when a
+     * pair is actually missing, so a synced network never touches the queue.
+     */
+    resolvePendingWhitelist?: () => Promise<
+      Map<string, IPendingRegistration[]> | { unreachable: string }
+    >
   }
 ): Promise<void> {
   const tronRpcUrl = context.tronContext?.tronRpcUrl
@@ -829,9 +880,35 @@ async function checkWhitelistIntegrity(
 
   consola.info(`On-chain has ${onChainPairSet.size} total pairs.`)
 
+  // Resolved lazily and at most once: a synced network must not pay a queue read, and
+  // both steps below grade the same missing pairs against the same answer.
+  let coverage:
+    | Map<string, IPendingRegistration[]>
+    | { unreachable: string }
+    | undefined
+  let unreachableReason: string | undefined
+  const pendingKeys = new Set<string>()
+  const splitPending = async (
+    missing: IWhitelistPair[]
+  ): Promise<{ pending: IWhitelistPair[]; uncovered: IWhitelistPair[] }> => {
+    if (missing.length === 0) return { pending: [], uncovered: [] }
+    coverage ??= (await context.resolvePendingWhitelist?.()) ?? new Map()
+    if (!(coverage instanceof Map)) {
+      unreachableReason = coverage.unreachable
+      return { pending: [], uncovered: missing }
+    }
+    const split = splitByPendingWhitelist(missing, coverage)
+    for (const pair of split.pending)
+      pendingKeys.add(
+        `${pair.contract.toLowerCase()}:${pair.selector.toLowerCase()}`
+      )
+    return split
+  }
+
   try {
     consola.start('Step 1/2: Checking Config vs. On-Chain Functions...')
     let granularFails = 0
+    const notWhitelisted: IWhitelistPair[] = []
 
     if (hasTronContext) {
       for (const expectedPair of expectedPairs) {
@@ -846,12 +923,7 @@ async function checkWhitelistIntegrity(
             ],
             'function isContractSelectorWhitelisted(address,bytes4) external view returns (bool)'
           )
-          if (!isWhitelisted) {
-            logError(
-              `Source of Truth FAILED: ${expectedPair.contract} / ${expectedPair.selector} is 'false'.`
-            )
-            granularFails++
-          }
+          if (!isWhitelisted) notWhitelisted.push(expectedPair)
         } catch (error: unknown) {
           const errorMessage =
             error instanceof Error ? error.message : String(error)
@@ -888,12 +960,7 @@ async function checkWhitelistIntegrity(
               }`
             )
             granularFails++
-          } else if (!result.result) {
-            logError(
-              `Source of Truth FAILED: ${pair.contract} / ${pair.selector} is 'false'.`
-            )
-            granularFails++
-          }
+          } else if (!result.result) notWhitelisted.push(pair)
         })
       } else {
         // No multicall3 on this chain: fire the reads concurrently (still one round-trip each,
@@ -911,12 +978,7 @@ async function checkWhitelistIntegrity(
                   pair.contract as Address,
                   pair.selector,
                 ])
-              if (!isWhitelisted) {
-                logError(
-                  `Source of Truth FAILED: ${pair.contract} / ${pair.selector} is 'false'.`
-                )
-                granularFails++
-              }
+              if (!isWhitelisted) notWhitelisted.push(pair)
             } catch (error: unknown) {
               const errorMessage =
                 error instanceof Error ? error.message : String(error)
@@ -930,9 +992,25 @@ async function checkWhitelistIntegrity(
       }
     }
 
+    const sourceOfTruth = await splitPending(notWhitelisted)
+    for (const pair of sourceOfTruth.pending)
+      consola.info(
+        `Whitelist pair ${pair.contract} / ${pair.selector} is expected but not yet whitelisted — expected-pending: a queued timelock operation whitelists it`
+      )
+    for (const pair of sourceOfTruth.uncovered) {
+      logError(
+        `Source of Truth FAILED: ${pair.contract} / ${pair.selector} is 'false'.`
+      )
+      granularFails++
+    }
+
     if (granularFails === 0) {
+      // Naming the pending pairs matters: "synced" on its own would claim the diamond
+      // already holds what only a queued operation will put there.
       consola.success(
-        'Source of Truth (isContractSelectorWhitelisted) is synced.'
+        sourceOfTruth.pending.length === 0
+          ? 'Source of Truth (isContractSelectorWhitelisted) is synced.'
+          : `Source of Truth (isContractSelectorWhitelisted) is synced apart from ${sourceOfTruth.pending.length} expected-pending pair(s).`
       )
     }
 
@@ -945,13 +1023,15 @@ async function checkWhitelistIntegrity(
       )
     }
 
-    const missingPairsList: string[] = []
+    const missingFromArray: IWhitelistPair[] = []
     for (const expectedPair of expectedPairs) {
       const key = `${expectedPair.contract.toLowerCase()}:${expectedPair.selector.toLowerCase()}`
       if (!onChainPairSet.has(key)) {
-        missingPairsList.push(key)
+        missingFromArray.push(expectedPair)
       }
     }
+    const pairArray = await splitPending(missingFromArray)
+    const missingPairsList = pairArray.uncovered
 
     const stalePairsList: string[] = []
     for (const onChainPair of onChainPairSet) {
@@ -962,7 +1042,11 @@ async function checkWhitelistIntegrity(
 
     if (missingPairsList.length === 0 && stalePairsList.length === 0) {
       consola.success(
-        `Pair Array (getAllContractSelectorPairs) is synced. (${onChainPairSet.size} pairs)`
+        `Pair Array (getAllContractSelectorPairs) is synced${
+          pairArray.pending.length === 0
+            ? ''
+            : ` apart from ${pairArray.pending.length} expected-pending pair(s)`
+        }. (${onChainPairSet.size} pairs)`
       )
     } else {
       // Use the executed wrapper, not `source diamondSyncWhitelist.sh && …`: the latter runs
@@ -977,8 +1061,7 @@ async function checkWhitelistIntegrity(
           `Pair Array is missing ${missingPairsList.length} pairs from config:`
         )
         missingPairsList.slice(0, 10).forEach((pair) => {
-          const [contract, selector] = pair.split(':')
-          logError(`  Missing: ${contract} / ${selector}`)
+          logError(`  Missing: ${pair.contract} / ${pair.selector}`)
         })
         if (missingPairsList.length > 10) {
           logError(`  ... and ${missingPairsList.length - 10} more`)
@@ -999,6 +1082,19 @@ async function checkWhitelistIntegrity(
         consola.warn(`\n💡 To fix stale pairs, run: ${syncCmd}`)
       }
     }
+
+    // The pair comparison stands on an independent on-chain signal, so an unreachable
+    // queue keeps every error and only reports the coverage it cost: a Mongo blip that
+    // turned a genuinely unsynced whitelist green would be far worse than a false alert
+    // during a rollout ([CONV:HEALTHCHECK-INTENT]).
+    if (unreachableReason)
+      context.logWarn?.(
+        `Timelock queue unreachable — expected-pending downgrade skipped, missing whitelist pairs reported as errors: ${unreachableReason}`
+      )
+    else if (pendingKeys.size > 0)
+      consola.info(
+        `${pendingKeys.size} expected whitelist pair(s) awaiting their queued timelock sync (expected-pending)`
+      )
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     logError(`Failed during whitelist integrity checks: ${errorMessage}`)
@@ -1789,14 +1885,14 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           }
           const address = ctx.deployedContracts[facet]
           // A facet routes by selector, so only a `diamondCut` record covers it. A
-          // `registerPeripheryContract` naming the same address binds a registry entry
-          // and routes nothing, so it must not stand in for the missing cut.
+          // `registerPeripheryContract` or a whitelist entry naming the same address
+          // routes nothing, so neither may stand in for the missing cut.
           if (
             address &&
             scheduled instanceof Map &&
             scheduled
               .get(String(address).toLowerCase())
-              ?.some((record) => record.peripheryName === undefined)
+              ?.some((record) => record.kind === 'facet-cut')
           ) {
             downgraded++
             consola.info(
@@ -2212,7 +2308,11 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           if (
             coverage
               .get(address.toLowerCase())
-              ?.some((record) => record.peripheryName === periphery)
+              ?.some(
+                (record) =>
+                  record.kind === 'periphery' &&
+                  record.peripheryName === periphery
+              )
           ) {
             downgraded++
             consola.info(
@@ -2643,6 +2743,8 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
               evmContext: ctx.publicClient
                 ? { publicClient: ctx.publicClient }
                 : undefined,
+              logWarn: ctx.logWarn,
+              resolvePendingWhitelist: () => resolvePendingRegistrations(ctx),
             }
           )
         } else {

--- a/script/deploy/safe/pending-registrations.test.ts
+++ b/script/deploy/safe/pending-registrations.test.ts
@@ -26,6 +26,17 @@ const ABI_REGISTER_PERIPHERY = parseAbi([
   'function registerPeripheryContract(string,address)',
 ])
 const ABI_UNRELATED = parseAbi(['function grantRole(bytes32,address)'])
+const ABI_SET_WHITELIST = parseAbi([
+  'function setContractSelectorWhitelist(address,bytes4,bool)',
+])
+const ABI_BATCH_SET_WHITELIST = parseAbi([
+  'function batchSetContractSelectorWhitelist(address[],bytes4[],bool)',
+])
+
+const DEX = '0x5555555555555555555555555555555555555555'
+const OTHER_DEX = '0x6666666666666666666666666666666666666666'
+const SELECTOR = '0xf8989325' as Hex
+const OTHER_SELECTOR = '0x2646478b' as Hex
 
 /** Encodes a `diamondCut` with one cut per `(address, action)` pair. */
 function diamondCut(cuts: Array<[string, number]>): Hex {
@@ -46,13 +57,13 @@ function diamondCut(cuts: Array<[string, number]>): Hex {
 describe('extractRegistrations', () => {
   it('returns the facet address for an Add cut', () => {
     expect(extractRegistrations(diamondCut([[FACET, 0]]))).toEqual([
-      { address: FACET.toLowerCase() },
+      { kind: 'facet-cut', address: FACET.toLowerCase() },
     ])
   })
 
   it('returns the facet address for a Replace cut', () => {
     expect(extractRegistrations(diamondCut([[FACET, 1]]))).toEqual([
-      { address: FACET.toLowerCase() },
+      { kind: 'facet-cut', address: FACET.toLowerCase() },
     ])
   })
 
@@ -68,7 +79,7 @@ describe('extractRegistrations', () => {
           [OTHER_FACET, 2],
         ])
       )
-    ).toEqual([{ address: FACET.toLowerCase() }])
+    ).toEqual([{ kind: 'facet-cut', address: FACET.toLowerCase() }])
   })
 
   it('returns the periphery address and the name it is bound to', () => {
@@ -77,7 +88,11 @@ describe('extractRegistrations', () => {
       args: ['Executor', PERIPHERY],
     })
     expect(extractRegistrations(data)).toEqual([
-      { address: PERIPHERY.toLowerCase(), peripheryName: 'Executor' },
+      {
+        kind: 'periphery',
+        address: PERIPHERY.toLowerCase(),
+        peripheryName: 'Executor',
+      },
     ])
   })
 
@@ -100,6 +115,63 @@ describe('extractRegistrations', () => {
   it('returns nothing for a non-string payload', () => {
     expect(extractRegistrations(undefined as unknown as Hex)).toEqual([])
   })
+
+  it('returns the pair a single whitelist setter grants', () => {
+    const data = encodeFunctionData({
+      abi: ABI_SET_WHITELIST,
+      args: [DEX, SELECTOR, true],
+    })
+    expect(extractRegistrations(data)).toEqual([
+      { kind: 'whitelist', address: DEX.toLowerCase(), selector: SELECTOR },
+    ])
+  })
+
+  it('ignores a whitelist setter that revokes the pair', () => {
+    const data = encodeFunctionData({
+      abi: ABI_SET_WHITELIST,
+      args: [DEX, SELECTOR, false],
+    })
+    expect(extractRegistrations(data)).toEqual([])
+  })
+
+  it('pairs a whitelist batch positionally', () => {
+    const data = encodeFunctionData({
+      abi: ABI_BATCH_SET_WHITELIST,
+      args: [[DEX, OTHER_DEX], [SELECTOR, OTHER_SELECTOR], true],
+    })
+    expect(extractRegistrations(data)).toEqual([
+      { kind: 'whitelist', address: DEX.toLowerCase(), selector: SELECTOR },
+      {
+        kind: 'whitelist',
+        address: OTHER_DEX.toLowerCase(),
+        selector: OTHER_SELECTOR,
+      },
+    ])
+  })
+
+  it('ignores a whitelist batch that revokes its pairs', () => {
+    const data = encodeFunctionData({
+      abi: ABI_BATCH_SET_WHITELIST,
+      args: [[DEX], [SELECTOR], false],
+    })
+    expect(extractRegistrations(data)).toEqual([])
+  })
+
+  it('ignores a length-mismatched batch — the facet reverts, so nothing lands', () => {
+    const data = encodeFunctionData({
+      abi: ABI_BATCH_SET_WHITELIST,
+      args: [[DEX, OTHER_DEX], [SELECTOR], true],
+    })
+    expect(extractRegistrations(data)).toEqual([])
+  })
+
+  it('lowercases the selector so a mixed-case payload still matches config', () => {
+    const data = encodeFunctionData({
+      abi: ABI_SET_WHITELIST,
+      args: [DEX, '0xF8989325' as Hex, true],
+    })
+    expect(extractRegistrations(data)[0]?.selector).toBe(SELECTOR)
+  })
 })
 
 describe('registrationsFromQueueDoc', () => {
@@ -117,6 +189,7 @@ describe('registrationsFromQueueDoc', () => {
     })
     expect(registrations.get(FACET.toLowerCase())).toEqual([
       {
+        kind: 'facet-cut',
         address: FACET.toLowerCase(),
         operationId: OPERATION_ID,
         target: DIAMOND.toLowerCase(),
@@ -264,7 +337,9 @@ describe('real-payload shapes the live queue actually carries', () => {
       ],
     })
     const registrations = extractRegistrations(data)
-    expect(registrations).toEqual([{ address: FACET.toLowerCase() }])
+    expect(registrations).toEqual([
+      { kind: 'facet-cut', address: FACET.toLowerCase() },
+    ])
     expect(registrations.map((r) => r.address)).not.toContain(
       INIT.toLowerCase()
     )
@@ -294,6 +369,7 @@ describe('real-payload shapes the live queue actually carries', () => {
     })
     expect(registrations.get(PERIPHERY.toLowerCase())).toEqual([
       {
+        kind: 'periphery',
         address: PERIPHERY.toLowerCase(),
         peripheryName: 'Other',
         operationId: OPERATION_ID,

--- a/script/deploy/safe/pending-registrations.test.ts
+++ b/script/deploy/safe/pending-registrations.test.ts
@@ -149,6 +149,24 @@ describe('extractRegistrations', () => {
     ])
   })
 
+  // The live queue's batches repeat one contract under up to seven selectors, so the
+  // per-pair records must not collapse to one entry per address.
+  it('keeps one record per selector when a batch repeats a contract', () => {
+    const data = encodeFunctionData({
+      abi: ABI_BATCH_SET_WHITELIST,
+      args: [
+        [DEX, DEX, DEX],
+        [SELECTOR, OTHER_SELECTOR, '0x12345678' as Hex],
+        true,
+      ],
+    })
+    expect(extractRegistrations(data).map((r) => r.selector)).toEqual([
+      SELECTOR,
+      OTHER_SELECTOR,
+      '0x12345678',
+    ])
+  })
+
   it('ignores a whitelist batch that revokes its pairs', () => {
     const data = encodeFunctionData({
       abi: ABI_BATCH_SET_WHITELIST,

--- a/script/deploy/safe/pending-registrations.ts
+++ b/script/deploy/safe/pending-registrations.ts
@@ -328,7 +328,9 @@ export function groupRegistrationsByNetwork(
  *
  * Only `queued` rows count: `executed` has already landed on-chain (the loupe shows
  * it), and `cancelled`/`failed` are terminal — a `failed` row in particular is not a
- * promise of anything, so treating it as intent would suppress a real alert forever.
+ * promise of anything, so treating it as intent would suppress a real alert forever. A
+ * `blocked` row is the one live status left out: it is still executable once an operator
+ * clears the cause, but nothing bounds how long that takes, so it reports as a finding.
  *
  * Known sharp edge, deliberately left erring toward over-alerting: a row marked
  * `failed` can still be a live, executable on-chain operation when what failed was a

--- a/script/deploy/safe/pending-registrations.ts
+++ b/script/deploy/safe/pending-registrations.ts
@@ -1,6 +1,6 @@
 /**
- * Scheduled-but-not-yet-executed diamond registrations, read from the timelock
- * execution queue.
+ * Scheduled-but-not-yet-executed diamond registrations and whitelist entries, read from
+ * the timelock execution queue.
  *
  * Import it from the health-check registration invariants to tell a rollout still
  * waiting on its timelock delay apart from a genuinely missing registration; intent
@@ -42,16 +42,38 @@ const ABI_REGISTER_PERIPHERY_CONTRACT = parseAbi([
   'function registerPeripheryContract(string,address)',
 ])
 
+const ABI_SET_WHITELIST = parseAbi([
+  'function setContractSelectorWhitelist(address,bytes4,bool)',
+])
+
+const ABI_BATCH_SET_WHITELIST = parseAbi([
+  'function batchSetContractSelectorWhitelist(address[],bytes4[],bool)',
+])
+
+/**
+ * What an inner call would leave in place. Consumers must match on this rather than on
+ * which optional fields happen to be set: each kind covers something the others do not,
+ * and a check keyed on the absence of a field silently widens every time a kind is added.
+ */
+export type RegistrationKind = 'facet-cut' | 'periphery' | 'whitelist'
+
 /** One address an inner call would leave registered, and what it registers it as. */
 export interface IDecodedRegistration {
-  /** Lowercased address the call registers. */
+  /** Which of the tracked calls this record came from. */
+  kind: RegistrationKind
+  /** Lowercased address the call registers, or whitelists for `whitelist`. */
   address: string
   /**
-   * Registry name the address is bound to. Absent for facet cuts, which route by
-   * selector and have no name. A periphery address registered under one name says
-   * nothing about any other name, so the caller must match this, not just the address.
+   * Registry name the address is bound to; `periphery` only. A periphery address
+   * registered under one name says nothing about any other name, so the caller must
+   * match this, not just the address.
    */
   peripheryName?: string
+  /**
+   * Lowercased selector whitelisted for `address`; `whitelist` only. Whitelisting is
+   * per contract *and* selector, so the caller must match this too.
+   */
+  selector?: Hex
 }
 
 /** One scheduled registration, traceable back to the timelock operation carrying it. */
@@ -63,12 +85,42 @@ export interface IPendingRegistration extends IDecodedRegistration {
 }
 
 /**
+ * Pairs positionally, dropping any entry that is not a usable address/selector pair.
+ *
+ * @param contracts - Contract addresses from the decoded call.
+ * @param selectors - Selectors from the decoded call, index-aligned with `contracts`.
+ * @returns One `whitelist` record per usable pair.
+ */
+function toWhitelistRegistrations(
+  contracts: readonly unknown[],
+  selectors: readonly unknown[]
+): IDecodedRegistration[] {
+  const registrations: IDecodedRegistration[] = []
+  contracts.forEach((contract, index) => {
+    const selector = selectors[index]
+    if (
+      typeof contract === 'string' &&
+      isAddress(contract) &&
+      typeof selector === 'string'
+    )
+      registrations.push({
+        kind: 'whitelist',
+        address: contract.toLowerCase(),
+        selector: selector.toLowerCase() as Hex,
+      })
+  })
+  return registrations
+}
+
+/**
  * Addresses a single queued inner call would leave registered on its target diamond.
  *
- * Recognises the two calls that register something: `diamondCut` (facet addresses
- * under an `Add`/`Replace` action — a `Remove` leaves nothing routed) and
- * `registerPeripheryContract` (the periphery address). Anything else — a role
- * change, a whitelist batch, an unknown selector — contributes nothing rather than
+ * Recognises the calls that leave something in place: `diamondCut` (facet addresses
+ * under an `Add`/`Replace` action — a `Remove` leaves nothing routed),
+ * `registerPeripheryContract` (the periphery address), and the whitelist setters
+ * `setContractSelectorWhitelist` / `batchSetContractSelectorWhitelist` with
+ * `_whitelisted` true — passing false un-whitelists, the counterpart of a `Remove`.
+ * Anything else — a role change, an unknown selector — contributes nothing rather than
  * throwing, because the queue legitimately carries operations this check has no
  * opinion about.
  *
@@ -90,7 +142,10 @@ export function extractRegistrations(
       const [facetAddress, action] = cut as [unknown, unknown, unknown]
       if (!ROUTING_CUT_ACTIONS.has(Number(action))) continue
       if (typeof facetAddress === 'string' && isAddress(facetAddress))
-        registrations.push({ address: facetAddress.toLowerCase() })
+        registrations.push({
+          kind: 'facet-cut',
+          address: facetAddress.toLowerCase(),
+        })
     }
     return registrations
   } catch {
@@ -112,9 +167,42 @@ export function extractRegistrations(
       isAddress(peripheryAddress) &&
       BigInt(peripheryAddress) !== 0n
     )
-      return [{ address: peripheryAddress.toLowerCase(), peripheryName }]
+      return [
+        {
+          kind: 'periphery',
+          address: peripheryAddress.toLowerCase(),
+          peripheryName,
+        },
+      ]
   } catch {
-    // Neither shape — the operation registers nothing this check tracks.
+    // Not a periphery registration; fall through to the whitelist shapes.
+  }
+
+  try {
+    const { args } = decodeFunctionData({ abi: ABI_SET_WHITELIST, data })
+    const [contract, selector, whitelisted] = args ?? []
+    return whitelisted === true
+      ? toWhitelistRegistrations([contract], [selector])
+      : []
+  } catch {
+    // Not the single-pair setter; fall through to the batch shape.
+  }
+
+  try {
+    const { args } = decodeFunctionData({ abi: ABI_BATCH_SET_WHITELIST, data })
+    const [contracts, selectors, whitelisted] = args ?? []
+    if (whitelisted !== true) return []
+    // The facet reverts on a length mismatch (`InvalidConfig`), so such a batch
+    // whitelists nothing at all rather than the pairs it could have paired up.
+    if (
+      !Array.isArray(contracts) ||
+      !Array.isArray(selectors) ||
+      contracts.length !== selectors.length
+    )
+      return []
+    return toWhitelistRegistrations(contracts, selectors)
+  } catch {
+    // None of the shapes — the operation registers nothing this check tracks.
   }
 
   return []

--- a/script/deploy/safe/pending-registrations.ts
+++ b/script/deploy/safe/pending-registrations.ts
@@ -2,8 +2,8 @@
  * Scheduled-but-not-yet-executed diamond registrations and whitelist entries, read from
  * the timelock execution queue.
  *
- * Import it from the health-check registration invariants to tell a rollout still
- * waiting on its timelock delay apart from a genuinely missing registration; intent
+ * Import it from the health-check invariants to tell a rollout still waiting on its
+ * timelock delay apart from a genuinely missing registration; intent
  * is for alerting only and must never reach a generator ([CONV:HEALTHCHECK-INTENT]
  * in `.agents/rules/601-healthcheck-invariants.md`).
  *
@@ -42,11 +42,11 @@ const ABI_REGISTER_PERIPHERY_CONTRACT = parseAbi([
   'function registerPeripheryContract(string,address)',
 ])
 
-const ABI_SET_WHITELIST = parseAbi([
+const ABI_SET_CONTRACT_SELECTOR_WHITELIST = parseAbi([
   'function setContractSelectorWhitelist(address,bytes4,bool)',
 ])
 
-const ABI_BATCH_SET_WHITELIST = parseAbi([
+const ABI_BATCH_SET_CONTRACT_SELECTOR_WHITELIST = parseAbi([
   'function batchSetContractSelectorWhitelist(address[],bytes4[],bool)',
 ])
 
@@ -57,7 +57,7 @@ const ABI_BATCH_SET_WHITELIST = parseAbi([
  */
 export type RegistrationKind = 'facet-cut' | 'periphery' | 'whitelist'
 
-/** One address an inner call would leave registered, and what it registers it as. */
+/** One address an inner call would leave in place, and what it leaves it as. */
 export interface IDecodedRegistration {
   /** Which of the tracked calls this record came from. */
   kind: RegistrationKind
@@ -179,7 +179,10 @@ export function extractRegistrations(
   }
 
   try {
-    const { args } = decodeFunctionData({ abi: ABI_SET_WHITELIST, data })
+    const { args } = decodeFunctionData({
+      abi: ABI_SET_CONTRACT_SELECTOR_WHITELIST,
+      data,
+    })
     const [contract, selector, whitelisted] = args ?? []
     return whitelisted === true
       ? toWhitelistRegistrations([contract], [selector])
@@ -189,7 +192,10 @@ export function extractRegistrations(
   }
 
   try {
-    const { args } = decodeFunctionData({ abi: ABI_BATCH_SET_WHITELIST, data })
+    const { args } = decodeFunctionData({
+      abi: ABI_BATCH_SET_CONTRACT_SELECTOR_WHITELIST,
+      data,
+    })
     const [contracts, selectors, whitelisted] = args ?? []
     if (whitelisted !== true) return []
     // The facet reverts on a length mismatch (`InvalidConfig`), so such a batch


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-918](https://linear.app/lifi-linear/issue/EXSC-918/intent-aware-whitelist-invariant-a-queued-whitelist-sync-reports-as)

Follow-up to EXSC-847 (#2270), which made `facets-registered` and `periphery-registered` intent-aware. The whitelist check was the one invariant of that family still reporting a rollout in flight as drift.

# Why did I implement it this way?

`config/whitelist.json` is merged before the Safe proposal syncing it executes, so in between, `checkWhitelistIntegrity` errored on every pair the queued operation was about to add — on both of its steps (`Source of Truth FAILED` from `isContractSelectorWhitelisted`, and `Pair Array is missing N pairs from config` from `getAllContractSelectorPairs`). Live today: `robinhood` red on `0xCC89feed…8599 / 0xf8989325` while its sync operation sat `queued`; same shape on `arc` (09-01) and `injective` (08-27).

Two independent reasons #2270's machinery didn't already cover it, both addressed here:

- **The decoder ignored whitelist calls.** `extractRegistrations` handled only `diamondCut` and `registerPeripheryContract` — a whitelist batch was explicitly documented as contributing nothing. It now also decodes `batchSetContractSelectorWhitelist` — the call `diamondSyncWhitelist.sh` and `proposePeripheryWithWhitelist.ts` actually emit — plus the singular `setContractSelectorWhitelist` defensively, both only with `_whitelisted` **true**; `false` un-whitelists and is ignored, the counterpart of a `Remove` cut. A length-mismatched batch reverts on-chain (`InvalidConfig`), so it decodes to nothing rather than to the pairs it could have paired up.
- **The downgrade was wired only into the two registration invariants.** A new pure `splitByPendingWhitelist` splits missing pairs by whether a queued operation whitelists **exactly** that contract *and* selector on **that** network's diamond. Matching the address alone would report a sync that is never coming — the same reasoning that makes the periphery caller match the registry name.

Design points worth a reviewer's attention:

- **Records now carry an explicit `kind`** (`facet-cut` / `periphery` / `whitelist`). `facets-registered` previously inferred "this is a cut" from `peripheryName === undefined`, which a whitelist record would have satisfied — a latent false-green on an error gate. Each consumer now matches its own shape, and there's a regression test that a queued whitelist entry does **not** downgrade a missing facet.
- **One lazy queue read, shared by both steps.** Resolved only when a pair is actually missing, so a synced network never touches MongoDB (tested).
- **An unreachable queue keeps every error** and adds a coverage warning, matching `facets-registered`: the pair comparison stands on an independent on-chain signal, and a Mongo blip turning a genuinely unsynced whitelist green is far worse than a false alert during a rollout.
- **Additions only.** A stale pair (on-chain, no longer in config) still errors even while its removal is queued — the removal side reads parked tasks, which carry no whitelist payloads. Called out in `[CONV:HEALTHCHECK-INTENT]`.
- The two "is synced" success lines now name the pending count instead of claiming the diamond already holds what only a queued operation will put there.

**Verified against the live queue (904 rows), not just fixtures.** The single `queued` row is robinhood's sync — carrying exactly the red pair and targeting robinhood's own diamond (`0xB477751B…14Af3`) — so this turns today's alert into expected-pending. Every inner-call selector present across all 904 rows was resolved: `batchSetContractSelectorWhitelist` appears 266 times (408 whitelist records, of which 91 are `_whitelisted=false` and correctly decode to nothing), and none of the undecoded selectors writes whitelist storage. The legacy writers that would have been a genuine coverage gap (`batchAddDex`, `batchSetFunctionApprovalBySignature`, `setContractWhitelist`) appear zero times and have no emitter left in the repo. 74 distinct networks have carried a whitelist row historically, so the behaviour change is fleet-wide, not robinhood-specific.

Mutation-tested each new guard rather than trusting the suite: dropping `kind === 'whitelist'`, dropping `kind === 'periphery'`, widening the selector comparison, or removing the "skip the queue when nothing is missing" short-circuit each fail exactly one dedicated test. The first two initially passed — the fixtures standing in for "a record of another kind" did not carry the field the surviving predicate compares, so the comparison did the rejecting and the discriminator was never exercised. Fixed in the second commit.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
