### PR TITLE
feat(deploy): record branch, scoped dirty tree and actor on deployment logs (EXSC-695)

### DIFF
--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -78,9 +78,22 @@ verification, and calls `logContractDeploymentInfo` →
 time, from the dev's machine**. The record (`IDeploymentRecord` in
 `script/deploy/shared/mongo-log-utils.ts`) carries name, network, version,
 address, constructor args, salt, a self-reported `verified` boolean, and the
-deployer's HEAD `gitCommitHash` — no branch, dirty-tree flag, or human
-identity. File logs (`deployments/{network}.json`) only land in git at PR
-merge; the deploy scripts never commit.
+provenance of the run that produced it: the deployer's HEAD `gitCommitHash`,
+the `repo` it was cloned from, the `gitBranch` checked out, the `actor`
+(`human`, `bot`, `ci`), and `dirtyTreeScoped` — the working-tree paths that
+differed from that commit, with the artefacts the deploy pipeline rewrites
+during its own run excluded. An **empty `dirtyTreeScoped` means the capture
+ran and the tree was clean; an absent one means no capture ran**, which is
+what every record written before the field existed looks like. Branch, tree
+and actor come from the same `captureGitProvenance` pass the Safe proposal
+document uses, so a deployment and the proposal that installs it cannot
+disagree about where they came from. The capture is self-reported context, not
+a control: it makes an honest mistake such as a deploy from an uncommitted
+edit visible, while `assertTreeRecordable` — not this record — is what refuses
+such a deploy, on the narrower set of build-affecting paths. Add `--dryRun` to
+the `add` command to print the record and the upsert without writing. File
+logs (`deployments/{network}.json`) only land in git at PR merge; the deploy
+scripts never commit.
 
 ### 4.2 Propose
 

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -80,21 +80,23 @@ time, from the dev's machine**. The record (`IDeploymentRecord` in
 address, constructor args, salt, a self-reported `verified` boolean, and the
 provenance of the run that produced it: the deployer's HEAD `gitCommitHash`,
 the `repo` it was cloned from, the `gitBranch` checked out, the `actor`
-(`human`, `bot`, `ci`), and `dirtyTreeScoped` — the working-tree paths that
-differed from that commit, with the artefacts the deploy pipeline rewrites
-during its own run excluded. An **empty `dirtyTreeScoped` means the capture
-ran and the tree was clean; an absent one means no capture ran, or ran and
-could not read the tree** — the same shape every record written before the
-field existed has. Branch, tree
-and actor come from the same `captureGitProvenance` pass the Safe proposal
-document uses, so a deployment and the proposal that installs it cannot
-disagree about where they came from. The capture is self-reported context, not
-a control: it makes an honest mistake such as a deploy from an uncommitted
-edit visible, while `assertTreeRecordable` — not this record — is what refuses
-such a deploy, on the narrower set of build-affecting paths. Add `--dryRun` to
-the `add` command to print the record and the upsert without writing. File
-logs (`deployments/{network}.json`) only land in git at PR merge; the deploy
-scripts never commit.
+(`human`, `bot` for a job that set `SAFE_PROPOSAL_ACTOR=bot`, `ci`, or
+`UNKNOWN` when nothing identified the caller), and `dirtyTreeScoped` — the
+working-tree paths that differed from that commit, excluding the artefacts the
+deploy pipeline rewrites during its own run (`deployments/` and
+`script/deploy/_targetState.json`). An **empty `dirtyTreeScoped` means the
+capture ran and the tree was clean; an absent one means no capture ran, or ran
+and could not read the tree** — the same shape every record written before the
+field existed has. Branch, tree and actor are read through the same
+`captureGitProvenance` helper the Safe proposal document is built from, so a
+deployment record and the proposal that installs it describe them by one
+definition rather than two. The capture is self-reported context, not a
+control: it makes an honest mistake such as a deploy from an uncommitted edit
+visible, while `assertTreeRecordable` — not this record — is what refuses such
+a deploy, on the narrower set of build-affecting paths. Add `--dryRun` (or
+`--dry-run`) to the `add` command to print the upsert it would apply without
+writing. File logs (`deployments/{network}.json`) only land in git at PR
+merge; the deploy scripts never commit.
 
 ### 4.2 Propose
 

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -83,8 +83,9 @@ the `repo` it was cloned from, the `gitBranch` checked out, the `actor`
 (`human`, `bot`, `ci`), and `dirtyTreeScoped` — the working-tree paths that
 differed from that commit, with the artefacts the deploy pipeline rewrites
 during its own run excluded. An **empty `dirtyTreeScoped` means the capture
-ran and the tree was clean; an absent one means no capture ran**, which is
-what every record written before the field existed looks like. Branch, tree
+ran and the tree was clean; an absent one means no capture ran, or ran and
+could not read the tree** — the same shape every record written before the
+field existed has. Branch, tree
 and actor come from the same `captureGitProvenance` pass the Safe proposal
 document uses, so a deployment and the proposal that installs it cannot
 disagree about where they came from. The capture is self-reported context, not

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -83,14 +83,15 @@ the `repo` it was cloned from, the `gitBranch` checked out, the `actor`
 (`human`, `bot` for a job that set `SAFE_PROPOSAL_ACTOR=bot`, `ci`, or
 `UNKNOWN` when nothing identified the caller), and `dirtyTreeScoped` — the
 working-tree paths that differed from that commit, excluding the artefacts the
