### PR TITLE
feat(safe): sign the Safe transaction hash by default (EXSC-871)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,9 +99,6 @@ ALLOW_FUTURE_NONCE_EXECUTION=
 # All deployment logs are stored in MongoDB (database: contract-deployments)
 
 # Safe Transaction Signing Configuration
-# Enable Safe transaction hash signing (set to true to enable, false to disable)
-# When enabled, uses eth_sign to sign the Safe tx hash instead of EIP-712 typed data
-# This is useful for hardware wallets (e.g. Ledger) that may reject large EIP-712 payloads
 # Safe transactions are signed as a hash (eth_sign over safeTxHash) by default.
 # Set this to exactly "true" to sign EIP-712 typed data instead; hardware wallets
 # render it inconsistently and reject it outright once the payload grows large.

--- a/.env.example
+++ b/.env.example
@@ -102,7 +102,10 @@ ALLOW_FUTURE_NONCE_EXECUTION=
 # Enable Safe transaction hash signing (set to true to enable, false to disable)
 # When enabled, uses eth_sign to sign the Safe tx hash instead of EIP-712 typed data
 # This is useful for hardware wallets (e.g. Ledger) that may reject large EIP-712 payloads
-ENABLE_SAFE_TX_HASH_SIGNING=false
+# Safe transactions are signed as a hash (eth_sign over safeTxHash) by default.
+# Set this to exactly "true" to sign EIP-712 typed data instead; hardware wallets
+# render it inconsistently and reject it outright once the payload grows large.
+ENABLE_SAFE_EIP712_SIGNING=false
 
 # Optional override for the on-disk 4byte selector-signature cache used by the
 # Safe scripts (defaults to .cache/selector-signatures.json)

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -249,9 +249,12 @@ signer sees:
 2. **Safe transaction details** — nonce (current/stale/future coloring), `to`
    + resolved name, raw data, proposer, stored `safeTxHash`, signature count
    vs threshold, drain origin-PR links where present.
-3. A **Ledger Flex "filmstrip"** (`renderLedgerFlexFlow`,
-   `ledger-flex-preview.ts`) — ASCII replica of the device screens for the
-   exact to-be-signed values.
+3. The value to verify on the device, which depends on the signing mode. In
+   the default hash mode: the `safeTxHash` to compare character by character
+   against the single message screen. Under `ENABLE_SAFE_EIP712_SIGNING=true`
+   and only when the transaction carries calldata: a **Ledger Flex
+   "filmstrip"** (`renderLedgerFlexFlow`, `ledger-flex-preview.ts`), an ASCII
+   replica of the device screens for the exact to-be-signed values.
 4. The action prompt: `Do Nothing` / `Sign` / `Sign & Execute` /
    `Sign and Execute With Deployer` / `Execute with Deployer`. The two
    deployer variants are the usual choice — see §2 on why the deployer

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -250,8 +250,10 @@ signer sees:
    + resolved name, raw data, proposer, stored `safeTxHash`, signature count
    vs threshold, drain origin-PR links where present.
 3. The value to verify on the device, which depends on the signing mode. In
-   the default hash mode: the `safeTxHash` to compare character by character
-   against the single message screen. Under `ENABLE_SAFE_EIP712_SIGNING=true`
+   the default hash mode: the single message screen, compared character by
+   character against the hash in the out-of-band message from the proposer —
+   not against the hash stored with the proposal, which the proposer controls
+   alongside the calldata. Under `ENABLE_SAFE_EIP712_SIGNING=true`
    and only when the transaction carries calldata: a **Ledger Flex
    "filmstrip"** (`renderLedgerFlexFlow`, `ledger-flex-preview.ts`), an ASCII
    replica of the device screens for the exact to-be-signed values.

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -215,7 +215,7 @@ chokepoint can likewise propose arbitrary calldata and is not gated.
 `runPropose` owner-gates the proposer on-chain; with `--timelock` it wraps all
 calls into one `scheduleBatch` via `wrapWithTimelockSchedule` (`safe-utils.ts`;
 live `getMinDelay()` with `config/timelockController.json` fallback, timestamp
-salt), resolves the nonce (`getNextNonce`), **signs immediately** (EIP-712),
+salt), resolves the nonce (`getNextNonce`), **signs immediately** (`eth_sign` over the `safeTxHash`),
 computes the `safeTxHash` via the Safe's on-chain `getTransactionHash`, and
 stores. The document (`ISafeTxDocument`) carries the raw Safe tx fields, the
 proposer's wallet address, an `intentHash` dedup key, a
@@ -257,8 +257,14 @@ signer sees:
    deployer variants are the usual choice — see §2 on why the deployer
    wallet broadcasts.
 
