### PR TITLE
fix(safe): import MAX_PROPOSAL_REASON_LENGTH from where it lives (EXSC-921)

### DIFF
--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -10,7 +10,7 @@ import {
   sanitizeProvenanceText,
 } from '../shared/git-provenance'
 
-import { MAX_PROPOSAL_REASON_LENGTH } from './safe-utils'
+import { MAX_PROPOSAL_REASON_LENGTH } from './proposal-intent'
 
 /** How many networks are named individually before the card switches to a count. */
 const NAMED_NETWORK_LIMIT = 4


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes EXSC-921.

A parallel session opened the byte-identical fix as #2313 with that ticket seven minutes after
this one; #2313 is closed in favour of this PR, which was already posted for review and green.
Also labelled `trivial` (single-line import fix).

# Why did I implement it this way?

`script/deploy/safe/proposal-card.ts` imports `MAX_PROPOSAL_REASON_LENGTH` from `./safe-utils`,
but that constant lives in `./proposal-intent`. `bun test script/` fails on `main` with:

```text
SyntaxError: Export named 'MAX_PROPOSAL_REASON_LENGTH' not found in module
  .../script/deploy/safe/safe-utils.ts
```

**How it got in.** Two PRs that were each green on their own crossed:

| PR | merged (UTC) | what it did |
| --- | --- | --- |
| #2298 | 11:03:36 | moved `MAX_PROPOSAL_REASON_LENGTH` out of `safe-utils.ts` into `proposal-intent.ts` |
| #2299 | 11:06:59 | added `proposal-card.ts`, which imports it from `safe-utils.ts` |

Three minutes apart, and neither PR's CI ever saw the other's change, so both merged green and
the combination is what breaks. Nothing was wrong with either diff in isolation.

**Why this direction.** The constant's home is `proposal-intent.ts`, and the sibling consumer
`provenance-display.ts` already imports it from there — so pointing `proposal-card.ts` at the
same place matches what's already the convention. Re-exporting it from `safe-utils.ts` would
also go green, but it would leave the constant with two import paths and re-couple
`safe-utils.ts` to something #2298 deliberately moved out.

Evidence, on a clean detached checkout of `origin/main` at `0bc30a141`:

| | `proposal-card.test.ts` | `bun test script/` |
| --- | --- | --- |
| `origin/main` as-is | 0 pass / **1 fail** | **1 fail** |
| with this change | passes | **1902 pass / 0 fail** |

`Run TypeScript Unit Tests` on `main` at `0bc30a141` is a `failure`, and every open PR inherits
that red — including #2286, whose `run-ts-tests` / `ts-tests-required` red is this and not its
own.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

No new test: `proposal-card.test.ts` already covers this and already fails on `main` — it is the
check that caught it. The gap is that no job runs the merged combination of two green PRs before
they land, which is a CI-ordering issue rather than a missing unit test.

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

