### PR TITLE
fix(clear-signing): format native currency amounts correctly

### DIFF
--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -11,7 +11,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -78,7 +82,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -151,7 +159,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -218,7 +230,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -291,7 +307,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -358,7 +378,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -425,7 +449,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -498,7 +526,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -571,7 +603,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -644,7 +680,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -717,7 +757,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -784,7 +828,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -857,7 +905,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -930,7 +982,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -997,7 +1053,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1070,7 +1130,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1143,7 +1207,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1216,7 +1284,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1283,7 +1355,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1356,7 +1432,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1423,7 +1503,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1490,7 +1574,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1557,7 +1645,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1624,7 +1716,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1697,7 +1793,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1764,7 +1864,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1831,7 +1935,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1898,7 +2006,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -1965,7 +2077,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2032,7 +2148,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2099,7 +2219,11 @@
           "label": "Amount to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2166,7 +2290,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2175,7 +2303,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2262,7 +2394,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2271,7 +2407,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2364,7 +2504,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2373,7 +2517,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2460,7 +2608,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2469,7 +2621,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2562,7 +2718,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2571,7 +2731,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2658,7 +2822,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2667,7 +2835,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2754,7 +2926,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2763,7 +2939,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2856,7 +3036,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2865,7 +3049,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2958,7 +3146,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -2967,7 +3159,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3060,7 +3256,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3069,7 +3269,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3162,7 +3366,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3171,7 +3379,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3258,7 +3470,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3267,7 +3483,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3360,7 +3580,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3369,7 +3593,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3462,7 +3690,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3471,7 +3703,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3558,7 +3794,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3567,7 +3807,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3660,7 +3904,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3669,7 +3917,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3762,7 +4014,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3771,7 +4027,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3864,7 +4124,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3873,7 +4137,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3960,7 +4228,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -3969,7 +4241,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4062,7 +4338,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4071,7 +4351,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4158,7 +4442,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4167,7 +4455,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4254,7 +4546,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4263,7 +4559,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4350,7 +4650,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4359,7 +4663,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4446,7 +4754,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4455,7 +4767,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4548,7 +4864,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4557,7 +4877,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4644,7 +4968,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4653,7 +4981,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4740,7 +5072,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4749,7 +5085,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4836,7 +5176,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4845,7 +5189,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4932,7 +5280,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -4941,7 +5293,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5028,7 +5384,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5037,7 +5397,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5124,7 +5488,11 @@
           "label": "Amount to Swap",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5133,7 +5501,11 @@
           "label": "Minimum to Bridge",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_bridgeData.sendingAssetId"
+            "tokenPath": "_bridgeData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5220,7 +5592,11 @@
           "label": "Amount to Send",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5229,7 +5605,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[-1].receivingAssetId"
+            "tokenPath": "_swapData.[-1].receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5295,7 +5675,11 @@
           "label": "Amount to Send",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[0].sendingAssetId"
+            "tokenPath": "_swapData.[0].sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5304,7 +5688,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[-1].receivingAssetId"
+            "tokenPath": "_swapData.[-1].receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5375,7 +5763,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.[-1].receivingAssetId"
+            "tokenPath": "_swapData.[-1].receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5441,7 +5833,11 @@
           "label": "Amount to Send",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.sendingAssetId"
+            "tokenPath": "_swapData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5450,7 +5846,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.receivingAssetId"
+            "tokenPath": "_swapData.receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5506,7 +5906,11 @@
           "label": "Amount to Send",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.sendingAssetId"
+            "tokenPath": "_swapData.sendingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5515,7 +5919,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.receivingAssetId"
+            "tokenPath": "_swapData.receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },
@@ -5576,7 +5984,11 @@
           "label": "Minimum to Receive",
           "format": "tokenAmount",
           "params": {
-            "tokenPath": "_swapData.receivingAssetId"
+            "tokenPath": "_swapData.receivingAssetId",
+            "nativeCurrencyAddress": [
+              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+              "0x0000000000000000000000000000000000000000"
+            ]
           },
           "visible": "always"
         },