-Signing is EIP-712 over the `SafeTx` struct, reconstructed from the row's raw
-fields — what is displayed and on the Ledger is what is signed. Each owner
+Signing is `eth_sign` over the `safeTxHash`, read from the Safe's own
+on-chain `getTransactionHash` so the digest is correct for that Safe's version.
+The device shows one value, which is the value the signer compares against the
+out-of-band message — rather than a typed-data payload hardware wallets render
+inconsistently and reject outright once it grows large. EIP-712 typed data
+remains available behind `ENABLE_SAFE_EIP712_SIGNING=true`; there is no
+automatic switch between the two, because a mode change mid-flow re-prompts the
+device in a different rendering than the one the signer was reading. Each owner
 runs the tool independently until the Safe's threshold is met — read
 on-chain per Safe at confirm time, never assumed; a new proposal already
 carries the proposer's signature.

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -62,6 +62,7 @@ import {
   getOrInitializeSafeClient,
   hasEnoughSignatures,
   isFutureNonceExecutionAllowed,
+  resolveSafeSigningMode,
   isSignedByProductionWallet,
   mongoSafeTxRowFilter,
   PrivateKeyTypeEnum,
@@ -435,7 +436,12 @@ const processTxs = async (
     // signer steps through so values can be compared screen-by-screen. EVM
     // only — the Flex EIP-712 blind-signing flow does not apply to Tron.
     // A display error must never block signing.
+    //
+    // Only for the typed-data flow. Hash signing shows one message screen, so
+    // printing these would tell the signer to compare against screens their
+    // device never displays.
     if (
+      resolveSafeSigningMode(process.env) === 'eip712' &&
       !isTronNetworkKey(network) &&
       tx.safeTx.data.data &&
       tx.safeTx.data.data !== '0x'
@@ -458,6 +464,14 @@ const processTxs = async (
       } catch (error) {
         consola.debug(`Ledger Flex filmstrip skipped: ${error}`)
       }
+    else if (!isTronNetworkKey(network))
+      consola.info(
+        [
+          'Ledger — the device shows one message screen holding the Safe transaction hash.',
+          `Compare it character by character against: ${tx.safeTxHash}`,
+          'At least 16 characters, 8 from each end. Four-and-four is grindable.',
+        ].join('\n')
+      )
 
     const integrity = evaluateProposalIntegrity({ nonceStatus })
     // Read from the normalised transaction, not the stored document: this is the
@@ -930,8 +944,11 @@ const main = defineCommand({
         throw error
       }
 
-      // Signing a Safe EIP-712 payload on a Ledger Flex needs blind signing on.
-      // Fail fast with enable instructions rather than dying mid-sign.
+      // Fail fast with enable instructions rather than dying mid-sign. The
+      // requirement is documented for the EIP-712 payload; whether a Flex also
+      // needs it for the single message screen hash signing shows has not been
+      // checked on a device, so the gate stays for both rather than being
+      // narrowed on an assumption.
       const { checkBlindSigningEnabled, closeLedgerConnection } = await import(
         './ledger'
       )

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -63,6 +63,7 @@ import {
   hasEnoughSignatures,
   isFutureNonceExecutionAllowed,
   resolveSafeSigningMode,
+  resolveSignerVerificationDisplay,
   isSignedByProductionWallet,
   mongoSafeTxRowFilter,
   PrivateKeyTypeEnum,
@@ -432,20 +433,13 @@ const processTxs = async (
 
     consola.info(detailLines.join('\n'))
 
-    // Ledger Flex signing filmstrip: reproduce the on-device screens the
-    // signer steps through so values can be compared screen-by-screen. EVM
-    // only — the Flex EIP-712 blind-signing flow does not apply to Tron.
     // A display error must never block signing.
-    //
-    // Only for the typed-data flow. Hash signing shows one message screen, so
-    // printing these would tell the signer to compare against screens their
-    // device never displays.
-    if (
-      resolveSafeSigningMode(process.env) === 'eip712' &&
-      !isTronNetworkKey(network) &&
-      tx.safeTx.data.data &&
-      tx.safeTx.data.data !== '0x'
+    const verificationDisplay = resolveSignerVerificationDisplay(
+      resolveSafeSigningMode(process.env),
+      isTronNetworkKey(network),
+      tx.safeTx.data.data
     )
+    if (verificationDisplay === 'filmstrip')
       try {
         const filmstrip = renderLedgerFlexFlow({
           chainId: chain.id,
@@ -464,11 +458,14 @@ const processTxs = async (
       } catch (error) {
         consola.debug(`Ledger Flex filmstrip skipped: ${error}`)
       }
-    else if (!isTronNetworkKey(network))
+    else if (verificationDisplay === 'hash-compare')
       consola.info(
         [
           'Ledger — the device shows one message screen holding the Safe transaction hash.',
-          `Compare it character by character against: ${tx.safeTxHash}`,
+          'Compare that screen against the hash in the out-of-band message from the',
+          'proposer. The hash stored with this proposal is not the authority here: the',
+          'proposer controls it as well as the calldata, so checking one against the',
+          'other confirms nothing.',
           'At least 16 characters, 8 from each end. Four-and-four is grindable.',
         ].join('\n')
       )

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -44,6 +44,7 @@ import {
   buildProposalProvenance,
   canExecuteWithNonceStatus,
   resolveSafeSigningMode,
+  resolveSignerVerificationDisplay,
   toSafeEthSignSignature,
   classifyDuplicateKeyError,
   pickTimelockSalt,
@@ -1206,8 +1207,8 @@ describe('releaseAllPooledSafeClients', () => {
 })
 
 describe('SafeClient.signTransaction chain id source', () => {
-  // These cover the typed-data path, which WP-3.4 made opt-in. Without the
-  // flag `signTransaction` signs the hash and never builds an EIP-712 domain.
+  // The flag is required: without it `signTransaction` signs the hash and
+  // never builds an EIP-712 domain, so these cases would not be reached.
   const previous = process.env.ENABLE_SAFE_EIP712_SIGNING
   beforeEach(() => {
     process.env.ENABLE_SAFE_EIP712_SIGNING = 'true'
@@ -2024,17 +2025,16 @@ describe('wrapWithTimelockSchedule', () => {
 
 describe('resolveSafeSigningMode', () => {
   it('signs the transaction hash by default', () => {
-    // WP-3.4 / T4-A3. The device shows one value the signer can compare against
-    // the out-of-band DM, instead of five fields it renders inconsistently.
+    // The device shows one value the signer can compare against the
+    // out-of-band DM, instead of five fields it renders inconsistently.
     expect(resolveSafeSigningMode({})).toBe('hash')
   })
 
   it.each([['true'], ['TRUE'], ['1'], ['yes'], ['false'], ['']])(
     'still signs the hash when the retired hash flag is set to %p',
     (value) => {
-      // ENABLE_SAFE_TX_HASH_SIGNING selected this mode when it was optional.
-      // It now describes the default, so honouring it either way would let a
-      // stale `=false` silently opt an operator back into typed data.
+      // Honouring this flag either way would let a stale `=false` silently
+      // opt an operator back into typed data.
       expect(
         resolveSafeSigningMode({ ENABLE_SAFE_TX_HASH_SIGNING: value })
       ).toBe('hash')
@@ -2131,6 +2131,59 @@ describe('toSafeEthSignSignature', () => {
   })
 })
 
+describe('toSafeEthSignSignature input validation', () => {
+  it.each([
+    ['non-hex r and s', `0x${'z'.repeat(128)}1b`],
+    ['a space in v', `0x${'ab'.repeat(64)} 1`],
+    ['a sign in v', `0x${'ab'.repeat(64)}+1`],
+  ])('refuses %s', (_label, signature) => {
+    // parseInt would read " 1" and "+1" as 1, so the shape has to be checked
+    // before v is parsed out of it.
+    expect(() => toSafeEthSignSignature(signature as `0x${string}`)).toThrow()
+  })
+})
+
+describe('resolveSignerVerificationDisplay', () => {
+  it('points a hash-mode signer at the hash screen, with or without calldata', () => {
+    expect(resolveSignerVerificationDisplay('hash', false, '0xdeadbeef')).toBe(
+      'hash-compare'
+    )
+    expect(resolveSignerVerificationDisplay('hash', false, '0x')).toBe(
+      'hash-compare'
+    )
+    expect(resolveSignerVerificationDisplay('hash', false, undefined)).toBe(
+      'hash-compare'
+    )
+  })
+
+  it('shows the filmstrip for typed data with calldata', () => {
+    expect(
+      resolveSignerVerificationDisplay('eip712', false, '0xdeadbeef')
+    ).toBe('filmstrip')
+  })
+
+  it.each([['0x'], [''], [undefined]])(
+    'shows nothing for typed data whose calldata is %p',
+    (callData) => {
+      // The device renders typed-data screens here, so naming the single hash
+      // screen would send the signer to compare against a screen this mode
+      // never shows.
+      expect(resolveSignerVerificationDisplay('eip712', false, callData)).toBe(
+        'none'
+      )
+    }
+  )
+
+  it.each([['hash'], ['eip712']] as const)(
+    'shows nothing on Tron in %s mode',
+    (mode) => {
+      expect(resolveSignerVerificationDisplay(mode, true, '0xdeadbeef')).toBe(
+        'none'
+      )
+    }
+  )
+})
+
 describe('SafeClient.signTransaction default path', () => {
   const previous = process.env.ENABLE_SAFE_EIP712_SIGNING
   beforeEach(() => {
@@ -2195,9 +2248,8 @@ describe('SafeClient.signTransaction default path', () => {
   })
 
   it('asks the Safe to hash the transaction it is about to sign', async () => {
-    // Hash signing makes this argument list the only thing that decides what
-    // gets signed — the typed-data path used to build the digest separately, so
-    // a wrong field showed up as a mismatch. Now nothing else would notice.
+    // This argument list is the only thing that decides what gets signed, so
+    // nothing downstream would notice a wrong field.
     const { client, hashArgs } = await makeClient()
     const safeTx = buildSafeTx({ nonce: 7n, value: 123n })
 
@@ -2237,11 +2289,10 @@ describe('SafeClient.signTransaction default path', () => {
   })
 
   it('does not fall back to hash signing when typed data fails', async () => {
-    // The fallback WP-3.4 removes ran in the other direction: EIP-712 failed and
-    // the device was re-prompted in a different rendering mid-flow, so a signer
-    // who had read one screen approved another. Asserting from the hash side
-    // would have passed on origin/main too — this has to opt into typed data,
-    // break it, and prove the hash path is never reached.
+    // Must opt into typed data and break it: asserting from the hash side
+    // would pass whether or not a fallback exists. A mid-flow switch would
+    // re-prompt the device in a different rendering, so a signer who had read
+    // one screen would approve another.
     process.env.ENABLE_SAFE_EIP712_SIGNING = 'true'
     const { client, calls } = await makeClient()
     const failing = client as unknown as {

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -2096,7 +2096,15 @@ describe('toSafeEthSignSignature', () => {
 
   it.each([
     ['too short', `0x${'11'.repeat(64)}`],
-    ['no prefix', `${'11'.repeat(65)}`],
+    // Both carry a valid recovery id at the v position on purpose: an input
+    // that fails the recovery-id check instead would pass this test whatever
+    // the length and prefix checks did.
+    ['too long behind a valid v', `0x${'11'.repeat(32)}${'22'.repeat(32)}1bff`],
+    [
+      'the right length without the prefix',
+      `aa${'11'.repeat(32)}${'22'.repeat(32)}1b`,
+    ],
+    ['not hex at all', 'not-a-signature'],
   ])('refuses a signature that is %s', (_label, value) => {
     expect(() => toSafeEthSignSignature(value as Hex)).toThrow()
   })
@@ -2139,9 +2147,14 @@ describe('SafeClient.signTransaction default path', () => {
     const { SafeClient } = await import('./safe-utils')
     const account = privateKeyToAccount(generatePrivateKey())
     const calls: string[] = []
+    const hashArgs: unknown[][] = []
     const publicClient = {
-      readContract: async ({ functionName }: { functionName: string }) => {
-        calls.push(functionName)
+      readContract: async (params: {
+        functionName: string
+        args: unknown[]
+      }) => {
+        calls.push(params.functionName)
+        hashArgs.push(params.args)
         return SAFE_TX_HASH
       },
       getChainId: async () => {
@@ -2167,7 +2180,7 @@ describe('SafeClient.signTransaction default path', () => {
       undefined,
       42161
     )
-    return { client, account, calls }
+    return { client, account, calls, hashArgs }
   }
 
   it('signs the Safe transaction hash, not typed data', async () => {
@@ -2181,6 +2194,29 @@ describe('SafeClient.signTransaction default path', () => {
     expect(signed.signatures.get(account.address.toLowerCase())).toBeDefined()
   })
 
+  it('asks the Safe to hash the transaction it is about to sign', async () => {
+    // Hash signing makes this argument list the only thing that decides what
+    // gets signed — the typed-data path used to build the digest separately, so
+    // a wrong field showed up as a mismatch. Now nothing else would notice.
+    const { client, hashArgs } = await makeClient()
+    const safeTx = buildSafeTx({ nonce: 7n, value: 123n })
+
+    await client.signTransaction(safeTx)
+
+    expect(hashArgs).toHaveLength(1)
+    expect(hashArgs[0]).toEqual([
+      safeTx.data.to,
+      safeTx.data.value,
+      safeTx.data.data,
+      safeTx.data.operation,
+      0n,
+      0n,
+      0n,
+      '0x0000000000000000000000000000000000000000',
+      '0x0000000000000000000000000000000000000000',
+      safeTx.data.nonce,
+    ])
+  })
   it('marks the signature so the Safe takes its eth_sign path', async () => {
     const { client, account } = await makeClient()
 
@@ -2200,15 +2236,18 @@ describe('SafeClient.signTransaction default path', () => {
     ).toBe(account.address)
   })
 
-  it('does not silently switch modes when signing fails', async () => {
-    // The fallback WP-3.4 removes: an EIP-712 failure used to re-prompt the
-    // device in a different rendering mid-flow, so a signer comparing what the
-    // screen showed against what they approved saw two different things.
-    const { client } = await makeClient()
+  it('does not fall back to hash signing when typed data fails', async () => {
+    // The fallback WP-3.4 removes ran in the other direction: EIP-712 failed and
+    // the device was re-prompted in a different rendering mid-flow, so a signer
+    // who had read one screen approved another. Asserting from the hash side
+    // would have passed on origin/main too — this has to opt into typed data,
+    // break it, and prove the hash path is never reached.
+    process.env.ENABLE_SAFE_EIP712_SIGNING = 'true'
+    const { client, calls } = await makeClient()
     const failing = client as unknown as {
-      signHash: () => Promise<never>
+      walletClient: { signTypedData: () => Promise<never> }
     }
-    failing.signHash = async () => {
+    failing.walletClient.signTypedData = async () => {
       throw new Error('device refused')
     }
 
@@ -2220,5 +2259,7 @@ describe('SafeClient.signTransaction default path', () => {
     }
 
     expect(threw).toBe(true)
+    expect(calls.filter((call) => call.startsWith('signMessage'))).toEqual([])
+    expect(calls).not.toContain('getTransactionHash')
   })
 })

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -29,9 +29,12 @@ import {
   decodeFunctionData,
   keccak256,
   encodeAbiParameters,
+  hashMessage,
+  recoverAddress,
   type Address,
   type Hex,
 } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 
 import { getRPCEnvVarName } from '../../utils/utils'
 
@@ -40,6 +43,8 @@ import {
   OperationTypeEnum,
   buildProposalProvenance,
   canExecuteWithNonceStatus,
+  resolveSafeSigningMode,
+  toSafeEthSignSignature,
   classifyDuplicateKeyError,
   pickTimelockSalt,
   wrapWithTimelockSchedule,
@@ -1201,6 +1206,17 @@ describe('releaseAllPooledSafeClients', () => {
 })
 
 describe('SafeClient.signTransaction chain id source', () => {
+  // These cover the typed-data path, which WP-3.4 made opt-in. Without the
+  // flag `signTransaction` signs the hash and never builds an EIP-712 domain.
+  const previous = process.env.ENABLE_SAFE_EIP712_SIGNING
+  beforeEach(() => {
+    process.env.ENABLE_SAFE_EIP712_SIGNING = 'true'
+  })
+  afterEach(() => {
+    if (previous === undefined) delete process.env.ENABLE_SAFE_EIP712_SIGNING
+    else process.env.ENABLE_SAFE_EIP712_SIGNING = previous
+  })
+
   const makeClient = async (knownChainId?: number) => {
     const { SafeClient } = await import('./safe-utils')
     const { privateKeyToAccount } = await import('viem/accounts')
@@ -2003,5 +2019,206 @@ describe('wrapWithTimelockSchedule', () => {
       else process.env[envKey] = previousRpc
       stub.stop()
     }
+  })
+})
+
+describe('resolveSafeSigningMode', () => {
+  it('signs the transaction hash by default', () => {
+    // WP-3.4 / T4-A3. The device shows one value the signer can compare against
+    // the out-of-band DM, instead of five fields it renders inconsistently.
+    expect(resolveSafeSigningMode({})).toBe('hash')
+  })
+
+  it.each([['true'], ['TRUE'], ['1'], ['yes'], ['false'], ['']])(
+    'still signs the hash when the retired hash flag is set to %p',
+    (value) => {
+      // ENABLE_SAFE_TX_HASH_SIGNING selected this mode when it was optional.
+      // It now describes the default, so honouring it either way would let a
+      // stale `=false` silently opt an operator back into typed data.
+      expect(
+        resolveSafeSigningMode({ ENABLE_SAFE_TX_HASH_SIGNING: value })
+      ).toBe('hash')
+    }
+  )
+
+  it('signs typed data only when explicitly asked', () => {
+    expect(resolveSafeSigningMode({ ENABLE_SAFE_EIP712_SIGNING: 'true' })).toBe(
+      'eip712'
+    )
+  })
+
+  it.each([['false'], ['TRUE'], ['1'], ['yes'], [''], [undefined]])(
+    'treats %p as not asking for typed data',
+    (value) => {
+      // Exact 'true' only, matching how every other escape hatch in this file
+      // reads its flag. Anything else is a typo, and a typo must not change the
+      // mode a hardware wallet renders.
+      expect(
+        resolveSafeSigningMode({ ENABLE_SAFE_EIP712_SIGNING: value })
+      ).toBe('hash')
+    }
+  )
+})
+
+describe('toSafeEthSignSignature', () => {
+  const R = `0x${'11'.repeat(32)}` as Hex
+  const S = '22'.repeat(32)
+
+  it.each([
+    ['1b', '1f'],
+    ['1c', '20'],
+  ])('marks v=%s as an eth_sign signature (%s)', (rawV, expectedV) => {
+    // Safe reads v > 30 as eth_sign and recovers over the EIP-191 digest with
+    // v - 4. 27 becomes 31, 28 becomes 32.
+    expect(toSafeEthSignSignature(`${R}${S}${rawV}` as Hex)).toBe(
+      `${R}${S}${expectedV}`
+    )
+  })
+
+  it.each([
+    ['00', '1f'],
+    ['01', '20'],
+  ])('normalises a v=%s wallet before marking it (%s)', (rawV, expectedV) => {
+    // A wallet returning 0/1 used to have 4 added blindly, giving v=4 or v=5 —
+    // which Safe reads as a contract signature and an approved hash, not as
+    // eth_sign at all.
+    expect(toSafeEthSignSignature(`${R}${S}${rawV}` as Hex)).toBe(
+      `${R}${S}${expectedV}`
+    )
+  })
+
+  it.each([['1f'], ['20'], ['02'], ['ff']])(
+    'refuses a v of %s rather than marking it twice',
+    (rawV) => {
+      expect(() => toSafeEthSignSignature(`${R}${S}${rawV}` as Hex)).toThrow()
+    }
+  )
+
+  it.each([
+    ['too short', `0x${'11'.repeat(64)}`],
+    ['no prefix', `${'11'.repeat(65)}`],
+  ])('refuses a signature that is %s', (_label, value) => {
+    expect(() => toSafeEthSignSignature(value as Hex)).toThrow()
+  })
+
+  it('produces a signature the Safe v>30 path recovers to the signer', async () => {
+    // The end-to-end claim, with an ephemeral key generated here: sign the Safe
+    // transaction hash the way this module frames it, then recover the way
+    // `checkNSignatures` does for v > 30 — EIP-191 digest, v - 4.
+    const account = privateKeyToAccount(generatePrivateKey())
+    const safeTxHash = keccak256('0xdeadbeef')
+    const raw = await account.signMessage({ message: { raw: safeTxHash } })
+    const framed = toSafeEthSignSignature(raw)
+
+    const v = parseInt(framed.slice(130, 132), 16)
+    expect(v).toBeGreaterThan(30)
+
+    const recovered = await recoverAddress({
+      hash: hashMessage({ raw: safeTxHash }),
+      signature: `${framed.slice(0, 130)}${(v - 4)
+        .toString(16)
+        .padStart(2, '0')}` as Hex,
+    })
+    expect(recovered).toBe(account.address)
+  })
+})
+
+describe('SafeClient.signTransaction default path', () => {
+  const previous = process.env.ENABLE_SAFE_EIP712_SIGNING
+  beforeEach(() => {
+    delete process.env.ENABLE_SAFE_EIP712_SIGNING
+  })
+  afterEach(() => {
+    if (previous !== undefined)
+      process.env.ENABLE_SAFE_EIP712_SIGNING = previous
+  })
+
+  const SAFE_TX_HASH = keccak256('0xfeed')
+
+  const makeClient = async () => {
+    const { SafeClient } = await import('./safe-utils')
+    const account = privateKeyToAccount(generatePrivateKey())
+    const calls: string[] = []
+    const publicClient = {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        calls.push(functionName)
+        return SAFE_TX_HASH
+      },
+      getChainId: async () => {
+        calls.push('getChainId')
+        return 999
+      },
+    }
+    const walletClient = {
+      signMessage: async ({ message }: { message: { raw: Hex } }) => {
+        calls.push(`signMessage:${message.raw}`)
+        return account.signMessage({ message: { raw: message.raw } })
+      },
+      signTypedData: async () => {
+        calls.push('signTypedData')
+        return `0x${'ab'.repeat(65)}`
+      },
+    }
+    const client = new SafeClient(
+      publicClient as never,
+      walletClient as never,
+      SAFE_ADDR,
+      account,
+      undefined,
+      42161
+    )
+    return { client, account, calls }
+  }
+
+  it('signs the Safe transaction hash, not typed data', async () => {
+    const { client, account, calls } = await makeClient()
+
+    const signed = await client.signTransaction(buildSafeTx())
+
+    expect(calls).toContain('getTransactionHash')
+    expect(calls).toContain(`signMessage:${SAFE_TX_HASH}`)
+    expect(calls).not.toContain('signTypedData')
+    expect(signed.signatures.get(account.address.toLowerCase())).toBeDefined()
+  })
+
+  it('marks the signature so the Safe takes its eth_sign path', async () => {
+    const { client, account } = await makeClient()
+
+    const signed = await client.signTransaction(buildSafeTx())
+    const data =
+      signed.signatures.get(account.address.toLowerCase())?.data ?? ''
+    const v = parseInt(data.slice(130, 132), 16)
+
+    expect(v).toBeGreaterThan(30)
+    expect(
+      await recoverAddress({
+        hash: hashMessage({ raw: SAFE_TX_HASH }),
+        signature: `${data.slice(0, 130)}${(v - 4)
+          .toString(16)
+          .padStart(2, '0')}` as Hex,
+      })
+    ).toBe(account.address)
+  })
+
+  it('does not silently switch modes when signing fails', async () => {
+    // The fallback WP-3.4 removes: an EIP-712 failure used to re-prompt the
+    // device in a different rendering mid-flow, so a signer comparing what the
+    // screen showed against what they approved saw two different things.
+    const { client } = await makeClient()
+    const failing = client as unknown as {
+      signHash: () => Promise<never>
+    }
+    failing.signHash = async () => {
+      throw new Error('device refused')
+    }
+
+    let threw = false
+    try {
+      await client.signTransaction(buildSafeTx())
+    } catch {
+      threw = true
+    }
+
+    expect(threw).toBe(true)
   })
 })

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -2138,8 +2138,15 @@ describe('toSafeEthSignSignature input validation', () => {
     ['a sign in v', `0x${'ab'.repeat(64)}+1`],
   ])('refuses %s', (_label, signature) => {
     // parseInt would read " 1" and "+1" as 1, so the shape has to be checked
-    // before v is parsed out of it.
-    expect(() => toSafeEthSignSignature(signature as `0x${string}`)).toThrow()
+    // before v is parsed out of it. The message must not report the length as
+    // the problem when the length is correct.
+    expect(() => toSafeEthSignSignature(signature as `0x${string}`)).toThrow(
+      /not all hex/u
+    )
+  })
+
+  it('reports the length when the length is what is wrong', () => {
+    expect(() => toSafeEthSignSignature('0xabcd')).toThrow(/got 6 characters/u)
   })
 })
 
@@ -2174,14 +2181,19 @@ describe('resolveSignerVerificationDisplay', () => {
     }
   )
 
-  it.each([['hash'], ['eip712']] as const)(
-    'shows nothing on Tron in %s mode',
-    (mode) => {
-      expect(resolveSignerVerificationDisplay(mode, true, '0xdeadbeef')).toBe(
-        'none'
-      )
-    }
-  )
+  it('still points a Tron hash-mode signer at the hash screen', () => {
+    // Signing does not branch on the network, so a Tron signer compares the
+    // same value on the same device. Only the Flex filmstrip is EVM-specific.
+    expect(resolveSignerVerificationDisplay('hash', true, '0xdeadbeef')).toBe(
+      'hash-compare'
+    )
+  })
+
+  it('shows no filmstrip on Tron in typed-data mode', () => {
+    expect(resolveSignerVerificationDisplay('eip712', true, '0xdeadbeef')).toBe(
+      'none'
+    )
+  })
 })
 
 describe('SafeClient.signTransaction default path', () => {

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -2137,8 +2137,8 @@ describe('SafeClient.signTransaction default path', () => {
     delete process.env.ENABLE_SAFE_EIP712_SIGNING
   })
   afterEach(() => {
-    if (previous !== undefined)
-      process.env.ENABLE_SAFE_EIP712_SIGNING = previous
+    if (previous === undefined) delete process.env.ENABLE_SAFE_EIP712_SIGNING
+    else process.env.ENABLE_SAFE_EIP712_SIGNING = previous
   })
 
   const SAFE_TX_HASH = keccak256('0xfeed')

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -275,6 +275,67 @@ export const retry = async <T>(
  * plus optional {@link TronWalletClient} for Tron TVM broadcast (`wallet/triggersmartcontract`).
  * The same private key backs both paths when initialized from `privateKey`.
  */
+
+/** How a Safe transaction is presented to the signing device. */
+export type SafeSigningMode = 'hash' | 'eip712'
+
+/**
+ * Which signing mode to use.
+ *
+ * Hash signing is the default (WP-3.4): the device shows the one `safeTxHash` a
+ * signer compares against the out-of-band message, rather than a typed-data
+ * payload that hardware wallets render inconsistently and reject outright when
+ * it grows large.
+ *
+ * @param env - Environment to read, normally `process.env`.
+ * @returns The mode. `ENABLE_SAFE_TX_HASH_SIGNING` is deliberately not read:
+ * it selected this mode while it was optional, so a stale `=false` would opt an
+ * operator back into typed data without them asking.
+ */
+export function resolveSafeSigningMode(
+  env: Record<string, string | undefined>
+): SafeSigningMode {
+  return env['ENABLE_SAFE_EIP712_SIGNING'] === 'true' ? 'eip712' : 'hash'
+}
+
+/** `v` values a wallet may return, and what each means before framing. */
+const RECOVERY_IDS = new Map([
+  [0, 27],
+  [1, 28],
+  [27, 27],
+  [28, 28],
+])
+
+/**
+ * Marks a signature as `eth_sign` for a Safe.
+ *
+ * `checkNSignatures` treats `v > 30` as eth_sign and recovers over the EIP-191
+ * digest with `v - 4`, so 27 and 28 become 31 and 32.
+ *
+ * @param signature - A 65-byte signature as returned by the wallet.
+ * @returns The same r and s with the marked `v`.
+ * @throws When the signature is not 65 bytes, or carries a `v` that is not a
+ * recovery id. Adding 4 blindly turned a wallet's `v=0` into `v=4`, which Safe
+ * reads as a contract signature, and would mark an already-marked signature a
+ * second time.
+ */
+export function toSafeEthSignSignature(signature: Hex): Hex {
+  if (!signature.startsWith('0x') || signature.length !== 132)
+    throw new Error(
+      `Expected a 65-byte signature as 0x + 130 hex characters, got ${signature.length} characters`
+    )
+
+  const recoveryId = RECOVERY_IDS.get(parseInt(signature.slice(130, 132), 16))
+  if (recoveryId === undefined)
+    throw new Error(
+      `Signature carries v=0x${signature.slice(
+        130,
+        132
+      )}, which is not a recovery id. Safe reads v below 27 as a contract signature or an approved hash, and v above 30 as already marked for eth_sign.`
+    )
+
+  return `${signature.slice(0, 130)}${(recoveryId + 4).toString(16)}` as Hex
+}
 export class SafeClient {
   /**
    * Public client for read operations
@@ -702,21 +763,7 @@ export class SafeClient {
           `Invalid signature format from wallet. Expected 0x + 130 hex chars but got: ${ethSignSignature}`
         )
 
-      // Extract r, s, v components from the signature
-      const r = ethSignSignature.slice(0, 66)
-      const s = ethSignSignature.slice(66, 130)
-
-      // Get v value from the signature and adjust for eth_sign
-      const vByte = ethSignSignature.slice(130, 132)
-      const vValue = parseInt(vByte, 16)
-
-      // For eth_sign signatures in Safe contracts, we need to add +4 to v
-      // This identifies it as an eth_sign signature (type 1)
-      const safeV = (vValue + 4).toString(16).padStart(2, '0')
-
-      // Format for Safe contract: r + s + v
-      // Safe expects signatures in format: r (32 bytes) + s (32 bytes) + v (1 byte)
-      const safeSignature = `0x${r.slice(2)}${s}${safeV}` as Hex
+      const safeSignature = toSafeEthSignSignature(ethSignSignature)
 
       console.log('Safe signature:', safeSignature)
 
@@ -765,15 +812,10 @@ export class SafeClient {
   public async signTransaction(
     safeTx: ISafeTransaction
   ): Promise<ISafeTransaction> {
-    // Optional flag to force tx-hash signing from the start instead of EIP-712
-    // typed data. Read directly from process.env so an unset flag does not
-    // throw — tx-hash signing also runs automatically as a fallback whenever
-    // the EIP-712 path fails.
-    if (process.env.ENABLE_SAFE_TX_HASH_SIGNING === 'true') {
+    if (resolveSafeSigningMode(process.env) === 'hash')
       return this.signTransactionWithHash(safeTx)
-    }
 
-    try {
+    {
       // Get chain ID for domain — prefer the config-resolved id so the hot
       // path between the operator's "Sign" selection and the Ledger prompt
       // makes no RPC call (a cold connection here delays the device display)
@@ -834,12 +876,6 @@ export class SafeClient {
       safeTx.signatures.set(signature.signer.toLowerCase(), signature)
 
       return safeTx
-    } catch (error: unknown) {
-      const errorMsg = error instanceof Error ? error.message : String(error)
-      consola.warn(
-        `[safe-utils] EIP-712 signing failed, falling back to tx-hash signing. Caught error: ${errorMsg}`
-      )
-      return this.signTransactionWithHash(safeTx)
     }
   }
 

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -308,6 +308,10 @@ export type SignerVerificationDisplay = 'filmstrip' | 'hash-compare' | 'none'
  * with no calldata has no screens to reproduce, and naming the single hash
  * screen there would describe a mode the device is not in.
  *
+ * Signing does not branch on the network — `signTransaction` dispatches on the
+ * mode alone — so a Tron signer compares the same hash on the same device. Only
+ * the Flex typed-data filmstrip is EVM-specific.
+ *
  * @param mode - The resolved signing mode.
  * @param isTron - Whether the network is Tron, where the Flex flow does not apply.
  * @param callData - The Safe transaction's calldata, if any.
@@ -318,8 +322,8 @@ export function resolveSignerVerificationDisplay(
   isTron: boolean,
   callData: string | undefined
 ): SignerVerificationDisplay {
-  if (isTron) return 'none'
   if (mode === 'hash') return 'hash-compare'
+  if (isTron) return 'none'
   return callData && callData !== '0x' ? 'filmstrip' : 'none'
 }
 
@@ -348,7 +352,9 @@ const RECOVERY_IDS = new Map([
 export function toSafeEthSignSignature(signature: Hex): Hex {
   if (!/^0x[0-9a-fA-F]{130}$/.test(signature))
     throw new Error(
-      `Expected a 65-byte signature as 0x + 130 hex characters, got ${signature.length} characters`
+      signature.length === 132
+        ? `Expected a 65-byte signature as 0x + 130 hex characters, got 132 characters that are not all hex: ${signature}`
+        : `Expected a 65-byte signature as 0x + 130 hex characters, got ${signature.length} characters`
     )
 
   const recoveryId = RECOVERY_IDS.get(parseInt(signature.slice(130, 132), 16))

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -282,20 +282,45 @@ export type SafeSigningMode = 'hash' | 'eip712'
 /**
  * Which signing mode to use.
  *
- * Hash signing is the default (WP-3.4): the device shows the one `safeTxHash` a
- * signer compares against the out-of-band message, rather than a typed-data
- * payload that hardware wallets render inconsistently and reject outright when
- * it grows large.
+ * Hash signing is the default: the device shows the one `safeTxHash` a signer
+ * compares against the out-of-band message, rather than a typed-data payload
+ * that hardware wallets render inconsistently and reject outright when it grows
+ * large.
  *
  * @param env - Environment to read, normally `process.env`.
- * @returns The mode. `ENABLE_SAFE_TX_HASH_SIGNING` is deliberately not read:
- * it selected this mode while it was optional, so a stale `=false` would opt an
- * operator back into typed data without them asking.
+ * @returns The mode. `ENABLE_SAFE_TX_HASH_SIGNING` is deliberately not read, so
+ * that a stale `=false` cannot opt an operator back into typed data.
  */
 export function resolveSafeSigningMode(
   env: Record<string, string | undefined>
 ): SafeSigningMode {
   return env['ENABLE_SAFE_EIP712_SIGNING'] === 'true' ? 'eip712' : 'hash'
+}
+
+/** Which on-device verification aid to show the signer. */
+export type SignerVerificationDisplay = 'filmstrip' | 'hash-compare' | 'none'
+
+/**
+ * Chooses the verification aid for a pending transaction.
+ *
+ * The signer must be pointed at a screen the device actually renders, so this
+ * follows the signing mode rather than the shape of the transaction. Typed data
+ * with no calldata has no screens to reproduce, and naming the single hash
+ * screen there would describe a mode the device is not in.
+ *
+ * @param mode - The resolved signing mode.
+ * @param isTron - Whether the network is Tron, where the Flex flow does not apply.
+ * @param callData - The Safe transaction's calldata, if any.
+ * @returns The aid to display.
+ */
+export function resolveSignerVerificationDisplay(
+  mode: SafeSigningMode,
+  isTron: boolean,
+  callData: string | undefined
+): SignerVerificationDisplay {
+  if (isTron) return 'none'
+  if (mode === 'hash') return 'hash-compare'
+  return callData && callData !== '0x' ? 'filmstrip' : 'none'
 }
 
 /** `v` values a wallet may return, and what each means before framing. */
@@ -314,13 +339,14 @@ const RECOVERY_IDS = new Map([
  *
  * @param signature - A 65-byte signature as returned by the wallet.
  * @returns The same r and s with the marked `v`.
- * @throws When the signature is not 65 bytes, or carries a `v` that is not a
- * recovery id. Adding 4 blindly turned a wallet's `v=0` into `v=4`, which Safe
- * reads as a contract signature, and would mark an already-marked signature a
- * second time.
+ * @throws When the signature is not 65 hex-encoded bytes, or carries a `v` that
+ * is not a recovery id. `v` must be normalised rather than incremented: Safe
+ * reads a `v` below 27 as a contract signature or an approved hash, so a wallet
+ * answering `v=0` would otherwise be marked as `v=4`, and an already-marked
+ * signature would be marked a second time.
  */
 export function toSafeEthSignSignature(signature: Hex): Hex {
-  if (!signature.startsWith('0x') || signature.length !== 132)
+  if (!/^0x[0-9a-fA-F]{130}$/.test(signature))
     throw new Error(
       `Expected a 65-byte signature as 0x + 130 hex characters, got ${signature.length} characters`
     )
@@ -779,12 +805,12 @@ export class SafeClient {
   }
 
   /**
-   * Alternative signing path: sign the Safe transaction hash via eth_sign
-   * instead of EIP-712 typed data.
+   * Signs the Safe transaction hash via eth_sign. This is the default path;
+   * EIP-712 typed data is the opt-in.
    *
-   * This is useful for hardware wallets (e.g. Ledger) that may reject very
-   * large EIP-712 payloads (status 0x6a80). The Safe contracts fully support
-   * eth_sign signatures over the Safe transaction hash.
+   * Hardware wallets (e.g. Ledger) reject very large EIP-712 payloads (status
+   * 0x6a80). The Safe contracts fully support eth_sign signatures over the Safe
+   * transaction hash.
    */
   public async signTransactionWithHash(
     safeTx: ISafeTransaction
@@ -816,9 +842,9 @@ export class SafeClient {
       return this.signTransactionWithHash(safeTx)
 
     {
-      // Get chain ID for domain — prefer the config-resolved id so the hot
-      // path between the operator's "Sign" selection and the Ledger prompt
-      // makes no RPC call (a cold connection here delays the device display)
+      // Prefer the config-resolved id so this path makes no RPC call between
+      // the operator's "Sign" selection and the Ledger prompt (a cold
+      // connection here delays the device display)
       const chainId =
         this.knownChainId ?? (await this.publicClient.getChainId())
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-871](https://linear.app/lifi-linear/issue/EXSC-871/wp-34-hash-based-signing-as-default) — WP-3.4, hash-based signing as default. Ruled by Daniel as the T4 refinement (A3). `Fixes` this time rather than `Ref`: this PR is the whole package.

# Why did I implement it this way?

`eth_sign` over the `safeTxHash` becomes the default signing mode and EIP-712 typed data becomes the opt-in. The Safe's own on-chain `getTransactionHash` is what gets signed, so the digest is correct for that Safe's version rather than reconstructed from an assumption about it.

**Why this is not a loss of on-device intent.** For timelock operations the Ledger already shows an undecoded calldata blob (`scheduleBatch` → `schedule` → `diamondCut`), so there was no intent on screen to lose. What changes is that the signer now compares **one value** against the out-of-band message instead of five fields, which is the comparison R1.5 / WP-7.2 is built around.

**The silent fallback is gone.** EIP-712 failure used to fall through to hash signing automatically, which re-prompted the device in a *different rendering* mid-flow — so a signer who had read one screen approved another. A failure now surfaces.

## Two defects found while wiring it

**`signHash` added 4 to whatever `v` the wallet returned.** Safe reads `v > 30` as eth_sign and recovers with `v - 4`, so 27 and 28 must become 31 and 32. A wallet answering `v = 0` or `1` — which some do — produced `v = 4` or `5`, and Safe reads those as a *contract signature* and an *approved hash*, entirely different verification paths. Recovery ids are now normalised, and anything else is refused, including a `v` already above 30 that would otherwise be marked a second time.

**The typed-data path signs different fields than `getTransactionHash` returns.** Its EIP-712 message hardcodes `safeTxGas`, `baseGas`, `gasPrice`, `gasToken` and `refundReceiver` to zero instead of reading `safeTx.data`. Inert while every proposal uses zeros, and deliberately left alone here, but it is exactly the divergence hash signing removes by construction — the hash comes from the Safe, over the real fields.

## The flag

`ENABLE_SAFE_TX_HASH_SIGNING` is **retired, not inverted**. It selected this mode while it was optional, so honouring a stale `=false` would opt an operator back into typed data without them asking. `ENABLE_SAFE_EIP712_SIGNING=true` is the new opt-in, exact-string only — a typo must not change what a hardware wallet renders.

## Evidence

Baseline on `origin/main` in a pristine worktree: **1992 pass / 0 fail**. With this change: **2033 pass / 0 fail**. `bunx tsc-files --noEmit` and `bunx eslint` clean; exit codes captured bare.

The framing is proven end-to-end against Safe's own algorithm, with a key generated in the test:

```text
sign safeTxHash with an ephemeral key -> frame it -> v = 31 or 32
recover over keccak256("\x19Ethereum Signed Message:\n32" || safeTxHash) with v - 4
  -> recovers to the signing address
```

`signTransaction` is covered behaviourally, not just through the mode predicate: it calls `getTransactionHash` and `signMessage`, never `signTypedData`; the resulting signature carries `v > 30` and recovers to the signer; and a failure in the hash path throws instead of switching modes.

| `v` from wallet | framed | why |
|---|---|---|
| 27 / 28 | 31 / 32 | the recovery ids viem returns |
| 0 / 1 | 31 / 32 | normalised first — previously became 4 / 5 |
| 31, 32, 2, 255 | refused | already marked, or not a recovery id at all |

## Trade-off, stated

The EIP-712 path was deliberately built to make **no RPC call** before the Ledger prompt — `knownChainId ?? getChainId()`, with a comment that a cold connection there delays the device display. Hash signing must read `getTransactionHash` from the Safe to stay version-correct, so that round trip comes back. It is inherent to the ticket's design (a locally computed digest would reintroduce exactly the version drift this removes), and it is one read on a path that already does several.

## This reverses a shipped decision, on purpose

#1898 (EXSC-96) made hash signing an **automatic fallback**: EIP-712 was tried
first and any failure silently retried over the hash. This PR removes that. The
reason is the one the fallback did not consider — the retry re-prompts the device
in a *different rendering*, so a signer who has read one screen approves another.
Flagging it because it inverts a ticketed decision, not because the trade-off is
in doubt.

## Found by the review gate, and fixed here

- **The signer was told to compare the device screen against `tx.safeTxHash`** —
  the stored Mongo field. The proposer controls that field *and* the calldata, so
  the comparison was DB-against-device, both written by the same party, and never
  reached the out-of-band message the docs name as the authority. The instruction
  now says so explicitly and no longer prints the stored value as a target.
- **The display branch conflated "typed-data mode" with "has calldata."** An
  operator on `ENABLE_SAFE_EIP712_SIGNING=true` whose proposal carried no calldata
  was told to look for the single hash screen — which that mode never shows.
  Reachable in practice: `propose-to-safe.ts` defaults `calldata` to `''`. The
  choice is now `resolveSignerVerificationDisplay`, a pure function with tests
  that fail against the old conflated form.
- **`toSafeEthSignSignature` checked length but not hex**, so a `v` of `" 1"` or
  `"+1"` passed through `parseInt`. It now matches the full signature shape.

## Second gate round, on the fix commits

The round-1 fixes were re-gated and three of them were wrong:

- **The doc hunk I added contradicted the fix it shipped with** — it still told
  the signer to compare against the stored `safeTxHash`, nine lines above the
  prose saying that is not the authority.
- **A Tron hash-mode signer got no guidance at all.** `signTransaction`
  dispatches on the mode alone, so Tron signs the same hash on the same device;
  only the Flex filmstrip is EVM-specific. The `isTron` short-circuit was
  suppressing both. Tron signers now get the hash guidance they never had.
- **The signature error reported the length as the fault when the length was
  right** and the characters were not hex — the least useful message possible at
  a signing chokepoint. The tests now assert the message, not just that it throws.

**Still open, and it limits what this PR achieves:** the instruction now names
"the out-of-band message from the proposer", but nothing in the repo emits that
message and `docs/MultisigSigningProcess.md` §9 lists the mechanical alternative
(a signer-side recomputed `safeTxHash`) as not implemented. This PR stops the
signer being pointed at a proposer-controlled value; it does not by itself give
them something to compare against. That is R1.5 / WP-7.2 work.

## Escalated, not fixed — needs a decision

- **`script/deploy/tron/propose-to-safe-tron.ts:322-326` hand-rolls the same
  eth_sign `v` framing** and was not moved onto `toSafeEthSignSignature`. Not
  exploitable today (that path signs with viem's `signMessage`, which always
  returns 27/28), but it double-marks an already-marked signature and emits a
  133-character signature for `v >= 0xfc`. Left alone because consolidating it
  changes a signing path this PR does not otherwise touch.
- **`script/deploy/safe/ledger.ts:137`** builds the signature without
  `padStart(2, '0')`, so a device `v` below 16 yields a 131-character string. It
  is caught by the length check rather than the recovery-id map, and no Ledger
  returns such a `v`. Pre-existing, untouched.
- **`confirm-safe-tx.ts` exports nothing**, so its operator-facing branches are
  only testable by extraction. This PR extracts the one it changed; the rest of
  the file's display logic remains unexercised.

## Not in scope

- The `safeTxGas`-and-friends divergence in the typed-data path, described above. It is pre-existing and now off the default path.
- `script/deploy/safe/safe-utils.test.ts:1224` carries a private-key literal that the pre-commit checker flags. It is on `origin/main` already and untouched here; the tests added by this PR generate ephemeral keys.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>


