### PR TITLE
fix(ci): diff changed files against the merge base in PR gates (EXSC-940)

### DIFF
--- a/.github/workflows/protectSecurityRelevantCode.yml
+++ b/.github/workflows/protectSecurityRelevantCode.yml
@@ -42,7 +42,10 @@ jobs:
           ##### -z so paths are emitted raw. Without it git C-quotes any path holding a
           ##### non-ASCII or control byte, and the leading quote breaks every ^-anchored
           ##### pattern below — adding '.github/workflows/pwné.yml' read as unprotected
-          mapfile -t -d '' FILES < <(git diff -z --name-only --no-renames origin/main HEAD)
+          ##### three-dot so the diff is against the merge base. Two-dot also lists the
+          ##### commits main gained since the branch point, which demands approval here
+          ##### for protected files this PR never touched
+          mapfile -t -d '' FILES < <(git diff -z --name-only --no-renames origin/main...HEAD)
 
           ##### make sure that there are modified files
           if [[ ${#FILES[@]} -eq 0 ]]; then

--- a/.github/workflows/protectSecurityRelevantCode.yml
+++ b/.github/workflows/protectSecurityRelevantCode.yml
@@ -49,7 +49,7 @@ jobs:
 
           ##### make sure that there are modified files
           if [[ ${#FILES[@]} -eq 0 ]]; then
-            echo -e "\033[31mNo files found. This should not happen. Please check the code of the Github action. Aborting now.\033[0m"
+            echo -e "\033[31mNo files differ from the merge base. Either this PR has no net change (e.g. a change and its revert) or origin/main could not be resolved. Aborting now.\033[0m"
             echo "CONTINUE=false" >> $GITHUB_ENV
             exit 1
           fi

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -122,11 +122,11 @@ jobs:
 
           ##### every comparison below is against the commit this branch forked from, not the
           ##### moving base-branch tip
-          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
-          if [[ -z "$MERGE_BASE" ]]; then
+          ##### `set -e` would abort on the failing substitution before any message is printed
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD) || {
             echo -e "\033[31mCould not determine the merge base with origin/$BASE_REF. Aborting now.\033[0m"
             exit 1
-          fi
+          }
 
           ##### Initialize variables
           MISSING_VERSION_TAG=()

--- a/.github/workflows/versionControlAndAuditCheck.yml
+++ b/.github/workflows/versionControlAndAuditCheck.yml
@@ -70,7 +70,10 @@ jobs:
 
           ##### get all files modified by this PR
           # --diff-filter=AM argument to only include files that were added or modified not deleted
-          FILES="$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}" HEAD)"
+          # three-dot so the diff is against the merge base. Two-dot also lists the commits the
+          # base branch gained since the branch point, which flags contracts this PR never
+          # touched as needing a version bump and an audit
+          FILES="$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD")"
 
           ##### if no files were modified, this is valid (e.g., just moving files around)
           if [[ -z "$FILES" ]]; then
@@ -117,6 +120,14 @@ jobs:
           ##### Read tmp file into variable
           CONTRACTS=$(cat modified_contracts.txt)
 
+          ##### every comparison below is against the commit this branch forked from, not the
+          ##### moving base-branch tip
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD)
+          if [[ -z "$MERGE_BASE" ]]; then
+            echo -e "\033[31mCould not determine the merge base with origin/$BASE_REF. Aborting now.\033[0m"
+            exit 1
+          fi
+
           ##### Initialize variables
           MISSING_VERSION_TAG=()
           MISSING_VERSION_UPDATE=()
@@ -144,7 +155,7 @@ jobs:
               echo -e "\033[32mFile contains a custom:version tag\033[0m"
 
               ##### Filter relevant code changes (exclude comments, pragma, license, empty lines)
-              DIFF_OUTPUT=$(git diff "origin/$BASE_REF" HEAD -- "$FILE_PATH")
+              DIFF_OUTPUT=$(git diff "$MERGE_BASE" HEAD -- "$FILE_PATH")
               RELEVANT_CHANGES=$(echo "$DIFF_OUTPUT" | grep -E '^[\+\-]' \
                 | grep -vE "^[\+\-][[:space:]]*(//|/\*|pragma)" \
                 | grep -vE '^(\+\+\+|---)' \
@@ -159,7 +170,7 @@ jobs:
                   echo "--------------------"
                   echo "Checking if version was updated..."
 
-                  OLD_FILE_CONTENT=$(git show "origin/$BASE_REF:${FILE_PATH}" 2>/dev/null || echo "")
+                  OLD_FILE_CONTENT=$(git show "$MERGE_BASE:${FILE_PATH}" 2>/dev/null || echo "")
                   OLD_VERSION=$(echo "$OLD_FILE_CONTENT" | grep -E '^/// @custom:version' | sed -E 's/^\/\/\/ @custom:version ([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
 
                   # If there was no old version line in the diff, it's a new file.


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-940](https://linear.app/lifi-linear/issue/EXSC-940/pr-gates-diff-against-the-merge-base-not-two-dot-tip-vs-tip) — found while working on #2327 / EXSC-920.

# Why did I implement it this way?

**⚠️ This PR touches `.github/` and therefore legitimately requires an Information Security Manager approval.** That red check is expected, not the bug being fixed.

Both PR gates computed the changed-file list with a **two-dot** diff:

```bash
git diff --name-only origin/main HEAD          # protectSecurityRelevantCode
git diff --name-only --diff-filter=AM "origin/${BASE_REF}" HEAD   # versionControlAndAuditCheck
```

Two-dot reports the symmetric difference between two commits, so it also lists everything the base branch gained since the branch point. Any PR branched before an unrelated change merged is judged on files it never touched:

- `protectSecurityRelevantCode` demanded an Information Security Manager approval. Observed on #2327: the PR touched only `script/**` and `.agents/**`, but #2326 had merged `.github/workflows/syncLedgerClearSigning.yml` into main after the branch point.
- `versionControlAndAuditCheck` listed contracts the PR never touched, which rewrites the PR title and makes the audit job demand an audit for them.

Three-dot (`origin/main...HEAD`) diffs against the merge base, which is the actual PR scope. In `versionControlAndAuditCheck` the per-contract step also resolves the merge base once and uses it for both the per-file diff and the `git show` that reads the previous `@custom:version` — mixing merge-base and tip there would let a contract changed without a version bump pass whenever the base branch had bumped it in the meantime.

Why it matters beyond the annoyance: `protectSecurityRelevantCode` is a security gate. Every spurious red trains reviewers to treat its failure as noise. The workaround today is to merge `origin/main` into the branch, which pushes the cost onto every unrelated PR.

The repo has no other two-dot base diff: `git grep 'git diff.*origin/'` over `.github/`, `*.sh` and `*.ts` returns nothing else. The remaining `git diff` uses are working-tree checks (`--exit-code`) or push-event before/after SHAs, both correct as they are.

## Verification

`pull_request_review: submitted` is the only trigger, so this can't be exercised by pushing. Instead both gates' `run:` bodies were extracted from the YAML (old = `origin/main`, new = this branch) and executed against real branches cut from a commit older than main's latest `.github/` change, with `GITHUB_ENV` captured. Every case ran on a real commit whose diff is printed in the harness output.

`protectSecurityRelevantCode` — `CONTINUE=true` means "approval required":

| Scenario | old | new |
|---|---|---|
| PR touches only `script/**` + `.agents/**`, main moved `.github/` (the #2327 shape) | `true` ❌ | `false` ✅ |
| PR genuinely touches `.github/` | `true` | `true` ✅ |
| PR touches `script/emergency/` | — | `true` ✅ |
| PR **deletes** a protected file | — | `true` ✅ |
| PR **renames** a protected file out of `.github/` | — | `true` ✅ |
| protected path with a non-ASCII byte (the `-z` guarantee) | — | `true` ✅ |
| empty diff | — | fails loudly (exit 1) ✅ |

`versionControlAndAuditCheck`, branched before the EcoFacet v2.0.0 bump that main already has:

| Scenario | old | new |
|---|---|---|
| PR touches no contract at all | flags `src/Facets/EcoFacet.sol` ❌ | no contracts ✅ |
| PR changes a contract **without** a version bump | — | step fails (exit 1) ✅ |
| PR changes a contract **and** bumps the version | — | passes ✅ |

Both files also re-checked with a YAML parse, `bash -n` on every `run:` body, and `prettier --check`. All step bodies were executed under GitHub's actual default shell for a `run:` with no `shell:` key, which is `bash -e` (no `pipefail`).

### The fix also closes a false *negative*

Two-dot compares the two commits' contents, so a branch that cherry-picks main's own protected change ends up with a diff that is empty for that file: the old gate reported "does not change any security-relevant code" and let it through. Three-dot flags it, because the file does differ from the merge base. Verified both ways.

### Two behaviours a reviewer should know about

**Version collision in `versionControlAndAuditCheck` is no longer caught by the version-control step.** If main ships `FooFacet` v2.0.0 after the branch point and the PR labels its own different change v2.0.0, the old code failed the step ("version was not updated" — comparing against main's tip) and the new code passes it (v1.1.0 → v2.0.0 against the merge base looks like a bump). The old behaviour was protective by accident: the same tip comparison also produced the reverse false positive, reporting untouched contracts as downgraded (v2.0.0 → v1.1.0). This is not a bypass — `audit-verification` still requires an audit-log entry for the contract at that version whose `auditCommitHash` is in *this* PR's commit list, and main's pre-existing entry is not, so such a PR still goes red. Detecting "this PR ships version X while main already ships a different X" is a check neither gate has ever had, and adding one is out of scope here.

**Criss-cross histories have more than one merge base.** The repo does allow merge commits, so this is reachable. `git diff` picks one base and warns. I built the case where a protected file is added on a branch, merged to main and reverted: two-dot flags it, three-dot does not — but performing the actual merge shows the file never lands (resolved as deleted), so three-dot matched the real merge outcome and two-dot's flag was itself spurious. The variant where both sides change the same protected file differently either gets flagged, or conflicts and cannot land silently.

### Pre-existing, not touched here

`protectSecurityRelevantCode` hardcodes `origin/main` rather than the PR's base ref. Under three-dot a stacked PR therefore over-reports its parent's protected files, which is the safe direction.

## Note on the gate firing on this PR

This does not loosen the ISM gate. Three-dot still demands approval from any PR that itself touches a protected path — it stops demanding it from PRs that never touched one. The seven scenarios above are the evidence.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug — n/a as a committed test: the trigger is `pull_request_review: submitted`, so there is no in-repo harness that can exercise it. The old-vs-new evidence is in the Verification section above.
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e — n/a, no contracts touched
- [x] I have updated any required documentation — the rationale lives in the workflow comments

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