--- a/config/clearSigningProposal.json
+++ b/config/clearSigningProposal.json
@@ -12,10 +12,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -83,10 +80,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -160,10 +154,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -231,10 +222,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -308,10 +296,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -379,10 +364,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -450,10 +432,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -527,10 +506,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -604,10 +580,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -681,10 +654,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -758,10 +728,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -829,10 +796,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -906,10 +870,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -983,10 +944,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1054,10 +1012,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1131,10 +1086,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1208,10 +1160,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1285,10 +1234,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1356,10 +1302,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1433,10 +1376,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1504,10 +1444,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1575,10 +1512,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1646,10 +1580,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1717,10 +1648,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1794,10 +1722,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1865,10 +1790,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -1936,10 +1858,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2007,10 +1926,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2078,10 +1994,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2149,10 +2062,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2220,10 +2130,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2291,10 +2198,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2304,10 +2208,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2395,10 +2296,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2408,10 +2306,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2505,10 +2400,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2518,10 +2410,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2609,10 +2498,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2622,10 +2508,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2719,10 +2602,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2732,10 +2612,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2823,10 +2700,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2836,10 +2710,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2927,10 +2798,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -2940,10 +2808,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3037,10 +2902,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3050,10 +2912,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3147,10 +3006,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3160,10 +3016,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3257,10 +3110,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3270,10 +3120,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3367,10 +3214,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3380,10 +3224,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3471,10 +3312,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3484,10 +3322,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3581,10 +3416,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3594,10 +3426,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3691,10 +3520,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3704,10 +3530,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3795,10 +3618,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3808,10 +3628,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3905,10 +3722,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -3918,10 +3732,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4015,10 +3826,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4028,10 +3836,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4125,10 +3930,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4138,10 +3940,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4229,10 +4028,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4242,10 +4038,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4339,10 +4132,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4352,10 +4142,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4443,10 +4230,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4456,10 +4240,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4547,10 +4328,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4560,10 +4338,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4651,10 +4426,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4664,10 +4436,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4755,10 +4524,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4768,10 +4534,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4865,10 +4628,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4878,10 +4638,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4969,10 +4726,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -4982,10 +4736,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5073,10 +4824,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5086,10 +4834,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5177,10 +4922,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5190,10 +4932,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5281,10 +5020,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5294,10 +5030,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5385,10 +5118,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5398,10 +5128,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5489,10 +5216,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5502,10 +5226,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_bridgeData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5593,10 +5314,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5606,10 +5324,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[-1].receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5676,24 +5391,14 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[0].sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
         {
           "path": "_minAmountOut",
           "label": "Minimum to Receive",
-          "format": "tokenAmount",
-          "params": {
-            "tokenPath": "_swapData.[-1].receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
-          },
+          "format": "amount",
           "visible": "always"
         },
         {
@@ -5764,10 +5469,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.[-1].receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5834,10 +5536,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5847,10 +5546,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
@@ -5907,24 +5603,14 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.sendingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },
         {
           "path": "_minAmountOut",
           "label": "Minimum to Receive",
-          "format": "tokenAmount",
-          "params": {
-            "tokenPath": "_swapData.receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
-          },
+          "format": "amount",
           "visible": "always"
         },
         {
@@ -5985,10 +5671,7 @@
           "format": "tokenAmount",
           "params": {
             "tokenPath": "_swapData.receivingAssetId",
-            "nativeCurrencyAddress": [
-              "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "0x0000000000000000000000000000000000000000"
-            ]
+            "nativeCurrencyAddress": "0x0000000000000000000000000000000000000000"
           },
           "visible": "always"
         },

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -294,6 +294,23 @@ const CHAIN_FIELD: IField = {
   visible: 'always',
 }
 
