### PR TITLE
fix(ci): rename clear-signing sync branch to open a fresh upstream PR

### DIFF
--- a/.github/workflows/syncLedgerClearSigning.yml
+++ b/.github/workflows/syncLedgerClearSigning.yml
@@ -38,7 +38,7 @@ jobs:
   sync-ledger:
     concurrency:
       # Collapse the two production triggers (schedule + push) into one group so
-      # they never force-push sync/lifi-erc7730 or update the upstream PR
+      # they never force-push sync/lifi-clear-signing or update the upstream PR
       # concurrently — a second concurrent run would break the
       # `--force-with-lease` push or send a duplicate Slack ping.
       # cancel-in-progress lets a newer production run supersede an in-flight
@@ -106,7 +106,7 @@ jobs:
           LEDGER_FORK: ${{ secrets.LEDGER_FORK || 'lifinance/clear-signing-erc7730-registry' }} # optional override
           LEDGER_UPSTREAM: ethereum/clear-signing-erc7730-registry # Ethereum Foundation-hosted (migrated from LedgerHQ in 2026)
           LEDGER_FILE_PATH: registry/lifi/calldata-LIFIDiamond.json
-          SYNC_BRANCH: sync/lifi-erc7730
+          SYNC_BRANCH: sync/lifi-clear-signing
           PR_TITLE: 'lifi: sync calldata-LIFIDiamond.json (deployments + display.formats)'
           # Dry-run only applies on workflow_dispatch. Cron + push triggers always
           # run for real (DRY_RUN evaluates to '' in those contexts, falling


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-934](https://linear.app/lifi-linear/issue/EXSC-934/clear-signing-sync-silently-no-ops-against-a-detached-upstream-pr) — Clear-signing sync silently no-ops against a detached upstream PR

# Why did I implement it this way?

`syncLedgerClearSigning.yml` decides whether to call `gh pr create` by looking for an open upstream PR with our head ref. GitHub stops following a PR's head branch once that branch is deleted and recreated: the PR stays open and keeps matching that lookup, but freezes at its last-seen commit.

That is the state of https://github.com/ethereum/clear-signing-erc7730-registry/pull/2948 — head pinned at `08760e48` (Sep 3) while the fork branch moved on. Every sync since has pushed the branch, resolved #2948, skipped PR creation, skipped the Slack ping, and exited green while publishing nothing upstream. The run triggered by #2323 did exactly this an hour ago: it committed `b8e2e8b`, pushed it, then printed `PR URL: .../pull/2948` and finished successfully. So the descriptor fixes from #2321 and #2323 are sitting on the fork with no pull request carrying them.

We cannot clear the blockage on the PR itself. Its author is `lifi-action-bot`, and we hold `pull` only on the EF repo, so the Close button is not available to us. Deleting the fork's head branch does not close it either — I tried that, and the PR's `updated_at` did not even move, which is consistent with the association being gone rather than stale.

Renaming the branch is what we can do from here. A head ref with no open PR against it makes the next sync take the `gh pr create` path and get a PR GitHub actually follows, which also restores the Slack notification (`pr_was_created=true`). The stale comment in the `concurrency` block is updated in the same commit so the file has no references to the old name.

This does not close #2948 — that needs `lifi-action-bot` or an EF maintainer, and is tracked on the ticket along with the `read:org` scope the sync still lacks for `gh pr edit`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