-deploy pipeline rewrites during its own run (`deployments/` and
-`script/deploy/_targetState.json`). An **empty `dirtyTreeScoped` means the
-capture ran and the tree was clean; an absent one means no capture ran, or ran
-and could not read the tree** — the same shape every record written before the
-field existed has. Branch, tree and actor are read through the same
-`captureGitProvenance` helper the Safe proposal document is built from, so a
-deployment record and the proposal that installs it describe them by one
-definition rather than two. The capture is self-reported context, not a
+deploy pipeline rewrites during its own run (`deployments/`). Governance
+inputs such as `script/deploy/_targetState.json` stay in the list. An **empty
+`dirtyTreeScoped` means the capture ran and the tree was clean; an absent one
+means no capture ran, or ran and could not read the tree** — the same shape
+every record written before the field existed has. A later clean re-log does
+not `$set` an empty list over a dirty one already stored. Branch, tree, actor
+and commit are read through the same `captureGitProvenance` helper the Safe
+proposal document is built from, so a deployment record and the proposal that
+installs it describe them by one definition rather than two. The capture is self-reported context, not a
 control: it makes an honest mistake such as a deploy from an uncommitted edit
 visible, while `assertTreeRecordable` — not this record — is what refuses such
 a deploy, on the narrower set of build-affecting paths. Add `--dryRun` (or

--- a/script/deploy/safe/provenance-display.test.ts
+++ b/script/deploy/safe/provenance-display.test.ts
@@ -44,6 +44,7 @@ function buildProvenance(
     gitCommit: SHA,
     gitBranch: 'feat/exsc-692',
     dirtyTreeScoped: [],
+    dirtyTreeRead: true,
     commitOnRemote: true,
     capturedAt: '2026-07-27T10:00:00.000Z',
     ...overrides,

--- a/script/deploy/safe/safe-utils.test.ts
+++ b/script/deploy/safe/safe-utils.test.ts
@@ -157,6 +157,7 @@ const FIXED_PROVENANCE: IProposalProvenance = {
   gitCommit: 'a'.repeat(40),
   gitBranch: 'test-branch',
   dirtyTreeScoped: [],
+  dirtyTreeRead: true,
   capturedAt: '2026-01-01T00:00:00.000Z',
 }
 

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1577,6 +1577,10 @@ function sanitizeOverride(
     dirtyTreeScoped: Array.isArray(override.dirtyTreeScoped)
       ? override.dirtyTreeScoped.map(sanitizeProvenanceText).filter(Boolean)
       : [],
+    dirtyTreeRead:
+      typeof override.dirtyTreeRead === 'boolean'
+        ? override.dirtyTreeRead
+        : Array.isArray(override.dirtyTreeScoped),
     ...(override.dirtyTreeTruncated === true
       ? { dirtyTreeTruncated: true }
       : {}),
@@ -1662,6 +1666,7 @@ export function buildProposalProvenance(
       gitCommit: PROVENANCE_UNKNOWN,
       gitBranch: PROVENANCE_UNKNOWN,
       dirtyTreeScoped: [],
+      dirtyTreeRead: false,
       captureErrors: [`provenance capture failed: ${error}`],
       ...(reason ? { reason } : {}),
       ...ticket,

--- a/script/deploy/shared/git-provenance.test.ts
+++ b/script/deploy/shared/git-provenance.test.ts
@@ -153,6 +153,7 @@ describe('captureGitProvenance — happy path', () => {
       gitCommit: SHA,
       gitBranch: BRANCH,
       dirtyTreeScoped: [],
+      dirtyTreeRead: true,
       commitOnRemote: true,
       prUrl: PR_URL,
     })
@@ -266,8 +267,10 @@ describe('captureGitProvenance — dirty tree scoping', () => {
 
     expect(provenance.dirtyTreeScoped).toEqual([
       'config/whitelist.json',
+      'script/deploy/_targetState.json',
       'src/Facets/Foo.sol',
     ])
+    expect(provenance.dirtyTreeRead).toBe(true)
     expect(provenance.dirtyTreeTruncated).toBeUndefined()
   })
 
@@ -275,6 +278,7 @@ describe('captureGitProvenance — dirty tree scoping', () => {
     const provenance = captureGitProvenance(contextWith(happyHandlers()))
 
     expect(provenance.dirtyTreeScoped).toEqual([])
+    expect(provenance.dirtyTreeRead).toBe(true)
     expect(provenance.captureErrors).toBeUndefined()
   })
 
@@ -285,6 +289,7 @@ describe('captureGitProvenance — dirty tree scoping', () => {
     const provenance = captureGitProvenance(contextWith(handlers))
 
     expect(provenance.dirtyTreeScoped).toEqual([])
+    expect(provenance.dirtyTreeRead).toBe(false)
     expect(
       provenance.captureErrors?.some((entry) => entry.includes('git status'))
     ).toBe(true)

--- a/script/deploy/shared/git-provenance.ts
+++ b/script/deploy/shared/git-provenance.ts
@@ -83,19 +83,17 @@ const MAX_BUFFER_BYTES = 8 * 1024 * 1024
 
 /**
  * Paths the deploy pipeline itself writes mid-run (`saveContract`,
- * `saveDiamondFacets`, `saveDiamondPeriphery`, `updateDiamondLogs`, the
- * target-state merge, and the untracked `deployments/*.lock` markers). They
- * turn a normal deploy's tree dirty while saying nothing about source drift.
+ * `saveDiamondFacets`, `saveDiamondPeriphery`, `updateDiamondLogs`, and the
+ * untracked `deployments/*.lock` markers). They turn a normal deploy's tree
+ * dirty while saying nothing about source drift.
  *
- * Governance inputs such as `config/whitelist.json` are deliberately NOT
- * excluded: a dirty whitelist at proposal time is exactly what a reviewer needs
+ * Governance inputs such as `config/whitelist.json` and
+ * `script/deploy/_targetState.json` are deliberately NOT excluded: a dirty
+ * whitelist or target state at proposal time is exactly what a reviewer needs
  * to see. Most build output (`out/`, `cache/`, `broadcast/`, …) is gitignored
  * and never reaches this filter.
  */
-const PROVENANCE_DIRTY_EXCLUDES: readonly RegExp[] = [
-  /^deployments\//u,
-  /^script\/deploy\/_targetState\.json$/u,
-]
+const PROVENANCE_DIRTY_EXCLUDES: readonly RegExp[] = [/^deployments\//u]
 
 /**
  * Branches a PR lookup is pointless for: the trunk itself, a detached HEAD, and
@@ -157,6 +155,11 @@ export interface IDirtyTree {
   paths: string[]
   /** True when more dirty paths existed than `paths` records. */
   truncated: boolean
+  /**
+   * Whether `git status` itself ran. `paths: []` is a clean tree only when
+   * this is true; a failed probe also returns an empty list.
+   */
+  readable: boolean
 }
 
 /** Ambient git state describing the code a run was produced from. */
@@ -181,6 +184,11 @@ export interface IGitProvenance {
   /** Present only when the dirty list was capped at {@link MAX_DIRTY_PATHS}. */
   dirtyTreeTruncated?: boolean
   /**
+   * Whether the dirty-tree probe ran. `dirtyTreeScoped: []` is a clean tree
+   * only when this is true — the same probe failure also returns an empty list.
+   */
+  dirtyTreeRead: boolean
+  /**
    * Whether `gitCommit` is reachable from a remote-tracking ref, i.e. whether a
    * reviewer can fetch the code that produced this run. Read from local refs
    * only (no network), so a stale checkout can report `false` for a commit that
@@ -200,6 +208,7 @@ const UNKNOWN_GIT_PROVENANCE: Omit<IGitProvenance, 'capturedAt'> = {
   gitCommit: PROVENANCE_UNKNOWN,
   gitBranch: PROVENANCE_UNKNOWN,
   dirtyTreeScoped: [],
+  dirtyTreeRead: false,
 }
 
 /**
@@ -382,7 +391,8 @@ function scopedDirtyTree(ctx: IResolvedContext): IDirtyTree {
   )
   // `null` means the probe failed, which is not the same as a clean tree — the
   // recorded error is what tells a reader the empty list is not a clean bill.
-  if (porcelain === null) return { paths: [], truncated: false }
+  if (porcelain === null)
+    return { paths: [], truncated: false, readable: false }
 
   const relevant = parsePorcelainPaths(porcelain).filter(
     (path) => !PROVENANCE_DIRTY_EXCLUDES.some((pattern) => pattern.test(path))
@@ -391,6 +401,7 @@ function scopedDirtyTree(ctx: IResolvedContext): IDirtyTree {
   return {
     paths: unique.slice(0, MAX_DIRTY_PATHS),
     truncated: unique.length > MAX_DIRTY_PATHS,
+    readable: true,
   }
 }
 
@@ -592,6 +603,7 @@ export function captureGitProvenance(
       gitCommit: sanitizeField(commit),
       gitBranch: sanitizeField(branch),
       dirtyTreeScoped: dirty.paths.map(sanitizeProvenanceText).filter(Boolean),
+      dirtyTreeRead: dirty.readable,
       ...(dirty.truncated ? { dirtyTreeTruncated: true } : {}),
       ...(onRemote === undefined ? {} : { commitOnRemote: onRemote }),
       ...(prUrl ? { prUrl } : {}),

--- a/script/deploy/shared/mongo-log-utils.test.ts
+++ b/script/deploy/shared/mongo-log-utils.test.ts
@@ -5,7 +5,20 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { deploymentRecordEqFilter, mongoEq } from './mongo-log-utils'
+import {
+  getGitBranch,
+  getScopedDirtyTree,
+  PROVENANCE_UNKNOWN,
+  type ProvenanceActor,
+} from './git-provenance'
+import {
+  buildDeploymentUpsert,
+  captureRecordProvenance,
+  deploymentRecordEqFilter,
+  mongoEq,
+  provenanceUpdate,
+  type IDeploymentRecord,
+} from './mongo-log-utils'
 
 describe('mongoEq', () => {
   it('wraps a plain value in an equality operator', () => {
@@ -73,5 +86,180 @@ describe('deploymentRecordEqFilter', () => {
     } as unknown as Parameters<typeof deploymentRecordEqFilter>[0])
 
     expect(filter).toEqual({ network: { $eq: 'arbitrum' } })
+  })
+})
+
+describe('provenanceUpdate — twin provenance fields', () => {
+  const hash = 'a'.repeat(40)
+  const repo = 'github.com/lifinance/contracts'
+  const captured = {
+    gitCommitHash: hash,
+    repo,
+    gitBranch: 'feature/exsc-695',
+    dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'],
+    dirtyTreeTruncated: false,
+    actor: 'human' as const,
+  }
+
+  it('sets branch, dirty tree and actor from a full capture', () => {
+    expect(provenanceUpdate(captured).set).toEqual({
+      gitCommitHash: hash,
+      repo,
+      gitBranch: 'feature/exsc-695',
+      dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'],
+      dirtyTreeTruncated: false,
+      actor: 'human',
+    })
+  })
+
+  /**
+   * The JSON sync path builds records with none of these fields, so an
+   * unconditional `$set` would erase on every sync what the add CLI recorded at
+   * deploy time. Paired with the case above so "not present" cannot pass by
+   * observing an update this function never populates at all.
+   */
+  it('leaves every twin field alone on a record that carries none', () => {
+    const update = provenanceUpdate({ gitCommitHash: hash, repo })
+
+    for (const field of [
+      'gitBranch',
+      'dirtyTreeScoped',
+      'dirtyTreeTruncated',
+      'actor',
+    ]) {
+      expect(update.set).not.toHaveProperty(field)
+      expect(update.setOnInsert).not.toHaveProperty(field)
+    }
+    expect(update.set).toHaveProperty('gitCommitHash', hash)
+  })
+
+  it.each([
+    ['gitBranch', { gitBranch: PROVENANCE_UNKNOWN }],
+    ['actor', { actor: PROVENANCE_UNKNOWN as ProvenanceActor }],
+  ])(
+    'records a failed %s capture on insert but never over an existing value',
+    (field, sentinelField) => {
+      const update = provenanceUpdate({
+        ...captured,
+        ...sentinelField,
+      })
+
+      expect(update.set).not.toHaveProperty(field)
+      expect(update.setOnInsert).toHaveProperty(field, PROVENANCE_UNKNOWN)
+    }
+  )
+
+  /**
+   * An empty list is the answer "this tree was clean", not a missing capture —
+   * and it has to be written, or a record logged from a dirty tree keeps its
+   * paths forever once the tree is cleaned and the deploy is re-run.
+   */
+  it('writes a clean tree as an empty list rather than omitting it', () => {
+    const update = provenanceUpdate({ ...captured, dirtyTreeScoped: [] })
+
+    expect(update.set).toHaveProperty('dirtyTreeScoped', [])
+    expect(update.set).toHaveProperty('dirtyTreeTruncated', false)
+  })
+
+  it('carries the truncation flag when the dirty list was capped', () => {
+    const update = provenanceUpdate({ ...captured, dirtyTreeTruncated: true })
+
+    expect(update.set).toHaveProperty('dirtyTreeTruncated', true)
+  })
+
+  /**
+   * Provenance must never become part of a deployment's identity: EXSC-695's
+   * safety note turns on the filter staying the four identity fields, and this
+   * whitelist is the other place a branch could leak into a query.
+   */
+  it('keeps the twin fields out of the equality-filter whitelist', () => {
+    const filter = deploymentRecordEqFilter({
+      network: 'arbitrum',
+      gitBranch: 'feature/exsc-695',
+      actor: 'human',
+      dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'],
+    })
+
+    expect(filter).toEqual({ network: { $eq: 'arbitrum' } })
+  })
+})
+
+describe('buildDeploymentUpsert', () => {
+  const now = new Date('2026-09-08T00:00:00.000Z')
+  const record: IDeploymentRecord = {
+    contractName: 'AcrossFacetV4',
+    network: 'arbitrum',
+    version: '1.0.0',
+    address: '0x1111111111111111111111111111111111111111',
+    optimizerRuns: '1000000',
+    timestamp: now,
+    constructorArgs: '0x',
+    salt: '',
+    verified: true,
+    solcVersion: '0.8.29',
+    evmVersion: 'cancun',
+    zkSolcVersion: '',
+    gitCommitHash: 'b'.repeat(40),
+    repo: 'github.com/lifinance/contracts',
+    gitBranch: 'feature/exsc-695',
+    dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'],
+    dirtyTreeTruncated: false,
+    actor: 'human',
+    createdAt: now,
+    updatedAt: now,
+    contractNetworkKey: 'AcrossFacetV4-arbitrum',
+    contractVersionKey: 'AcrossFacetV4-1.0.0',
+  }
+
+  it('puts the captured provenance into the update the CLI applies', () => {
+    const { update } = buildDeploymentUpsert(record, now)
+
+    expect(update.$set).toMatchObject({
+      gitBranch: 'feature/exsc-695',
+      dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'],
+      dirtyTreeTruncated: false,
+      actor: 'human',
+      updatedAt: now,
+    })
+  })
+
+  /**
+   * The identity a re-log matches on. A provenance field in here would insert a
+   * second row for the same deployed address on every deploy from a new branch.
+   */
+  it('matches on the four identity fields only', () => {
+    const { filter } = buildDeploymentUpsert(record, now)
+
+    expect(filter).toEqual({
+      contractName: { $eq: 'AcrossFacetV4' },
+      network: { $eq: 'arbitrum' },
+      version: { $eq: '1.0.0' },
+      address: { $eq: '0x1111111111111111111111111111111111111111' },
+    })
+  })
+
+  it('claims only the creation stamp on insert for a fully captured record', () => {
+    const { update } = buildDeploymentUpsert(record, now)
+
+    expect(update.$setOnInsert).toEqual({ createdAt: now })
+  })
+})
+
+describe('captureRecordProvenance', () => {
+  /**
+   * Runs against this checkout, so it asserts that the shared capture is
+   * actually reached and mapped onto record fields — not which branch a
+   * reviewer happens to be on.
+   */
+  it('maps the shared git capture onto record fields', () => {
+    const provenance = captureRecordProvenance()
+
+    expect(provenance.gitBranch).toBeTruthy()
+    expect(provenance.gitBranch).toBe(getGitBranch())
+    expect(provenance.dirtyTreeScoped).toEqual(getScopedDirtyTree().paths)
+    expect(['human', 'bot', 'ci', PROVENANCE_UNKNOWN]).toContain(
+      provenance.actor
+    )
+    expect(typeof provenance.dirtyTreeTruncated).toBe('boolean')
   })
 })

--- a/script/deploy/shared/mongo-log-utils.test.ts
+++ b/script/deploy/shared/mongo-log-utils.test.ts
@@ -154,15 +154,17 @@ describe('provenanceUpdate — twin provenance fields', () => {
   )
 
   /**
-   * An empty list is the answer "this tree was clean", not a missing capture —
-   * and it has to be written, or a record logged from a dirty tree keeps its
-   * paths forever once the tree is cleaned and the deploy is re-run.
+   * An empty list is the answer "this tree was clean" on a first insert.
+   * Writing it through `$set` would let a later clean re-log erase the dirty
+   * list that is the tell-tale of the deploy this field exists to surface.
    */
-  it('writes a clean tree as an empty list rather than omitting it', () => {
+  it('records a clean tree on insert only, never over an existing dirty list', () => {
     const update = provenanceUpdate({ ...captured, dirtyTreeScoped: [] })
 
-    expect(update.set).toHaveProperty('dirtyTreeScoped', [])
-    expect(update.set).toHaveProperty('dirtyTreeTruncated', false)
+    expect(update.set).not.toHaveProperty('dirtyTreeScoped')
+    expect(update.set).not.toHaveProperty('dirtyTreeTruncated')
+    expect(update.setOnInsert).toHaveProperty('dirtyTreeScoped', [])
+    expect(update.setOnInsert).toHaveProperty('dirtyTreeTruncated', false)
   })
 
   it('carries the truncation flag when the dirty list was capped', () => {
@@ -341,11 +343,23 @@ describe('captureRecordProvenance', () => {
   it('maps branch, dirty paths and actor off the git answers it was given', () => {
     const provenance = capture(baseAnswers)
 
+    expect(provenance.gitCommitHash).toBe(HEAD)
     expect(provenance.gitBranch).toBe('feature/exsc-695')
     expect(provenance.dirtyTreeScoped).toEqual(['src/Facets/AcrossFacetV4.sol'])
     expect(provenance.dirtyTreeTruncated).toBe(false)
     expect(provenance.actor).toBe('human')
     expect(provenance.captureErrors).toBeUndefined()
+  })
+
+  it('takes the commit from the shared capture, including the CI SHA', () => {
+    const sha = 'd'.repeat(40)
+    const provenance = captureRecordProvenance({
+      cwd: REPO,
+      env: { GITHUB_ACTIONS: 'true', GITHUB_SHA: sha },
+      run: gitRunner(baseAnswers),
+    })
+
+    expect(provenance.gitCommitHash).toBe(sha)
   })
 
   it('records a clean tree as an empty list', () => {

--- a/script/deploy/shared/mongo-log-utils.test.ts
+++ b/script/deploy/shared/mongo-log-utils.test.ts
@@ -1,4 +1,6 @@
 import {
+  afterEach,
+  beforeEach,
   describe,
   expect,
   it,
@@ -6,15 +8,17 @@ import {
 } from 'bun:test'
 
 import {
-  getGitBranch,
-  getScopedDirtyTree,
   PROVENANCE_UNKNOWN,
+  resetGitProvenanceCache,
+  type CommandRunner,
+  type ICommandResult,
   type ProvenanceActor,
 } from './git-provenance'
 import {
   buildDeploymentUpsert,
   captureRecordProvenance,
   deploymentRecordEqFilter,
+  describeDirtyTree,
   mongoEq,
   provenanceUpdate,
   type IDeploymentRecord,
@@ -245,21 +249,166 @@ describe('buildDeploymentUpsert', () => {
   })
 })
 
-describe('captureRecordProvenance', () => {
-  /**
-   * Runs against this checkout, so it asserts that the shared capture is
-   * actually reached and mapped onto record fields — not which branch a
-   * reviewer happens to be on.
-   */
-  it('maps the shared git capture onto record fields', () => {
-    const provenance = captureRecordProvenance()
+describe('describeDirtyTree', () => {
+  it.each([
+    ['unknown', { dirtyTreeScoped: undefined }, 'unknown'],
+    ['no', { dirtyTreeScoped: [] }, 'no'],
+    [
+      '1 path(s)',
+      { dirtyTreeScoped: ['src/Facets/AcrossFacetV4.sol'] },
+      '1 path(s)',
+    ],
+    [
+      '2+ path(s)',
+      {
+        dirtyTreeScoped: ['a.sol', 'b.sol'],
+        dirtyTreeTruncated: true,
+      },
+      '2+ path(s)',
+    ],
+  ])('renders %s', (_label, record, expected) => {
+    expect(describeDirtyTree(record)).toBe(expected)
+  })
 
-    expect(provenance.gitBranch).toBeTruthy()
-    expect(provenance.gitBranch).toBe(getGitBranch())
-    expect(provenance.dirtyTreeScoped).toEqual(getScopedDirtyTree().paths)
-    expect(['human', 'bot', 'ci', PROVENANCE_UNKNOWN]).toContain(
-      provenance.actor
+  /**
+   * The one rendering that must never be wrong: no readable capture has to look
+   * different from a clean tree, or the summary a deployer reads invents a
+   * clean bill of health.
+   */
+  it('never renders an absent capture the way it renders a clean tree', () => {
+    expect(describeDirtyTree({ dirtyTreeScoped: undefined })).not.toBe(
+      describeDirtyTree({ dirtyTreeScoped: [] })
     )
-    expect(typeof provenance.dirtyTreeTruncated).toBe('boolean')
+  })
+})
+
+describe('captureRecordProvenance', () => {
+  /** Canned git answers, keyed by the subcommand the capture asks for. */
+  const gitRunner =
+    (answers: Record<string, ICommandResult>): CommandRunner =>
+    (command, args) => {
+      const key = `${command} ${args.join(' ')}`
+      return (
+        answers[key] ?? {
+          status: 128,
+          stdout: '',
+          stderr: `no stub for ${key}`,
+        }
+      )
+    }
+
+  const ok = (stdout: string): ICommandResult => ({
+    status: 0,
+    stdout,
+    stderr: '',
+  })
+  const failed: ICommandResult = {
+    status: 128,
+    stdout: '',
+    stderr: 'fatal: not a git repository',
+  }
+
+  const REPO = '/repo'
+  const HEAD = 'c'.repeat(40)
+  const baseAnswers: Record<string, ICommandResult> = {
+    'git rev-parse --show-toplevel': ok(`${REPO}\n`),
+    'git rev-parse HEAD': ok(`${HEAD}\n`),
+    'git rev-parse --abbrev-ref HEAD': ok('feature/exsc-695\n'),
+    'git status --porcelain --untracked-files=normal': ok(
+      ' M src/Facets/AcrossFacetV4.sol\n'
+    ),
+    [`git branch --remotes --contains ${HEAD}`]: ok('  origin/main\n'),
+    'git config user.name': ok('Provenance Tester\n'),
+    'git config user.email': ok('provenance@example.com\n'),
+  }
+
+  const capture = (answers: Record<string, ICommandResult>) =>
+    captureRecordProvenance({
+      cwd: REPO,
+      env: {},
+      run: gitRunner(answers),
+    })
+
+  beforeEach(() => {
+    // The capture memoises a success for the process lifetime, and `bun test`
+    // runs every file in one process.
+    resetGitProvenanceCache()
+  })
+  afterEach(() => {
+    resetGitProvenanceCache()
+  })
+
+  it('maps branch, dirty paths and actor off the git answers it was given', () => {
+    const provenance = capture(baseAnswers)
+
+    expect(provenance.gitBranch).toBe('feature/exsc-695')
+    expect(provenance.dirtyTreeScoped).toEqual(['src/Facets/AcrossFacetV4.sol'])
+    expect(provenance.dirtyTreeTruncated).toBe(false)
+    expect(provenance.actor).toBe('human')
+    expect(provenance.captureErrors).toBeUndefined()
+  })
+
+  it('records a clean tree as an empty list', () => {
+    const provenance = capture({
+      ...baseAnswers,
+      'git status --porcelain --untracked-files=normal': ok(''),
+    })
+
+    expect(provenance.dirtyTreeScoped).toEqual([])
+    expect(provenance.dirtyTreeTruncated).toBe(false)
+  })
+
+  /**
+   * The fix this pairs with: the shared capture collects every probe's failure
+   * in one bag, so keying the dirty list on that bag let an unrelated failure —
+   * here the remote-containment probe on a tree `git status` read fine — delete
+   * a list that was actually known, and with it the clearing of a stale one.
+   */
+  it.each([
+    ['clean', '', []],
+    [
+      'dirty',
+      ' M src/Facets/AcrossFacetV4.sol\n',
+      ['src/Facets/AcrossFacetV4.sol'],
+    ],
+  ])(
+    'still records a %s tree when an unrelated probe failed',
+    (_label, porcelain, expected) => {
+      // The clean row is the one that discriminates: a non-empty list is
+      // evidence in itself and survives either rule, so only an empty one
+      // forces the question of whether the tree probe actually ran.
+      const provenance = capture({
+        ...baseAnswers,
+        'git status --porcelain --untracked-files=normal': ok(
+          porcelain as string
+        ),
+        [`git branch --remotes --contains ${HEAD}`]: failed,
+      })
+
+      expect(provenance.dirtyTreeScoped).toEqual(expected)
+      expect(provenance.dirtyTreeTruncated).toBe(false)
+      expect(provenance.captureErrors?.length).toBeGreaterThan(0)
+    }
+  )
+
+  it('omits the dirty list when the tree itself could not be read', () => {
+    const provenance = capture({
+      ...baseAnswers,
+      'git status --porcelain --untracked-files=normal': failed,
+    })
+
+    expect(provenance).not.toHaveProperty('dirtyTreeScoped')
+    expect(provenance).not.toHaveProperty('dirtyTreeTruncated')
+    // Paired positive: the capture still ran and answered everything else, so
+    // the two absences above are the tree probe's, not an empty result.
+    expect(provenance.gitBranch).toBe('feature/exsc-695')
+    expect(provenance.captureErrors?.join(' ')).toContain('git status')
+  })
+
+  it('reports the sentinel branch when git answers nothing', () => {
+    const provenance = capture({})
+
+    expect(provenance.gitBranch).toBe(PROVENANCE_UNKNOWN)
+    expect(provenance).not.toHaveProperty('dirtyTreeScoped')
   })
 })

--- a/script/deploy/shared/mongo-log-utils.ts
+++ b/script/deploy/shared/mongo-log-utils.ts
@@ -15,7 +15,6 @@ import { sleep } from '../../utils/delay'
 
 import {
   captureGitProvenance,
-  getScopedDirtyTree,
   PROVENANCE_UNKNOWN,
   type ICaptureProvenanceOptions,
   type ProvenanceActor,
@@ -185,29 +184,20 @@ export function captureRecordProvenance(
   captureErrors?: string[]
 } {
   const captured = captureGitProvenance({ resolvePrUrl: false, ...options })
-  // The dirty tree is read again through its own error collector, because an
-  // empty list is only safe to record once its own probe is known to have run:
-  // the shared capture returns one both for a clean tree and for a `git status`
-  // it could not execute, and its collector is shared with every other probe,
-  // so neither an empty list nor an empty collector separates the two. A failed
-  // probe recorded as "clean" would hide exactly the dirty deploy this field
-  // exists to surface.
-  const dirtyErrors: string[] = []
-  const dirtyTree = getScopedDirtyTree({ ...options, errors: dirtyErrors })
-  const dirtyTreeRead = dirtyErrors.length === 0
-  const captureErrors = [...(captured.captureErrors ?? []), ...dirtyErrors]
   return {
-    gitCommitHash: getCurrentGitCommitHash(),
+    gitCommitHash: captured.gitCommit,
     repo: getCurrentRepo(),
     gitBranch: captured.gitBranch,
-    ...(dirtyTreeRead
+    ...(captured.dirtyTreeRead
       ? {
-          dirtyTreeScoped: dirtyTree.paths,
-          dirtyTreeTruncated: dirtyTree.truncated,
+          dirtyTreeScoped: captured.dirtyTreeScoped,
+          dirtyTreeTruncated: captured.dirtyTreeTruncated === true,
         }
       : {}),
     actor: captured.actor,
-    ...(captureErrors.length > 0 ? { captureErrors } : {}),
+    ...(captured.captureErrors?.length
+      ? { captureErrors: captured.captureErrors }
+      : {}),
   }
 }
 
@@ -222,16 +212,21 @@ export function captureRecordProvenance(
  * nothing to lose. `gitCommitHash` is the exception, unchanged here: its
  * sentinel is a plain truthy string and still reaches `$set`.
  *
- * The dirty list is the exception that has to be written unconditionally once a
- * capture ran: an empty list is the meaningful answer "this tree was clean", and
- * a re-run from a tree that has since been cleaned must clear the paths — and
- * the truncation flag with them — rather than leave the earlier run's showing.
+ * A later clean capture must not `$set` an empty dirty list over a dirty one:
+ * that is the tell-tale of the deploy this field exists to surface, and the
+ * person who produced it is the one who would re-log from a cleaned tree.
+ * An empty list is therefore a real answer on insert only, same as the
+ * `UNKNOWN` sentinels. A new non-empty list still `$set`s — that is more
+ * evidence, not less.
  *
  * @param record - The record about to be written.
  * @returns The two update fragments, either of which may be empty.
  */
 export function provenanceUpdate(record: IRecordProvenance): IProvenanceUpdate {
   const capturedDirtyTree = record.dirtyTreeScoped !== undefined
+  const dirtyPaths = record.dirtyTreeScoped ?? []
+  const dirtyEvidence =
+    dirtyPaths.length > 0 || record.dirtyTreeTruncated === true
   return {
     set: {
       ...(record.gitCommitHash ? { gitCommitHash: record.gitCommitHash } : {}),
@@ -244,7 +239,7 @@ export function provenanceUpdate(record: IRecordProvenance): IProvenanceUpdate {
       ...(record.actor && record.actor !== PROVENANCE_UNKNOWN
         ? { actor: record.actor }
         : {}),
-      ...(capturedDirtyTree
+      ...(dirtyEvidence
         ? {
             dirtyTreeScoped: record.dirtyTreeScoped,
             dirtyTreeTruncated: record.dirtyTreeTruncated === true,
@@ -260,6 +255,12 @@ export function provenanceUpdate(record: IRecordProvenance): IProvenanceUpdate {
         : {}),
       ...(record.actor === PROVENANCE_UNKNOWN
         ? { actor: PROVENANCE_UNKNOWN }
+        : {}),
+      ...(capturedDirtyTree && !dirtyEvidence
+        ? {
+            dirtyTreeScoped: [],
+            dirtyTreeTruncated: false,
+          }
         : {}),
     },
   }

--- a/script/deploy/shared/mongo-log-utils.ts
+++ b/script/deploy/shared/mongo-log-utils.ts
@@ -15,7 +15,9 @@ import { sleep } from '../../utils/delay'
 
 import {
   captureGitProvenance,
+  getScopedDirtyTree,
   PROVENANCE_UNKNOWN,
+  type ICaptureProvenanceOptions,
   type ProvenanceActor,
 } from './git-provenance'
 import { REPO_UNKNOWN, readRepoIdentity } from './repo-identity'
@@ -69,14 +71,19 @@ export interface IDeploymentRecord {
    * Working-tree paths that differed from `gitCommitHash` at log time, with the
    * artefacts the deploy pipeline rewrites during its own run excluded. An
    * empty array means the capture ran and found a clean tree; absent means no
-   * capture ran. Broader on purpose than the build-affecting set
-   * `assertTreeRecordable` refuses a deploy on: this one is a reviewer's view of
-   * the whole tree, not the subset that changes what a rebuild produces.
+   * capture ran, or ran and could not read the tree. Broader on purpose than
+   * the build-affecting paths `assertTreeRecordable` refuses a deploy on: this
+   * one is a reviewer's view of the whole tree, not the subset that changes
+   * what a rebuild produces.
    */
   dirtyTreeScoped?: string[]
   /** True when more dirty paths existed than `dirtyTreeScoped` records. */
   dirtyTreeTruncated?: boolean
-  /** Execution context the deploy ran in: a human, an unattended bot, or CI. */
+  /**
+   * Execution context the deploy ran in: `'human'`, `'bot'` (an unattended job
+   * that set `SAFE_PROPOSAL_ACTOR=bot`), `'ci'`, or `'UNKNOWN'` when nothing
+   * identified the caller.
+   */
   actor?: ProvenanceActor
   /** When this record was created in the database */
   createdAt: Date
@@ -168,33 +175,39 @@ export interface IProvenanceUpdate {
  * document is built from, so a deployment and the proposal that installs it
  * cannot disagree about the branch or the dirty tree they came from.
  *
+ * @param options - Overrides forwarded to the capture; production passes none.
  * @returns The provenance fields, each degraded to a sentinel on failure, plus
  * any non-fatal capture problems so a sentinel stays explainable.
  */
-export function captureRecordProvenance(): IRecordProvenance & {
+export function captureRecordProvenance(
+  options?: ICaptureProvenanceOptions
+): IRecordProvenance & {
   captureErrors?: string[]
 } {
-  const captured = captureGitProvenance({ resolvePrUrl: false })
-  // An empty dirty list is only claimed when nothing went wrong: the capture
-  // returns one both for a clean tree and for a status probe it could not run,
-  // and a failed probe recorded as "clean" would hide exactly the dirty deploy
-  // this field exists to surface. Paths that WERE found are recorded either way.
-  const dirtyTreeKnown =
-    captured.dirtyTreeScoped.length > 0 || !captured.captureErrors?.length
+  const captured = captureGitProvenance({ resolvePrUrl: false, ...options })
+  // The dirty tree is read again through its own error collector, because an
+  // empty list is only safe to record once its own probe is known to have run:
+  // the shared capture returns one both for a clean tree and for a `git status`
+  // it could not execute, and its collector is shared with every other probe,
+  // so neither an empty list nor an empty collector separates the two. A failed
+  // probe recorded as "clean" would hide exactly the dirty deploy this field
+  // exists to surface.
+  const dirtyErrors: string[] = []
+  const dirtyTree = getScopedDirtyTree({ ...options, errors: dirtyErrors })
+  const dirtyTreeRead = dirtyErrors.length === 0
+  const captureErrors = [...(captured.captureErrors ?? []), ...dirtyErrors]
   return {
     gitCommitHash: getCurrentGitCommitHash(),
     repo: getCurrentRepo(),
     gitBranch: captured.gitBranch,
-    ...(dirtyTreeKnown
+    ...(dirtyTreeRead
       ? {
-          dirtyTreeScoped: captured.dirtyTreeScoped,
-          dirtyTreeTruncated: captured.dirtyTreeTruncated ?? false,
+          dirtyTreeScoped: dirtyTree.paths,
+          dirtyTreeTruncated: dirtyTree.truncated,
         }
       : {}),
     actor: captured.actor,
-    ...(captured.captureErrors
-      ? { captureErrors: captured.captureErrors }
-      : {}),
+    ...(captureErrors.length > 0 ? { captureErrors } : {}),
   }
 }
 
@@ -203,9 +216,11 @@ export function captureRecordProvenance(): IRecordProvenance & {
  *
  * The add CLI writes these to Mongo only, so a JSON-sourced record carries
  * none of them and an unconditional `$set` would erase what Mongo already
- * holds. The `UNKNOWN` sentinels are handled the same way for the opposite
- * reason: each is a real answer on a fresh insert, and a downgrade on an
- * existing one, so it goes in only where there is nothing to lose.
+ * holds. The `UNKNOWN` sentinels of `repo`, `gitBranch` and `actor` are handled
+ * the same way for the opposite reason: each is a real answer on a fresh
+ * insert, and a downgrade on an existing one, so it goes in only where there is
+ * nothing to lose. `gitCommitHash` is the exception, unchanged here: its
+ * sentinel is a plain truthy string and still reaches `$set`.
  *
  * The dirty list is the exception that has to be written unconditionally once a
  * capture ran: an empty list is the meaningful answer "this tree was clean", and
@@ -248,6 +263,22 @@ export function provenanceUpdate(record: IRecordProvenance): IProvenanceUpdate {
         : {}),
     },
   }
+}
+
+/**
+ * Renders a record's scoped dirty tree for a one-line human summary.
+ *
+ * @param record - The record whose dirty tree to describe.
+ * @returns `'unknown'` when no readable capture happened — which must never
+ * read as a clean tree — `'no'` for a clean one, else the path count.
+ */
+export function describeDirtyTree(
+  record: Pick<IDeploymentRecord, 'dirtyTreeScoped' | 'dirtyTreeTruncated'>
+): string {
+  const paths = record.dirtyTreeScoped
+  if (paths === undefined) return 'unknown'
+  if (paths.length === 0) return 'no'
+  return `${paths.length}${record.dirtyTreeTruncated ? '+' : ''} path(s)`
 }
 
 /** A single-record upsert: the identity it matches on, and the update it applies. */

--- a/script/deploy/shared/mongo-log-utils.ts
+++ b/script/deploy/shared/mongo-log-utils.ts
@@ -164,9 +164,9 @@ export interface IProvenanceUpdate {
 /**
  * Captures every provenance field for a record about to be logged.
  *
- * Shares one {@link captureGitProvenance} pass with the Safe proposal document,
- * so a deployment and the proposal that installs it cannot disagree about the
- * branch or the dirty tree they came from.
+ * Reads {@link captureGitProvenance}, the same capture the Safe proposal
+ * document is built from, so a deployment and the proposal that installs it
+ * cannot disagree about the branch or the dirty tree they came from.
  *
  * @returns The provenance fields, each degraded to a sentinel on failure, plus
  * any non-fatal capture problems so a sentinel stays explainable.
@@ -175,12 +175,22 @@ export function captureRecordProvenance(): IRecordProvenance & {
   captureErrors?: string[]
 } {
   const captured = captureGitProvenance({ resolvePrUrl: false })
+  // An empty dirty list is only claimed when nothing went wrong: the capture
+  // returns one both for a clean tree and for a status probe it could not run,
+  // and a failed probe recorded as "clean" would hide exactly the dirty deploy
+  // this field exists to surface. Paths that WERE found are recorded either way.
+  const dirtyTreeKnown =
+    captured.dirtyTreeScoped.length > 0 || !captured.captureErrors?.length
   return {
     gitCommitHash: getCurrentGitCommitHash(),
     repo: getCurrentRepo(),
     gitBranch: captured.gitBranch,
-    dirtyTreeScoped: captured.dirtyTreeScoped,
-    dirtyTreeTruncated: captured.dirtyTreeTruncated ?? false,
+    ...(dirtyTreeKnown
+      ? {
+          dirtyTreeScoped: captured.dirtyTreeScoped,
+          dirtyTreeTruncated: captured.dirtyTreeTruncated ?? false,
+        }
+      : {}),
     actor: captured.actor,
     ...(captured.captureErrors
       ? { captureErrors: captured.captureErrors }

--- a/script/deploy/shared/mongo-log-utils.ts
+++ b/script/deploy/shared/mongo-log-utils.ts
@@ -13,6 +13,11 @@ import {
 import type { EnvironmentEnum } from '../../common/types'
 import { sleep } from '../../utils/delay'
 
+import {
+  captureGitProvenance,
+  PROVENANCE_UNKNOWN,
+  type ProvenanceActor,
+} from './git-provenance'
 import { REPO_UNKNOWN, readRepoIdentity } from './repo-identity'
 
 /**
@@ -54,6 +59,25 @@ export interface IDeploymentRecord {
    * and could not identify a remote.
    */
   repo?: string
+  /**
+   * Branch checked out when the record was logged, `'HEAD'` on a detached
+   * checkout, or `'UNKNOWN'` when the capture failed. Absent on records written
+   * before this field existed.
+   */
+  gitBranch?: string
+  /**
+   * Working-tree paths that differed from `gitCommitHash` at log time, with the
+   * artefacts the deploy pipeline rewrites during its own run excluded. An
+   * empty array means the capture ran and found a clean tree; absent means no
+   * capture ran. Broader on purpose than the build-affecting set
+   * `assertTreeRecordable` refuses a deploy on: this one is a reviewer's view of
+   * the whole tree, not the subset that changes what a rebuild produces.
+   */
+  dirtyTreeScoped?: string[]
+  /** True when more dirty paths existed than `dirtyTreeScoped` records. */
+  dirtyTreeTruncated?: boolean
+  /** Execution context the deploy ran in: a human, an unattended bot, or CI. */
+  actor?: ProvenanceActor
   /** When this record was created in the database */
   createdAt: Date
   /** When this record was last updated in the database */
@@ -120,38 +144,157 @@ export function getCurrentRepo(): string {
   return identity
 }
 
+/** The record fields describing which code and whose run produced a deployment. */
+export type IRecordProvenance = Pick<
+  IDeploymentRecord,
+  | 'gitCommitHash'
+  | 'repo'
+  | 'gitBranch'
+  | 'dirtyTreeScoped'
+  | 'dirtyTreeTruncated'
+  | 'actor'
+>
+
 /** The provenance halves of an upsert: what to set, and what only to set on insert. */
 export interface IProvenanceUpdate {
-  set: Partial<Pick<IDeploymentRecord, 'gitCommitHash' | 'repo'>>
-  setOnInsert: Partial<Pick<IDeploymentRecord, 'gitCommitHash' | 'repo'>>
+  set: Partial<IRecordProvenance>
+  setOnInsert: Partial<IRecordProvenance>
+}
+
+/**
+ * Captures every provenance field for a record about to be logged.
+ *
+ * Shares one {@link captureGitProvenance} pass with the Safe proposal document,
+ * so a deployment and the proposal that installs it cannot disagree about the
+ * branch or the dirty tree they came from.
+ *
+ * @returns The provenance fields, each degraded to a sentinel on failure, plus
+ * any non-fatal capture problems so a sentinel stays explainable.
+ */
+export function captureRecordProvenance(): IRecordProvenance & {
+  captureErrors?: string[]
+} {
+  const captured = captureGitProvenance({ resolvePrUrl: false })
+  return {
+    gitCommitHash: getCurrentGitCommitHash(),
+    repo: getCurrentRepo(),
+    gitBranch: captured.gitBranch,
+    dirtyTreeScoped: captured.dirtyTreeScoped,
+    dirtyTreeTruncated: captured.dirtyTreeTruncated ?? false,
+    actor: captured.actor,
+    ...(captured.captureErrors
+      ? { captureErrors: captured.captureErrors }
+      : {}),
+  }
 }
 
 /**
  * Splits a record's provenance fields across `$set` and `$setOnInsert`.
  *
  * The add CLI writes these to Mongo only, so a JSON-sourced record carries
- * neither and an unconditional `$set` would erase what Mongo already holds.
- * `REPO_UNKNOWN` is handled the same way for the opposite reason: it is a real
- * answer on a fresh insert, and a downgrade on an existing one, so it goes in
- * only where there is nothing to lose.
+ * none of them and an unconditional `$set` would erase what Mongo already
+ * holds. The `UNKNOWN` sentinels are handled the same way for the opposite
+ * reason: each is a real answer on a fresh insert, and a downgrade on an
+ * existing one, so it goes in only where there is nothing to lose.
+ *
+ * The dirty list is the exception that has to be written unconditionally once a
+ * capture ran: an empty list is the meaningful answer "this tree was clean", and
+ * a re-run from a tree that has since been cleaned must clear the paths — and
+ * the truncation flag with them — rather than leave the earlier run's showing.
  *
  * @param record - The record about to be written.
  * @returns The two update fragments, either of which may be empty.
  */
-export function provenanceUpdate(
-  record: Pick<IDeploymentRecord, 'gitCommitHash' | 'repo'>
-): IProvenanceUpdate {
+export function provenanceUpdate(record: IRecordProvenance): IProvenanceUpdate {
+  const capturedDirtyTree = record.dirtyTreeScoped !== undefined
   return {
     set: {
       ...(record.gitCommitHash ? { gitCommitHash: record.gitCommitHash } : {}),
       ...(record.repo && record.repo !== REPO_UNKNOWN
         ? { repo: record.repo }
         : {}),
+      ...(record.gitBranch && record.gitBranch !== PROVENANCE_UNKNOWN
+        ? { gitBranch: record.gitBranch }
+        : {}),
+      ...(record.actor && record.actor !== PROVENANCE_UNKNOWN
+        ? { actor: record.actor }
+        : {}),
+      ...(capturedDirtyTree
+        ? {
+            dirtyTreeScoped: record.dirtyTreeScoped,
+            dirtyTreeTruncated: record.dirtyTreeTruncated === true,
+          }
+        : {}),
     },
     setOnInsert: {
       // '' = "predates EXSC-330"
       ...(record.gitCommitHash ? {} : { gitCommitHash: '' }),
       ...(record.repo === REPO_UNKNOWN ? { repo: REPO_UNKNOWN } : {}),
+      ...(record.gitBranch === PROVENANCE_UNKNOWN
+        ? { gitBranch: PROVENANCE_UNKNOWN }
+        : {}),
+      ...(record.actor === PROVENANCE_UNKNOWN
+        ? { actor: PROVENANCE_UNKNOWN }
+        : {}),
+    },
+  }
+}
+
+/** A single-record upsert: the identity it matches on, and the update it applies. */
+export interface IDeploymentUpsert {
+  filter: Filter<IDeploymentRecord>
+  update: {
+    $set: Partial<IDeploymentRecord> & { updatedAt: Date }
+    $setOnInsert: Partial<IDeploymentRecord> & { createdAt: Date }
+  }
+}
+
+/**
+ * Builds the upsert for one deployment record.
+ *
+ * The filter is deliberately the four identity fields only. Provenance stays
+ * out of it: matching on branch or dirtiness would make every re-log from a
+ * different tree insert a second row for the same deployed address.
+ *
+ * @param record - The record about to be written.
+ * @param now - Timestamp for the `updatedAt`/`createdAt` stamps.
+ * @returns The filter and update to hand to `updateOne`.
+ */
+export function buildDeploymentUpsert(
+  record: IDeploymentRecord,
+  now: Date = new Date()
+): IDeploymentUpsert {
+  const provenance = provenanceUpdate(record)
+  return {
+    filter: {
+      contractName: mongoEq(record.contractName),
+      network: mongoEq(record.network),
+      version: mongoEq(record.version),
+      address: mongoEq(record.address),
+    },
+    update: {
+      $set: {
+        contractName: record.contractName,
+        network: record.network,
+        version: record.version,
+        address: record.address,
+        optimizerRuns: record.optimizerRuns,
+        timestamp: record.timestamp,
+        constructorArgs: record.constructorArgs,
+        salt: record.salt,
+        verified: record.verified,
+        solcVersion: record.solcVersion,
+        evmVersion: record.evmVersion,
+        zkSolcVersion: record.zkSolcVersion,
+        ...provenance.set,
+        contractNetworkKey: record.contractNetworkKey,
+        contractVersionKey: record.contractVersionKey,
+        updatedAt: now,
+      },
+      $setOnInsert: {
+        createdAt: now,
+        ...provenance.setOnInsert,
+      },
     },
   }
 }

--- a/script/deploy/update-deployment-logs.cli.test.ts
+++ b/script/deploy/update-deployment-logs.cli.test.ts
@@ -216,8 +216,9 @@ describe('update-deployment-logs add — provenance capture', () => {
         repoRoot: makeRepo({ branch: 'main', dirty: false }),
       })
 
-      expect(upsert.update.$set).toMatchObject({
-        gitBranch: 'main',
+      expect(upsert.update.$set).toHaveProperty('gitBranch', 'main')
+      expect(upsert.update.$set).not.toHaveProperty('dirtyTreeScoped')
+      expect(upsert.update.$setOnInsert).toMatchObject({
         dirtyTreeScoped: [],
         dirtyTreeTruncated: false,
       })

--- a/script/deploy/update-deployment-logs.cli.test.ts
+++ b/script/deploy/update-deployment-logs.cli.test.ts
@@ -273,8 +273,22 @@ describe('update-deployment-logs add — provenance capture', () => {
       expect(upsert.update.$set).not.toHaveProperty('gitBranch')
       expect(upsert.update.$setOnInsert).toMatchObject({
         gitBranch: 'UNKNOWN',
+        repo: 'UNKNOWN',
       })
+      // The actor survives: `git config user.name` answers from the global
+      // config outside a checkout, so who ran it is still known.
+      expect(upsert.update.$set).toHaveProperty('actor', 'human')
+      // The dirty list must be absent, not empty: the capture returns an empty
+      // list for an unreadable tree as well as a clean one, and only the
+      // recorded errors separate them.
+      expect(upsert.update.$set).not.toHaveProperty('dirtyTreeScoped')
+      expect(upsert.update.$set).not.toHaveProperty('dirtyTreeTruncated')
+      // Paired positives, so the two absences above cannot pass on a run that
+      // printed no upsert fields at all.
+      expect(upsert.update.$set).toHaveProperty('contractName', CONTRACT)
       expect(output).toContain('branch UNKNOWN')
+      expect(output).toContain('dirty unknown')
+      expect(output).toContain('Provenance capture:')
     },
     CASE_TIMEOUT_MS
   )

--- a/script/deploy/update-deployment-logs.cli.test.ts
+++ b/script/deploy/update-deployment-logs.cli.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Placement proof for the deploy-log provenance capture: the `add` CLI has to
+ * capture branch, scoped dirty tree and actor from the tree it is invoked in,
+ * and carry them into the upsert it applies. `shared/mongo-log-utils.test.ts`
+ * covers what the pure functions decide with those values.
+ *
+ * Each case runs the real CLI in a throwaway git repo, because a tree whose
+ * dirtiness the test controls is the only way to observe the capture rather
+ * than assume it. `--dryRun` is what keeps the probes off a real store; the
+ * store URI is made unparseable as well, so a probe that ignored the flag dies
+ * on connect instead of writing.
+ *
+ * Every absence assertion is paired with a positive marker, and a child killed
+ * by a timeout is treated as no result at all.
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+const ADD_CLI = join(REPO_ROOT, 'script/deploy/update-deployment-logs.ts')
+
+/** Long enough for a bun start-up plus a handful of git probes. */
+const TIMEOUT_MS = 60_000
+/** Per-case budget: these spawn a real CLI, well past bun's 5 s default. */
+const CASE_TIMEOUT_MS = 90_000
+
+const CONTRACT = 'AcrossFacetV4'
+const CONTRACT_PATH = `src/Facets/${CONTRACT}.sol`
+const ADDRESS = '0x1111111111111111111111111111111111111111'
+
+interface IUpsertShape {
+  filter: Record<string, { $eq: unknown }>
+  update: {
+    $set: Record<string, unknown>
+    $setOnInsert: Record<string, unknown>
+  }
+}
+
+/**
+ * Builds a repo on a named branch, optionally leaving one source file dirty.
+ * @param options - branch to check out, and whether to diverge the source
+ * @returns the repository root
+ */
+const makeRepo = (options: { branch: string; dirty: boolean }): string => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'deploy-log-provenance-'))
+  const run = (...args: string[]) =>
+    spawnSync('git', args, { cwd: repoRoot, encoding: 'utf8' })
+
+  run('init', '-b', options.branch)
+  run('config', 'user.email', 'provenance@example.com')
+  run('config', 'user.name', 'provenance')
+  mkdirSync(join(repoRoot, 'src/Facets'), { recursive: true })
+  writeFileSync(
+    join(repoRoot, CONTRACT_PATH),
+    `// SPDX-License-Identifier: LGPL-3.0-only\ncontract ${CONTRACT} {}\n`
+  )
+  run('add', '.')
+  run('commit', '-m', 'deployed state', '--no-gpg-sign')
+
+  if (options.dirty)
+    writeFileSync(
+      join(repoRoot, CONTRACT_PATH),
+      `// SPDX-License-Identifier: LGPL-3.0-only\ncontract ${CONTRACT} { uint256 public unreviewed; }\n`
+    )
+
+  return repoRoot
+}
+
+/**
+ * Rejects a child whose result cannot be reasoned about, and — first — one that
+ * reached a real store. A probe that wrote is the one most likely to look like a
+ * timeout, so the breach check runs before the usability checks.
+ * @param result - what `spawnSync` returned
+ * @param output - the child's combined stdout and stderr
+ */
+const assertChildIsUsable = (
+  result: { error?: Error; signal: NodeJS.Signals | null },
+  output: string
+): void => {
+  if (/Connected to MongoDB|Successfully added\/updated/i.test(output))
+    throw new Error(
+      'a probe reached a real deployment store — the child environment is not isolated'
+    )
+  if (result.error) throw result.error
+  if (result.signal)
+    throw new Error(
+      `child was killed by ${result.signal} after ${TIMEOUT_MS}ms, so its output proves nothing`
+    )
+}
+
+/**
+ * Runs the real `add` CLI in a throwaway repo and parses what it would write.
+ * @param options - the repo to run in, and extra CLI arguments
+ * @returns the child's combined output, exit status, and the parsed upsert
+ */
+const runAdd = (options: {
+  repoRoot: string
+  extraArgs?: string[]
+}): { output: string; status: number | null; upsert: IUpsertShape } => {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+  }
+  // `bun test` sets NODE_ENV=test; this child is exercised as a CLI.
+  delete env.NODE_ENV
+  // Bun auto-loads the repo env file into THIS process, so the child inherits a
+  // real production environment unless every store name is neutralised here.
+  // Deliberately malformed rather than unroutable: a driver spends 30 s of
+  // server selection on an unreachable host, where a URI it cannot parse throws
+  // on construction — so a probe that got past `--dryRun` dies at once.
+  env.MONGODB_URI = 'blocked-in-tests://no-store'
+  env.SC_MONGODB_URI = env.MONGODB_URI
+
+  const result = spawnSync(
+    'bun',
+    [
+      ADD_CLI,
+      'add',
+      '--env',
+      'staging',
+      '--contract',
+      CONTRACT,
+      '--network',
+      'arbitrum',
+      '--version',
+      '1.0.0',
+      '--address',
+      ADDRESS,
+      '--optimizer-runs',
+      '1000000',
+      '--timestamp',
+      '2026-09-08 00:00:00',
+      '--constructor-args',
+      '0x',
+      '--verified',
+      'false',
+      '--dryRun',
+      ...(options.extraArgs ?? []),
+    ],
+    {
+      cwd: options.repoRoot,
+      encoding: 'utf8',
+      env,
+      timeout: TIMEOUT_MS,
+      maxBuffer: Infinity,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  )
+
+  const output = `${result.stdout}${result.stderr}`
+  assertChildIsUsable(result, output)
+
+  const start = result.stdout.indexOf('{')
+  if (start === -1)
+    throw new Error(`the CLI printed no upsert document:\n${output}`)
+
+  return {
+    output,
+    status: result.status,
+    upsert: JSON.parse(result.stdout.slice(start)) as IUpsertShape,
+  }
+}
+
+describe('update-deployment-logs add — provenance capture', () => {
+  it(
+    'records the branch, the actor and a dirty source file it was run from',
+    () => {
+      const { output, status, upsert } = runAdd({
+        repoRoot: makeRepo({ branch: 'feature/exsc-695', dirty: true }),
+      })
+
+      expect(status).toBe(0)
+      expect(upsert.update.$set).toMatchObject({
+        gitBranch: 'feature/exsc-695',
+        dirtyTreeScoped: [CONTRACT_PATH],
+        dirtyTreeTruncated: false,
+        actor: 'human',
+      })
+      // The signer-visible half: a reviewer reading the deploy output, not the
+      // record, has to see the dirty tree too.
+      expect(output).toContain('Deployed from a dirty tree')
+      expect(output).toContain(CONTRACT_PATH)
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  it(
+    'records a clean tree as an empty list rather than omitting the field',
+    () => {
+      const { output, upsert } = runAdd({
+        repoRoot: makeRepo({ branch: 'main', dirty: false }),
+      })
+
+      expect(upsert.update.$set).toMatchObject({
+        gitBranch: 'main',
+        dirtyTreeScoped: [],
+        dirtyTreeTruncated: false,
+      })
+      expect(output).toContain('dirty no')
+      expect(output).not.toContain('Deployed from a dirty tree')
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  it(
+    'reports CI as the actor and takes the branch from the workflow environment',
+    () => {
+      const repoRoot = makeRepo({ branch: 'feature/exsc-695', dirty: false })
+      const detach = spawnSync('git', ['checkout', '--detach'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      })
+      expect(detach.status).toBe(0)
+
+      const previous = {
+        actions: process.env.GITHUB_ACTIONS,
+        ref: process.env.GITHUB_REF_NAME,
+      }
+      process.env.GITHUB_ACTIONS = 'true'
+      process.env.GITHUB_REF_NAME = 'refs/pull/2331/merge'
+      try {
+        const { upsert } = runAdd({ repoRoot })
+
+        expect(upsert.update.$set).toMatchObject({
+          actor: 'ci',
+          gitBranch: 'refs/pull/2331/merge',
+        })
+      } finally {
+        if (previous.actions === undefined) delete process.env.GITHUB_ACTIONS
+        else process.env.GITHUB_ACTIONS = previous.actions
+        if (previous.ref === undefined) delete process.env.GITHUB_REF_NAME
+        else process.env.GITHUB_REF_NAME = previous.ref
+      }
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  it(
+    'never lets provenance into the identity the upsert matches on',
+    () => {
+      const { upsert } = runAdd({
+        repoRoot: makeRepo({ branch: 'feature/exsc-695', dirty: true }),
+      })
+
+      expect(Object.keys(upsert.filter).sort()).toEqual([
+        'address',
+        'contractName',
+        'network',
+        'version',
+      ])
+      expect(upsert.filter.address).toEqual({ $eq: ADDRESS })
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  it(
+    'reports unknown provenance instead of a clean tree outside a git checkout',
+    () => {
+      // No `git init`: every probe fails, and the one answer that must never be
+      // invented here is "the tree was clean".
+      const { output, upsert } = runAdd({
+        repoRoot: mkdtempSync(join(tmpdir(), 'deploy-log-no-git-')),
+      })
+
+      expect(upsert.update.$set).not.toHaveProperty('gitBranch')
+      expect(upsert.update.$setOnInsert).toMatchObject({
+        gitBranch: 'UNKNOWN',
+      })
+      expect(output).toContain('branch UNKNOWN')
+    },
+    CASE_TIMEOUT_MS
+  )
+})

--- a/script/deploy/update-deployment-logs.cli.test.ts
+++ b/script/deploy/update-deployment-logs.cli.test.ts
@@ -113,6 +113,13 @@ const runAdd = (options: {
   }
   // `bun test` sets NODE_ENV=test; this child is exercised as a CLI.
   delete env.NODE_ENV
+  // Isolate git identity: `git config user.name` reads the global config when
+  // there is no checkout, so a runner with no identity and a laptop with one
+  // disagree on `actor`. Local repo config from `makeRepo` still applies.
+  const isolatedHome = mkdtempSync(join(tmpdir(), 'deploy-log-home-'))
+  env.HOME = isolatedHome
+  env.GIT_CONFIG_NOSYSTEM = '1'
+  env.GIT_CONFIG_GLOBAL = join(isolatedHome, '.gitconfig')
   // The capture reads the workflow environment in preference to git, so on an
   // Actions runner every case below would observe the runner's own branch and
   // actor instead of the throwaway repo it just built — and the suite would
@@ -328,10 +335,9 @@ describe('update-deployment-logs add — provenance capture', () => {
       expect(upsert.update.$setOnInsert).toMatchObject({
         gitBranch: 'UNKNOWN',
         repo: 'UNKNOWN',
+        actor: 'UNKNOWN',
       })
-      // The actor survives: `git config user.name` answers from the global
-      // config outside a checkout, so who ran it is still known.
-      expect(upsert.update.$set).toHaveProperty('actor', 'human')
+      expect(upsert.update.$set).not.toHaveProperty('actor')
       // The dirty list must be absent, not empty: the capture returns an empty
       // list for an unreadable tree as well as a clean one, and only the
       // recorded errors separate them.

--- a/script/deploy/update-deployment-logs.cli.test.ts
+++ b/script/deploy/update-deployment-logs.cli.test.ts
@@ -105,12 +105,29 @@ const assertChildIsUsable = (
 const runAdd = (options: {
   repoRoot: string
   extraArgs?: string[]
+  ci?: Record<string, string>
+  flag?: string
 }): { output: string; status: number | null; upsert: IUpsertShape } => {
   const env: Record<string, string> = {
     ...(process.env as Record<string, string>),
   }
   // `bun test` sets NODE_ENV=test; this child is exercised as a CLI.
   delete env.NODE_ENV
+  // The capture reads the workflow environment in preference to git, so on an
+  // Actions runner every case below would observe the runner's own branch and
+  // actor instead of the throwaway repo it just built — and the suite would
+  // pass locally and fail in CI. Cleared here, then set explicitly by the one
+  // case that is about the CI branch.
+  for (const name of [
+    'CI',
+    'GITHUB_ACTIONS',
+    'GITHUB_ACTOR',
+    'GITHUB_HEAD_REF',
+    'GITHUB_REF_NAME',
+    'GITHUB_SHA',
+  ])
+    delete env[name]
+  Object.assign(env, options.ci ?? {})
   // Bun auto-loads the repo env file into THIS process, so the child inherits a
   // real production environment unless every store name is neutralised here.
   // Deliberately malformed rather than unroutable: a driver spends 30 s of
@@ -142,7 +159,7 @@ const runAdd = (options: {
       '0x',
       '--verified',
       'false',
-      '--dryRun',
+      options.flag ?? '--dryRun',
       ...(options.extraArgs ?? []),
     ],
     {
@@ -220,25 +237,61 @@ describe('update-deployment-logs add — provenance capture', () => {
       })
       expect(detach.status).toBe(0)
 
-      const previous = {
-        actions: process.env.GITHUB_ACTIONS,
-        ref: process.env.GITHUB_REF_NAME,
-      }
-      process.env.GITHUB_ACTIONS = 'true'
-      process.env.GITHUB_REF_NAME = 'refs/pull/2331/merge'
-      try {
-        const { upsert } = runAdd({ repoRoot })
+      const { upsert } = runAdd({
+        repoRoot,
+        // The values a real `pull_request` run sets, and the precedence that
+        // matters: HEAD_REF is the source branch and wins over REF_NAME, which
+        // on that event names the synthetic merge ref.
+        ci: {
+          GITHUB_ACTIONS: 'true',
+          GITHUB_HEAD_REF: 'feature/exsc-695',
+          GITHUB_REF_NAME: '2331/merge',
+        },
+      })
 
-        expect(upsert.update.$set).toMatchObject({
-          actor: 'ci',
-          gitBranch: 'refs/pull/2331/merge',
-        })
-      } finally {
-        if (previous.actions === undefined) delete process.env.GITHUB_ACTIONS
-        else process.env.GITHUB_ACTIONS = previous.actions
-        if (previous.ref === undefined) delete process.env.GITHUB_REF_NAME
-        else process.env.GITHUB_REF_NAME = previous.ref
-      }
+      expect(upsert.update.$set).toMatchObject({
+        actor: 'ci',
+        gitBranch: 'feature/exsc-695',
+      })
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  /**
+   * Every sibling flag on this command is kebab-cased, so `--dry-run` is the
+   * spelling a caller types. Read as `false` it would not be a no-op: the CLI
+   * would fall through to a real upsert.
+   */
+  it(
+    'honours the kebab spelling of the dry-run flag',
+    () => {
+      const { output, upsert } = runAdd({
+        repoRoot: makeRepo({ branch: 'main', dirty: false }),
+        flag: '--dry-run',
+      })
+
+      expect(output).toContain('Dry run: nothing was written to MongoDB')
+      expect(upsert.update.$set).toHaveProperty('gitBranch', 'main')
+    },
+    CASE_TIMEOUT_MS
+  )
+
+  it(
+    'caps the recorded dirty list and says so',
+    () => {
+      const repoRoot = makeRepo({ branch: 'main', dirty: false })
+      // One more than MAX_DIRTY_PATHS, so the cap is crossed rather than met.
+      for (let index = 0; index <= 20; index++)
+        writeFileSync(
+          join(repoRoot, `src/Facets/Extra${index}.sol`),
+          `contract Extra${index} {}\n`
+        )
+
+      const { output, upsert } = runAdd({ repoRoot })
+
+      expect(upsert.update.$set.dirtyTreeScoped).toHaveLength(20)
+      expect(upsert.update.$set).toHaveProperty('dirtyTreeTruncated', true)
+      expect(output).toContain('dirty 20+ path(s)')
     },
     CASE_TIMEOUT_MS
   )
@@ -288,7 +341,7 @@ describe('update-deployment-logs add — provenance capture', () => {
       expect(upsert.update.$set).toHaveProperty('contractName', CONTRACT)
       expect(output).toContain('branch UNKNOWN')
       expect(output).toContain('dirty unknown')
-      expect(output).toContain('Provenance capture:')
+      expect(output).toContain('Provenance capture problem:')
     },
     CASE_TIMEOUT_MS
   )

--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -686,8 +686,8 @@ const addCommand = defineCommand({
       description: 'EVM version',
       required: false,
     },
-    // Single word: citty drops a passed value for a multi-word flag that
-    // carries a default (see `fix/citty-multiword-default-flags`).
+    // Single word: citty discards a passed value for a multi-word flag that
+    // carries a default.
     dryRun: {
       type: 'boolean',
       description:

--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -30,6 +30,7 @@ import {
   buildDeploymentUpsert,
   captureRecordProvenance,
   deploymentRecordEqFilter,
+  describeDirtyTree,
   provenanceUpdate,
   type IDeploymentRecord,
   type IUpdateConfig,
@@ -53,15 +54,6 @@ const config: IUpdateConfig = {
   ),
   batchSize: 100,
   databaseName: 'contract-deployments',
-}
-
-/** Renders the scoped dirty tree for the one-line provenance summary. */
-function describeDirtyTree(record: IDeploymentRecord): string {
-  const paths = record.dirtyTreeScoped
-  // Absent means no capture ran, which must not read as a clean tree.
-  if (paths === undefined) return 'unknown'
-  if (paths.length === 0) return 'no'
-  return `${paths.length}${record.dirtyTreeTruncated ? '+' : ''} path(s)`
 }
 
 /** Invalidate deployment cache for an environment after writing to MongoDB */
@@ -686,13 +678,16 @@ const addCommand = defineCommand({
       description: 'EVM version',
       required: false,
     },
-    // Single word: citty discards a passed value for a multi-word flag that
-    // carries a default.
     dryRun: {
       type: 'boolean',
+      // Every sibling flag here is kebab-cased, so `--dry-run` is the spelling a
+      // caller reaches for. Both the alias and the absent `default` are needed:
+      // citty resolves a kebab spelling through its own fallback only for an arg
+      // that carries no default, and a `--dry-run` silently read as `false`
+      // would make a dry run a real write.
+      alias: 'dry-run',
       description:
-        'Print the record and the upsert it would apply, without connecting to MongoDB',
-      default: false,
+        'Print the upsert that would be applied, without connecting to MongoDB',
     },
   },
   async run({ args }) {
@@ -709,8 +704,11 @@ const addCommand = defineCommand({
     }
 
     const { captureErrors, ...provenanceFields } = captureRecordProvenance()
+    // Info, not warn: `logContractDeploymentInfo` runs this command with
+    // stderr discarded unless DEBUG is set, and consola sends warnings there —
+    // so a warning about the tree a deploy came from would never be seen.
     for (const problem of captureErrors ?? [])
-      consola.warn(`Provenance capture: ${problem}`)
+      consola.info(`Provenance capture problem: ${problem}`)
 
     // Create deployment record
     const record: IDeploymentRecord = {
@@ -743,7 +741,7 @@ const addCommand = defineCommand({
       }, dirty ${describeDirtyTree(record)}`
     )
     if (record.dirtyTreeScoped?.length)
-      consola.warn(
+      consola.info(
         `Deployed from a dirty tree: ${record.dirtyTreeScoped.join(', ')}${
           record.dirtyTreeTruncated ? ', …' : ''
         }`

--- a/script/deploy/update-deployment-logs.ts
+++ b/script/deploy/update-deployment-logs.ts
@@ -27,9 +27,9 @@ import { getEnvVar } from '../utils/utils'
 
 import { createDefaultCache } from './shared/deployment-cache'
 import {
+  buildDeploymentUpsert,
+  captureRecordProvenance,
   deploymentRecordEqFilter,
-  getCurrentGitCommitHash,
-  getCurrentRepo,
   provenanceUpdate,
   type IDeploymentRecord,
   type IUpdateConfig,
@@ -53,6 +53,15 @@ const config: IUpdateConfig = {
   ),
   batchSize: 100,
   databaseName: 'contract-deployments',
+}
+
+/** Renders the scoped dirty tree for the one-line provenance summary. */
+function describeDirtyTree(record: IDeploymentRecord): string {
+  const paths = record.dirtyTreeScoped
+  // Absent means no capture ran, which must not read as a clean tree.
+  if (paths === undefined) return 'unknown'
+  if (paths.length === 0) return 'no'
+  return `${paths.length}${record.dirtyTreeTruncated ? '+' : ''} path(s)`
 }
 
 /** Invalidate deployment cache for an environment after writing to MongoDB */
@@ -190,37 +199,7 @@ class DeploymentLogManager {
   public async upsertDeployment(record: IDeploymentRecord): Promise<void> {
     if (!this.collection) throw new Error('Collection not initialized')
 
-    const filter = {
-      contractName: mongoEq(record.contractName),
-      network: mongoEq(record.network),
-      version: mongoEq(record.version),
-      address: mongoEq(record.address),
-    }
-
-    const update = {
-      $set: {
-        contractName: record.contractName,
-        network: record.network,
-        version: record.version,
-        address: record.address,
-        optimizerRuns: record.optimizerRuns,
-        timestamp: record.timestamp,
-        constructorArgs: record.constructorArgs,
-        salt: record.salt,
-        verified: record.verified,
-        solcVersion: record.solcVersion,
-        evmVersion: record.evmVersion,
-        zkSolcVersion: record.zkSolcVersion,
-        ...provenanceUpdate(record).set,
-        contractNetworkKey: record.contractNetworkKey,
-        contractVersionKey: record.contractVersionKey,
-        updatedAt: new Date(),
-      },
-      $setOnInsert: {
-        createdAt: new Date(),
-        ...provenanceUpdate(record).setOnInsert,
-      },
-    }
+    const { filter, update } = buildDeploymentUpsert(record)
 
     await this.collection.updateOne(filter, update, { upsert: true })
   }
@@ -707,6 +686,14 @@ const addCommand = defineCommand({
       description: 'EVM version',
       required: false,
     },
+    // Single word: citty drops a passed value for a multi-word flag that
+    // carries a default (see `fix/citty-multiword-default-flags`).
+    dryRun: {
+      type: 'boolean',
+      description:
+        'Print the record and the upsert it would apply, without connecting to MongoDB',
+      default: false,
+    },
   },
   async run({ args }) {
     // Validate environment
@@ -720,6 +707,10 @@ const addCommand = defineCommand({
       consola.error('Verified must be either "true" or "false"')
       process.exit(1)
     }
+
+    const { captureErrors, ...provenanceFields } = captureRecordProvenance()
+    for (const problem of captureErrors ?? [])
+      consola.warn(`Provenance capture: ${problem}`)
 
     // Create deployment record
     const record: IDeploymentRecord = {
@@ -739,12 +730,33 @@ const addCommand = defineCommand({
         typeof args['zk-solc-version'] === 'string'
           ? args['zk-solc-version']
           : '',
-      gitCommitHash: getCurrentGitCommitHash(),
-      repo: getCurrentRepo(),
+      ...provenanceFields,
       createdAt: new Date(),
       updatedAt: new Date(),
       contractNetworkKey: `${args.contract}-${args.network}`,
       contractVersionKey: `${args.contract}-${args.version}`,
+    }
+
+    consola.info(
+      `Deployment provenance: branch ${record.gitBranch}, actor ${
+        record.actor
+      }, dirty ${describeDirtyTree(record)}`
+    )
+    if (record.dirtyTreeScoped?.length)
+      consola.warn(
+        `Deployed from a dirty tree: ${record.dirtyTreeScoped.join(', ')}${
+          record.dirtyTreeTruncated ? ', …' : ''
+        }`
+      )
+
+    if (args.dryRun) {
+      consola.info('Dry run: nothing was written to MongoDB')
+      // The upsert, not just the record, because that is what a reviewer needs
+      // to see: which provenance fields reach `$set` and which only `$setOnInsert`.
+      process.stdout.write(
+        `${JSON.stringify(buildDeploymentUpsert(record), null, 2)}\n`
+      )
+      return
     }
 
     const manager = new DeploymentLogManager(


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-695](https://linear.app/lifi-linear/issue/EXSC-695/s9-deploy-log-twin-provenance-fields) (S9, under EXSC-686 · Multisig Signing Process 2.0)

# Why did I implement it this way?

A deployment record answered "which commit?" and nothing else, so a deploy from an
uncommitted edit — the tell-tale of the rogue-deployer scenario — was invisible to anyone
reviewing the record afterwards. This adds `gitBranch`, `dirtyTreeScoped`,
`dirtyTreeTruncated` and `actor` next to `gitCommitHash` on `IDeploymentRecord`, read
through `captureGitProvenance`, the same helper the Safe proposal document is built from
(EXSC-691/692/693), so a record and the proposal that installs it describe branch, tree and
actor by one definition rather than two.

Three decisions worth a reviewer's attention:

- **Provenance stays out of the record's identity.** The upsert filter remains the four
  identity fields, and the new fields are deliberately not added to
  `DEPLOYMENT_QUERY_EQ_KEYS`. A branch in either place would insert a second row for the
  same deployed address on every deploy from a new branch. Both are pinned by tests.
- **An empty dirty list is a claim, so it is only made when its own probe ran.** The shared
  capture returns an empty list both for a clean tree and for a `git status` it could not
  execute, and its error collector is shared with every other probe — so neither the list
  nor the collector separates the two. The dirty tree is therefore read through its own
  collector, and the field is written *absent* when that probe failed. Recording a failed
  probe as "clean" would suppress exactly what the field exists to show.
- **The dirty scope is broader than the one `assertTreeRecordable` blocks on.** That gate
  refuses a deploy on build-affecting paths only; this record is a reviewer's view of the
  whole tree minus the artefacts the deploy pipeline rewrites during its own run. Both
  scopes are intentional and the docstring says which is which.

The two summary lines print at info level on purpose: `logContractDeploymentInfo` runs this
command with stderr discarded unless `DEBUG` is set, so a *warning* about the tree a deploy
came from would never have been seen — which is the visible half of A1.2.

`add --dryRun` (or `--dry-run`) prints the upsert without connecting to MongoDB. It is what
makes the capture demonstrable without writing to the deployment store, and what the
placement tests drive.

## Evidence

Every new behaviour was broken deliberately and the failure recorded, then restored from
git. **Ten mutations, ten caught:**

| Mutation | Tests that fired |
|---|---|
| `gitBranch` dropped from `provenanceUpdate.set` | 5 (3 CLI, 2 unit) |
| dirty list written only when non-empty | 2 |
| branch/actor written unconditionally (a JSON sync would erase Mongo's copy) | 4 |
| `gitBranch` added to `DEPLOYMENT_QUERY_EQ_KEYS` | 1 |
| the `add` command stops capturing provenance at all | 4 (placement) |
| an unreadable tree recorded as clean | 1 |
| dirty readability re-derived from the whole capture's error bag | 1 (the clean-tree row) |
| the kebab `--dry-run` spelling loses its alias | 1 |
| an absent capture rendered like a clean tree | 3 |
| the actor hardcoded instead of read from the capture | 1 |

Two of those are worth reading. `--dry-run` is the spelling every sibling flag on this
command teaches, and citty resolves a kebab spelling through its own fallback only for an
arg carrying no `default` — so a `--dry-run` read as `false` made a dry run a real Mongo
write. Both spellings are now probed against the real CLI. And the dirty-readability
mutation survived the first version of its test: a dirty tree is recorded under both the
right rule and the wrong one, so only a *clean* tree forces the question of whether the
probe ran. The test now carries that row.

Placement is proven by running the real `add` CLI in throwaway git repos whose dirtiness the
test controls (`update-deployment-logs.cli.test.ts`), not by calling the pure functions
alone: dirty tree, clean tree, the dirty-list cap, CI actor with a detached HEAD, the kebab
flag, and a directory that is not a git checkout. Those probes point every store URI at an
unparseable value and assert no child ever reached a store. They also clear `CI` /
`GITHUB_*` from the child environment — without that the capture prefers the workflow's
branch and actor over the throwaway repo, so the suite would have passed locally and failed
on a runner. Verified by running both files with a full `pull_request` environment set: 36
pass, 0 fail.

Real-repo run, this branch with one source file deliberately dirty:

```text
ℹ Deployment provenance: branch feature/exsc-695-deploy-log-provenance, actor human, dirty 5 path(s)
ℹ Deployed from a dirty tree: script/deploy/shared/mongo-log-utils.ts, …, src/Facets/AcrossFacetV4.sol
"gitBranch": "feature/exsc-695-deploy-log-provenance",
"actor": "human",
"dirtyTreeScoped": [ …, "src/Facets/AcrossFacetV4.sol" ],
"dirtyTreeTruncated": false
```

`bun test script/`: 2610 pass, 0 fail. `bunx tsc --noEmit` clean for the touched files,
eslint clean, markdownlint 0 errors. Nothing was written to any deployment store.

## Deliberately not in this PR

- **The new fields stay out of `DEPLOYMENT_QUERY_EQ_KEYS`.** EXSC-695 says not to add them
  without a reason, and a test holds them out. Filtering records by `actor` or `gitBranch`
  is a separate, arguable feature.
- **`batchUpsertDeployments` still builds its own upsert.** It normalises absent fields to
  `''` where `buildDeploymentUpsert` writes them through, so folding the two together would
  change what a JSON sync writes. `RecordTransformer` emits none of the provenance fields,
  so the sync path cannot erase them either way — pinned by a test.
- **`gitCommitHash`'s `'UNKNOWN'` still reaches `$set`,** unlike the other sentinels: it is
  a plain truthy string and predates this work. The docstring now names it as the exception
  rather than implying otherwise.
- **`dirtyTreeScoped` inherits the shared capture's `git status` parsing,** which reads
  porcelain without `-z`, so a dirty path containing a space or non-ASCII bytes is recorded
  git-quoted. Changing that changes the proposal document too.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