+// LI.FI calldata carries the chain's native currency in `address` asset-id
+// fields via two sentinels, so neither resolves to ERC-20 metadata. Without
+// this, `tokenAmount` has no decimals or ticker to format with and wallets fall
+// back to the raw integer — a bare `7538051138939978` on the signing screen
+// where `0.007538051138939978 ETH` belongs.
+const NATIVE_CURRENCY_ADDRESSES = [
+  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+  '0x0000000000000000000000000000000000000000',
+]
+
+// Every `tokenAmount` field goes through this: any asset-id path in this
+// diamond can hold a native sentinel, so opting in per-site would only leave
+// room to forget one.
+function tokenAmountParams(tokenPath: string): Record<string, unknown> {
+  return { tokenPath, nativeCurrencyAddress: NATIVE_CURRENCY_ADDRESSES }
+}
+
 function bridgeFacetName(fnName: string): string {
   // startBridgeTokensViaXxx | swapAndStartBridgeTokensViaXxx
   // Strip Packed/Min/ERC20/Native suffixes; keep the bridge identity + version.
@@ -497,7 +514,7 @@ function buildStartFormat(fn: IAbiFn): IFormatEntry {
         path: '_bridgeData.minAmount',
         label: 'Amount to Bridge',
         format: 'tokenAmount',
-        params: { tokenPath: '_bridgeData.sendingAssetId' },
+        params: tokenAmountParams('_bridgeData.sendingAssetId'),
         visible: 'always',
       },
       CHAIN_FIELD,
@@ -520,14 +537,14 @@ function buildSwapAndStartFormat(fn: IAbiFn): IFormatEntry {
         path: '_swapData.[0].fromAmount',
         label: 'Amount to Swap',
         format: 'tokenAmount',
-        params: { tokenPath: '_swapData.[0].sendingAssetId' },
+        params: tokenAmountParams('_swapData.[0].sendingAssetId'),
         visible: 'always',
       },
       {
         path: '_bridgeData.minAmount',
         label: 'Minimum to Bridge',
         format: 'tokenAmount',
-        params: { tokenPath: '_bridgeData.sendingAssetId' },
+        params: tokenAmountParams('_bridgeData.sendingAssetId'),
         visible: 'always',
       },
       CHAIN_FIELD,
@@ -570,14 +587,14 @@ const SWAP_TEMPLATES: Record<string, IFormatEntry> = {
         path: '_swapData.fromAmount',
         label: 'Amount to Send',
         format: 'tokenAmount',
-        params: { tokenPath: '_swapData.sendingAssetId' },
+        params: tokenAmountParams('_swapData.sendingAssetId'),
         visible: 'always',
       },
       {
         path: '_minAmountOut',
         label: 'Minimum to Receive',
         format: 'tokenAmount',
-        params: { tokenPath: '_swapData.receivingAssetId' },
+        params: tokenAmountParams('_swapData.receivingAssetId'),
         visible: 'always',
       },
       {
@@ -629,7 +646,7 @@ SWAP_TEMPLATES.swapTokensSingleV3NativeToERC20 = {
       path: '_minAmountOut',
       label: 'Minimum to Receive',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.receivingAssetId' },
+      params: tokenAmountParams('_swapData.receivingAssetId'),
       visible: 'always',
     },
     {
@@ -669,14 +686,14 @@ SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToERC20 = {
       path: '_swapData.[0].fromAmount',
       label: 'Amount to Send',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.[0].sendingAssetId' },
+      params: tokenAmountParams('_swapData.[0].sendingAssetId'),
       visible: 'always',
     },
     {
       path: '_minAmountOut',
       label: 'Minimum to Receive',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.[-1].receivingAssetId' },
+      params: tokenAmountParams('_swapData.[-1].receivingAssetId'),
       visible: 'always',
     },
     {
@@ -725,7 +742,7 @@ SWAP_TEMPLATES.swapTokensMultipleV3NativeToERC20 = {
       path: '_minAmountOut',
       label: 'Minimum to Receive',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.[-1].receivingAssetId' },
+      params: tokenAmountParams('_swapData.[-1].receivingAssetId'),
       visible: 'always',
     },
     {
@@ -770,14 +787,14 @@ SWAP_TEMPLATES.swapTokensGeneric = {
       path: '_swapData.[0].fromAmount',
       label: 'Amount to Send',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.[0].sendingAssetId' },
+      params: tokenAmountParams('_swapData.[0].sendingAssetId'),
       visible: 'always',
     },
     {
       path: '_minAmount',
       label: 'Minimum to Receive',
       format: 'tokenAmount',
-      params: { tokenPath: '_swapData.[-1].receivingAssetId' },
+      params: tokenAmountParams('_swapData.[-1].receivingAssetId'),
       visible: 'always',
     },
     {

--- a/tasks/buildClearSigningProposal.ts
+++ b/tasks/buildClearSigningProposal.ts
@@ -294,21 +294,20 @@ const CHAIN_FIELD: IField = {
   visible: 'always',
 }
 
-// LI.FI calldata carries the chain's native currency in `address` asset-id
-// fields via two sentinels, so neither resolves to ERC-20 metadata. Without
-// this, `tokenAmount` has no decimals or ticker to format with and wallets fall
-// back to the raw integer — a bare `7538051138939978` on the signing screen
-// where `0.007538051138939978 ETH` belongs.
-const NATIVE_CURRENCY_ADDRESSES = [
-  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-  '0x0000000000000000000000000000000000000000',
-]
+// `LibAsset.isNativeAsset` accepts exactly one sentinel — the zero address — so
+// that is the only value declared here. (`0xEeee…EEeE` is an outbound
+// translation for bridges that expect it, e.g. SquidFacet and GardenFacet;
+// no asset-id input is ever read as native at that value.) Without this param
+// `tokenAmount` has no decimals or ticker to format the sentinel with and
+// wallets fall back to the raw integer — a bare `7538051138939978` on the
+// signing screen where `0.007538051138939978 ETH` belongs.
+const NATIVE_CURRENCY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 // Every `tokenAmount` field goes through this: any asset-id path in this
-// diamond can hold a native sentinel, so opting in per-site would only leave
+// diamond can hold the native sentinel, so opting in per-site would only leave
 // room to forget one.
 function tokenAmountParams(tokenPath: string): Record<string, unknown> {
-  return { tokenPath, nativeCurrencyAddress: NATIVE_CURRENCY_ADDRESSES }
+  return { tokenPath, nativeCurrencyAddress: NATIVE_CURRENCY_ADDRESS }
 }
 
 function bridgeFacetName(fnName: string): string {
@@ -630,12 +629,35 @@ const SWAP_TEMPLATES: Record<string, IFormatEntry> = {
 // (or the @.value for the legacy descriptor) is replaced. We just reproduce
 // the existing descriptor's field shape and append `interpolatedIntent`.
 
-SWAP_TEMPLATES.swapTokensSingleV3ERC20ToNative = {
-  // Cast: the ERC20ToERC20 entry is the literal object above and always present
-  // at this point. Required because `Record<string, T>` indexed access returns
-  // `T | undefined` under `noUncheckedIndexedAccess`.
-  ...(SWAP_TEMPLATES.swapTokensSingleV3ERC20ToERC20 as IFormatEntry),
+// The ERC20→Native variants send `address(this).balance` and never read the
+// `receivingAssetId` they are handed (`swapTokensSingleV3ERC20ToNative` and
+// `_transferNativeTokensAndEmitEvent` in GenericSwapFacetV3). Formatting
+// `_minAmountOut` against that unvalidated field would let crafted calldata put
+// any ticker and decimals on a guaranteed-native amount — `1 USDC` on screen for
+// 1e6 wei of native, on a transaction that succeeds. The output currency is
+// fixed, so state it rather than derive it.
+function withNativeMinAmountOut(base: IFormatEntry): IFormatEntry {
+  return {
+    ...base,
+    fields: base.fields.map((field) =>
+      field.path === '_minAmountOut'
+        ? {
+            path: field.path,
+            label: field.label,
+            format: 'amount',
+            visible: 'always' as const,
+          }
+        : field
+    ),
+  }
 }
+
+// Cast: the ERC20ToERC20 entry is the literal object above and always present
+// at this point. Required because `Record<string, T>` indexed access returns
+// `T | undefined` under `noUncheckedIndexedAccess`.
+SWAP_TEMPLATES.swapTokensSingleV3ERC20ToNative = withNativeMinAmountOut(
+  SWAP_TEMPLATES.swapTokensSingleV3ERC20ToERC20 as IFormatEntry
+)
 SWAP_TEMPLATES.swapTokensSingleV3NativeToERC20 = {
   intent: 'Swap',
   interpolatedIntent:
@@ -728,10 +750,10 @@ SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToERC20 = {
     },
   ],
 }
-SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToNative = {
-  // See note on the SingleV3 variant above re. the cast.
-  ...(SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToERC20 as IFormatEntry),
-}
+// See notes on the SingleV3 variant above re. the cast and the native output.
+SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToNative = withNativeMinAmountOut(
+  SWAP_TEMPLATES.swapTokensMultipleV3ERC20ToERC20 as IFormatEntry
+)
 SWAP_TEMPLATES.swapTokensMultipleV3NativeToERC20 = {
   intent: 'Swap',
   interpolatedIntent:


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-928](https://linear.app/lifi-linear/issue/EXSC-928/clear-signing-tokenamount-fields-render-native-currency-as-raw-wei) — Clear-signing: `tokenAmount` fields render native currency as raw wei

# Why did I implement it this way?

Every `tokenAmount` field in the proposal formats its value against a `tokenPath` asset id, but LI.FI calldata represents the chain's native currency with the zero address. That resolves to no ERC-20 metadata, so wallets have no decimals or ticker to format with and fall back to rendering the raw integer. An ERC20→Native swap currently shows `Minimum to Receive: 7538051138939978` where `0.007538051138939978 ETH` belongs. ERC-7730's `tokenAmount` format has a `nativeCurrencyAddress` param for exactly this case; we were not passing it.

I routed all `tokenAmount` construction sites through a `tokenAmountParams(tokenPath)` helper rather than spreading a constant at each site. Any asset-id path in this diamond can hold the native sentinel, so a per-site opt-in only leaves room to forget one when a new format is added — the helper makes the correct thing the only thing. The sentinel is a module constant next to the other shared field definitions.

The declared sentinel is the zero address only, because that is the sole value `LibAsset.isNativeAsset` accepts. `0xEeee…EEeE` is not native to this diamond: it appears in `src/` only as an outbound translation for bridges that expect it (`SquidFacet`, `GardenFacet` both convert `address(0)` → `0xEeee…` on the way out), never as an accepted input. Declaring it would make the screen and the contract disagree — calldata carrying it would render as `1 ETH` while the diamond attempts `transferFrom` on it.

**Correcting two formats that were deriving native amounts from calldata.** `swapTokensSingleV3ERC20ToNative` and `swapTokensMultipleV3ERC20ToNative` send `address(this).balance` and never read the `receivingAssetId` they are handed — the single variant ignores it entirely, and the multi variant's `_transferNativeTokensAndEmitEvent` computes the output from the contract balance. Formatting `_minAmountOut` against that unvalidated field let crafted calldata put any ticker and decimals on a guaranteed-native amount: `_swapData.receivingAssetId = <USDC>` with `_minAmountOut = 1000000` renders `Minimum to Receive: 1 USDC` while the contract only guarantees 1e6 wei of native, on a transaction that succeeds. Both now use `format: "amount"` — an integer format that resolves against the chain's native currency and takes no path — which is what the two `@.value` inputs on the Native→ERC20 variants already use. The rendered string for honest calldata is unchanged; the spoofing path is closed. The four sibling variants (`…ERC20ToERC20`, `…NativeToERC20`) keep `tokenAmount`, because there `receivingAssetId` is the asset actually balance-checked and transferred.

This is all pre-existing and not a regression from #2321 — I checked the pre-#2321 descriptor and it also had 0 of 105 `tokenAmount` fields carrying the param.

**Scope of the fix.** The proposal now emits 101 `tokenAmount` fields, all carrying `nativeCurrencyAddress`: 62 on `_bridgeData.sendingAssetId` (every bridge and swap-and-bridge amount), 33 on `_swapData.[0].sendingAssetId`, and 6 across the remaining swap paths. Two fields that were `tokenAmount` before this PR are now `amount` per the paragraph above. Only the two ERC20→Native swap cases are *confirmed* broken — I decoded their fixture calldata and both carry `receivingAssetId = 0x0000…0000`, and the EF registry's test runner renders bare wei for them today. The other 99 share the same pattern and the same failure mode, but I have not observed them failing.

The two `tokenAmount` fields left without the param in the merged registry file belong to `swapTokensGeneric`, which no longer exists in `src/Facets` (superseded by `GenericSwapFacetV3`). The generator still carries a dead `SWAP_TEMPLATES.swapTokensGeneric` entry, but with the function gone from the ABI it is never emitted, so the merge treats the registry's stale copy as unowned and preserves it. I left both the dead template and the stale selector alone — pruning deprecated owned selectors is EXSC-761. The template's two sites were converted along with the rest so it stays internally consistent if it is ever revived.

**Verification.** Beyond lint/typecheck/tests, I ran `tasks/generateLedgerClearSigning.ts` against the live registry file to confirm what the sync will actually produce: `abi` still absent, zero empty-`fields` formats (both #2321 guarantees intact), 69 formats, 101/103 `tokenAmount` fields carrying the param, and 4 `amount` fields. The merged descriptor validates against `specs/erc7730-v2.schema.json` (ajv, draft 2020-12). The generator is idempotent: a second run is byte-identical.

**What this PR does not prove.** Whether a wallet renders `0.007538051138939978 ETH` specifically is only observable when the EF registry's test runners execute the fixture. This change makes the descriptor correct per the ERC-7730 spec; the rendered string is confirmed on the registry side, where the LI.FI-owned `testsv2` fixture also needs its stale labels and missing `interpolatedIntent` refreshed before that PR goes green.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
