### PR TITLE
fix(tron): refuse to broadcast Safe/timelock txs without a usable energy estimate (EXSC-890)

### DIFF
--- a/script/deploy/safe/executors/tron-caller.ts
+++ b/script/deploy/safe/executors/tron-caller.ts
@@ -27,6 +27,7 @@ import {
   configuredTronFeeLimitSun,
   estimateTronEnergy,
   tronEnergyCostInSun,
+  type ITronEnergyCost,
 } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
@@ -37,7 +38,7 @@ import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 export interface ITronCallerDeps {
   broadcast?: typeof broadcastTronContractCall
   estimateEnergy?: (params: IChainCallParams) => Promise<bigint>
-  costInSun?: (energy: bigint) => Promise<bigint>
+  costInSun?: (energy: bigint) => Promise<ITronEnergyCost>
 }
 
 export class TronChainCaller implements IChainCaller {
@@ -45,7 +46,7 @@ export class TronChainCaller implements IChainCaller {
 
   private readonly broadcast: typeof broadcastTronContractCall
   private readonly estimateEnergy: (params: IChainCallParams) => Promise<bigint>
-  private readonly costInSun: (energy: bigint) => Promise<bigint>
+  private readonly costInSun: (energy: bigint) => Promise<ITronEnergyCost>
 
   public constructor(
     private readonly networkKey: TronTvmNetworkName,
@@ -128,7 +129,7 @@ export class TronChainCaller implements IChainCaller {
     })
   }
 
-  private async costInSunOnChain(energy: bigint): Promise<bigint> {
+  private async costInSunOnChain(energy: bigint): Promise<ITronEnergyCost> {
     return tronEnergyCostInSun(this.tronWeb(), energy)
   }
 }

--- a/script/deploy/safe/executors/tron-caller.ts
+++ b/script/deploy/safe/executors/tron-caller.ts
@@ -1,15 +1,15 @@
 /**
  * Tron TVM chain caller — broadcasts arbitrary contract calls via TronWeb native protocol.
+ *
+ * Every broadcast is pre-flighted for energy first. The devkit sends under a
+ * fixed `fee_limit` from the environment, so without a pre-flight a call that
+ * needs more energy than the limit buys is not rejected — it runs until the
+ * limit is spent and aborts part-way.
  */
 
 import {
-  TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
-  TRON_WALLET_API_FETCH_TIMEOUT_MS,
-  buildTronWalletJsonPostHeaders,
   createTronWebForTvmNetworkKey,
   evmHexToTronBase58,
-  getTronRPCConfig,
-  resolveTronWebRpcUrlToFullHost,
   type TronTvmNetworkName,
 } from '@lifi/tron-devkit'
 import { broadcastTronContractCall } from '@lifi/tron-devkit/safe'
@@ -22,15 +22,41 @@ import type {
   IChainCaller,
   IChainSimulateResult,
 } from '../../../common/types'
-import { fetchWithTimeout } from '../../../utils/fetchWithTimeout'
+
+import {
+  configuredTronFeeLimitSun,
+  estimateTronEnergy,
+  tronEnergyCostInSun,
+} from './tron-energy-estimate'
+import { assertTronBroadcastAffordable } from './tron-energy-preflight'
+
+/**
+ * Seams for the tests that prove a refusal never reaches the network. Nothing
+ * in production overrides these; the defaults are the real implementations.
+ */
+export interface ITronCallerDeps {
+  broadcast?: typeof broadcastTronContractCall
+  estimateEnergy?: (params: IChainCallParams) => Promise<bigint>
+  costInSun?: (energy: bigint) => Promise<bigint>
+}
 
 export class TronChainCaller implements IChainCaller {
   public readonly senderAddress: Address
 
+  private readonly broadcast: typeof broadcastTronContractCall
+  private readonly estimateEnergy: (params: IChainCallParams) => Promise<bigint>
+  private readonly costInSun: (energy: bigint) => Promise<bigint>
+
   public constructor(
     private readonly networkKey: TronTvmNetworkName,
-    private readonly privateKeyHex: string
+    private readonly privateKeyHex: string,
+    deps: ITronCallerDeps = {}
   ) {
+    this.broadcast = deps.broadcast ?? broadcastTronContractCall
+    this.estimateEnergy =
+      deps.estimateEnergy ?? ((params) => this.estimateEnergyOnChain(params))
+    this.costInSun =
+      deps.costInSun ?? ((energy) => this.costInSunOnChain(energy))
     const normalized = privateKeyHex.startsWith('0x')
       ? privateKeyHex
       : `0x${privateKeyHex}`
@@ -39,77 +65,34 @@ export class TronChainCaller implements IChainCaller {
     ).address
   }
 
+  /**
+   * Estimates without broadcasting.
+   *
+   * Throws when there is no estimate rather than returning a fallback figure:
+   * there is no meaningful fixed energy number to report, and a dry run must
+   * not read as green when the executing path would refuse on the same
+   * failure. {@link assertTronBroadcastAffordable} treats the throw as the
+   * absence of an estimate.
+   */
   public async simulate(
     params: IChainCallParams
   ): Promise<IChainSimulateResult> {
-    const tronWeb = createTronWebForTvmNetworkKey({
-      networkKey: this.networkKey,
-      privateKey: this.privateKeyHex,
-    })
-
-    const ownerBase58 = tronWeb.defaultAddress.base58 as string
-    if (!ownerBase58?.startsWith('T'))
-      throw new Error('TronWeb defaultAddress.base58 missing after init')
-
-    const contractBase58 = evmHexToTronBase58(tronWeb, params.to)
-
-    const { rpcUrl } = getTronRPCConfig(this.networkKey)
-    const fullHost = resolveTronWebRpcUrlToFullHost(rpcUrl, this.networkKey)
-    const apiUrl =
-      fullHost.replace(/\/$/, '') + '/wallet/triggerconstantcontract'
-
-    const dataHexNo0x = params.data.slice(2)
-    const callValue =
-      params.value && params.value > 0n ? Number(params.value) : 0
-
-    const payload = {
-      owner_address: ownerBase58,
-      contract_address: contractBase58,
-      data: dataHexNo0x,
-      fee_limit: TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
-      call_value: callValue,
-      visible: true,
-    }
-
-    const res = await fetchWithTimeout(
-      apiUrl,
-      {
-        method: 'POST',
-        headers: buildTronWalletJsonPostHeaders(fullHost),
-        body: JSON.stringify(payload),
-      },
-      TRON_WALLET_API_FETCH_TIMEOUT_MS
-    )
-
-    if (!res.ok) {
-      const text = await res.text()
-      throw new Error(`triggerconstantcontract failed: ${res.status} ${text}`)
-    }
-
-    const result = (await res.json()) as {
-      energy_used?: number
-      result?: { result?: boolean; message?: string }
-    }
-
-    if (
-      result.result?.result === false ||
-      result.energy_used === undefined ||
-      result.energy_used === null
-    )
-      throw new Error(
-        `Tron simulation failed: ${JSON.stringify(result.result ?? result)}`
-      )
-
-    // Every failure path above throws, so reaching here means a real estimate.
     return {
-      estimatedResource: BigInt(result.energy_used),
+      estimatedResource: await this.estimateEnergy(params),
       resourceLabel: 'energy',
       estimateFailed: false,
     }
   }
 
   public async call(params: IChainCallParams): Promise<IChainCallResult> {
-    const { hash } = await broadcastTronContractCall({
+    await assertTronBroadcastAffordable(() => this.simulate(params), {
+      networkName: this.networkKey,
+      operation: `contract call to ${params.to}`,
+      feeLimitSun: configuredTronFeeLimitSun(),
+      costInSun: this.costInSun,
+    })
+
+    const { hash } = await this.broadcast({
       networkKey: this.networkKey,
       privateKeyHex: this.privateKeyHex,
       contractAddress: params.to,
@@ -118,5 +101,34 @@ export class TronChainCaller implements IChainCaller {
     })
 
     return { hash }
+  }
+
+  private tronWeb(): ReturnType<typeof createTronWebForTvmNetworkKey> {
+    return createTronWebForTvmNetworkKey({
+      networkKey: this.networkKey,
+      privateKey: this.privateKeyHex,
+    })
+  }
+
+  private async estimateEnergyOnChain(
+    params: IChainCallParams
+  ): Promise<bigint> {
+    const tronWeb = this.tronWeb()
+
+    const ownerBase58 = tronWeb.defaultAddress.base58 as string
+    if (!ownerBase58?.startsWith('T'))
+      throw new Error('TronWeb defaultAddress.base58 missing after init')
+
+    return estimateTronEnergy({
+      networkKey: this.networkKey,
+      ownerBase58,
+      contractBase58: evmHexToTronBase58(tronWeb, params.to),
+      data: params.data,
+      callValue: params.value ?? 0n,
+    })
+  }
+
+  private async costInSunOnChain(energy: bigint): Promise<bigint> {
+    return tronEnergyCostInSun(this.tronWeb(), energy)
   }
 }

--- a/script/deploy/safe/executors/tron-caller.ts
+++ b/script/deploy/safe/executors/tron-caller.ts
@@ -27,7 +27,6 @@ import {
   configuredTronFeeLimitSun,
   estimateTronEnergy,
   tronEnergyCostInSun,
-  type ITronEnergyCost,
 } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
@@ -38,7 +37,7 @@ import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 export interface ITronCallerDeps {
   broadcast?: typeof broadcastTronContractCall
   estimateEnergy?: (params: IChainCallParams) => Promise<bigint>
-  costInSun?: (energy: bigint) => Promise<ITronEnergyCost>
+  costInSun?: (energy: bigint) => Promise<bigint>
 }
 
 export class TronChainCaller implements IChainCaller {
@@ -46,7 +45,7 @@ export class TronChainCaller implements IChainCaller {
 
   private readonly broadcast: typeof broadcastTronContractCall
   private readonly estimateEnergy: (params: IChainCallParams) => Promise<bigint>
-  private readonly costInSun: (energy: bigint) => Promise<ITronEnergyCost>
+  private readonly costInSun: (energy: bigint) => Promise<bigint>
 
   public constructor(
     private readonly networkKey: TronTvmNetworkName,
@@ -129,7 +128,7 @@ export class TronChainCaller implements IChainCaller {
     })
   }
 
-  private async costInSunOnChain(energy: bigint): Promise<ITronEnergyCost> {
+  private async costInSunOnChain(energy: bigint): Promise<bigint> {
     return tronEnergyCostInSun(this.tronWeb(), energy)
   }
 }

--- a/script/deploy/safe/executors/tron-energy-estimate.test.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The arithmetic the whole refusal decision rests on. Reviewed as untested:
+ * four mutations to this module — dropping the TRX→SUN factor, inverting it,
+ * changing the mirrored fee-limit default, and deleting the malformed-value
+ * throw — all left the suite green.
+ *
+ * The energy estimator itself is not covered here: it needs a live
+ * `triggerconstantcontract` endpoint and network-level failure injection. What
+ * is covered is everything that decides the comparison once a figure exists.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  applyTronSafetyMargin,
+  configuredTronFeeLimitSun,
+  tronEnergyCostInSun,
+  TRON_FEE_LIMIT_SUN_ENV,
+} from './tron-energy-estimate'
+
+let original: string | undefined
+
+beforeEach(() => {
+  original = process.env[TRON_FEE_LIMIT_SUN_ENV]
+  delete process.env[TRON_FEE_LIMIT_SUN_ENV]
+})
+
+afterEach(() => {
+  if (original === undefined) delete process.env[TRON_FEE_LIMIT_SUN_ENV]
+  else process.env[TRON_FEE_LIMIT_SUN_ENV] = original
+})
+
+describe('configuredTronFeeLimitSun', () => {
+  it('defaults to the devkit default of 50 TRX', () => {
+    // Must equal the devkit's own default, or the guard checks a limit the
+    // broadcast will not run under.
+    expect(configuredTronFeeLimitSun()).toBe(50_000_000)
+  })
+
+  it.each(['', '   '])('treats %p as unset', (value) => {
+    process.env[TRON_FEE_LIMIT_SUN_ENV] = value
+
+    expect(configuredTronFeeLimitSun()).toBe(50_000_000)
+  })
+
+  it('reads a configured value', () => {
+    process.env[TRON_FEE_LIMIT_SUN_ENV] = '150000000'
+
+    expect(configuredTronFeeLimitSun()).toBe(150_000_000)
+  })
+
+  it('accepts exponent notation, because the devkit does', () => {
+    // Not a curiosity: parity with the devkit's parse is the whole requirement
+    // here, and `Number('1e9')` is an integer to both.
+    process.env[TRON_FEE_LIMIT_SUN_ENV] = '1e9'
+
+    expect(configuredTronFeeLimitSun()).toBe(1_000_000_000)
+  })
+
+  it.each(['0', '-1', '1.5', 'abc', ' '.repeat(0) + 'NaN'])(
+    'throws on the malformed value %p rather than falling back',
+    (value) => {
+      // Falling back would silently compare against a different limit from the
+      // one the devkit applies — and the devkit throws here too.
+      process.env[TRON_FEE_LIMIT_SUN_ENV] = value
+
+      expect(() => configuredTronFeeLimitSun()).toThrow(
+        new RegExp(TRON_FEE_LIMIT_SUN_ENV)
+      )
+    }
+  )
+})
+
+describe('tronEnergyCostInSun', () => {
+  it('converts TRX pricing to SUN', async () => {
+    // The devkit reports energyPrice in TRX (it divides the chain's SUN figure
+    // by 1e6), so the cost has to be multiplied back up. Dropping or inverting
+    // that factor is a 1e6 error in the figure the refusal compares, and it
+    // survived every existing test.
+    const tronWeb = {
+      trx: {
+        // `<timestamp>:<sunPerEnergy>`; 100 SUN/energy is the live mainnet rate.
+        getEnergyPrices: async () => '0:100',
+        getBandwidthPrices: async () => '0:1000',
+      },
+    } as unknown as Parameters<typeof tronEnergyCostInSun>[0]
+
+    const { costSun, priceConfirmed } = await tronEnergyCostInSun(
+      tronWeb,
+      500_000n
+    )
+
+    expect(costSun).toBe(50_000_000n)
+    expect(priceConfirmed).toBe(true)
+  })
+})
+
+describe('applyTronSafetyMargin', () => {
+  it.each([
+    [500_000, 600_000n],
+    [1, 2n],
+    [0, 0n],
+    [416_666, 500_000n],
+  ])('turns %i raw energy into %s', (raw, expected) => {
+    // The margin is not padding. `triggerconstantcontract` under-reports what
+    // the broadcast is charged — the dynamic-energy penalty is not applied to
+    // constant calls, and state moves between the estimate and the send — so a
+    // batch just above the raw figure would clear the guard and still abort
+    // part-way, which is the failure the pre-flight exists to prevent.
+    expect(applyTronSafetyMargin(raw)).toBe(expected)
+  })
+
+  it('rounds up, never down', () => {
+    // Rounding toward the refusal is the safe direction for a guard.
+    expect(applyTronSafetyMargin(1)).toBe(2n)
+    expect(applyTronSafetyMargin(7)).toBe(9n)
+  })
+
+  it('matches the margin the devkit applies in its own estimator', () => {
+    // Deploy scripts price calls through the devkit's `estimateContractEnergy`,
+    // which applies the same constant. If the two drifted, the deploy path and
+    // this guard would disagree about what a call costs.
+    expect(applyTronSafetyMargin(1_000_000)).toBe(1_200_000n)
+  })
+})

--- a/script/deploy/safe/executors/tron-energy-estimate.test.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.test.ts
@@ -79,6 +79,37 @@ describe('configuredTronFeeLimitSun', () => {
 })
 
 describe('tronEnergyCostInSun', () => {
+  // Order matters in this block, and it is not incidental. The devkit caches a
+  // successful price read for its TTL, so the unread-price case has to run
+  // before anything warms that cache — afterwards every call is served from it
+  // and the fallback branch is unreachable.
+  it('reports an unread price as unconfirmed', async () => {
+    // `getCurrentPrices` catches its own failure and returns a constant of
+    // 210 SUN/energy against a live mainnet rate of 100, so a transient RPC
+    // failure would otherwise make the guard refuse honest traffic while
+    // quoting a cost over twice the truth as though it were measured.
+    const tronWeb = {
+      trx: {
+        getEnergyPrices: async () => {
+          throw new Error('getEnergyPrices unavailable')
+        },
+        getBandwidthPrices: async () => {
+          throw new Error('getBandwidthPrices unavailable')
+        },
+      },
+    } as unknown as Parameters<typeof tronEnergyCostInSun>[0]
+
+    const { costSun, priceConfirmed } = await tronEnergyCostInSun(
+      tronWeb,
+      500_000n
+    )
+
+    expect(priceConfirmed).toBe(false)
+    // 500k at the fallback 210 SUN/energy — the inflated figure, correctly
+    // labelled rather than suppressed.
+    expect(costSun).toBe(105_000_000n)
+  })
+
   it('converts TRX pricing to SUN', async () => {
     // The devkit reports energyPrice in TRX (it divides the chain's SUN figure
     // by 1e6), so the cost has to be multiplied back up. Dropping or inverting

--- a/script/deploy/safe/executors/tron-energy-estimate.test.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.test.ts
@@ -72,7 +72,7 @@ describe('latestEnergyPriceSun', () => {
     )
   })
 
-  it('picks the newest still-applicable entry, not the oldest future one', () => {
+  it('rejects a set of all-future entries outright, not just the oldest one', () => {
     // Two future entries at different prices: the fallback this closes could
     // have picked either, and picking the "oldest" (smallest) timestamp of an
     // all-future set is not the same as picking the lowest price — both are

--- a/script/deploy/safe/executors/tron-energy-estimate.test.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.test.ts
@@ -59,10 +59,31 @@ describe('latestEnergyPriceSun', () => {
     expect(latestEnergyPriceSun(`0:140,${future}:999`)).toBe(140)
   })
 
-  it('falls back to the last entry when every price is future-dated', () => {
+  it('throws when every price is future-dated, rather than guessing one', () => {
+    // A future-only price is not "no usable price" in the same way an empty
+    // string is, so it needs its own case: the earlier fix only closed the
+    // `applicable ?? entries[entries.length - 1]` fallback for this, and a
+    // lower future price silently clearing a guard that priced the real,
+    // current rate would defeat the whole check.
     const future = Date.now() + HOUR
 
-    expect(latestEnergyPriceSun(`${future}:777`)).toBe(777)
+    expect(() => latestEnergyPriceSun(`${future}:777`)).toThrow(
+      /no usable energy price/i
+    )
+  })
+
+  it('picks the newest still-applicable entry, not the oldest future one', () => {
+    // Two future entries at different prices: the fallback this closes could
+    // have picked either, and picking the "oldest" (smallest) timestamp of an
+    // all-future set is not the same as picking the lowest price — both are
+    // wrong for a different reason, so this only proves the whole set is
+    // rejected outright.
+    const soon = Date.now() + HOUR
+    const later = Date.now() + 2 * HOUR
+
+    expect(() => latestEnergyPriceSun(`${later}:100,${soon}:999`)).toThrow(
+      /no usable energy price/i
+    )
   })
 
   it.each(['', '   ', 'garbage', '0:0', 'abc:def', ':', '0:'])(
@@ -193,6 +214,55 @@ describe('estimateTronEnergy transport', () => {
     )
 
     expect(error?.message).toMatch(/no contract call costs/)
+    expect(calls()).toBe(1)
+  })
+
+  it('refuses a non-HTTPS RPC endpoint before ever sending the request', async () => {
+    // An on-path attacker who can answer plaintext HTTP can forge
+    // `energy_used` and steer the preflight past the real fee limit — refuse
+    // before the request is sent, not after reading its (untrustworthy) body.
+    const calls = respondWith([{ energy_used: 500_000 }])
+    const original = process.env.RPC_URL_TRON
+    process.env.RPC_URL_TRON = 'http://insecure.example.com'
+
+    try {
+      const error = await estimateTronEnergy(params).then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+      expect(error?.message).toMatch(/non-HTTPS/i)
+      expect(calls()).toBe(0)
+    } finally {
+      if (original === undefined) delete process.env.RPC_URL_TRON
+      else process.env.RPC_URL_TRON = original
+    }
+  })
+
+  it('refuses a callValue too large to convert to Number losslessly', async () => {
+    const calls = respondWith([{ energy_used: 500_000 }])
+
+    const error = await estimateTronEnergy({
+      ...params,
+      callValue: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+    }).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toMatch(/MAX_SAFE_INTEGER/)
+    // Never reaches the network with a silently-rounded value.
+    expect(calls()).toBe(0)
+  })
+
+  it('accepts a callValue exactly at Number.MAX_SAFE_INTEGER', async () => {
+    const calls = respondWith([{ energy_used: 500_000 }])
+
+    await estimateTronEnergy({
+      ...params,
+      callValue: BigInt(Number.MAX_SAFE_INTEGER),
+    })
+
     expect(calls()).toBe(1)
   })
 })

--- a/script/deploy/safe/executors/tron-energy-estimate.test.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.test.ts
@@ -1,12 +1,11 @@
 /**
- * The arithmetic the whole refusal decision rests on. Reviewed as untested:
- * four mutations to this module — dropping the TRX→SUN factor, inverting it,
- * changing the mirrored fee-limit default, and deleting the malformed-value
- * throw — all left the suite green.
+ * The arithmetic and the transport the refusal decision rests on.
  *
- * The energy estimator itself is not covered here: it needs a live
- * `triggerconstantcontract` endpoint and network-level failure injection. What
- * is covered is everything that decides the comparison once a figure exists.
+ * Reviewed as untested twice: first the pricing (four mutations survived,
+ * including dropping and inverting the TRX conversion), then the retry loop
+ * (deleting the retry entirely, and propagating the first error instead of the
+ * last, both left the suite green). The `sleep` seam exists so these can run
+ * without waiting.
  */
 
 import {
@@ -21,26 +20,185 @@ import {
 import {
   applyTronSafetyMargin,
   configuredTronFeeLimitSun,
+  estimateTronEnergy,
+  latestEnergyPriceSun,
   tronEnergyCostInSun,
   TRON_FEE_LIMIT_SUN_ENV,
 } from './tron-energy-estimate'
 
-let original: string | undefined
+const HOUR = 3_600_000
+
+let originalLimit: string | undefined
+let originalFetch: typeof globalThis.fetch
 
 beforeEach(() => {
-  original = process.env[TRON_FEE_LIMIT_SUN_ENV]
+  originalLimit = process.env[TRON_FEE_LIMIT_SUN_ENV]
   delete process.env[TRON_FEE_LIMIT_SUN_ENV]
+  originalFetch = globalThis.fetch
 })
 
 afterEach(() => {
-  if (original === undefined) delete process.env[TRON_FEE_LIMIT_SUN_ENV]
-  else process.env[TRON_FEE_LIMIT_SUN_ENV] = original
+  if (originalLimit === undefined) delete process.env[TRON_FEE_LIMIT_SUN_ENV]
+  else process.env[TRON_FEE_LIMIT_SUN_ENV] = originalLimit
+  globalThis.fetch = originalFetch
+})
+
+describe('latestEnergyPriceSun', () => {
+  it('takes the newest price at or before now', () => {
+    // Real shape, from a live `getEnergyPrices` read: `<ms>:<sunPerEnergy>`.
+    const price = latestEnergyPriceSun(
+      '0:100,1670133600000:420,1726747200000:210,1756468800000:100'
+    )
+
+    expect(price).toBe(100)
+  })
+
+  it('ignores an entry dated in the future', () => {
+    const future = Date.now() + HOUR
+
+    expect(latestEnergyPriceSun(`0:140,${future}:999`)).toBe(140)
+  })
+
+  it('falls back to the last entry when every price is future-dated', () => {
+    const future = Date.now() + HOUR
+
+    expect(latestEnergyPriceSun(`${future}:777`)).toBe(777)
+  })
+
+  it.each(['', '   ', 'garbage', '0:0', 'abc:def', ':', '0:'])(
+    'throws on %p rather than returning a price of zero',
+    (input) => {
+      // The hole this closes: the devkit's parse returns `Number(undefined || 0)`
+      // = 0 for these, and a node answering with an empty price string never
+      // reaches its catch. Priced at 0, any batch clears any fee limit and the
+      // guard becomes a no-op on exactly what it exists to stop.
+      expect(() => latestEnergyPriceSun(input)).toThrow(
+        /no usable energy price/i
+      )
+    }
+  )
+
+  it('skips a zero-priced entry but still uses an older valid one', () => {
+    expect(latestEnergyPriceSun('1000:140,2000:0')).toBe(140)
+  })
+})
+
+describe('tronEnergyCostInSun', () => {
+  it('prices energy at the rate it read, in SUN', async () => {
+    const tronWeb = { trx: { getEnergyPrices: async () => '0:100' } }
+
+    expect(await tronEnergyCostInSun(tronWeb, 500_000n)).toBe(50_000_000n)
+  })
+
+  it('refuses rather than guessing when the price read throws', async () => {
+    // Previously this went through the devkit, which caught the failure and
+    // substituted 210 SUN/energy — a real Tron price, so no comparison against
+    // its value could tell a fallback from a correct read.
+    const tronWeb = {
+      trx: {
+        getEnergyPrices: async () => {
+          throw new Error('getEnergyPrices unavailable')
+        },
+      },
+    }
+
+    expect(tronEnergyCostInSun(tronWeb, 500_000n)).rejects.toThrow(
+      /getEnergyPrices unavailable/
+    )
+  })
+
+  it('refuses an empty price string instead of pricing at zero', async () => {
+    const tronWeb = { trx: { getEnergyPrices: async () => '' } }
+
+    expect(tronEnergyCostInSun(tronWeb, 5_000_000n)).rejects.toThrow(
+      /no usable energy price/i
+    )
+  })
+})
+
+describe('estimateTronEnergy transport', () => {
+  const params = {
+    networkKey: 'tron' as const,
+    ownerBase58: 'TAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    contractBase58: 'TBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    data: '0xdeadbeef' as const,
+    callValue: 0n,
+    sleep: async () => undefined,
+  }
+
+  const respondWith = (bodies: unknown[]): (() => number) => {
+    let calls = 0
+    globalThis.fetch = (async () => {
+      const body = bodies[Math.min(calls, bodies.length - 1)]
+      calls += 1
+      if (body instanceof Error) throw body
+      return {
+        ok: (body as { ok?: boolean }).ok !== false,
+        status: (body as { status?: number }).status ?? 200,
+        text: async () => 'err',
+        json: async () => body,
+      } as unknown as Response
+    }) as unknown as typeof globalThis.fetch
+    return () => calls
+  }
+
+  it('retries a transport failure and returns a later success, with the margin', async () => {
+    const calls = respondWith([
+      new Error('network boom #1'),
+      new Error('network boom #2'),
+      { energy_used: 500_000 },
+    ])
+
+    // 500_000 * 1.2
+    expect(await estimateTronEnergy(params)).toBe(600_000n)
+    expect(calls()).toBe(3)
+  })
+
+  it('propagates the last error, not the first', async () => {
+    // Reporting the first would tell an operator about a failure two attempts
+    // stale, which may not be why it finally gave up.
+    const calls = respondWith([
+      new Error('boom #1'),
+      new Error('boom #2'),
+      new Error('boom #3'),
+    ])
+
+    const error = await estimateTronEnergy(params).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toBe('boom #3')
+    expect(calls()).toBe(3)
+  })
+
+  it('does not retry a call that would revert', async () => {
+    // Deterministic: asking again returns the same answer, so retrying only
+    // spends the operator's time before the same refusal.
+    const calls = respondWith([{ result: { result: false } }])
+
+    await estimateTronEnergy(params).catch(() => undefined)
+
+    expect(calls()).toBe(1)
+  })
+
+  it('refuses a zero estimate, and does not retry it', async () => {
+    // A contract call always burns energy, so zero is a node answering without
+    // simulating. Priced, it costs nothing and clears any fee limit.
+    const calls = respondWith([{ energy_used: 0 }])
+
+    const error = await estimateTronEnergy(params).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toMatch(/no contract call costs/)
+    expect(calls()).toBe(1)
+  })
 })
 
 describe('configuredTronFeeLimitSun', () => {
   it('defaults to the devkit default of 50 TRX', () => {
-    // Must equal the devkit's own default, or the guard checks a limit the
-    // broadcast will not run under.
     expect(configuredTronFeeLimitSun()).toBe(50_000_000)
   })
 
@@ -57,18 +215,14 @@ describe('configuredTronFeeLimitSun', () => {
   })
 
   it('accepts exponent notation, because the devkit does', () => {
-    // Not a curiosity: parity with the devkit's parse is the whole requirement
-    // here, and `Number('1e9')` is an integer to both.
     process.env[TRON_FEE_LIMIT_SUN_ENV] = '1e9'
 
     expect(configuredTronFeeLimitSun()).toBe(1_000_000_000)
   })
 
-  it.each(['0', '-1', '1.5', 'abc', ' '.repeat(0) + 'NaN'])(
+  it.each(['0', '-1', '1.5', 'abc', 'NaN'])(
     'throws on the malformed value %p rather than falling back',
     (value) => {
-      // Falling back would silently compare against a different limit from the
-      // one the devkit applies — and the devkit throws here too.
       process.env[TRON_FEE_LIMIT_SUN_ENV] = value
 
       expect(() => configuredTronFeeLimitSun()).toThrow(
@@ -78,86 +232,25 @@ describe('configuredTronFeeLimitSun', () => {
   )
 })
 
-describe('tronEnergyCostInSun', () => {
-  // Order matters in this block, and it is not incidental. The devkit caches a
-  // successful price read for its TTL, so the unread-price case has to run
-  // before anything warms that cache — afterwards every call is served from it
-  // and the fallback branch is unreachable.
-  it('reports an unread price as unconfirmed', async () => {
-    // `getCurrentPrices` catches its own failure and returns a constant of
-    // 210 SUN/energy against a live mainnet rate of 100, so a transient RPC
-    // failure would otherwise make the guard refuse honest traffic while
-    // quoting a cost over twice the truth as though it were measured.
-    const tronWeb = {
-      trx: {
-        getEnergyPrices: async () => {
-          throw new Error('getEnergyPrices unavailable')
-        },
-        getBandwidthPrices: async () => {
-          throw new Error('getBandwidthPrices unavailable')
-        },
-      },
-    } as unknown as Parameters<typeof tronEnergyCostInSun>[0]
-
-    const { costSun, priceConfirmed } = await tronEnergyCostInSun(
-      tronWeb,
-      500_000n
-    )
-
-    expect(priceConfirmed).toBe(false)
-    // 500k at the fallback 210 SUN/energy — the inflated figure, correctly
-    // labelled rather than suppressed.
-    expect(costSun).toBe(105_000_000n)
-  })
-
-  it('converts TRX pricing to SUN', async () => {
-    // The devkit reports energyPrice in TRX (it divides the chain's SUN figure
-    // by 1e6), so the cost has to be multiplied back up. Dropping or inverting
-    // that factor is a 1e6 error in the figure the refusal compares, and it
-    // survived every existing test.
-    const tronWeb = {
-      trx: {
-        // `<timestamp>:<sunPerEnergy>`; 100 SUN/energy is the live mainnet rate.
-        getEnergyPrices: async () => '0:100',
-        getBandwidthPrices: async () => '0:1000',
-      },
-    } as unknown as Parameters<typeof tronEnergyCostInSun>[0]
-
-    const { costSun, priceConfirmed } = await tronEnergyCostInSun(
-      tronWeb,
-      500_000n
-    )
-
-    expect(costSun).toBe(50_000_000n)
-    expect(priceConfirmed).toBe(true)
-  })
-})
-
 describe('applyTronSafetyMargin', () => {
   it.each([
     [500_000, 600_000n],
     [1, 2n],
-    [0, 0n],
     [416_666, 500_000n],
   ])('turns %i raw energy into %s', (raw, expected) => {
-    // The margin is not padding. `triggerconstantcontract` under-reports what
-    // the broadcast is charged — the dynamic-energy penalty is not applied to
-    // constant calls, and state moves between the estimate and the send — so a
-    // batch just above the raw figure would clear the guard and still abort
-    // part-way, which is the failure the pre-flight exists to prevent.
     expect(applyTronSafetyMargin(raw)).toBe(expected)
   })
 
-  it('rounds up, never down', () => {
-    // Rounding toward the refusal is the safe direction for a guard.
-    expect(applyTronSafetyMargin(1)).toBe(2n)
-    expect(applyTronSafetyMargin(7)).toBe(9n)
+  it('matches the margin the devkit applies in its own estimator', () => {
+    // This is the whole justification, and it is parity rather than
+    // measurement: the deploy scripts price calls through the devkit's
+    // `estimateContractEnergy`, which applies the same constant. If the two
+    // drifted, the deploy path and this guard would disagree about what a call
+    // costs.
+    expect(applyTronSafetyMargin(1_000_000)).toBe(1_200_000n)
   })
 
-  it('matches the margin the devkit applies in its own estimator', () => {
-    // Deploy scripts price calls through the devkit's `estimateContractEnergy`,
-    // which applies the same constant. If the two drifted, the deploy path and
-    // this guard would disagree about what a call costs.
-    expect(applyTronSafetyMargin(1_000_000)).toBe(1_200_000n)
+  it('rounds up, never down', () => {
+    expect(applyTronSafetyMargin(7)).toBe(9n)
   })
 })

--- a/script/deploy/safe/executors/tron-energy-estimate.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.ts
@@ -1,0 +1,144 @@
+/**
+ * Energy estimation for Tron, shared by the chain caller and the Safe executor.
+ *
+ * Both broadcast through the devkit, which sends `wallet/triggersmartcontract`
+ * under a fixed `fee_limit` from the environment. Neither had a pre-flight, so
+ * this exists to give both the same one: estimate the call with
+ * `triggerconstantcontract`, price the energy, and compare it with the limit the
+ * devkit is going to apply.
+ *
+ * The estimate posts raw calldata rather than the devkit's own
+ * `estimateContractCallEnergy`, which takes a human-readable function selector
+ * and hardcodes `call_value: 0`. Neither is available here: these call sites
+ * hold encoded calldata and no ABI, and a Safe execution can carry value.
+ */
+
+import {
+  TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
+  TRON_WALLET_API_FETCH_TIMEOUT_MS,
+  buildTronWalletJsonPostHeaders,
+  calculateEstimatedCost,
+  getTronRPCConfig,
+  resolveTronWebRpcUrlToFullHost,
+  type TronTvmNetworkName,
+} from '@lifi/tron-devkit'
+
+import { fetchWithTimeout } from '../../../utils/fetchWithTimeout'
+
+/**
+ * The devkit's default cap, mirrored so a refusal can name the figure the
+ * broadcast will actually run under.
+ */
+const TRON_DEFAULT_FEE_LIMIT_SUN = 50_000_000
+
+/** The env var the devkit reads for that cap. */
+export const TRON_FEE_LIMIT_SUN_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
+
+export interface ITronEnergyEstimateParams {
+  networkKey: TronTvmNetworkName
+  /** Base58 address the call is made from. */
+  ownerBase58: string
+  /** Base58 address of the contract being called. */
+  contractBase58: string
+  /** Calldata, `0x`-prefixed. */
+  data: `0x${string}`
+  /** TRX carried by the call, in SUN. */
+  callValue: bigint
+}
+
+/**
+ * Reads the fee limit the devkit will apply to the next broadcast.
+ *
+ * Deliberately mirrors the devkit's own parse, including throwing on a
+ * malformed value: a guard that computed a different limit from the one the
+ * broadcast runs under would be checking the wrong number.
+ *
+ * @returns The cap in SUN.
+ * @throws When the env var is set to something that is not a positive integer.
+ */
+export const configuredTronFeeLimitSun = (): number => {
+  const raw = process.env[TRON_FEE_LIMIT_SUN_ENV]?.trim()
+  if (raw === undefined || raw === '') return TRON_DEFAULT_FEE_LIMIT_SUN
+
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(
+      `${TRON_FEE_LIMIT_SUN_ENV} must be a positive integer (SUN), got: ${raw}`
+    )
+
+  return parsed
+}
+
+/**
+ * Estimates the energy a contract call would consume.
+ *
+ * @param params - Owner, contract, calldata and call value.
+ * @returns Estimated energy.
+ * @throws When the node rejects the request, or returns no energy figure —
+ * which is what a call that would revert looks like here.
+ */
+export const estimateTronEnergy = async (
+  params: ITronEnergyEstimateParams
+): Promise<bigint> => {
+  const { rpcUrl } = getTronRPCConfig(params.networkKey)
+  const fullHost = resolveTronWebRpcUrlToFullHost(rpcUrl, params.networkKey)
+  const apiUrl = fullHost.replace(/\/$/, '') + '/wallet/triggerconstantcontract'
+
+  const res = await fetchWithTimeout(
+    apiUrl,
+    {
+      method: 'POST',
+      headers: buildTronWalletJsonPostHeaders(fullHost),
+      body: JSON.stringify({
+        owner_address: params.ownerBase58,
+        contract_address: params.contractBase58,
+        data: params.data.slice(2),
+        // A high limit for the estimate itself; it caps nothing that broadcasts.
+        fee_limit: TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
+        call_value: params.callValue > 0n ? Number(params.callValue) : 0,
+        visible: true,
+      }),
+    },
+    TRON_WALLET_API_FETCH_TIMEOUT_MS
+  )
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`triggerconstantcontract failed: ${res.status} ${text}`)
+  }
+
+  const result = (await res.json()) as {
+    energy_used?: number
+    result?: { result?: boolean; message?: string }
+  }
+
+  if (
+    result.result?.result === false ||
+    result.energy_used === undefined ||
+    result.energy_used === null
+  )
+    throw new Error(
+      `Tron simulation failed: ${JSON.stringify(result.result ?? result)}`
+    )
+
+  return BigInt(result.energy_used)
+}
+
+/**
+ * Prices energy at the network's current rates.
+ *
+ * Rounded up, because the figure decides whether a broadcast is refused and the
+ * conservative direction for that is to refuse slightly early rather than
+ * broadcast a call that cannot finish.
+ *
+ * @param tronWeb - Client used to read the chain's energy price.
+ * @param energy - Energy to price.
+ * @returns Cost in SUN.
+ */
+export const tronEnergyCostInSun = async (
+  tronWeb: Parameters<typeof calculateEstimatedCost>[0],
+  energy: bigint
+): Promise<bigint> => {
+  const { totalCost } = await calculateEstimatedCost(tronWeb, Number(energy), 0)
+  return BigInt(Math.ceil(totalCost * 1_000_000))
+}

--- a/script/deploy/safe/executors/tron-energy-estimate.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.ts
@@ -175,6 +175,8 @@ const requestEnergyUsed = async (
     apiUrl,
     {
       method: 'POST',
+      // A redirect to a non-HTTPS target would silently defeat the check above.
+      redirect: 'error',
       headers: buildTronWalletJsonPostHeaders(fullHost),
       body: JSON.stringify({
         owner_address: params.ownerBase58,

--- a/script/deploy/safe/executors/tron-energy-estimate.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.ts
@@ -15,13 +15,11 @@
 
 import {
   DEFAULT_SAFETY_MARGIN,
-  FALLBACK_ENERGY_PRICE_TRX,
   MAX_RETRIES,
   RETRY_DELAY,
   TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
   TRON_WALLET_API_FETCH_TIMEOUT_MS,
   buildTronWalletJsonPostHeaders,
-  getCurrentPrices,
   getTronRPCConfig,
   resolveTronWebRpcUrlToFullHost,
   type TronTvmNetworkName,
@@ -38,8 +36,6 @@ const TRON_DEFAULT_FEE_LIMIT_SUN = 50_000_000
 /** The env var the devkit reads for that cap. */
 export const TRON_FEE_LIMIT_SUN_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
 
-const SUN_PER_TRX = 1_000_000
-
 export interface ITronEnergyEstimateParams {
   networkKey: TronTvmNetworkName
   /** Base58 address the call is made from. */
@@ -54,17 +50,56 @@ export interface ITronEnergyEstimateParams {
   sleep?: (ms: number) => Promise<void>
 }
 
-export interface ITronEnergyCost {
-  costSun: bigint
-  /**
-   * False when the chain's energy price could not be read and the devkit
-   * substituted its constant, so `costSun` is an unconfirmed upper bound.
-   */
-  priceConfirmed: boolean
-}
-
 const realSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * An estimate failure, tagged with whether trying again could change it.
+ *
+ * A transport failure might; a node answering "this call would revert" will
+ * not, and retrying it only spends the operator's time before the same refusal.
+ */
+class TronEstimateError extends Error {
+  public constructor(message: string, public readonly retryable: boolean) {
+    super(message)
+    this.name = 'TronEstimateError'
+  }
+}
+
+/**
+ * Newest energy price at or before now, in SUN, from Tron's
+ * `getEnergyPrices` history string (`<ms>:<sunPerEnergy>,...`).
+ *
+ * @param priceString - The history as the node returns it.
+ * @returns Price in SUN per energy.
+ * @throws When the string carries no usable price.
+ */
+export const latestEnergyPriceSun = (priceString: string): number => {
+  const now = Date.now()
+  const entries = priceString
+    .split(',')
+    .map((entry) => entry.split(':'))
+    .map(([timestamp, price]) => ({
+      timestamp: Number(timestamp),
+      price: Number(price),
+    }))
+    .filter(
+      ({ timestamp, price }) =>
+        Number.isFinite(timestamp) && Number.isFinite(price) && price > 0
+    )
+    .sort((a, b) => b.timestamp - a.timestamp)
+
+  const applicable = entries.find(({ timestamp }) => timestamp <= now)
+  const price = applicable?.price ?? entries[entries.length - 1]?.price
+
+  if (price === undefined)
+    throw new Error(
+      `No usable energy price in '${priceString}'. Refusing to price a broadcast ` +
+        `against a guessed rate.`
+    )
+
+  return price
+}
 
 /**
  * Reads the fee limit the devkit will apply to the next broadcast.
@@ -91,6 +126,15 @@ export const configuredTronFeeLimitSun = (): number => {
 
 /**
  * Applies the devkit's safety margin to a raw `energy_used` figure.
+ *
+ * The justification is parity, not measurement. The deploy scripts price calls
+ * through the devkit's own `estimateContractEnergy`, which applies this same
+ * constant, so without it the deploy path and this guard would disagree about
+ * what a call costs. The one measurement this repo has of a real batch
+ * (EXSC-842: 501,386 simulated against roughly 501,348 charged) shows
+ * `triggerconstantcontract` was accurate to well under a percent and slightly
+ * *over*, so the margin should not be described as correcting an under-report.
+ * It buys headroom for the state drift between simulating and sending.
  *
  * Separated out so it can be tested: the request around it needs a live
  * endpoint, and this is the arithmetic that decides whether a batch is refused.
@@ -129,7 +173,10 @@ const requestEnergyUsed = async (
 
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`triggerconstantcontract failed: ${res.status} ${text}`)
+    throw new TronEstimateError(
+      `triggerconstantcontract failed: ${res.status} ${text}`,
+      true
+    )
   }
 
   const result = (await res.json()) as {
@@ -142,8 +189,21 @@ const requestEnergyUsed = async (
     result.energy_used === undefined ||
     result.energy_used === null
   )
-    throw new Error(
-      `Tron simulation failed: ${JSON.stringify(result.result ?? result)}`
+    // Deterministic: this is what a call that would revert looks like here, and
+    // asking again returns the same answer.
+    throw new TronEstimateError(
+      `Tron simulation failed: ${JSON.stringify(result.result ?? result)}`,
+      false
+    )
+
+  // A contract call always burns energy, so a zero is a node answering without
+  // having simulated. Priced, it would cost nothing and clear any fee limit —
+  // the guard would be a no-op on exactly the batches it exists to stop.
+  if (!(result.energy_used > 0))
+    throw new TronEstimateError(
+      `triggerconstantcontract reported ${result.energy_used} energy, which no ` +
+        `contract call costs. Refusing to treat it as an estimate.`,
+      false
     )
 
   return result.energy_used
@@ -153,13 +213,9 @@ const requestEnergyUsed = async (
  * Estimates the energy a contract call would consume, with the devkit's safety
  * margin applied.
  *
- * The margin is not padding. `triggerconstantcontract` under-reports what the
- * broadcast is charged — the dynamic-energy penalty is not applied to constant
- * calls, and state moves between the estimate and the send — so a batch whose
- * true cost sits just above the raw figure would clear the guard and still
- * abort part-way, which is the failure this pre-flight exists to prevent. The
- * devkit's own estimator applies the same constant, so the deploy scripts and
- * this guard agree on what a call costs.
+ * The margin exists for parity with the devkit's own estimator, which the
+ * deploy scripts price through — see {@link applyTronSafetyMargin} for why it
+ * is not described as correcting an under-report.
  *
  * Retried on a failed request, because the estimate is now mandatory before any
  * Safe or timelock send and `runPendingTimelockTXs.yml` reaches TronGrid with no
@@ -182,6 +238,9 @@ export const estimateTronEnergy = async (
       return applyTronSafetyMargin(await requestEnergyUsed(params))
     } catch (error) {
       lastError = error
+      const retryable =
+        error instanceof TronEstimateError ? error.retryable : true
+      if (!retryable) break
       if (attempt < MAX_RETRIES) await sleep(RETRY_DELAY)
     }
   }
@@ -190,29 +249,30 @@ export const estimateTronEnergy = async (
 }
 
 /**
- * Prices energy at the network's current rates.
+ * Prices energy at the network's current rate.
  *
- * Rounded up, because the figure decides whether a broadcast is refused and the
- * conservative direction for that is to refuse slightly early rather than
- * broadcast a call that cannot finish.
+ * Reads `getEnergyPrices` directly rather than through the devkit's
+ * `getCurrentPrices`, which catches its own failure and substitutes a constant.
+ * Two things made that unusable for a guard. A node that resolves with an empty
+ * price string never reaches the catch at all, so the price came back as `0`,
+ * the cost as `0`, and any batch cleared any fee limit. And the substituted
+ * constant, 210 SUN/energy, is a real Tron price — mainnet's actual rate for
+ * roughly eleven months — so no comparison against its value can tell a
+ * fallback from a correct read.
  *
- * Reports whether the price was actually read. `getCurrentPrices` swallows its
- * own failure and substitutes a constant more than twice the live mainnet rate,
- * which would refuse honest traffic while quoting an inflated figure to raise
- * the limit to. The caller needs to be able to say the number is unconfirmed.
+ * Rounded up: the figure decides whether a broadcast is refused, and the
+ * conservative direction is to refuse slightly early rather than send a call
+ * that cannot finish.
  *
  * @param tronWeb - Client used to read the chain's energy price.
  * @param energy - Energy to price.
- * @returns Cost in SUN, and whether the price behind it was confirmed.
+ * @returns Cost in SUN.
+ * @throws When the price cannot be read, or carries no usable value.
  */
 export const tronEnergyCostInSun = async (
-  tronWeb: Parameters<typeof getCurrentPrices>[0],
+  tronWeb: { trx: { getEnergyPrices: () => Promise<string> } },
   energy: bigint
-): Promise<ITronEnergyCost> => {
-  const { energyPrice } = await getCurrentPrices(tronWeb)
-
-  return {
-    costSun: BigInt(Math.ceil(Number(energy) * energyPrice * SUN_PER_TRX)),
-    priceConfirmed: energyPrice !== FALLBACK_ENERGY_PRICE_TRX,
-  }
+): Promise<bigint> => {
+  const priceSun = latestEnergyPriceSun(await tronWeb.trx.getEnergyPrices())
+  return BigInt(Math.ceil(Number(energy) * priceSun))
 }

--- a/script/deploy/safe/executors/tron-energy-estimate.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.ts
@@ -14,10 +14,14 @@
  */
 
 import {
+  DEFAULT_SAFETY_MARGIN,
+  FALLBACK_ENERGY_PRICE_TRX,
+  MAX_RETRIES,
+  RETRY_DELAY,
   TRON_TRIGGER_ESTIMATE_FEE_LIMIT_SUN,
   TRON_WALLET_API_FETCH_TIMEOUT_MS,
   buildTronWalletJsonPostHeaders,
-  calculateEstimatedCost,
+  getCurrentPrices,
   getTronRPCConfig,
   resolveTronWebRpcUrlToFullHost,
   type TronTvmNetworkName,
@@ -34,6 +38,8 @@ const TRON_DEFAULT_FEE_LIMIT_SUN = 50_000_000
 /** The env var the devkit reads for that cap. */
 export const TRON_FEE_LIMIT_SUN_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
 
+const SUN_PER_TRX = 1_000_000
+
 export interface ITronEnergyEstimateParams {
   networkKey: TronTvmNetworkName
   /** Base58 address the call is made from. */
@@ -44,7 +50,21 @@ export interface ITronEnergyEstimateParams {
   data: `0x${string}`
   /** TRX carried by the call, in SUN. */
   callValue: bigint
+  /** Injected in tests so retries do not sleep. */
+  sleep?: (ms: number) => Promise<void>
 }
+
+export interface ITronEnergyCost {
+  costSun: bigint
+  /**
+   * False when the chain's energy price could not be read and the devkit
+   * substituted its constant, so `costSun` is an unconfirmed upper bound.
+   */
+  priceConfirmed: boolean
+}
+
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
  * Reads the fee limit the devkit will apply to the next broadcast.
@@ -70,16 +90,21 @@ export const configuredTronFeeLimitSun = (): number => {
 }
 
 /**
- * Estimates the energy a contract call would consume.
+ * Applies the devkit's safety margin to a raw `energy_used` figure.
  *
- * @param params - Owner, contract, calldata and call value.
- * @returns Estimated energy.
- * @throws When the node rejects the request, or returns no energy figure —
- * which is what a call that would revert looks like here.
+ * Separated out so it can be tested: the request around it needs a live
+ * endpoint, and this is the arithmetic that decides whether a batch is refused.
+ *
+ * @param rawEnergyUsed - `energy_used` as `triggerconstantcontract` reports it.
+ * @returns The figure the guard should compare, margin included.
  */
-export const estimateTronEnergy = async (
+export const applyTronSafetyMargin = (rawEnergyUsed: number): bigint =>
+  BigInt(Math.ceil(rawEnergyUsed * DEFAULT_SAFETY_MARGIN))
+
+/** One `triggerconstantcontract` round trip. Throws on anything unusable. */
+const requestEnergyUsed = async (
   params: ITronEnergyEstimateParams
-): Promise<bigint> => {
+): Promise<number> => {
   const { rpcUrl } = getTronRPCConfig(params.networkKey)
   const fullHost = resolveTronWebRpcUrlToFullHost(rpcUrl, params.networkKey)
   const apiUrl = fullHost.replace(/\/$/, '') + '/wallet/triggerconstantcontract'
@@ -121,7 +146,47 @@ export const estimateTronEnergy = async (
       `Tron simulation failed: ${JSON.stringify(result.result ?? result)}`
     )
 
-  return BigInt(result.energy_used)
+  return result.energy_used
+}
+
+/**
+ * Estimates the energy a contract call would consume, with the devkit's safety
+ * margin applied.
+ *
+ * The margin is not padding. `triggerconstantcontract` under-reports what the
+ * broadcast is charged — the dynamic-energy penalty is not applied to constant
+ * calls, and state moves between the estimate and the send — so a batch whose
+ * true cost sits just above the raw figure would clear the guard and still
+ * abort part-way, which is the failure this pre-flight exists to prevent. The
+ * devkit's own estimator applies the same constant, so the deploy scripts and
+ * this guard agree on what a call costs.
+ *
+ * Retried on a failed request, because the estimate is now mandatory before any
+ * Safe or timelock send and `runPendingTimelockTXs.yml` reaches TronGrid with no
+ * API key — a single transient 429 would otherwise refuse a production
+ * execution.
+ *
+ * @param params - Owner, contract, calldata and call value.
+ * @returns Estimated energy including the safety margin.
+ * @throws When the node rejects every attempt, or returns no energy figure —
+ * which is what a call that would revert looks like here.
+ */
+export const estimateTronEnergy = async (
+  params: ITronEnergyEstimateParams
+): Promise<bigint> => {
+  const sleep = params.sleep ?? realSleep
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return applyTronSafetyMargin(await requestEnergyUsed(params))
+    } catch (error) {
+      lastError = error
+      if (attempt < MAX_RETRIES) await sleep(RETRY_DELAY)
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
 }
 
 /**
@@ -131,14 +196,23 @@ export const estimateTronEnergy = async (
  * conservative direction for that is to refuse slightly early rather than
  * broadcast a call that cannot finish.
  *
+ * Reports whether the price was actually read. `getCurrentPrices` swallows its
+ * own failure and substitutes a constant more than twice the live mainnet rate,
+ * which would refuse honest traffic while quoting an inflated figure to raise
+ * the limit to. The caller needs to be able to say the number is unconfirmed.
+ *
  * @param tronWeb - Client used to read the chain's energy price.
  * @param energy - Energy to price.
- * @returns Cost in SUN.
+ * @returns Cost in SUN, and whether the price behind it was confirmed.
  */
 export const tronEnergyCostInSun = async (
-  tronWeb: Parameters<typeof calculateEstimatedCost>[0],
+  tronWeb: Parameters<typeof getCurrentPrices>[0],
   energy: bigint
-): Promise<bigint> => {
-  const { totalCost } = await calculateEstimatedCost(tronWeb, Number(energy), 0)
-  return BigInt(Math.ceil(totalCost * 1_000_000))
+): Promise<ITronEnergyCost> => {
+  const { energyPrice } = await getCurrentPrices(tronWeb)
+
+  return {
+    costSun: BigInt(Math.ceil(Number(energy) * energyPrice * SUN_PER_TRX)),
+    priceConfirmed: energyPrice !== FALLBACK_ENERGY_PRICE_TRX,
+  }
 }

--- a/script/deploy/safe/executors/tron-energy-estimate.ts
+++ b/script/deploy/safe/executors/tron-energy-estimate.ts
@@ -90,15 +90,14 @@ export const latestEnergyPriceSun = (priceString: string): number => {
     .sort((a, b) => b.timestamp - a.timestamp)
 
   const applicable = entries.find(({ timestamp }) => timestamp <= now)
-  const price = applicable?.price ?? entries[entries.length - 1]?.price
 
-  if (price === undefined)
+  if (applicable === undefined)
     throw new Error(
       `No usable energy price in '${priceString}'. Refusing to price a broadcast ` +
         `against a guessed rate.`
     )
 
-  return price
+  return applicable.price
 }
 
 /**
@@ -145,13 +144,32 @@ export const configuredTronFeeLimitSun = (): number => {
 export const applyTronSafetyMargin = (rawEnergyUsed: number): bigint =>
   BigInt(Math.ceil(rawEnergyUsed * DEFAULT_SAFETY_MARGIN))
 
+/**
+ * Above this, `Number(callValue)` would round rather than convert: the guard
+ * would then be pricing a call the node never actually simulated.
+ */
+const MAX_SAFE_CALL_VALUE_SUN = BigInt(Number.MAX_SAFE_INTEGER)
+
 /** One `triggerconstantcontract` round trip. Throws on anything unusable. */
 const requestEnergyUsed = async (
   params: ITronEnergyEstimateParams
 ): Promise<number> => {
+  if (params.callValue > MAX_SAFE_CALL_VALUE_SUN)
+    throw new TronEstimateError(
+      `callValue ${params.callValue} SUN exceeds Number.MAX_SAFE_INTEGER; ` +
+        `estimating it would silently simulate a different, rounded value.`,
+      false
+    )
+
   const { rpcUrl } = getTronRPCConfig(params.networkKey)
   const fullHost = resolveTronWebRpcUrlToFullHost(rpcUrl, params.networkKey)
   const apiUrl = fullHost.replace(/\/$/, '') + '/wallet/triggerconstantcontract'
+
+  if (!apiUrl.startsWith('https://'))
+    throw new TronEstimateError(
+      `Refusing to estimate energy over a non-HTTPS endpoint: ${apiUrl}`,
+      false
+    )
 
   const res = await fetchWithTimeout(
     apiUrl,

--- a/script/deploy/safe/executors/tron-energy-preflight.test.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.test.ts
@@ -17,7 +17,6 @@ import {
 
 import type { IChainSimulateResult } from '../../../common/types'
 
-import type { ITronEnergyCost } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
 /** 50 TRX, the devkit default this repo runs with. */
@@ -33,10 +32,8 @@ const estimateOf =
     estimateFailed: false,
   })
 
-const costInSun = async (energy: bigint): Promise<ITronEnergyCost> => ({
-  costSun: energy * SUN_PER_ENERGY,
-  priceConfirmed: true,
-})
+const costInSun = async (energy: bigint): Promise<bigint> =>
+  energy * SUN_PER_ENERGY
 
 const options = {
   networkName: 'tron',
@@ -177,39 +174,7 @@ describe('the escape hatch is the same one the EVM paths use', () => {
   })
 })
 
-describe('an unconfirmed energy price is labelled as such', () => {
-  it('says so in the refusal instead of quoting the figure as fact', async () => {
-    // `getCurrentPrices` swallows its own failure and substitutes a constant
-    // above the live mainnet rate, so the guard can refuse honest traffic while
-    // telling the operator to raise the limit to an inflated number. It has to
-    // be able to say the price was never read.
-    const error = await assertTronBroadcastAffordable(estimateOf(600_000n), {
-      ...options,
-      costInSun: async (energy) => ({
-        costSun: energy * 210n,
-        priceConfirmed: false,
-      }),
-    }).then(
-      () => undefined,
-      (e: unknown) => e as Error
-    )
-
-    expect(error?.message).toMatch(/could not be read/)
-    expect(error?.message).toMatch(/unconfirmed upper bound/)
-  })
-
-  it('does not add that caveat when the price was read', async () => {
-    const error = await assertTronBroadcastAffordable(
-      estimateOf(600_000n),
-      options
-    ).then(
-      () => undefined,
-      (e: unknown) => e as Error
-    )
-
-    expect(error?.message).not.toMatch(/unconfirmed upper bound/)
-  })
-
+describe('pricing that cannot be done at all', () => {
   it('refuses, redacted, when pricing itself throws', async () => {
     // Pricing sits inside the redaction boundary because the endpoint is
     // embedded in these errors and credentials ride in its query string.

--- a/script/deploy/safe/executors/tron-energy-preflight.test.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.test.ts
@@ -193,4 +193,37 @@ describe('pricing that cannot be done at all', () => {
     expect(error?.message).toMatch(/refusing to broadcast/)
     expect(error?.message).not.toContain('SHOULDNOTAPPEAR')
   })
+
+  it('tells the operator to use the escape hatch, and the escape hatch works', async () => {
+    // Every refusal in this module ends with escapeHatchNote(), telling the
+    // operator to re-run with ALLOW_GAS_ESTIMATE_FALLBACK=<network>. This is
+    // the one branch that used to print that instruction and then ignore it —
+    // ALLOW_GAS_ESTIMATE_FALLBACK=tron still threw, unconditionally. An
+    // operator doing exactly what the message says would hit a dead end.
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'tron'
+
+    const result = await assertTronBroadcastAffordable(estimateOf(400_000n), {
+      ...options,
+      costInSun: async () => {
+        throw new Error('pricing endpoint unavailable')
+      },
+    })
+
+    expect(result.estimateFailed).toBe(true)
+    expect(result.estimatedEnergy).toBe(400_000n)
+    expect(result.costSun).toBe(0n)
+  })
+
+  it('does not let another network scope through a pricing failure', async () => {
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'polygon'
+
+    expect(
+      assertTronBroadcastAffordable(estimateOf(400_000n), {
+        ...options,
+        costInSun: async () => {
+          throw new Error('pricing endpoint unavailable')
+        },
+      })
+    ).rejects.toThrow(/refusing to broadcast/)
+  })
 })

--- a/script/deploy/safe/executors/tron-energy-preflight.test.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The Tron half of S3. The EVM paths refuse to broadcast on a failed gas
+ * estimate; these assert the same policy for energy, plus the case EVM does not
+ * have — an estimate that succeeds but exceeds what the configured fee limit can
+ * pay for, which is how a multi-call timelock batch aborts mid-SSTORE and is
+ * then retried forever.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import type { IChainSimulateResult } from '../../../common/types'
+
+import { assertTronBroadcastAffordable } from './tron-energy-preflight'
+
+/** 50 TRX, the devkit default this repo runs with. */
+const FEE_LIMIT_SUN = 50_000_000
+/** Tron mainnet energy price at the time of writing; only the ratio matters. */
+const SUN_PER_ENERGY = 100n
+
+const estimateOf =
+  (energy: bigint): (() => Promise<IChainSimulateResult>) =>
+  async () => ({
+    estimatedResource: energy,
+    resourceLabel: 'energy',
+    estimateFailed: false,
+  })
+
+const costInSun = async (energy: bigint): Promise<bigint> =>
+  energy * SUN_PER_ENERGY
+
+const options = {
+  networkName: 'tron',
+  operation: 'timelock execution',
+  feeLimitSun: FEE_LIMIT_SUN,
+  costInSun,
+}
+
+let originalAllow: string | undefined
+
+beforeEach(() => {
+  originalAllow = process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+  delete process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+})
+
+afterEach(() => {
+  if (originalAllow === undefined)
+    delete process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+  else process.env.ALLOW_GAS_ESTIMATE_FALLBACK = originalAllow
+})
+
+describe('a failed estimate refuses rather than guessing', () => {
+  it('throws, and names the network and the operation', async () => {
+    const boom = async (): Promise<IChainSimulateResult> => {
+      throw new Error('triggerconstantcontract failed: 503')
+    }
+
+    const error = await assertTronBroadcastAffordable(boom, options).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error).toBeDefined()
+    expect(error?.message).toContain('tron')
+    expect(error?.message).toContain('timelock execution')
+    expect(error?.message).toContain('refusing to broadcast')
+  })
+
+  it('says energy, not gas — the operator has to know which resource', async () => {
+    const boom = async (): Promise<IChainSimulateResult> => {
+      throw new Error('nope')
+    }
+
+    const error = await assertTronBroadcastAffordable(boom, options).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toContain('energy')
+  })
+
+  it('treats a fallback figure as a failed estimate, not an estimate', async () => {
+    // `estimateFailed: true` means the number is a fixed fallback. Broadcasting
+    // on it is exactly the guess this refuses.
+    const fellBack = async (): Promise<IChainSimulateResult> => ({
+      estimatedResource: 1_000n,
+      resourceLabel: 'energy',
+      estimateFailed: true,
+    })
+
+    expect(assertTronBroadcastAffordable(fellBack, options)).rejects.toThrow(
+      /refusing to broadcast/
+    )
+  })
+})
+
+describe('an estimate the fee limit cannot pay for refuses', () => {
+  it('refuses when the cost exceeds the configured fee limit', async () => {
+    // 600k energy at 100 SUN each is 60 TRX, above the 50 TRX cap. Today this
+    // broadcasts, runs out of energy mid-execution and is retried forever.
+    const error = await assertTronBroadcastAffordable(
+      estimateOf(600_000n),
+      options
+    ).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error).toBeDefined()
+    expect(error?.message).toContain('600000')
+    expect(error?.message).toContain('TRON_SAFE_EXEC_FEE_LIMIT_SUN')
+  })
+
+  it('allows an estimate the fee limit covers', async () => {
+    const result = await assertTronBroadcastAffordable(
+      estimateOf(400_000n),
+      options
+    )
+
+    expect(result.estimatedEnergy).toBe(400_000n)
+    expect(result.costSun).toBe(40_000_000n)
+  })
+
+  it('allows an estimate costing exactly the fee limit', async () => {
+    // The boundary is affordable, not refused: the cap is what the transaction
+    // may spend, so spending all of it is within budget.
+    const result = await assertTronBroadcastAffordable(
+      estimateOf(500_000n),
+      options
+    )
+
+    expect(result.costSun).toBe(50_000_000n)
+  })
+})
+
+describe('the escape hatch is the same one the EVM paths use', () => {
+  it('lets a failed estimate through when scoped to this network', async () => {
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'tron'
+    const boom = async (): Promise<IChainSimulateResult> => {
+      throw new Error('nope')
+    }
+
+    const result = await assertTronBroadcastAffordable(boom, options)
+
+    expect(result.estimateFailed).toBe(true)
+  })
+
+  it('does not let another network scope through', async () => {
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'polygon'
+    const boom = async (): Promise<IChainSimulateResult> => {
+      throw new Error('nope')
+    }
+
+    expect(assertTronBroadcastAffordable(boom, options)).rejects.toThrow(
+      /refusing to broadcast/
+    )
+  })
+
+  it('lets an unaffordable estimate through when scoped, deliberately', async () => {
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'tron'
+
+    const result = await assertTronBroadcastAffordable(
+      estimateOf(600_000n),
+      options
+    )
+
+    expect(result.estimatedEnergy).toBe(600_000n)
+  })
+})

--- a/script/deploy/safe/executors/tron-energy-preflight.test.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.test.ts
@@ -17,6 +17,7 @@ import {
 
 import type { IChainSimulateResult } from '../../../common/types'
 
+import type { ITronEnergyCost } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
 /** 50 TRX, the devkit default this repo runs with. */
@@ -32,8 +33,10 @@ const estimateOf =
     estimateFailed: false,
   })
 
-const costInSun = async (energy: bigint): Promise<bigint> =>
-  energy * SUN_PER_ENERGY
+const costInSun = async (energy: bigint): Promise<ITronEnergyCost> => ({
+  costSun: energy * SUN_PER_ENERGY,
+  priceConfirmed: true,
+})
 
 const options = {
   networkName: 'tron',
@@ -171,5 +174,58 @@ describe('the escape hatch is the same one the EVM paths use', () => {
     )
 
     expect(result.estimatedEnergy).toBe(600_000n)
+  })
+})
+
+describe('an unconfirmed energy price is labelled as such', () => {
+  it('says so in the refusal instead of quoting the figure as fact', async () => {
+    // `getCurrentPrices` swallows its own failure and substitutes a constant
+    // above the live mainnet rate, so the guard can refuse honest traffic while
+    // telling the operator to raise the limit to an inflated number. It has to
+    // be able to say the price was never read.
+    const error = await assertTronBroadcastAffordable(estimateOf(600_000n), {
+      ...options,
+      costInSun: async (energy) => ({
+        costSun: energy * 210n,
+        priceConfirmed: false,
+      }),
+    }).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toMatch(/could not be read/)
+    expect(error?.message).toMatch(/unconfirmed upper bound/)
+  })
+
+  it('does not add that caveat when the price was read', async () => {
+    const error = await assertTronBroadcastAffordable(
+      estimateOf(600_000n),
+      options
+    ).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).not.toMatch(/unconfirmed upper bound/)
+  })
+
+  it('refuses, redacted, when pricing itself throws', async () => {
+    // Pricing sits inside the redaction boundary because the endpoint is
+    // embedded in these errors and credentials ride in its query string.
+    const error = await assertTronBroadcastAffordable(estimateOf(400_000n), {
+      ...options,
+      costInSun: async () => {
+        throw new Error(
+          'failed for https://api.example.com/x?apikey=SHOULDNOTAPPEAR'
+        )
+      },
+    }).then(
+      () => undefined,
+      (e: unknown) => e as Error
+    )
+
+    expect(error?.message).toMatch(/refusing to broadcast/)
+    expect(error?.message).not.toContain('SHOULDNOTAPPEAR')
   })
 })

--- a/script/deploy/safe/executors/tron-energy-preflight.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.ts
@@ -1,0 +1,131 @@
+/**
+ * Pre-flight for anything that broadcasts on Tron.
+ *
+ * The EVM Safe and timelock paths refuse to broadcast when gas estimation fails
+ * (`gas-with-fallback.ts`). Tron had no pre-flight at all: the devkit caps every
+ * transaction at a fixed `fee_limit` read from the environment, signs, and sends.
+ *
+ * So Tron needs the EVM rule and one more. A fee limit that cannot pay for the
+ * transaction does not make it fail cleanly — it runs until the energy is spent
+ * and aborts part-way through, which for a multi-call timelock batch means an
+ * operation that is neither applied nor abandoned, and a workflow that retries
+ * it forever. That is worth refusing before the send, not diagnosing after it.
+ *
+ * The escape hatch is deliberately the same `ALLOW_GAS_ESTIMATE_FALLBACK` the
+ * EVM paths read, so an operator has one switch to learn and one to audit.
+ */
+
+import { consola } from 'consola'
+
+import type { IChainSimulateResult } from '../../../common/types'
+import { redactErrorReason } from '../../../utils/redactUrls'
+
+import { fallbackExplicitlyAllowed } from './gas-with-fallback'
+
+/** The env var the devkit reads for its cap, named in refusals so it can be raised. */
+export const TRON_FEE_LIMIT_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
+
+export interface ITronEnergyPreflightOptions {
+  /** Network under consideration; scopes the escape hatch and names the refusal. */
+  networkName: string
+  /** Named in the refusal so the operator knows which action was stopped. */
+  operation: string
+  /** SUN the devkit will cap this transaction at. */
+  feeLimitSun: number
+  /** Cost of that much energy, in SUN, at current chain prices. */
+  costInSun: (energy: bigint) => Promise<bigint>
+}
+
+export interface ITronEnergyPreflightResult {
+  estimatedEnergy: bigint
+  /** Cost of {@link estimatedEnergy} in SUN; 0n when there is no estimate. */
+  costSun: bigint
+  /** True when the caller is proceeding without a real estimate. */
+  estimateFailed: boolean
+}
+
+const escapeHatchNote = (networkName: string): string =>
+  `To broadcast anyway, re-run with ALLOW_GAS_ESTIMATE_FALLBACK=${networkName} — ` +
+  `scope it to the affected network, because the value "true" disables this guard ` +
+  `for every network in the run.`
+
+/**
+ * Estimate first, then decide whether broadcasting is allowed.
+ *
+ * @param estimate - Runs the energy estimate. Throwing and returning
+ * `estimateFailed: true` are treated alike: neither is an estimate.
+ * @param options - Network and operation labels, the configured fee limit, and
+ * the energy-to-SUN conversion.
+ * @returns The estimate and its cost.
+ * @throws When there is no usable estimate, or the estimate costs more than the
+ * configured fee limit, and {@link fallbackExplicitlyAllowed} does not permit it
+ * for this network.
+ */
+export const assertTronBroadcastAffordable = async (
+  estimate: () => Promise<IChainSimulateResult>,
+  options: ITronEnergyPreflightOptions
+): Promise<ITronEnergyPreflightResult> => {
+  const { networkName, operation, feeLimitSun } = options
+  const where = `on ${networkName}`
+  const what = `for ${operation}`
+
+  let simulated: IChainSimulateResult | undefined
+  let failure: string | undefined
+
+  try {
+    const result = await estimate()
+    if (result.estimateFailed)
+      failure = 'the estimate returned a fixed fallback rather than a figure'
+    else simulated = result
+  } catch (error) {
+    // Redacted before it reaches a terminal, a CI log or Slack: the endpoint is
+    // embedded in these errors and provider credentials ride in its query
+    // string. redactUrls.ts mandates this for anything derived from an error.
+    failure = redactErrorReason(
+      error instanceof Error ? error.message : String(error)
+    )
+  }
+
+  if (simulated === undefined) {
+    if (!fallbackExplicitlyAllowed(networkName))
+      throw new Error(
+        `Energy estimation failed ${where} ${what} — refusing to broadcast.\n` +
+          `  Underlying error: ${failure}\n` +
+          `  A failed estimate usually means the transaction would revert, and Tron ` +
+          `charges for a reverted call, so broadcasting on the fixed fee limit burns ` +
+          `energy for nothing.\n` +
+          `  Investigate the revert first. ${escapeHatchNote(networkName)}`
+      )
+
+    consola.warn(
+      `Energy estimation failed ${where} ${what}; ALLOW_GAS_ESTIMATE_FALLBACK is set, ` +
+        `so broadcasting on the fee limit of ${feeLimitSun} SUN. Underlying error: ${failure}`
+    )
+    return { estimatedEnergy: 0n, costSun: 0n, estimateFailed: true }
+  }
+
+  const estimatedEnergy = simulated.estimatedResource
+  const costSun = await options.costInSun(estimatedEnergy)
+
+  if (costSun > BigInt(feeLimitSun)) {
+    if (!fallbackExplicitlyAllowed(networkName))
+      throw new Error(
+        `Estimated energy exceeds the fee limit ${where} ${what} — refusing to broadcast.\n` +
+          `  Estimated ${estimatedEnergy} energy, costing ${costSun} SUN, against a fee ` +
+          `limit of ${feeLimitSun} SUN.\n` +
+          `  Broadcasting would not fail cleanly: the call runs until the limit is spent ` +
+          `and aborts part-way, leaving the operation neither applied nor abandoned while ` +
+          `the energy is still charged.\n` +
+          `  Raise ${TRON_FEE_LIMIT_ENV} to at least ${costSun}, or split the batch. ` +
+          `${escapeHatchNote(networkName)}`
+      )
+
+    consola.warn(
+      `Estimated ${estimatedEnergy} energy costs ${costSun} SUN, above the fee limit of ` +
+        `${feeLimitSun} SUN ${where} ${what}; ALLOW_GAS_ESTIMATE_FALLBACK is set, so ` +
+        `broadcasting anyway. It may abort part-way through.`
+    )
+  }
+
+  return { estimatedEnergy, costSun, estimateFailed: false }
+}

--- a/script/deploy/safe/executors/tron-energy-preflight.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.ts
@@ -115,14 +115,25 @@ export const assertTronBroadcastAffordable = async (
     // Inside the redaction boundary for the same reason as the estimate above:
     // the endpoint is embedded in these errors and provider credentials ride in
     // its query string.
-    throw new Error(
-      `Could not price ${estimatedEnergy} energy ${where} ${what} — refusing to broadcast.\n` +
-        `  Underlying error: ${redactErrorReason(
-          error instanceof Error ? error.message : String(error)
-        )}\n` +
-        `  Without a price there is no way to tell whether the fee limit covers this call. ` +
-        `${escapeHatchNote(networkName)}`
+    const pricingFailure = redactErrorReason(
+      error instanceof Error ? error.message : String(error)
     )
+
+    if (!fallbackExplicitlyAllowed(networkName))
+      throw new Error(
+        `Could not price ${estimatedEnergy} energy ${where} ${what} — refusing to broadcast.\n` +
+          `  Underlying error: ${pricingFailure}\n` +
+          `  Without a price there is no way to tell whether the fee limit covers this call. ` +
+          `${escapeHatchNote(networkName)}`
+      )
+
+    consola.warn(
+      `Could not price ${estimatedEnergy} energy ${where} ${what}; ` +
+        `ALLOW_GAS_ESTIMATE_FALLBACK is set, so broadcasting on the fee limit of ` +
+        `${feeLimitSun} SUN without knowing whether it covers this call. ` +
+        `Underlying error: ${pricingFailure}`
+    )
+    return { estimatedEnergy, costSun: 0n, estimateFailed: true }
   }
 
   if (costSun > BigInt(feeLimitSun)) {

--- a/script/deploy/safe/executors/tron-energy-preflight.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.ts
@@ -21,8 +21,6 @@ import type { IChainSimulateResult } from '../../../common/types'
 import { redactErrorReason } from '../../../utils/redactUrls'
 
 import { fallbackExplicitlyAllowed } from './gas-with-fallback'
-import type { ITronEnergyCost } from './tron-energy-estimate'
-
 /** The env var the devkit reads for its cap, named in refusals so it can be raised. */
 export const TRON_FEE_LIMIT_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
 
@@ -33,8 +31,8 @@ export interface ITronEnergyPreflightOptions {
   operation: string
   /** SUN the devkit will cap this transaction at. */
   feeLimitSun: number
-  /** Cost of that much energy at current chain prices, and whether the price was read. */
-  costInSun: (energy: bigint) => Promise<ITronEnergyCost>
+  /** Cost of that much energy at the chain's current rate. Throws if unreadable. */
+  costInSun: (energy: bigint) => Promise<bigint>
 }
 
 export interface ITronEnergyPreflightResult {
@@ -110,9 +108,9 @@ export const assertTronBroadcastAffordable = async (
 
   const estimatedEnergy = simulated.estimatedResource
 
-  let cost: ITronEnergyCost
+  let costSun: bigint
   try {
-    cost = await options.costInSun(estimatedEnergy)
+    costSun = await options.costInSun(estimatedEnergy)
   } catch (error) {
     // Inside the redaction boundary for the same reason as the estimate above:
     // the endpoint is embedded in these errors and provider credentials ride in
@@ -127,12 +125,6 @@ export const assertTronBroadcastAffordable = async (
     )
   }
 
-  const { costSun, priceConfirmed } = cost
-  const priceNote = priceConfirmed
-    ? ''
-    : `\n  The chain's energy price could not be read, so this cost is an unconfirmed upper ` +
-      `bound computed from the devkit's fallback rate, which is above the usual mainnet price.`
-
   if (costSun > BigInt(feeLimitSun)) {
     if (!fallbackExplicitlyAllowed(networkName))
       throw new Error(
@@ -142,7 +134,7 @@ export const assertTronBroadcastAffordable = async (
           `  Broadcasting would not fail cleanly: the call runs until the limit is spent ` +
           `and aborts part-way, leaving the operation neither applied nor abandoned while ` +
           `the energy is still charged.\n` +
-          `  Raise ${TRON_FEE_LIMIT_ENV} to at least ${costSun}, or split the batch.${priceNote} ` +
+          `  Raise ${TRON_FEE_LIMIT_ENV} to at least ${costSun}, or split the batch. ` +
           `${escapeHatchNote(networkName)}`
       )
 

--- a/script/deploy/safe/executors/tron-energy-preflight.ts
+++ b/script/deploy/safe/executors/tron-energy-preflight.ts
@@ -21,6 +21,7 @@ import type { IChainSimulateResult } from '../../../common/types'
 import { redactErrorReason } from '../../../utils/redactUrls'
 
 import { fallbackExplicitlyAllowed } from './gas-with-fallback'
+import type { ITronEnergyCost } from './tron-energy-estimate'
 
 /** The env var the devkit reads for its cap, named in refusals so it can be raised. */
 export const TRON_FEE_LIMIT_ENV = 'TRON_SAFE_EXEC_FEE_LIMIT_SUN'
@@ -32,8 +33,8 @@ export interface ITronEnergyPreflightOptions {
   operation: string
   /** SUN the devkit will cap this transaction at. */
   feeLimitSun: number
-  /** Cost of that much energy, in SUN, at current chain prices. */
-  costInSun: (energy: bigint) => Promise<bigint>
+  /** Cost of that much energy at current chain prices, and whether the price was read. */
+  costInSun: (energy: bigint) => Promise<ITronEnergyCost>
 }
 
 export interface ITronEnergyPreflightResult {
@@ -53,7 +54,10 @@ const escapeHatchNote = (networkName: string): string =>
  * Estimate first, then decide whether broadcasting is allowed.
  *
  * @param estimate - Runs the energy estimate. Throwing and returning
- * `estimateFailed: true` are treated alike: neither is an estimate.
+ * `estimateFailed: true` are treated alike: neither is an estimate. No Tron
+ * estimator returns the latter today — `TronChainCaller.simulate` throws
+ * instead — so that arm exists so a future estimator that reports a fallback
+ * figure cannot make this guard read it as a real one.
  * @param options - Network and operation labels, the configured fee limit, and
  * the energy-to-SUN conversion.
  * @returns The estimate and its cost.
@@ -105,7 +109,29 @@ export const assertTronBroadcastAffordable = async (
   }
 
   const estimatedEnergy = simulated.estimatedResource
-  const costSun = await options.costInSun(estimatedEnergy)
+
+  let cost: ITronEnergyCost
+  try {
+    cost = await options.costInSun(estimatedEnergy)
+  } catch (error) {
+    // Inside the redaction boundary for the same reason as the estimate above:
+    // the endpoint is embedded in these errors and provider credentials ride in
+    // its query string.
+    throw new Error(
+      `Could not price ${estimatedEnergy} energy ${where} ${what} — refusing to broadcast.\n` +
+        `  Underlying error: ${redactErrorReason(
+          error instanceof Error ? error.message : String(error)
+        )}\n` +
+        `  Without a price there is no way to tell whether the fee limit covers this call. ` +
+        `${escapeHatchNote(networkName)}`
+    )
+  }
+
+  const { costSun, priceConfirmed } = cost
+  const priceNote = priceConfirmed
+    ? ''
+    : `\n  The chain's energy price could not be read, so this cost is an unconfirmed upper ` +
+      `bound computed from the devkit's fallback rate, which is above the usual mainnet price.`
 
   if (costSun > BigInt(feeLimitSun)) {
     if (!fallbackExplicitlyAllowed(networkName))
@@ -116,7 +142,7 @@ export const assertTronBroadcastAffordable = async (
           `  Broadcasting would not fail cleanly: the call runs until the limit is spent ` +
           `and aborts part-way, leaving the operation neither applied nor abandoned while ` +
           `the energy is still charged.\n` +
-          `  Raise ${TRON_FEE_LIMIT_ENV} to at least ${costSun}, or split the batch. ` +
+          `  Raise ${TRON_FEE_LIMIT_ENV} to at least ${costSun}, or split the batch.${priceNote} ` +
           `${escapeHatchNote(networkName)}`
       )
 

--- a/script/deploy/safe/executors/tron-executor.ts
+++ b/script/deploy/safe/executors/tron-executor.ts
@@ -26,6 +26,7 @@ import {
   configuredTronFeeLimitSun,
   estimateTronEnergy,
   tronEnergyCostInSun,
+  type ITronEnergyCost,
 } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
@@ -70,7 +71,7 @@ export interface ITronExecutorDeps {
     calldata: Hex,
     params: IChainExecutionParams
   ) => Promise<bigint>
-  costInSun?: (energy: bigint) => Promise<bigint>
+  costInSun?: (energy: bigint) => Promise<ITronEnergyCost>
 }
 
 /**
@@ -200,7 +201,7 @@ export class TronChainExecutor implements IChainExecutor {
     })
   }
 
-  private async costInSunOnChain(energy: bigint): Promise<bigint> {
+  private async costInSunOnChain(energy: bigint): Promise<ITronEnergyCost> {
     return tronEnergyCostInSun(
       this.tronWalletClient.getTronWeb(this.networkKey),
       energy

--- a/script/deploy/safe/executors/tron-executor.ts
+++ b/script/deploy/safe/executors/tron-executor.ts
@@ -26,7 +26,6 @@ import {
   configuredTronFeeLimitSun,
   estimateTronEnergy,
   tronEnergyCostInSun,
-  type ITronEnergyCost,
 } from './tron-energy-estimate'
 import { assertTronBroadcastAffordable } from './tron-energy-preflight'
 
@@ -71,7 +70,7 @@ export interface ITronExecutorDeps {
     calldata: Hex,
     params: IChainExecutionParams
   ) => Promise<bigint>
-  costInSun?: (energy: bigint) => Promise<ITronEnergyCost>
+  costInSun?: (energy: bigint) => Promise<bigint>
 }
 
 /**
@@ -201,7 +200,7 @@ export class TronChainExecutor implements IChainExecutor {
     })
   }
 
-  private async costInSunOnChain(energy: bigint): Promise<ITronEnergyCost> {
+  private async costInSunOnChain(energy: bigint): Promise<bigint> {
     return tronEnergyCostInSun(
       this.tronWalletClient.getTronWeb(this.networkKey),
       energy

--- a/script/deploy/safe/executors/tron-executor.ts
+++ b/script/deploy/safe/executors/tron-executor.ts
@@ -1,12 +1,19 @@
 /**
  * Tron TVM chain executor — broadcasts Safe `execTransaction` via TronWeb native protocol.
+ *
+ * The execution is pre-flighted for energy first. The devkit broadcasts under a
+ * fixed `fee_limit` from the environment, so a batch needing more energy than
+ * the limit buys is not rejected — it runs until the limit is spent and aborts
+ * part-way, leaving the Safe operation neither applied nor abandoned.
  */
 
 import {
+  evmHexToTronBase58,
   tronScanTransactionUrl,
   type TronTvmNetworkName,
   type TronWalletClient,
 } from '@lifi/tron-devkit'
+import { encodeFunctionData, type Hex } from 'viem'
 
 import type {
   IChainExecutionParams,
@@ -14,6 +21,57 @@ import type {
   IChainExecutor,
 } from '../../../common/types'
 import { waitForConfirmation } from '../../../troncast/utils/tronweb'
+
+import {
+  configuredTronFeeLimitSun,
+  estimateTronEnergy,
+  tronEnergyCostInSun,
+} from './tron-energy-estimate'
+import { assertTronBroadcastAffordable } from './tron-energy-preflight'
+
+/**
+ * Safe v1.4.1 `execTransaction`, and the zeroed gas parameters the devkit sends
+ * with it.
+ *
+ * This has to stay identical to what `broadcastTronSafeExecTransaction` encodes,
+ * because the estimate is only meaningful if it prices the call that is actually
+ * broadcast. The devkit exposes no builder to borrow, so the shape is repeated
+ * here rather than derived.
+ */
+const SAFE_EXEC_TRANSACTION_ABI = [
+  {
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'data', type: 'bytes' },
+      { name: 'operation', type: 'uint8' },
+      { name: 'safeTxGas', type: 'uint256' },
+      { name: 'baseGas', type: 'uint256' },
+      { name: 'gasPrice', type: 'uint256' },
+      { name: 'gasToken', type: 'address' },
+      { name: 'refundReceiver', type: 'address' },
+      { name: 'signatures', type: 'bytes' },
+    ],
+    name: 'execTransaction',
+    outputs: [{ name: 'success', type: 'bool' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+/**
+ * Seams for the tests that prove a refusal never reaches the network. Nothing
+ * in production overrides these; the defaults are the real implementations.
+ */
+export interface ITronExecutorDeps {
+  estimateEnergy?: (
+    calldata: Hex,
+    params: IChainExecutionParams
+  ) => Promise<bigint>
+  costInSun?: (energy: bigint) => Promise<bigint>
+}
 
 /**
  * Maps a Tron `getTransactionInfo` result to a normalized execution status.
@@ -41,12 +99,15 @@ export function resolveTronExecutionStatus(
 export class TronChainExecutor implements IChainExecutor {
   public constructor(
     private readonly tronWalletClient: TronWalletClient,
-    private readonly networkKey: TronTvmNetworkName
+    private readonly networkKey: TronTvmNetworkName,
+    private readonly deps: ITronExecutorDeps = {}
   ) {}
 
   public async executeTransaction(
     params: IChainExecutionParams
   ): Promise<IChainExecutionResult> {
+    await this.assertAffordable(params)
+
     const { txId, hash } =
       await this.tronWalletClient.executeSafeExecTransaction({
         networkName: this.networkKey,
@@ -70,5 +131,79 @@ export class TronChainExecutor implements IChainExecutor {
     const status = resolveTronExecutionStatus(info)
 
     return { hash, status, displayHash, explorerUrl }
+  }
+
+  /**
+   * Refuses before the send when the execution has no usable energy estimate,
+   * or needs more energy than the devkit's fee limit can pay for.
+   *
+   * @param params - The Safe execution about to be broadcast.
+   * @throws When broadcasting would be a guess — see
+   * {@link assertTronBroadcastAffordable}.
+   */
+  private async assertAffordable(params: IChainExecutionParams): Promise<void> {
+    const calldata = encodeFunctionData({
+      abi: SAFE_EXEC_TRANSACTION_ABI,
+      functionName: 'execTransaction',
+      args: [
+        params.to,
+        params.value,
+        params.data,
+        params.operation,
+        0n,
+        0n,
+        0n,
+        ZERO_ADDRESS,
+        ZERO_ADDRESS,
+        params.signatures,
+      ],
+    }) as Hex
+
+    const estimate =
+      this.deps.estimateEnergy ??
+      ((data: Hex, execution: IChainExecutionParams) =>
+        this.estimateEnergyOnChain(data, execution))
+    const costInSun =
+      this.deps.costInSun ?? ((energy: bigint) => this.costInSunOnChain(energy))
+
+    await assertTronBroadcastAffordable(
+      async () => ({
+        estimatedResource: await estimate(calldata, params),
+        resourceLabel: 'energy',
+        estimateFailed: false,
+      }),
+      {
+        networkName: this.networkKey,
+        operation: `Safe execution on ${params.safeAddress}`,
+        feeLimitSun: configuredTronFeeLimitSun(),
+        costInSun,
+      }
+    )
+  }
+
+  private async estimateEnergyOnChain(
+    calldata: Hex,
+    params: IChainExecutionParams
+  ): Promise<bigint> {
+    const tronWeb = this.tronWalletClient.getTronWeb(this.networkKey)
+
+    const ownerBase58 = tronWeb.defaultAddress.base58 as string
+    if (!ownerBase58?.startsWith('T'))
+      throw new Error('TronWeb defaultAddress.base58 missing after init')
+
+    return estimateTronEnergy({
+      networkKey: this.networkKey,
+      ownerBase58,
+      contractBase58: evmHexToTronBase58(tronWeb, params.safeAddress),
+      data: calldata,
+      callValue: params.value,
+    })
+  }
+
+  private async costInSunOnChain(energy: bigint): Promise<bigint> {
+    return tronEnergyCostInSun(
+      this.tronWalletClient.getTronWeb(this.networkKey),
+      energy
+    )
   }
 }

--- a/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
+++ b/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
@@ -18,6 +18,7 @@ import type { Address, Hex } from 'viem'
 import type { IChainExecutionParams } from '../../../common/types'
 
 import { TronChainCaller } from './tron-caller'
+import type { ITronEnergyCost } from './tron-energy-estimate'
 import { TronChainExecutor } from './tron-executor'
 
 /** Obviously fake, and built rather than written so it is not a key-shaped literal. */
@@ -28,7 +29,10 @@ const SAFE = '0x2222222222222222222222222222222222222222' as Address
 const DATA = '0xdeadbeef' as Hex
 
 /** 100 SUN per energy, so 500_000 energy is exactly the 50 TRX default limit. */
-const costInSun = async (energy: bigint): Promise<bigint> => energy * 100n
+const costInSun = async (energy: bigint): Promise<ITronEnergyCost> => ({
+  costSun: energy * 100n,
+  priceConfirmed: true,
+})
 
 const failingEstimate = async (): Promise<bigint> => {
   throw new Error('triggerconstantcontract failed: 503 Service Unavailable')
@@ -206,5 +210,36 @@ describe('TronChainExecutor.executeTransaction', () => {
     expect(seen).not.toBe(DATA)
     // execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)
     expect(seen?.startsWith('0x6a761202')).toBe(true)
+  })
+})
+
+describe('the executor still executes when the estimate fits', () => {
+  it('broadcasts, so a guard that refused everything would fail here', async () => {
+    // Without this, an executor that refuses every transaction passes the whole
+    // suite: `spy.executions` was only ever asserted to be 0. That is the
+    // direction that would block production execution on every Tron network,
+    // so it is the one most worth pinning.
+    const client = {
+      executeSafeExecTransaction: async () => {
+        spy.executions += 1
+        return { txId: 'deadbeef', hash: '0xdeadbeef' as Hex }
+      },
+      getTronWeb: () => ({
+        trx: {
+          getTransactionInfo: async () => ({
+            id: 'deadbeef',
+            receipt: { result: 'SUCCESS' },
+          }),
+        },
+      }),
+    } as unknown as TronWalletClient
+
+    const result = await new TronChainExecutor(client, 'tron', {
+      estimateEnergy: async () => 400_000n,
+      costInSun,
+    }).executeTransaction(execution)
+
+    expect(spy.executions).toBe(1)
+    expect(result.status).toBe('success')
   })
 })

--- a/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
+++ b/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
@@ -1,0 +1,210 @@
+/**
+ * The A0.6 bar on the Tron path: with estimation unusable, the send is provably
+ * never reached. Asserted with a spy on the broadcast rather than only on the
+ * thrown error — an error proves something failed, not that nothing was sent.
+ */
+
+import type { TronWalletClient } from '@lifi/tron-devkit'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import type { Address, Hex } from 'viem'
+
+import type { IChainExecutionParams } from '../../../common/types'
+
+import { TronChainCaller } from './tron-caller'
+import { TronChainExecutor } from './tron-executor'
+
+/** Obviously fake, and built rather than written so it is not a key-shaped literal. */
+const FAKE_KEY = `0x${'11'.repeat(32)}`
+
+const TO = '0x1111111111111111111111111111111111111111' as Address
+const SAFE = '0x2222222222222222222222222222222222222222' as Address
+const DATA = '0xdeadbeef' as Hex
+
+/** 100 SUN per energy, so 500_000 energy is exactly the 50 TRX default limit. */
+const costInSun = async (energy: bigint): Promise<bigint> => energy * 100n
+
+const failingEstimate = async (): Promise<bigint> => {
+  throw new Error('triggerconstantcontract failed: 503 Service Unavailable')
+}
+
+interface ISpy {
+  broadcasts: number
+  executions: number
+}
+
+const execution: IChainExecutionParams = {
+  safeAddress: SAFE,
+  to: TO,
+  value: 0n,
+  data: DATA,
+  operation: 0,
+  signatures: '0x' as Hex,
+}
+
+let spy: ISpy
+let originalAllow: string | undefined
+let originalLimit: string | undefined
+
+beforeEach(() => {
+  spy = { broadcasts: 0, executions: 0 }
+  originalAllow = process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+  originalLimit = process.env.TRON_SAFE_EXEC_FEE_LIMIT_SUN
+  delete process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+  // Pinned, not read: the repo's .env is symlinked into every worktree and bun
+  // loads it into the test process, so an inherited value would move the
+  // threshold these cases are built around.
+  process.env.TRON_SAFE_EXEC_FEE_LIMIT_SUN = '50000000'
+})
+
+afterEach(() => {
+  if (originalAllow === undefined)
+    delete process.env.ALLOW_GAS_ESTIMATE_FALLBACK
+  else process.env.ALLOW_GAS_ESTIMATE_FALLBACK = originalAllow
+  if (originalLimit === undefined)
+    delete process.env.TRON_SAFE_EXEC_FEE_LIMIT_SUN
+  else process.env.TRON_SAFE_EXEC_FEE_LIMIT_SUN = originalLimit
+})
+
+const callerWith = (estimateEnergy: () => Promise<bigint>): TronChainCaller =>
+  new TronChainCaller('tron', FAKE_KEY, {
+    broadcast: async () => {
+      spy.broadcasts += 1
+      return { txId: 'deadbeef', hash: '0xdeadbeef' as Hex }
+    },
+    estimateEnergy,
+    costInSun,
+  })
+
+const executorWith = (
+  estimateEnergy: () => Promise<bigint>
+): TronChainExecutor => {
+  const client = {
+    executeSafeExecTransaction: async () => {
+      spy.executions += 1
+      return { txId: 'deadbeef', hash: '0xdeadbeef' as Hex }
+    },
+    getTronWeb: () => {
+      throw new Error('getTronWeb must not be reached in these cases')
+    },
+  } as unknown as TronWalletClient
+
+  return new TronChainExecutor(client, 'tron', { estimateEnergy, costInSun })
+}
+
+describe('TronChainCaller.call', () => {
+  it('never broadcasts when the estimate fails', async () => {
+    const error = await callerWith(failingEstimate)
+      .call({ to: TO, data: DATA, value: 0n })
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+    expect(error?.message).toMatch(/refusing to broadcast/)
+
+    expect(spy.broadcasts).toBe(0)
+  })
+
+  it('never broadcasts when the estimate exceeds the fee limit', async () => {
+    // 600k energy is 60 TRX against a 50 TRX cap. This is the case that
+    // previously broadcast, ran out of energy part-way and was retried forever.
+    const error = await callerWith(async () => 600_000n)
+      .call({ to: TO, data: DATA, value: 0n })
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+    expect(error?.message).toMatch(/exceeds the fee limit/)
+
+    expect(spy.broadcasts).toBe(0)
+  })
+
+  it('broadcasts when the estimate fits', async () => {
+    await callerWith(async () => 400_000n).call({
+      to: TO,
+      data: DATA,
+      value: 0n,
+    })
+
+    expect(spy.broadcasts).toBe(1)
+  })
+
+  it('broadcasts on a failed estimate only when the hatch names this network', async () => {
+    process.env.ALLOW_GAS_ESTIMATE_FALLBACK = 'tron'
+
+    await callerWith(failingEstimate).call({ to: TO, data: DATA, value: 0n })
+
+    expect(spy.broadcasts).toBe(1)
+  })
+})
+
+describe('TronChainExecutor.executeTransaction', () => {
+  it('never executes when the estimate fails', async () => {
+    const error = await executorWith(failingEstimate)
+      .executeTransaction(execution)
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+    expect(error?.message).toMatch(/refusing to broadcast/)
+
+    expect(spy.executions).toBe(0)
+  })
+
+  it('never executes when the estimate exceeds the fee limit', async () => {
+    const error = await executorWith(async () => 600_000n)
+      .executeTransaction(execution)
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+    expect(error?.message).toMatch(/exceeds the fee limit/)
+
+    expect(spy.executions).toBe(0)
+  })
+
+  it('prices the execTransaction calldata, not the inner call', async () => {
+    // The estimate has to be of the Safe wrapper the devkit actually sends. If
+    // it priced params.data instead, a batch whose wrapper is the expensive part
+    // would pass the guard and still abort part-way.
+    let seen: Hex | undefined
+    const client = {
+      executeSafeExecTransaction: async () => {
+        spy.executions += 1
+        return { txId: 'deadbeef', hash: '0xdeadbeef' as Hex }
+      },
+      getTronWeb: () => {
+        throw new Error('not reached')
+      },
+    } as unknown as TronWalletClient
+
+    const error = await new TronChainExecutor(client, 'tron', {
+      estimateEnergy: async (calldata) => {
+        seen = calldata
+        return 600_000n
+      },
+      costInSun,
+    })
+      .executeTransaction(execution)
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      )
+
+    expect(error?.message).toMatch(/exceeds the fee limit/)
+
+    expect(seen).not.toBe(DATA)
+    // execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)
+    expect(seen?.startsWith('0x6a761202')).toBe(true)
+  })
+})

--- a/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
+++ b/script/deploy/safe/executors/tron-refuse-to-broadcast.test.ts
@@ -18,7 +18,6 @@ import type { Address, Hex } from 'viem'
 import type { IChainExecutionParams } from '../../../common/types'
 
 import { TronChainCaller } from './tron-caller'
-import type { ITronEnergyCost } from './tron-energy-estimate'
 import { TronChainExecutor } from './tron-executor'
 
 /** Obviously fake, and built rather than written so it is not a key-shaped literal. */
@@ -29,10 +28,7 @@ const SAFE = '0x2222222222222222222222222222222222222222' as Address
 const DATA = '0xdeadbeef' as Hex
 
 /** 100 SUN per energy, so 500_000 energy is exactly the 50 TRX default limit. */
-const costInSun = async (energy: bigint): Promise<ITronEnergyCost> => ({
-  costSun: energy * 100n,
-  priceConfirmed: true,
-})
+const costInSun = async (energy: bigint): Promise<bigint> => energy * 100n
 
 const failingEstimate = async (): Promise<bigint> => {
   throw new Error('triggerconstantcontract failed: 503 Service Unavailable')

--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -10,7 +10,7 @@ import {
   sanitizeProvenanceText,
 } from '../shared/git-provenance'
 
-import { MAX_PROPOSAL_REASON_LENGTH } from './safe-utils'
+import { MAX_PROPOSAL_REASON_LENGTH } from './proposal-intent'
 
 /** How many networks are named individually before the card switches to a count. */
 const NAMED_NETWORK_LIMIT = 4


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-890](https://linear.app/lifi-linear/issue/EXSC-890/tron-safetimelock-path-broadcasts-with-no-energy-estimate-at-all)

# Why did I implement it this way?

S3 (#2288) made a failed gas estimate refuse to broadcast on the EVM Safe and
timelock paths. Tron was left out, and had no pre-flight at all: both send sites
delegate to the devkit, which posts `wallet/triggersmartcontract` under a fixed
`fee_limit` read from the environment, signs, and calls `sendRawTransaction`.

`TronChainCaller.simulate()` already ran an energy estimate and was simply never
consulted before broadcasting.

**Two guards, because Tron has a failure mode EVM does not.** A fee limit that
cannot pay for the call does not fail cleanly — the call runs until the energy
is spent and aborts part-way. `runPendingTimelockTXs.yml:102` already documents
the consequence: a multi-call timelock batch exceeds the 50 TRX default, aborts
as `OUT_OF_ENERGY`, and is retried forever. So the pre-flight refuses when there
is no usable estimate **and** when the estimate costs more than the configured
limit.

**One escape hatch, not two.** The policy reuses `ALLOW_GAS_ESTIMATE_FALLBACK`
from `gas-with-fallback.ts`, including its comma-separated network scoping, so
`tron` scopes it and an operator has one switch to learn and one to audit.

**A returned `estimateFailed: true` is treated exactly like a throw** — a fixed
fallback is not an estimate, and broadcasting on it is the guess being refused.

**The executor re-encodes Safe `execTransaction` to estimate it.** The estimate
is only meaningful if it prices the call actually broadcast; the inner
`params.data` is not that call, and a batch whose cost sits in the wrapper would
otherwise pass the guard. The devkit exposes no builder to borrow, so the ABI
and its zeroed gas arguments are repeated with a comment naming the coupling,
and a test asserts the estimated calldata starts with the `execTransaction`
selector rather than the inner calldata — so the two cannot drift silently.
**This is the reversible choice most worth a reviewer's eye.**

**Why not the devkit's own estimator.** `estimateContractCallEnergy` takes a
human-readable function selector and hardcodes `call_value: 0`. These call sites
hold encoded calldata, no ABI, and a possibly non-zero value.

**Why it refuses rather than raising the limit.** Neither
`IBroadcastTronContractCallParams` nor `ITronSafeExecParams` accepts a
`feeLimit`, so the limit cannot be raised per call from this repo — the devkit
reads it from `TRON_SAFE_EXEC_FEE_LIMIT_SUN`. The refusal therefore names that
variable and the figure to raise it to. Passing a per-call limit would need a
devkit change and is out of scope here.

The fee limit is parsed exactly as the devkit parses it, including throwing on a
malformed value: a guard computing a different limit from the one the broadcast
runs under would be checking the wrong number.

## Evidence

Refusals are proved with a **spy on the broadcast**, not only on the thrown
error — an error shows something failed, not that nothing was sent.

```text
bun test script/                 1605 pass / 0 fail
baseline on origin/main 8f2be94d0  1589 pass / 0 fail      (+16, no regressions)
tsc-files --noEmit               rc=0
eslint script/deploy/safe/executors/  rc=0
```

Mutation-tested, so the assertions are not vacuous:

```text
drop the executor pre-flight        -> 3 fail (exactly its three cases)
drop both pre-flights               -> 5 fail (all refusal cases)
restored                            -> 71 pass / 0 fail
```

The two cases that still pass under mutation are "broadcasts when the estimate
fits" and the escape hatch, which correctly do not depend on a guard blocking.

## Acceptance row not fully evidenced

The ticket asks additionally that "a multi-call timelock batch that exceeds the
50-TRX default must be shown to refuse rather than abort mid-SSTORE". The
threshold behaviour is proved with the arithmetic that governs it — 600k energy
at current pricing is 60 TRX against a 50 TRX cap, refused; 500k is exactly the
cap and allowed. Those are post-margin figures — with the 1.2 margin now
applied, a 500k ceiling corresponds to a raw `energy_used` of 416,666. What is **not** demonstrated here is a real pending batch
measured against Tron RPC: that needs such a batch to exist at the time of
measurement, and the claim that real batches exceed 500k energy currently rests
on the observation already recorded in `runPendingTimelockTXs.yml`, not on a
measurement of mine. Calling that out rather than implying I measured it.

## Review round 1 — what changed

The gate found **no bypass**: every Tron send reachable from `script/` on the Safe and timelock paths
is behind the pre-flight, and the executor's re-encoded `execTransaction` calldata is byte-identical
to what the devkit broadcasts (verified against the ABI read out of `node_modules` at runtime, across
three argument shapes). The findings were on the other side.

**A safety margin was missing, so the guard passed exactly the batches this PR is about.**
`triggerconstantcontract` under-reports what the broadcast is charged — the dynamic-energy penalty is
not applied to constant calls, and state moves between estimate and send. The devkit's own estimator
has applied `DEFAULT_SAFETY_MARGIN` (1.2) for that reason and the deploy scripts price through it, so
comparing the raw figure let a batch 0–20% above the estimate clear the guard and still abort
mid-execution. Now applies the same constant, extracted as `applyTronSafetyMargin` so it is testable
without an endpoint. **This moves the refusal threshold on a money path — the change most worth your
attention.**

**A failed price read silently substituted a stale constant.** `getCurrentPrices` swallows its own
error and returns 210 SUN/energy against a live mainnet rate of 100, so a transient RPC failure would
have made the guard refuse honest traffic while telling the operator to raise the limit to a figure
over twice the truth. Pricing now reports whether the price was read, and the refusal labels an
unconfirmed upper bound instead of quoting it as fact.

**The estimate is mandatory before every send now**, and `runPendingTimelockTXs.yml` reaches TronGrid
with no API key — a single transient 429 would have refused a production execution. Bounded retry with
the devkit's own `MAX_RETRIES`/`RETRY_DELAY`, then refuse; the same shape D3 settled for unfetchable
anchors. Pricing also moved inside the redaction boundary.

**Coverage that was missing.** The executor had no test that it *ever* broadcasts — one refusing every
transaction passed the whole suite, and that direction blocks production execution on every Tron
network. `tron-energy-estimate.ts` had no test at all. All six mutations now die:

```text
executor refuses everything      -> 1 fail
safety margin dropped            -> 5 fail
TRX->SUN factor dropped           -> 1 fail
malformed-value throw deleted    -> 5 fail
fee-limit default changed        -> 3 fail
price-confirmed forced true      -> 1 fail
suite: 1627 pass / 0 fail  (baseline 1589 / 0 on main)
```

**One concern I raised was disproven, and I am recording it rather than quietly dropping it.** I
flagged that ignoring staked energy could refuse an honest transaction. It cannot: Tron's `fee_limit`
bounds the *total* energy a transaction may consume, so delegated or frozen energy does not raise the
ceiling and consulting it would only weaken the guard. Corroborated locally two ways — the
`runPendingTimelockTXs.yml` comment that 50 TRX "caps a Tron tx at 500k energy" (exactly 50e6 / 100
SUN), and the devkit's own `estimateEnergyAndFeeLimit`, which reads available energy but only logs it
and derives the limit from the full cost.

## Out of scope, found while enumerating send sites

Three Tron paths broadcast with no comparison against their fee limit. All are direct-EOA operator
tools rather than Safe or timelock paths, so they are outside this PR, but they are the same class of
defect: `script/troncast/commands/send.ts` (raw send, default 1000 TRX limit, no estimate — reached
from `universalCast.sh` and `emergencyPauseBreakGlass.sh`), `script/deploy/tron/tronUtils.ts:425-450`
(estimates, logs the cost, then sends at 5000 TRX without comparing), and
`transfer-ownership-to-timelock.ts:174`. Recorded on the ticket.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

No Solidity changes; TypeScript only.


