### PR TITLE
fix(safe): import MAX_PROPOSAL_REASON_LENGTH from proposal-intent (EXSC-921)

### DIFF
--- a/script/deploy/safe/proposal-card.ts
+++ b/script/deploy/safe/proposal-card.ts
@@ -10,7 +10,7 @@ import {
   sanitizeProvenanceText,
 } from '../shared/git-provenance'
 
-import { MAX_PROPOSAL_REASON_LENGTH } from './safe-utils'
+import { MAX_PROPOSAL_REASON_LENGTH } from './proposal-intent'
 
 /** How many networks are named individually before the card switches to a count. */
 const NAMED_NETWORK_LIMIT = 4


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-921](https://linear.app/lifi-linear/issue/EXSC-921/proposal-cardts-imports-max-proposal-reason-length-from-the-wrong)

# Why did I implement it this way?

`proposal-card.ts` imported `MAX_PROPOSAL_REASON_LENGTH` from `./safe-utils`, which does not export it — `safe-utils.ts` only *imports* other members from `./proposal-intent`. The constant is defined and exported in `proposal-intent.ts`, which is where the sibling modules (`provenance-display.ts`, `provenance-display.test.ts`) already import it from. Re-pointing the one import matches them and needs no re-export.

Direction matters here, not just the name: `proposal-intent.ts` documents itself as the dependency-free leaf ("what lets `safe-utils.ts` import it without a cycle"). Importing from the leaf keeps `proposal-card.ts` matching its own "pure: rows in, text out" docstring — re-exporting the constant from `safe-utils` instead would have pulled that module's Safe/Mongo/network graph into the renderer.

Effect on `main` today:

```text
script/deploy/safe/proposal-card.ts(13,10): error TS2305: Module '"./safe-utils"' has no exported member 'MAX_PROPOSAL_REASON_LENGTH'.
```

Anything that merges `main` and type-checks this file inherits the failure — found while merging `main` into #2293. Introduced in ac3dd16a4 (#2299).

Verification on this branch:

- `bunx tsc-files --noEmit script/deploy/safe/proposal-card.ts` → clean (fails on `main` at 0bc30a141)
- `bunx tsx script/utils/validateScripts.ts --base origin/main` → passes
- `bun test script/deploy/safe/` → 1086 pass, 0 fail
- `bunx eslint script/deploy/safe/proposal-card.ts` → clean

Two things found while verifying, deliberately **not** in this PR:

1. `validate-scripts` reported `pass` on #2299 even though `proposal-card.ts` was in that PR's changed-file set — running `tsc-files --noEmit` over exactly that five-file set locally exits 2 with the error above. Why the CI type check didn't fail is worth its own look; tracked on EXSC-921.
2. `script/deploy/safe/test-ledger.ts` treats `getLedgerAccount()`'s result as the account itself, but it returns `{ account, transport }` (4x TS2339, and the `signMessage` guard makes the script exit 1 unconditionally). Separate defect, separate PR.

Also noted and left alone: the `MAX_FIELD_CHARS` docstring says `reason` has its "own tighter cap", but `MAX_PROPOSAL_REASON_LENGTH` is also 200. Pre-existing and unrelated — kept out so this stays a one-line, cleanly cherry-pickable fix.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
