### PR TITLE
feat(deploy): gate the zk, direct-build and Tron toolchains (EXSC-933)

### DIFF
--- a/.github/workflows/deploy-smoke-test.yml
+++ b/.github/workflows/deploy-smoke-test.yml
@@ -52,6 +52,10 @@ jobs:
               - 'script/utils/**'
               - 'script/tasks/**'
               - 'script/resources/**'
+              # The pipeline sources these; helperFunctions.sh is the chokepoint every
+              # deploy passes through, so a change to it that skipped this job would
+              # never have run the pipeline test at all.
+              - 'script/*.sh'
               - '.env.example'
               - 'package.json'
               - 'bun.lock'

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -44,6 +44,14 @@ only the quick-start; this is the full guide.
    your machine does not: rerun `foundryup --install "$(cat .foundry-version)"`
    after the pin changes, or deploys will refuse.
 
+   The zkEVM toolchain is pinned separately, in `foundry.toml`
+   `[external.zksync]` (`foundry_zksync` for the binary release, `zksolc` for
+   the compiler it drives). `install_foundry_zksync` installs that release and
+   then refuses unless both pins hold, so `FOUNDRY_ZKSYNC_VERSION` cannot be
+   used to build a deployment against a release the repository does not pin.
+   The Tron deploy scripts deploy pre-built Forge artifacts and check
+   `.foundry-version` before loading any of them.
+
 4. Set up environment variables:
 
    ```bash

--- a/script/deploy/resources/deployGroupingHelpers.sh
+++ b/script/deploy/resources/deployGroupingHelpers.sh
@@ -223,8 +223,11 @@ function updateFoundryTomlForGroup() {
     fi
 
     # Ahead of the sed below, so a refusal cannot leave foundry.toml rewritten for a group
-    # whose build never ran.
-    if ! assertFoundryVersionOrFail; then
+    # whose build never ran — but only under STRICT. The tolerant mode swallows build
+    # failures for the playground runner and its two callers in multiNetworkExecution.sh
+    # rely on that, so refusing there would abort a whole multi-network group on a
+    # mismatch the per-network gate in deploySingleContract already refuses.
+    if [[ "$STRICT" == "true" ]] && ! assertFoundryVersionOrFail; then
         return 1
     fi
 

--- a/script/deploy/resources/deployGroupingHelpers.sh
+++ b/script/deploy/resources/deployGroupingHelpers.sh
@@ -222,6 +222,12 @@ function updateFoundryTomlForGroup() {
         return 1
     fi
 
+    # Ahead of the sed below, so a refusal cannot leave foundry.toml rewritten for a group
+    # whose build never ran.
+    if ! assertFoundryVersionOrFail; then
+        return 1
+    fi
+
     case "$group" in
         "$GROUP_LONDON")
             # Update solc version and EVM version in profile.default section only

--- a/script/deploy/shared/assert-zk-toolchain.test.ts
+++ b/script/deploy/shared/assert-zk-toolchain.test.ts
@@ -20,6 +20,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   symlinkSync,
   writeFileSync,
@@ -321,6 +322,36 @@ describe('verify-zk-toolchain.sh — the checker', () => {
     expect(output).toContain(ZKSOLC_PIN)
   })
 
+  it('refuses a zksolc whose version merely starts with the pin', () => {
+    // The comparison was a bare substring test, so pin 1.5.15 accepted a 1.5.155
+    // toolchain — a false green in the one check that decides the compiler is the
+    // pinned one. Anchored on the value's closing quote now.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: `{ zksolc = "${ZKSOLC_PIN}5" }` },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('does not name the pinned zksolc')
+  })
+
+  it('still accepts the exact pin, so the anchoring is not blanket', () => {
+    // The paired positive: an anchor that refused everything would satisfy the case
+    // above while disabling the gate.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: `{ zksolc = "${ZKSOLC_PIN}" }` },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=0')
+  })
+
   it('refuses when FOUNDRY_ZKSYNC is not exported, because zksolc is then unpinned', () => {
     // The only mechanism pinning zksolc is that env var, so an unset value means the
     // toolchain picks its own default - which is what a lost pin silently produced.
@@ -511,31 +542,40 @@ describe('the placement, driven through the real deploy CLI', () => {
 })
 
 describe('install_foundry_zksync is the chokepoint every zk build passes', () => {
-  const ZK_FORGE_SITES = [
-    'script/deploy/deploySingleContract.sh',
-    'script/deploy/deployContractToNetworks.sh',
-    'script/tasks/proposeContractToNetworks.sh',
-    'script/tasks/diamondUpdateFacet.sh',
-    'script/scriptMaster.sh',
-    'script/helperFunctions.sh',
-  ] as const
+  /**
+   * Every shell script under `script/`, found rather than listed.
+   * @param relative - directory to walk, relative to the repo root
+   * @returns Repo-relative paths of every `.sh` file beneath it
+   */
+  const shellScripts = (relative = 'script'): string[] =>
+    readdirSync(join(REPO_ROOT, relative), { withFileTypes: true }).flatMap(
+      (entry) =>
+        entry.isDirectory()
+          ? shellScripts(`${relative}/${entry.name}`)
+          : entry.name.endsWith('.sh')
+          ? [`${relative}/${entry.name}`]
+          : []
+    )
 
   it('is called by every script that reaches for the zk forge', () => {
-    // A list, so a new zk build site added without an install call is a failing test rather
-    // than a silent gap; the ordering itself is proven by the CLI drive above.
-    const reachingForZkForge = ZK_FORGE_SITES.filter((path) =>
-      readFileSync(join(REPO_ROOT, path), 'utf8').includes(
-        'foundry-zksync/forge'
-      )
+    // Discovered, not enumerated. A hardcoded list only catches a new call site added to
+    // one of the files already on it — a brand-new script reaching for the zk forge was
+    // invisible to it, which is the gap the list was supposed to close.
+    const scripts = shellScripts().map((path) => ({
+      path,
+      source: readFileSync(join(REPO_ROOT, path), 'utf8'),
+    }))
+
+    const reachingForZkForge = scripts.filter((file) =>
+      file.source.includes('foundry-zksync/forge')
     )
-    const gated = reachingForZkForge.filter((path) =>
-      readFileSync(join(REPO_ROOT, path), 'utf8').includes(
-        'install_foundry_zksync'
-      )
+    const ungated = reachingForZkForge.filter(
+      (file) => !file.source.includes('install_foundry_zksync')
     )
 
+    // Paired: without this, a walk that found nothing would pass while checking nothing.
     expect(reachingForZkForge.length).toBeGreaterThan(0)
-    expect(gated).toEqual(reachingForZkForge)
+    expect(ungated.map((file) => file.path)).toEqual([])
   })
 
   it('refuses every caller, because the check is inside it rather than beside it', () => {
@@ -640,6 +680,30 @@ describe('the ungated forge build sites', () => {
       true
     )
     expect(farm.foundryToml()).not.toBe(before)
+  })
+
+  it('leaves the tolerant group path tolerant, as #2325 decided', () => {
+    // updateFoundryTomlForGroup's default mode swallows build failures for the
+    // playground runner, and multiNetworkExecution.sh's two callers rely on that
+    // return contract. Refusing here would abort a whole multi-network group on a
+    // mismatch the per-network gate in deploySingleContract refuses anyway, which is
+    // the behaviour change #2325 examined and declined to make.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+    writeStub(
+      join(farm.root, 'bin', 'forge'),
+      'forge',
+      join(farm.root, 'argv.log'),
+      'forge Version: 0.0.1'
+    )
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `source script/deploy/resources/deployGroupingHelpers.sh`,
+      `updateFoundryTomlForGroup "$GROUP_LONDON"`,
+      `echo "GROUP_RC=$?"`,
+    ])
+
+    expect(output).toContain('GROUP_RC=0')
   })
 
   it('refuses the deploy-salt build before it starts a forge', () => {

--- a/script/deploy/shared/assert-zk-toolchain.test.ts
+++ b/script/deploy/shared/assert-zk-toolchain.test.ts
@@ -369,6 +369,21 @@ describe('verify-zk-toolchain.sh — the checker', () => {
     expect(output).toContain('9.9.9')
   })
 
+  it('refuses a key that merely contains the zksolc substring', () => {
+    // grep/sed without a token boundary treat `notzksolc` as `zksolc`, so a value
+    // that never requested the compiler still passed when it carried the pin.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: `{ notzksolc = "${ZKSOLC_PIN}" }` },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('exactly one zksolc key')
+  })
+
   it('refuses a value carrying two zksolc keys rather than picking one', () => {
     // Which one forge honours is not ours to guess, and guessing wrong is a
     // false green.

--- a/script/deploy/shared/assert-zk-toolchain.test.ts
+++ b/script/deploy/shared/assert-zk-toolchain.test.ts
@@ -352,6 +352,38 @@ describe('verify-zk-toolchain.sh — the checker', () => {
     expect(output).toContain('SEAM_RC=0')
   })
 
+  it('refuses a zksolc pin that only appears elsewhere in the value', () => {
+    // Anchoring on the value's quotes was not enough: the pinned string appearing
+    // in any other field, or in a trailing comment, read as pinned while the
+    // zksolc key named something else. The key's value is parsed now.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: `{ zksolc = "9.9.9", other = "${ZKSOLC_PIN}" }` },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('does not name the pinned zksolc')
+    expect(output).toContain('9.9.9')
+  })
+
+  it('refuses a value carrying two zksolc keys rather than picking one', () => {
+    // Which one forge honours is not ours to guess, and guessing wrong is a
+    // false green.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: `{ zksolc = "${ZKSOLC_PIN}", zksolc = "9.9.9" }` },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('exactly one zksolc key')
+  })
+
   it('refuses when FOUNDRY_ZKSYNC is not exported, because zksolc is then unpinned', () => {
     // The only mechanism pinning zksolc is that env var, so an unset value means the
     // toolchain picks its own default - which is what a lost pin silently produced.
@@ -542,26 +574,38 @@ describe('the placement, driven through the real deploy CLI', () => {
 })
 
 describe('install_foundry_zksync is the chokepoint every zk build passes', () => {
+  /** The checker itself, which names the binary in prose rather than running it. */
+  const CHECKER = 'script/utils/verify-zk-toolchain.sh'
+
   /**
-   * Every shell script under `script/`, found rather than listed.
+   * Every build script under `script/`, found rather than listed.
    * @param relative - directory to walk, relative to the repo root
-   * @returns Repo-relative paths of every `.sh` file beneath it
+   * @returns Repo-relative paths of every non-test `.sh` or `.ts` beneath it
    */
-  const shellScripts = (relative = 'script'): string[] =>
+  const buildScripts = (relative = 'script'): string[] =>
     readdirSync(join(REPO_ROOT, relative), { withFileTypes: true }).flatMap(
-      (entry) =>
-        entry.isDirectory()
-          ? shellScripts(`${relative}/${entry.name}`)
-          : entry.name.endsWith('.sh')
-          ? [`${relative}/${entry.name}`]
+      (entry) => {
+        const path = `${relative}/${entry.name}`
+        if (entry.isDirectory()) return buildScripts(path)
+        if (path === CHECKER) return []
+        // `.ts` as well as `.sh`: a zk build started with spawn() from
+        // TypeScript would have been invisible to a shell-only walk, which is
+        // the same gap this test exists to close. Tests are excluded — they
+        // reference the binary by name on purpose.
+        return /\.(sh|ts)$/.test(entry.name) && !entry.name.endsWith('.test.ts')
+          ? [path]
           : []
+      }
     )
 
   it('is called by every script that reaches for the zk forge', () => {
     // Discovered, not enumerated. A hardcoded list only catches a new call site added to
     // one of the files already on it — a brand-new script reaching for the zk forge was
-    // invisible to it, which is the gap the list was supposed to close.
-    const scripts = shellScripts().map((path) => ({
+    // invisible to it, which is the gap the list was supposed to close. The checker is
+    // skipped by path: it mentions the binary in a comment and `install_foundry_zksync`
+    // in a fix hint, so it passed on two unrelated string matches and would have flipped
+    // to a false failure if either were reworded.
+    const scripts = buildScripts().map((path) => ({
       path,
       source: readFileSync(join(REPO_ROOT, path), 'utf8'),
     }))

--- a/script/deploy/shared/assert-zk-toolchain.test.ts
+++ b/script/deploy/shared/assert-zk-toolchain.test.ts
@@ -1,0 +1,800 @@
+/**
+ * Covers the zkEVM toolchain pre-flight: the checker's verdicts, the bash seam's
+ * fail-closed behaviour, and where the gate sits relative to the zk build.
+ *
+ * Placement is answered by running `script/deploy/deployContractToNetworks.sh` for real
+ * against a `./foundry-zksync/forge` that records every argv it is handed, so "did a zk
+ * build start?" is answered by bash. Classifying shell text to answer the same question was
+ * wrong four times on the EVM counterpart.
+ *
+ * Every case runs in a throwaway tree whose `foundry-zksync/`, `.env` and `foundry.toml` are
+ * its own, so no case can touch the checkout's toolchain or read its secrets, and `curl` and
+ * `wget` are stubbed to fail so the installer can never reach the network.
+ */
+
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..')
+const SEAM = 'script/deploy/shared/assertZkToolchain.sh'
+const CHECKER = 'script/utils/verify-zk-toolchain.sh'
+const PIN_READER = 'script/utils/zkToolchainPins.sh'
+const CALL = 'assertZkToolchainOrFail'
+
+const REFUSAL = 'Cannot confirm the zkEVM toolchain matches the pins'
+const ZK_BUILD_ARGV = 'build --zksync --skip test'
+
+const FOUNDRY_TOML = readFileSync(join(REPO_ROOT, 'foundry.toml'), 'utf8')
+
+/**
+ * Reads a pin out of the checkout's own foundry.toml, so no expected value in this file is
+ * a second copy of a number that lives in the repo.
+ *
+ * @param key - Pin name inside `[external.zksync]`.
+ * @returns The pinned value.
+ */
+const pin = (key: string): string => {
+  const section = FOUNDRY_TOML.split('[external.zksync]')[1] ?? ''
+  const value = (section.split(/\n\[/)[0] ?? '').match(
+    new RegExp(`^${key}\\s*=\\s*["']([^"']+)["']`, 'm')
+  )?.[1]
+  if (value === undefined) throw new Error(`no ${key} pin in foundry.toml`)
+  return value
+}
+
+const ZKSOLC_PIN = pin('zksolc')
+const ZK_FOUNDRY_PIN = pin('foundry_zksync')
+
+/** A `.env` the deploy scripts accept, holding only path settings and no credentials. */
+const HARMLESS_ENV = [
+  'PRODUCTION=false',
+  'CONTRACT_DIRECTORY="src/"',
+  'DEPLOY_SCRIPT_DIRECTORY="script/deploy/facets/"',
+  'TASKS_SCRIPT_DIRECTORY="script/tasks/"',
+  'CONFIG_SCRIPT_DIRECTORY="script/tasks/solidity/"',
+  'TARGET_STATE_PATH="script/deploy/_targetState.json"',
+  'LOG_FILE_PATH="deployments/_deployments_log_file.json"',
+  'BYTECODE_STORAGE_PATH="deployments/_bytecode_storage.json"',
+  'DEPLOY_REQUIREMENTS_PATH="script/deploy/resources/deployRequirements.json"',
+  'DEPLOY_CONFIG_FILE_PATH="config/"',
+  'FOUNDRY_TOML_FILE_PATH="foundry.toml"',
+  'MAX_ATTEMPTS_PER_SCRIPT_EXECUTION=1',
+  'MAX_ATTEMPTS_PER_CONTRACT_DEPLOYMENT=1',
+  'MAX_CONCURRENT_JOBS=1',
+  'SEND_PROPOSALS_DIRECTLY_TO_DIAMOND=false',
+  'COMPILE_ON_STARTUP=false',
+  '',
+].join('\n')
+
+/** A contract the grouping code can resolve a version for, deployed to a zkEVM network. */
+const DRIVE_CONTRACT = 'Executor'
+const DRIVE_CONTRACT_SOURCE = 'src/Periphery/Executor.sol'
+const DRIVE_NETWORK = 'abstract'
+
+interface IFarm {
+  /** Root the scripts are run from. */
+  root: string
+  /** Every argv the stubbed binaries were handed, in order. */
+  argv: () => string[]
+  /** Current text of the farm's foundry.toml. */
+  foundryToml: () => string
+}
+
+/**
+ * Writes an executable stub that appends its argv to a log.
+ *
+ * @param path - Where to write it.
+ * @param label - Prefix each logged line carries, so callers can tell the stubs apart.
+ * @param log - Argv log path.
+ * @param versionOutput - Printed for `--version`; omit to make every call a no-op success.
+ * @param exitCode - Status for calls other than `--version`.
+ */
+const writeStub = (
+  path: string,
+  label: string,
+  log: string,
+  versionOutput?: string,
+  exitCode = 0
+): void => {
+  const versionBranch =
+    versionOutput === undefined
+      ? ''
+      : `if [ "$1" = "--version" ]; then\n${versionOutput
+          .split('\n')
+          .map((line) => `  echo "${line}"`)
+          .join('\n')}\n  exit 0\nfi\n`
+  writeFileSync(
+    path,
+    `#!/bin/bash\nprintf '${label} %s\\n' "$*" >> ${log}\n${versionBranch}exit ${exitCode}\n`
+  )
+  chmodSync(path, 0o755)
+}
+
+/**
+ * Builds a throwaway tree the deploy scripts can run in: the repo's script/config/lib
+ * directories are shared by symlink, while `foundry-zksync/`, `foundry.toml`, `.env` and the
+ * one source file the drive needs are the farm's own, so a case can drift them freely.
+ *
+ * `src/` is a real directory holding a symlink to the one contract, because
+ * `getContractFilePath` runs `find src` without `-L` and would not descend into a symlinked
+ * directory.
+ *
+ * @param options.zkForgeVersion - Version the stubbed `./foundry-zksync/forge` reports.
+ * Omit to leave the install directory empty.
+ * @param options.foundryToml - Replacement foundry.toml text.
+ * @param options.env - Extra `.env` lines. These have to go in the file rather than in the
+ * child's environment: the scripts read `.env` under `set -a` inside their own body, which
+ * overwrites anything exported beforehand.
+ * @returns Handles on the farm.
+ */
+const makeFarm = (options?: {
+  zkForgeVersion?: string
+  foundryToml?: string
+  env?: string[]
+}): IFarm => {
+  const root = mkdtempSync(join(tmpdir(), 'zk-toolchain-farm-'))
+  const log = join(root, 'argv.log')
+  writeFileSync(log, '')
+
+  for (const entry of ['script', 'config', 'lib', 'out'])
+    if (existsSync(join(REPO_ROOT, entry)))
+      symlinkSync(join(REPO_ROOT, entry), join(root, entry))
+  // A copy, not a symlink: the drives below write deployment records, and a symlink would
+  // land them in the checkout. One case did exactly that before this was changed.
+  cpSync(join(REPO_ROOT, 'deployments'), join(root, 'deployments'), {
+    recursive: true,
+  })
+  for (const entry of ['remappings.txt', '.foundry-version'])
+    copyFileSync(join(REPO_ROOT, entry), join(root, entry))
+
+  writeFileSync(
+    join(root, 'foundry.toml'),
+    options?.foundryToml ?? FOUNDRY_TOML
+  )
+  writeFileSync(
+    join(root, '.env'),
+    [HARMLESS_ENV, ...(options?.env ?? []), ''].join('\n')
+  )
+
+  mkdirSync(join(root, 'src', 'Periphery'), { recursive: true })
+  symlinkSync(
+    join(REPO_ROOT, DRIVE_CONTRACT_SOURCE),
+    join(root, 'src', 'Periphery', `${DRIVE_CONTRACT}.sol`)
+  )
+
+  mkdirSync(join(root, 'foundry-zksync'))
+  if (options?.zkForgeVersion !== undefined)
+    for (const binary of ['forge', 'cast'])
+      writeStub(
+        join(root, 'foundry-zksync', binary),
+        `zk-${binary}`,
+        log,
+        `forge Version: 1.6.0\nfoundry-zksync-${options.zkForgeVersion}`
+      )
+
+  // Every binary that could reach the network or a chain, stubbed inert. `forge` reports the
+  // pinned version so the EVM gate is not what refuses in these cases.
+  mkdirSync(join(root, 'bin'))
+  writeStub(
+    join(root, 'bin', 'forge'),
+    'forge',
+    log,
+    `forge Version: ${readFileSync(
+      join(REPO_ROOT, '.foundry-version'),
+      'utf8'
+    ).trim()}`
+  )
+  for (const binary of ['cast', 'bun', 'bunx', 'curl', 'wget'])
+    writeStub(join(root, 'bin', binary), binary, log, undefined, 1)
+
+  return {
+    root,
+    argv: () =>
+      readFileSync(log, 'utf8')
+        .split('\n')
+        .filter((line) => line !== ''),
+    foundryToml: () => readFileSync(join(root, 'foundry.toml'), 'utf8'),
+  }
+}
+
+/**
+ * Runs a bash snippet inside a farm, with the farm's stub directory first on PATH.
+ *
+ * @param farm - Farm to run in.
+ * @param lines - Snippet lines.
+ * @param environment - Extra environment for the child.
+ * @returns Everything the snippet printed.
+ */
+const runInFarm = (
+  farm: IFarm,
+  lines: string[],
+  environment: Record<string, string> = {}
+): string => {
+  const result = spawnSync('bash', ['-c', lines.join('\n')], {
+    cwd: farm.root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...environment,
+      PATH: `${join(farm.root, 'bin')}:${process.env.PATH ?? ''}`,
+    },
+  })
+  return `${result.stdout}${result.stderr}`
+}
+
+/**
+ * Runs the real bash seam in a farm.
+ *
+ * @param farm - Farm to run in.
+ * @param environment - Extra environment, e.g. a tampered `FOUNDRY_ZKSYNC`.
+ * @param sourcePins - Whether to source the pin reader, which is what exports
+ * `FOUNDRY_ZKSYNC` on the real deploy path.
+ * @returns The seam's output plus its own `SEAM_RC=` line.
+ */
+const runSeam = (
+  farm: IFarm,
+  environment: Record<string, string> = {},
+  sourcePins = true
+): string =>
+  runInFarm(
+    farm,
+    [
+      `error() { echo "ERROR:$*"; }`,
+      ...(sourcePins
+        ? [
+            `source ${PIN_READER}`,
+            `ZKSOLC_VERSION=$(getZkToolchainPin zksolc)`,
+            `if [[ -n "$ZKSOLC_VERSION" ]]; then export FOUNDRY_ZKSYNC="{ zksolc = \\"$ZKSOLC_VERSION\\" }"; fi`,
+          ]
+        : []),
+      `source ${SEAM}`,
+      CALL,
+      `echo "SEAM_RC=$?"`,
+    ],
+    environment
+  )
+
+describe('verify-zk-toolchain.sh — the checker', () => {
+  it('passes, and prints the pair it confirmed, when both pins hold', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runInFarm(farm, [
+      `source ${PIN_READER}`,
+      `export FOUNDRY_ZKSYNC="{ zksolc = \\"$(getZkToolchainPin zksolc)\\" }"`,
+      `bash ${CHECKER}`,
+      `echo "CHECKER_RC=$?"`,
+    ])
+
+    expect(output).toContain('CHECKER_RC=0')
+    expect(output).toContain(ZK_FOUNDRY_PIN)
+    expect(output).toContain(ZKSOLC_PIN)
+  })
+
+  it('refuses when the zksolc pin is gone from foundry.toml', () => {
+    // The pin's absence is the reason FOUNDRY_ZKSYNC ends up unset on the deploy path: the
+    // export is conditional on a non-empty pin, so a lost pin silently fell back to
+    // whatever zksolc the binary defaults to.
+    const farm = makeFarm({
+      zkForgeVersion: ZK_FOUNDRY_PIN,
+      foundryToml: FOUNDRY_TOML.replace(/^zksolc = .*$/m, ''),
+    })
+
+    const output = runSeam(farm)
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('zk toolchain pins missing')
+    expect(output).toContain(REFUSAL)
+  })
+
+  it('refuses when FOUNDRY_ZKSYNC names a different zksolc than the pin', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    // sourcePins off: the pin reader is what exports FOUNDRY_ZKSYNC, and letting it run
+    // would overwrite the tampered value this case is about.
+    const output = runSeam(
+      farm,
+      { FOUNDRY_ZKSYNC: '{ zksolc = "0.0.1" }' },
+      false
+    )
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('does not name the pinned zksolc')
+    expect(output).toContain(ZKSOLC_PIN)
+  })
+
+  it('refuses when FOUNDRY_ZKSYNC is not exported, because zksolc is then unpinned', () => {
+    // The only mechanism pinning zksolc is that env var, so an unset value means the
+    // toolchain picks its own default - which is what a lost pin silently produced.
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runSeam(farm, { FOUNDRY_ZKSYNC: '' }, false)
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('zksolc is unpinned')
+    expect(output).toContain(ZKSOLC_PIN)
+  })
+
+  it('refuses when FOUNDRY_ZKSYNC_VERSION diverges from the committed pin', () => {
+    // The one shape the pre-existing installer cannot catch: it compares the binary against
+    // the override, so an override plus a matching binary read as a clean install.
+    const farm = makeFarm({ zkForgeVersion: 'v9.9.9' })
+
+    const output = runSeam(farm, { FOUNDRY_ZKSYNC_VERSION: 'v9.9.9' })
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('overrides the committed foundry-zksync pin')
+    expect(output).toContain(ZK_FOUNDRY_PIN)
+  })
+
+  it('refuses when the installed foundry-zksync is a different release', () => {
+    const farm = makeFarm({ zkForgeVersion: 'v9.9.9' })
+
+    const output = runSeam(farm)
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('foundry-zksync version mismatch')
+    expect(output).toContain('v9.9.9')
+  })
+
+  it('refuses when there is no foundry-zksync binary at all', () => {
+    const farm = makeFarm()
+
+    const output = runSeam(farm)
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('no executable foundry-zksync forge')
+  })
+
+  it('refuses when the binary answers --version with nothing parseable', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+    writeFileSync(
+      join(farm.root, 'foundry-zksync', 'forge'),
+      '#!/bin/bash\necho "who knows"\nexit 0\n'
+    )
+    chmodSync(join(farm.root, 'foundry-zksync', 'forge'), 0o755)
+
+    const output = runSeam(farm)
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('could not parse the foundry-zksync version')
+  })
+})
+
+describe('assertZkToolchainOrFail — the bash seam fails closed', () => {
+  /**
+   * Builds a tree that looks like a checkout to the seam, so the "checker cannot run" cases
+   * are driven rather than argued.
+   *
+   * @param include - Which of the seam's two dependencies to place in it.
+   * @returns Path to the tree.
+   */
+  const treeWith = (include: {
+    checker: boolean
+    pinReader: boolean
+  }): string => {
+    const root = mkdtempSync(join(tmpdir(), 'zk-toolchain-root-'))
+    mkdirSync(join(root, 'script', 'utils'), { recursive: true })
+    copyFileSync(join(REPO_ROOT, 'foundry.toml'), join(root, 'foundry.toml'))
+    if (include.checker)
+      copyFileSync(join(REPO_ROOT, CHECKER), join(root, CHECKER))
+    if (include.pinReader)
+      copyFileSync(join(REPO_ROOT, PIN_READER), join(root, PIN_READER))
+    return root
+  }
+
+  /**
+   * Runs the seam with its checker lookup pointed at a chosen tree, and a matching zk
+   * binary inside that tree so only the missing dependency can be what refuses.
+   *
+   * @param root - Tree to run in.
+   * @returns The seam's output plus its `SEAM_RC=` line.
+   */
+  const runSeamIn = (root: string): string => {
+    mkdirSync(join(root, 'foundry-zksync'), { recursive: true })
+    const log = join(root, 'argv.log')
+    writeFileSync(log, '')
+    writeStub(
+      join(root, 'foundry-zksync', 'forge'),
+      'zk-forge',
+      log,
+      `forge Version: 1.6.0\nfoundry-zksync-${ZK_FOUNDRY_PIN}`
+    )
+
+    const result = spawnSync(
+      'bash',
+      [
+        '-c',
+        [
+          `error() { echo "ERROR:$*"; }`,
+          `export FOUNDRY_ZKSYNC='{ zksolc = "${ZKSOLC_PIN}" }'`,
+          `source ${join(REPO_ROOT, SEAM)}`,
+          CALL,
+          `echo "SEAM_RC=$?"`,
+        ].join('\n'),
+      ],
+      { cwd: root, encoding: 'utf8' }
+    )
+    return `${result.stdout}${result.stderr}`
+  }
+
+  it('refuses when the checker is not in the tree', () => {
+    const output = runSeamIn(treeWith({ checker: false, pinReader: true }))
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain('zk toolchain checker not found')
+  })
+
+  it('passes in the same tree once the checker is restored', () => {
+    // Without this counterpart the case above would pass against a seam that refuses
+    // everything, including a healthy toolchain.
+    const output = runSeamIn(treeWith({ checker: true, pinReader: true }))
+
+    expect(output).toContain('SEAM_RC=0')
+    expect(output).not.toContain(REFUSAL)
+  })
+
+  it('refuses when the checker is there but cannot run', () => {
+    const output = runSeamIn(treeWith({ checker: true, pinReader: false }))
+
+    expect(output).toContain('SEAM_RC=1')
+    expect(output).toContain(REFUSAL)
+  })
+})
+
+describe('the placement, driven through the real deploy CLI', () => {
+  /**
+   * Runs `deployContractToNetworks.sh` for one zkEVM network, which is the shortest real
+   * path to a zk build: with no london or cancun network in the set, the zkEVM wave is the
+   * first thing that builds.
+   *
+   * @param farm - Farm to run in.
+   * @param environment - Extra environment for the child.
+   * @returns The run's output.
+   */
+  const driveDeployCli = (
+    farm: IFarm,
+    environment: Record<string, string> = {}
+  ): string =>
+    runInFarm(
+      farm,
+      [
+        `bash script/deploy/deployContractToNetworks.sh ${DRIVE_CONTRACT} ${DRIVE_NETWORK}`,
+      ],
+      environment
+    )
+
+  it('refuses before any zk build starts', () => {
+    const farm = makeFarm({ zkForgeVersion: 'v9.9.9' })
+
+    const output = driveDeployCli(farm, { FOUNDRY_ZKSYNC_VERSION: 'v9.9.9' })
+
+    expect(output).toContain(REFUSAL)
+    // The installer's own comparison is satisfied here, so without the gate this run
+    // proceeds to build.
+    expect(output).toContain('Version matches expected v9.9.9')
+    expect(farm.argv().some((argv) => argv.includes(ZK_BUILD_ARGV))).toBe(false)
+    // Paired with the absence above: a run that never reached the installer would also
+    // record no build, and would prove nothing.
+    expect(
+      farm.argv().some((argv) => argv.includes('zk-forge --version'))
+    ).toBe(true)
+    expect(output).toContain('aborting before deploying any zkEVM network')
+  })
+
+  it('stays silent and lets the zk build run when the toolchain is pinned', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = driveDeployCli(farm)
+
+    expect(output).not.toContain(REFUSAL)
+    expect(farm.argv().some((argv) => argv.includes(ZK_BUILD_ARGV))).toBe(true)
+  })
+})
+
+describe('install_foundry_zksync is the chokepoint every zk build passes', () => {
+  const ZK_FORGE_SITES = [
+    'script/deploy/deploySingleContract.sh',
+    'script/deploy/deployContractToNetworks.sh',
+    'script/tasks/proposeContractToNetworks.sh',
+    'script/tasks/diamondUpdateFacet.sh',
+    'script/scriptMaster.sh',
+    'script/helperFunctions.sh',
+  ] as const
+
+  it('is called by every script that reaches for the zk forge', () => {
+    // A list, so a new zk build site added without an install call is a failing test rather
+    // than a silent gap; the ordering itself is proven by the CLI drive above.
+    const reachingForZkForge = ZK_FORGE_SITES.filter((path) =>
+      readFileSync(join(REPO_ROOT, path), 'utf8').includes(
+        'foundry-zksync/forge'
+      )
+    )
+    const gated = reachingForZkForge.filter((path) =>
+      readFileSync(join(REPO_ROOT, path), 'utf8').includes(
+        'install_foundry_zksync'
+      )
+    )
+
+    expect(reachingForZkForge.length).toBeGreaterThan(0)
+    expect(gated).toEqual(reachingForZkForge)
+  })
+
+  it('refuses every caller, because the check is inside it rather than beside it', () => {
+    const farm = makeFarm({ zkForgeVersion: 'v9.9.9' })
+
+    const output = runInFarm(
+      farm,
+      [
+        `source script/helperFunctions.sh >/dev/null 2>&1`,
+        `install_foundry_zksync >/dev/null`,
+        `echo "INSTALL_RC=$?"`,
+      ],
+      { FOUNDRY_ZKSYNC_VERSION: 'v9.9.9' }
+    )
+
+    expect(output).toContain('INSTALL_RC=1')
+  })
+
+  it('stops diamondUpdateFacet, whose call site used to ignore the status', () => {
+    // Two call sites called the installer bare, so its verdict was discarded and the zk
+    // forge script ran anyway. Driven rather than read: gum is stubbed so the prompts the
+    // function reaches after the gate do not block.
+    const farm = makeFarm({ zkForgeVersion: 'v9.9.9' })
+    writeStub(join(farm.root, 'bin', 'gum'), 'gum', join(farm.root, 'argv.log'))
+
+    const output = runInFarm(
+      farm,
+      [
+        `source script/helperFunctions.sh >/dev/null 2>&1`,
+        `source script/tasks/diamondUpdateFacet.sh >/dev/null 2>&1`,
+        `diamondUpdateFacet ${DRIVE_NETWORK} staging LiFiDiamond UpdateCoreFacets true`,
+        `echo "UPDATE_RC=$?"`,
+      ],
+      { FOUNDRY_ZKSYNC_VERSION: 'v9.9.9' }
+    )
+
+    expect(output).toContain('UPDATE_RC=1')
+    expect(output).toContain(REFUSAL)
+    expect(output).toContain('Version matches expected v9.9.9')
+    expect(farm.argv().some((argv) => argv.includes('forge script'))).toBe(
+      false
+    )
+    expect(
+      farm.argv().some((argv) => argv.includes('zk-forge --version'))
+    ).toBe(true)
+  })
+
+  it('returns 0 for a pinned toolchain, so the refusal is not unconditional', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `install_foundry_zksync >/dev/null`,
+      `echo "INSTALL_RC=$?"`,
+    ])
+
+    expect(output).toContain('INSTALL_RC=0')
+  })
+})
+
+describe('the ungated forge build sites', () => {
+  it('refuses the per-group build before foundry.toml is rewritten', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+    writeStub(
+      join(farm.root, 'bin', 'forge'),
+      'forge',
+      join(farm.root, 'argv.log'),
+      'forge Version: 0.0.1'
+    )
+    const before = farm.foundryToml()
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `source script/deploy/resources/deployGroupingHelpers.sh`,
+      `updateFoundryTomlForGroup "$GROUP_LONDON" true`,
+      `echo "GROUP_RC=$?"`,
+    ])
+
+    expect(output).toContain('GROUP_RC=1')
+    expect(output).toContain('Cannot confirm the local foundry')
+    expect(farm.argv().some((argv) => argv.startsWith('forge build'))).toBe(
+      false
+    )
+    // A refusal that had already rewritten the profile would leave the checkout pointed at
+    // a group whose build never ran.
+    expect(farm.foundryToml()).toBe(before)
+  })
+
+  it('rewrites foundry.toml and builds once the forge matches', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+    const before = farm.foundryToml()
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `source script/deploy/resources/deployGroupingHelpers.sh`,
+      `updateFoundryTomlForGroup "$GROUP_LONDON" true`,
+      `echo "GROUP_RC=$?"`,
+    ])
+
+    expect(output).toContain('GROUP_RC=0')
+    expect(farm.argv().some((argv) => argv.startsWith('forge build'))).toBe(
+      true
+    )
+    expect(farm.foundryToml()).not.toBe(before)
+  })
+
+  it('refuses the deploy-salt build before it starts a forge', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+    writeStub(
+      join(farm.root, 'bin', 'forge'),
+      'forge',
+      join(farm.root, 'argv.log'),
+      'forge Version: 0.0.1'
+    )
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `ensureStandardArtifactForSalt NoSuchContractForTheSaltPath`,
+      `echo "SALT_RC=$?"`,
+    ])
+
+    expect(output).toContain('SALT_RC=1')
+    expect(output).toContain('Cannot confirm the local foundry')
+    expect(farm.argv().some((argv) => argv.startsWith('forge build'))).toBe(
+      false
+    )
+  })
+
+  it('runs the deploy-salt build once the forge matches', () => {
+    const farm = makeFarm({ zkForgeVersion: ZK_FOUNDRY_PIN })
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `ensureStandardArtifactForSalt NoSuchContractForTheSaltPath`,
+      `echo "SALT_RC=$?"`,
+    ])
+
+    // Still 1 - the stub produces no artifact - but for the later reason, which is what
+    // separates "the gate refused" from "the build failed".
+    expect(output).toContain('SALT_RC=1')
+    expect(output).not.toContain('Cannot confirm the local foundry')
+    expect(farm.argv().some((argv) => argv.startsWith('forge build'))).toBe(
+      true
+    )
+  })
+
+  it('refuses scriptMaster startup compile before it starts a forge', () => {
+    const farm = makeFarm({
+      zkForgeVersion: ZK_FOUNDRY_PIN,
+      env: ['COMPILE_ON_STARTUP=true'],
+    })
+    writeStub(
+      join(farm.root, 'bin', 'forge'),
+      'forge',
+      join(farm.root, 'argv.log'),
+      'forge Version: 0.0.1'
+    )
+    // gum drives the interactive prompts that follow the compile step, so a run that got
+    // past the gate does not hang.
+    writeStub(join(farm.root, 'bin', 'gum'), 'gum', join(farm.root, 'argv.log'))
+
+    const output = runInFarm(farm, [
+      `source script/helperFunctions.sh >/dev/null 2>&1`,
+      `source script/scriptMaster.sh >/dev/null 2>&1`,
+      `scriptMaster`,
+      `echo "MASTER_RC=$?"`,
+    ])
+
+    expect(output).toContain('MASTER_RC=1')
+    expect(output).toContain('Cannot confirm the local foundry')
+    expect(farm.argv().some((argv) => argv.startsWith('forge build'))).toBe(
+      false
+    )
+  })
+})
+
+describe('deployAndStoreCREATE3Factory needs no gate of its own', () => {
+  it('cannot reach its fallback build after the seam refuses', () => {
+    // Its `forge build` is only reached when the preceding executeAndParse left a
+    // chain-unsupported message in STDERR_CONTENT. The seam's refusal replaces that
+    // message, so a refused run cannot enter the branch - which is why a second gate here
+    // would only duplicate the first.
+    const source = readFileSync(
+      join(REPO_ROOT, 'script/deploy/deployAndStoreCREATE3Factory.sh'),
+      'utf8'
+    )
+    const seamRefusal = readFileSync(
+      join(REPO_ROOT, 'script/helperFunctions.sh'),
+      'utf8'
+    ).match(/STDERR_CONTENT="(refused:[^"]*)"/)
+
+    expect(seamRefusal).not.toBeNull()
+    expect(source).toContain('executeAndParse')
+    expect(source).toContain(
+      // eslint-disable-next-line no-template-curly-in-string
+      '"${STDERR_CONTENT:-}" == *"Chain"*'
+    )
+    expect(seamRefusal?.[1]).not.toContain('Chain')
+  })
+})
+
+describe('the checkout itself', () => {
+  it('carries both zk pins, so the gate has something to compare against', () => {
+    expect(ZKSOLC_PIN).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(ZK_FOUNDRY_PIN).toMatch(/^v?\d+\.\d+\.\d+$|^nightly-/)
+  })
+
+  it('keeps the zk pin reader loadable on its own', () => {
+    // The checker sources it without helperFunctions.sh, which reads .env and would need a
+    // configured tree.
+    const result = spawnSync(
+      'bash',
+      ['-c', `source ${PIN_READER}\ngetZkToolchainPin zksolc`],
+      { cwd: REPO_ROOT, encoding: 'utf8' }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe(ZKSOLC_PIN)
+  })
+})
+
+describe('deploy-smoke-test triggers on the deploy chokepoint', () => {
+  it('lists a filter that matches the file the seam lives in', () => {
+    const workflow = readFileSync(
+      join(REPO_ROOT, '.github/workflows/deploy-smoke-test.yml'),
+      'utf8'
+    )
+    const filters = (workflow.match(/^\s+- '([^']+)'$/gm) ?? []).map((line) =>
+      line.trim().replace(/^- '/, '').replace(/'$/, '')
+    )
+
+    /**
+     * Whether any filter glob matches a path, with `**` spanning separators and `*` not.
+     *
+     * @param path - Repository-relative path.
+     * @returns True when the smoke job would run for a change to it.
+     */
+    const covered = (path: string): boolean =>
+      filters.some((glob) =>
+        new RegExp(
+          `^${glob
+            .split('**')
+            .map((part) =>
+              part
+                .split('*')
+                .map((atom) => atom.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+                .join('[^/]*')
+            )
+            .join('.*')}$`
+        ).test(path)
+      )
+
+    expect(covered('script/helperFunctions.sh')).toBe(true)
+    expect(covered('script/scriptMaster.sh')).toBe(true)
+    expect(covered('script/deploy/shared/assertZkToolchain.sh')).toBe(true)
+    expect(covered(CHECKER)).toBe(true)
+    expect(covered(PIN_READER)).toBe(true)
+    // A matcher that answered true for everything would make the assertions above empty.
+    expect(covered('README.md')).toBe(false)
+    expect(covered('docs/Setup.md')).toBe(false)
+  })
+})

--- a/script/deploy/shared/assertZkToolchain.sh
+++ b/script/deploy/shared/assertZkToolchain.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# assertZkToolchainOrFail: Refuses a zkEVM build whose toolchain does not match the pins in
+# foundry.toml [external.zksync]. The comparison is delegated to
+# script/utils/verify-zk-toolchain.sh so every caller reaches one verdict.
+#
+# Usage: assertZkToolchainOrFail [INSTALL_DIR]
+#   INSTALL_DIR - foundry-zksync install directory (default: ./foundry-zksync)
+#
+# Routing/Behavior:
+#   - Checker exits 0: returns 0, prints nothing
+#   - Pin missing, zksolc unpinned, or binary version mismatch: the checker prints why, returns 1
+#   - Checker missing or unrunnable: returns 1
+#
+# Returns: 0 to continue, 1 to refuse. Never exits.
+# Example: assertZkToolchainOrFail || return 1
+function assertZkToolchainOrFail() {
+  local INSTALL_DIR="${1:-./foundry-zksync}"
+  local GIT_ROOT
+  GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  local CHECKER="$GIT_ROOT/script/utils/verify-zk-toolchain.sh"
+
+  if [[ ! -f "$CHECKER" ]]; then
+    error "zk toolchain checker not found at $CHECKER. Refusing to build for zkEVM. Nothing has been broadcast."
+    return 1
+  fi
+
+  # Only an explicit success permits the build, so an unrunnable checker refuses too.
+  if bash "$CHECKER" --quiet --dir "$INSTALL_DIR"; then
+    return 0
+  fi
+
+  error "Cannot confirm the zkEVM toolchain matches the pins in $GIT_ROOT/foundry.toml [external.zksync], so a rebuild would not reproduce this deployment. Refusing to build for zkEVM. Nothing has been broadcast."
+  return 1
+}

--- a/script/deploy/tron/assertTronToolchain.test.ts
+++ b/script/deploy/tron/assertTronToolchain.test.ts
@@ -42,6 +42,28 @@ const PINNED = readFileSync(join(REPO_ROOT, '.foundry-version'), 'utf8').trim()
 const REFUSAL = 'Cannot confirm the local foundry matches'
 
 /**
+ * Await a rejection without using Bun's `.rejects` matcher, which is not a thenable
+ * (`[CONV:TEST-ASSERT-REJECTS]`).
+ *
+ * @param promise - Call expected to reject.
+ * @param match - Substring or pattern of the error message.
+ */
+async function expectRejects(
+  promise: Promise<unknown>,
+  match: RegExp | string
+): Promise<void> {
+  let error: Error | undefined
+  try {
+    await promise
+  } catch (caught) {
+    error = caught as Error
+  }
+  expect(error).toBeInstanceOf(Error)
+  if (match instanceof RegExp) expect(error?.message).toMatch(match)
+  else expect(error?.message).toContain(match)
+}
+
+/**
  * Records every checker path it is handed, so the assertions are on a spy rather than only
  * on a thrown error.
  *
@@ -261,9 +283,10 @@ describe('the placement in deployContractWithLogging', () => {
     const { deployContractWithLogging } = await import('./tronUtils')
     const spy = deployerSpy()
 
-    expect(
-      deployContractWithLogging(spy.deployer, 'Executor', [], true)
-    ).rejects.toThrow(REFUSAL)
+    await expectRejects(
+      deployContractWithLogging(spy.deployer, 'Executor', [], true),
+      REFUSAL
+    )
     expect(spy.calls).toEqual([])
   })
 
@@ -274,14 +297,15 @@ describe('the placement in deployContractWithLogging', () => {
 
     // Still a rejection - there is no artifact for that name - but for the later reason,
     // which is what separates "the gate refused" from "the gate was not there".
-    expect(
+    await expectRejects(
       deployContractWithLogging(
         spy.deployer,
         'NoSuchContractOnTheTronPath',
         [],
         true
-      )
-    ).rejects.toThrow(/Failed to load NoSuchContractOnTheTronPath artifact/)
+      ),
+      /Failed to load NoSuchContractOnTheTronPath artifact/
+    )
     expect(spy.calls).toEqual([])
   })
 })

--- a/script/deploy/tron/assertTronToolchain.test.ts
+++ b/script/deploy/tron/assertTronToolchain.test.ts
@@ -337,28 +337,43 @@ describe('the placement at the deploy chokepoint', () => {
 })
 
 describe('the gate is on the Tron seams a deployment cannot avoid', () => {
-  it('guards every deploy site, because each one asserts recordability first', () => {
-    // A counting invariant, paired with the executable proof above that the recordability
-    // assert refuses: if a new site called deployContract without it, the counts diverge.
-    const sources = [
-      'script/deploy/tron',
-      'script/deploy/tron/helpers',
-    ].flatMap((directory) =>
-      readdirSync(join(REPO_ROOT, directory))
-        .filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
-        .map((entry) => readFileSync(join(REPO_ROOT, directory, entry), 'utf8'))
+  it('guards every deploy site, per file', () => {
+    // Per file, not across all of them. The aggregate form — total asserts >= total
+    // deploys — passed at 12 >= 11 while `deploy-safe-tron.ts` broadcast two contracts
+    // with no gate at all: the definition in tronUtils.ts and an import elsewhere made
+    // up the difference. An invariant a file with zero guards cannot fail is an
+    // acceptance criterion that encodes the regression it exists to catch.
+    const files = ['script/deploy/tron', 'script/deploy/tron/helpers'].flatMap(
+      (directory) =>
+        readdirSync(join(REPO_ROOT, directory))
+          .filter(
+            (entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts')
+          )
+          .map((entry) => ({
+            path: `${directory}/${entry}`,
+            source: readFileSync(join(REPO_ROOT, directory, entry), 'utf8'),
+          }))
     )
 
-    const count = (needle: string): number =>
-      sources.reduce(
-        (total, source) => total + source.split(needle).length - 1,
+    const occurrences = (source: string, needle: string): number =>
+      source.split(needle).length - 1
+
+    const ungated = files
+      .map((file) => ({
+        path: file.path,
+        deploys: occurrences(file.source, 'deployer.deployContract('),
+        asserts: occurrences(file.source, 'assertTronDeploymentRecordable('),
+      }))
+      .filter((file) => file.deploys > file.asserts)
+
+    expect(ungated).toEqual([])
+    // Paired positive: if nothing deployed anywhere, the check above is vacuous.
+    expect(
+      files.reduce(
+        (n, f) => n + occurrences(f.source, 'deployer.deployContract('),
         0
       )
-
-    expect(count('deployer.deployContract(')).toBeGreaterThan(0)
-    expect(count('assertTronDeploymentRecordable(')).toBeGreaterThanOrEqual(
-      count('deployer.deployContract(')
-    )
+    ).toBeGreaterThan(0)
   })
 
   it('works from the contracts-tron checkout, which carries the same checker', () => {

--- a/script/deploy/tron/assertTronToolchain.test.ts
+++ b/script/deploy/tron/assertTronToolchain.test.ts
@@ -362,7 +362,17 @@ describe('the gate is on the Tron seams a deployment cannot avoid', () => {
       .map((file) => ({
         path: file.path,
         deploys: occurrences(file.source, 'deployer.deployContract('),
-        asserts: occurrences(file.source, 'assertTronDeploymentRecordable('),
+        // Either gate counts. `assertTronDeploymentRecordable` is the fuller
+        // check and is what a recorded LI.FI deployment needs; the Safe
+        // singleton and proxy factory in deploy-safe-tron.ts are third-party
+        // artifacts built by `forge build -C safe/london` and never written to
+        // the deployment log, so they take the toolchain check alone. Requiring
+        // the fuller one there refused every run: it validates constructor args
+        // against the artifact ABI, and that committed build declares none
+        // while its source declares one.
+        asserts:
+          occurrences(file.source, 'assertTronDeploymentRecordable(') +
+          occurrences(file.source, 'assertTronToolchainOrThrow('),
       }))
       .filter((file) => file.deploys > file.asserts)
 

--- a/script/deploy/tron/assertTronToolchain.test.ts
+++ b/script/deploy/tron/assertTronToolchain.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Covers the Tron deploy path's toolchain pre-flight: the decision, the fail-closed cases,
+ * and that it runs before anything reaches a chain.
+ *
+ * Placement is proven by driving the real seams — `deployContractWithLogging` and the
+ * `deploy-and-register-periphery` CLI — with no `forge` on PATH, and asserting on a spy that
+ * the deployer was never called. The counterpart puts a matching `forge` on PATH and shows
+ * the same call getting past the gate, so neither direction can pass while observing
+ * nothing.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  FOUNDRY_VERSION_CHECKER,
+  assertTronToolchainOrThrow,
+  resetTronToolchainCache,
+  spawnFoundryVersionChecker,
+  type ICheckerResult,
+} from './assertTronToolchain'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..')
+const PINNED = readFileSync(join(REPO_ROOT, '.foundry-version'), 'utf8').trim()
+const REFUSAL = 'Cannot confirm the local foundry matches'
+
+/**
+ * Records every checker path it is handed, so the assertions are on a spy rather than only
+ * on a thrown error.
+ *
+ * @param result - What the fake checker returns.
+ * @returns The runner plus the calls it saw.
+ */
+const spyRunner = (
+  result: ICheckerResult
+): { run: (path: string) => ICheckerResult; calls: string[] } => {
+  const calls: string[] = []
+  return {
+    run: (path: string) => {
+      calls.push(path)
+      return result
+    },
+    calls,
+  }
+}
+
+/**
+ * Puts a `forge` of a chosen version on PATH.
+ *
+ * @param version - Version the stub reports. Omit for a PATH with no `forge`.
+ * @returns The directory to prepend to PATH.
+ */
+const forgeStub = (version?: string): string => {
+  const stubDirectory = mkdtempSync(join(tmpdir(), 'tron-toolchain-stub-'))
+  if (version !== undefined) {
+    const forge = join(stubDirectory, 'forge')
+    writeFileSync(
+      forge,
+      `#!/bin/bash\necho "forge Version: ${version}"\necho "Commit SHA: deadbeef"\n`
+    )
+    chmodSync(forge, 0o755)
+  }
+  return stubDirectory
+}
+
+/**
+ * PATH with every directory carrying a real `forge` removed, so the absent case is
+ * reproducible on a machine that has one.
+ *
+ * @returns The filtered PATH.
+ */
+const pathWithoutForge = (): string =>
+  (process.env.PATH ?? '')
+    .split(':')
+    .filter(
+      (directory) => directory !== '' && !existsSync(join(directory, 'forge'))
+    )
+    .join(':')
+
+describe('assertTronToolchainOrThrow — the decision', () => {
+  beforeEach(resetTronToolchainCache)
+
+  it('returns, and consults the checker, when the toolchain matches', () => {
+    const spy = spyRunner({ status: 0, output: '' })
+
+    expect(() =>
+      assertTronToolchainOrThrow({
+        repoRoot: '/somewhere',
+        run: spy.run,
+        exists: () => true,
+      })
+    ).not.toThrow()
+    // Paired with the no-throw above: a gate that returned without running anything would
+    // also not throw.
+    expect(spy.calls).toEqual([join('/somewhere', FOUNDRY_VERSION_CHECKER)])
+  })
+
+  it('throws when the checker reports a mismatch, and carries its output', () => {
+    const spy = spyRunner({ status: 1, output: 'foundry version mismatch' })
+
+    expect(() =>
+      assertTronToolchainOrThrow({
+        repoRoot: '/somewhere',
+        run: spy.run,
+        exists: () => true,
+      })
+    ).toThrow(/Cannot confirm the local foundry matches[\s\S]*version mismatch/)
+    expect(spy.calls).toHaveLength(1)
+  })
+
+  it('throws when the checker is not in the tree, without running anything', () => {
+    const spy = spyRunner({ status: 0, output: '' })
+
+    expect(() =>
+      assertTronToolchainOrThrow({
+        repoRoot: '/somewhere',
+        run: spy.run,
+        exists: () => false,
+      })
+    ).toThrow(/Foundry version checker not found/)
+    expect(spy.calls).toEqual([])
+  })
+
+  it('throws when the checker could not be started at all', () => {
+    // A null status is what spawn reports for a failure to launch. "We could not tell" and
+    // "it matches" must not share an outcome.
+    const spy = spyRunner({ status: null, output: 'spawn bash ENOENT' })
+
+    expect(() =>
+      assertTronToolchainOrThrow({
+        repoRoot: '/somewhere',
+        run: spy.run,
+        exists: () => true,
+      })
+    ).toThrow(REFUSAL)
+  })
+
+  it('resolves the checker against the working directory by default', () => {
+    const spy = spyRunner({ status: 0, output: '' })
+
+    assertTronToolchainOrThrow({ run: spy.run, exists: () => true })
+
+    expect(spy.calls).toEqual([join(process.cwd(), FOUNDRY_VERSION_CHECKER)])
+  })
+
+  it('runs the checker once, however many contracts a script deploys', () => {
+    const spy = spyRunner({ status: 0, output: '' })
+
+    for (let index = 0; index < 5; index++)
+      assertTronToolchainOrThrow({ run: spy.run, exists: () => true })
+
+    expect(spy.calls).toHaveLength(1)
+  })
+
+  it('does not cache a refusal, so a fixed toolchain is picked up', () => {
+    const failing = spyRunner({ status: 1, output: '' })
+    expect(() =>
+      assertTronToolchainOrThrow({ run: failing.run, exists: () => true })
+    ).toThrow(REFUSAL)
+
+    const passing = spyRunner({ status: 0, output: '' })
+    expect(() =>
+      assertTronToolchainOrThrow({ run: passing.run, exists: () => true })
+    ).not.toThrow()
+    expect(passing.calls).toHaveLength(1)
+  })
+})
+
+describe('the real checker, run the way the deploy path runs it', () => {
+  const originalPath = process.env.PATH
+
+  beforeEach(resetTronToolchainCache)
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  it('refuses when the local forge is a different version', () => {
+    process.env.PATH = `${forgeStub('0.0.1')}:${pathWithoutForge()}`
+
+    expect(() => assertTronToolchainOrThrow({ repoRoot: REPO_ROOT })).toThrow(
+      REFUSAL
+    )
+  })
+
+  it('refuses when there is no forge at all', () => {
+    process.env.PATH = pathWithoutForge()
+
+    expect(() => assertTronToolchainOrThrow({ repoRoot: REPO_ROOT })).toThrow(
+      REFUSAL
+    )
+  })
+
+  it('permits the pinned version, so the refusal is not unconditional', () => {
+    process.env.PATH = `${forgeStub(PINNED)}:${pathWithoutForge()}`
+
+    expect(() =>
+      assertTronToolchainOrThrow({ repoRoot: REPO_ROOT })
+    ).not.toThrow()
+  })
+
+  it('reports a real exit status through the default runner', () => {
+    process.env.PATH = pathWithoutForge()
+
+    const result = spawnFoundryVersionChecker(
+      join(REPO_ROOT, FOUNDRY_VERSION_CHECKER)
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.output).toContain('forge')
+  })
+})
+
+describe('the placement in deployContractWithLogging', () => {
+  const originalPath = process.env.PATH
+
+  beforeEach(resetTronToolchainCache)
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  /**
+   * A deployer that records whether anything was ever sent to a chain.
+   *
+   * @returns The stand-in and its call log.
+   */
+  const deployerSpy = (): {
+    deployer: { deployContract: (...args: unknown[]) => Promise<never> }
+    calls: unknown[][]
+  } => {
+    const calls: unknown[][] = []
+    return {
+      deployer: {
+        deployContract: async (...args: unknown[]) => {
+          calls.push(args)
+          throw new Error('the spy must never be reached in these cases')
+        },
+      },
+      calls,
+    }
+  }
+
+  it('refuses before the artifact is loaded or the deployer is called', async () => {
+    process.env.PATH = `${forgeStub('0.0.1')}:${pathWithoutForge()}`
+    const { deployContractWithLogging } = await import('./tronUtils')
+    const spy = deployerSpy()
+
+    expect(
+      deployContractWithLogging(spy.deployer, 'Executor', [], true)
+    ).rejects.toThrow(REFUSAL)
+    expect(spy.calls).toEqual([])
+  })
+
+  it('gets past the gate when the forge matches', async () => {
+    process.env.PATH = `${forgeStub(PINNED)}:${pathWithoutForge()}`
+    const { deployContractWithLogging } = await import('./tronUtils')
+    const spy = deployerSpy()
+
+    // Still a rejection - there is no artifact for that name - but for the later reason,
+    // which is what separates "the gate refused" from "the gate was not there".
+    expect(
+      deployContractWithLogging(
+        spy.deployer,
+        'NoSuchContractOnTheTronPath',
+        [],
+        true
+      )
+    ).rejects.toThrow(/Failed to load NoSuchContractOnTheTronPath artifact/)
+    expect(spy.calls).toEqual([])
+  })
+})
+
+describe('the placement at the deploy chokepoint', () => {
+  const originalPath = process.env.PATH
+
+  beforeEach(resetTronToolchainCache)
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  /**
+   * Drives `assertTronDeploymentRecordable`, which every Tron deploy site calls immediately
+   * before its `deployer.deployContract`. Driven in process rather than through the deploy
+   * CLIs: those import the demo-script helpers, which need generated typechain bindings that
+   * CI does not build, so a CLI spawn would fail at module load in CI and prove nothing.
+   *
+   * @param forgeVersion - Version the stubbed forge reports.
+   * @returns The error it threw, or undefined.
+   */
+  const driveChokepoint = async (
+    forgeVersion: string
+  ): Promise<Error | undefined> => {
+    process.env.PATH = `${forgeStub(forgeVersion)}:${pathWithoutForge()}`
+    const { assertTronDeploymentRecordable } = await import('./tronUtils')
+    try {
+      assertTronDeploymentRecordable(
+        { abi: [{ type: 'constructor', inputs: [] }] },
+        [],
+        'Executor',
+        'tron'
+      )
+      return undefined
+    } catch (error) {
+      return error as Error
+    }
+  }
+
+  it('refuses a drifted toolchain at the last step before a broadcast', async () => {
+    const error = await driveChokepoint('0.0.1')
+
+    expect(error?.message).toContain(REFUSAL)
+  })
+
+  it('lets a pinned toolchain through the same call', async () => {
+    // Paired with the case above: without this, a chokepoint that threw unconditionally
+    // would look correct.
+    const error = await driveChokepoint(PINNED)
+
+    expect(error).toBeUndefined()
+  })
+})
+
+describe('the gate is on the Tron seams a deployment cannot avoid', () => {
+  it('guards every deploy site, because each one asserts recordability first', () => {
+    // A counting invariant, paired with the executable proof above that the recordability
+    // assert refuses: if a new site called deployContract without it, the counts diverge.
+    const sources = [
+      'script/deploy/tron',
+      'script/deploy/tron/helpers',
+    ].flatMap((directory) =>
+      readdirSync(join(REPO_ROOT, directory))
+        .filter((entry) => entry.endsWith('.ts') && !entry.endsWith('.test.ts'))
+        .map((entry) => readFileSync(join(REPO_ROOT, directory, entry), 'utf8'))
+    )
+
+    const count = (needle: string): number =>
+      sources.reduce(
+        (total, source) => total + source.split(needle).length - 1,
+        0
+      )
+
+    expect(count('deployer.deployContract(')).toBeGreaterThan(0)
+    expect(count('assertTronDeploymentRecordable(')).toBeGreaterThanOrEqual(
+      count('deployer.deployContract(')
+    )
+  })
+
+  it('works from the contracts-tron checkout, which carries the same checker', () => {
+    // Tron cut proposals run from a fork checkout, so the gate resolves its checker against
+    // the working directory rather than against this repository.
+    const source = readFileSync(
+      join(REPO_ROOT, 'script/deploy/tron/assertTronToolchain.ts'),
+      'utf8'
+    )
+
+    expect(source).toContain('process.cwd()')
+    expect(existsSync(join(REPO_ROOT, FOUNDRY_VERSION_CHECKER))).toBe(true)
+  })
+})

--- a/script/deploy/tron/assertTronToolchain.ts
+++ b/script/deploy/tron/assertTronToolchain.ts
@@ -1,0 +1,104 @@
+/**
+ * Toolchain pre-flight for the Tron deploy path.
+ *
+ * Tron contracts are deployed from Forge artifacts that are built beforehand by a plain
+ * `forge build`, and the bytecode that reaches chain is whatever that build produced. The
+ * EVM deploy path refuses when the local forge does not match `.foundry-version`; nothing
+ * gated the Tron path, so a drifted forge could put bytecode on chain that no later rebuild
+ * reproduces.
+ *
+ * The comparison is delegated to the same `script/utils/verify-foundry-version.sh` the CI
+ * foundry setup and the bash deploy seam run, so there is one verdict rather than a second
+ * implementation of it. The checker is resolved relative to the working directory rather
+ * than to this file, so the `contracts-tron` checkout gates itself with its own pin.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** Path of the checker, relative to the repository root. */
+export const FOUNDRY_VERSION_CHECKER = 'script/utils/verify-foundry-version.sh'
+
+/** What running the checker produced. `status` is null when it could not be started. */
+export interface ICheckerResult {
+  status: number | null
+  output: string
+}
+
+/** Runs the checker at an absolute path. */
+export type TCheckerRunner = (checkerPath: string) => ICheckerResult
+
+/**
+ * Runs the real checker through bash.
+ *
+ * @param checkerPath - Absolute path of the checker script.
+ * @returns Its exit status and combined output.
+ */
+export const spawnFoundryVersionChecker: TCheckerRunner = (checkerPath) => {
+  const result = spawnSync('bash', [checkerPath, '--quiet'], {
+    encoding: 'utf8',
+    // Passed explicitly: bun's spawnSync snapshots the environment it was started with, so
+    // a child would not see the PATH the caller is actually running under.
+    env: { ...process.env },
+  })
+  return {
+    status: result.error ? null : result.status,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}${
+      result.error ? result.error.message : ''
+    }`.trim(),
+  }
+}
+
+/** Set once the checker has passed in this process, so N deployments cost one spawn. */
+let toolchainConfirmed = false
+
+/** Clears the per-process pass so the next call re-runs the checker. */
+export const resetTronToolchainCache = (): void => {
+  toolchainConfirmed = false
+}
+
+/**
+ * Refuses the Tron deploy path unless the local forge matches the checked-out
+ * `.foundry-version`.
+ *
+ * Only an exit status of 0 permits the deploy: a missing or unrunnable checker refuses too,
+ * because "we could not tell" and "it matches" must not share an outcome.
+ *
+ * @param options.repoRoot - Repository root to resolve the checker against. Defaults to the
+ * working directory, which is where these scripts are run from.
+ * @param options.run - Checker runner. Defaults to spawning the real checker.
+ * @param options.exists - Existence probe for the checker path.
+ * @throws When the toolchain cannot be confirmed to match the pin.
+ */
+export function assertTronToolchainOrThrow(options?: {
+  repoRoot?: string
+  run?: TCheckerRunner
+  exists?: (path: string) => boolean
+}): void {
+  if (toolchainConfirmed) return
+
+  const repoRoot = options?.repoRoot ?? process.cwd()
+  const run = options?.run ?? spawnFoundryVersionChecker
+  const exists = options?.exists ?? existsSync
+  const checkerPath = join(repoRoot, FOUNDRY_VERSION_CHECKER)
+
+  if (!exists(checkerPath))
+    throw new Error(
+      `Foundry version checker not found at ${checkerPath}, so the toolchain that built these artifacts cannot be confirmed. Refusing to deploy to Tron. Nothing has been broadcast.`
+    )
+
+  const { status, output } = run(checkerPath)
+
+  if (status !== 0)
+    throw new Error(
+      `Cannot confirm the local foundry matches ${join(
+        repoRoot,
+        '.foundry-version'
+      )}, so a rebuild would not reproduce this deployment. Refusing to deploy to Tron. Nothing has been broadcast.${
+        output ? `\n${output}` : ''
+      }`
+    )
+
+  toolchainConfirmed = true
+}

--- a/script/deploy/tron/assertTronToolchain.ts
+++ b/script/deploy/tron/assertTronToolchain.ts
@@ -7,6 +7,12 @@
  * gated the Tron path, so a drifted forge could put bytecode on chain that no later rebuild
  * reproduces.
  *
+ * This checks the forge that is about to run, not the one that built the artifacts on
+ * disk, and those can differ: build with a drifted forge, `foundryup` back to the pin, and
+ * the deploy passes over bytecode no rebuild reproduces. Closing that needs the compiler
+ * version read out of the artifact's own metadata; until then the guarantee is "the
+ * toolchain here is the pinned one", not "these artifacts were built with it".
+ *
  * The comparison is delegated to the same `script/utils/verify-foundry-version.sh` the CI
  * foundry setup and the bash deploy seam run, so there is one verdict rather than a second
  * implementation of it. The checker is resolved relative to the working directory rather
@@ -51,11 +57,13 @@ export const spawnFoundryVersionChecker: TCheckerRunner = (checkerPath) => {
 }
 
 /** Set once the checker has passed in this process, so N deployments cost one spawn. */
-let toolchainConfirmed = false
+// Keyed by the repo root it was confirmed for, not a bare flag: a pass for one checkout
+// must not authorise another, and the flag was read before the root was even resolved.
+const confirmedRoots = new Set<string>()
 
 /** Clears the per-process pass so the next call re-runs the checker. */
 export const resetTronToolchainCache = (): void => {
-  toolchainConfirmed = false
+  confirmedRoots.clear()
 }
 
 /**
@@ -76,9 +84,9 @@ export function assertTronToolchainOrThrow(options?: {
   run?: TCheckerRunner
   exists?: (path: string) => boolean
 }): void {
-  if (toolchainConfirmed) return
-
   const repoRoot = options?.repoRoot ?? process.cwd()
+  if (confirmedRoots.has(repoRoot)) return
+
   const run = options?.run ?? spawnFoundryVersionChecker
   const exists = options?.exists ?? existsSync
   const checkerPath = join(repoRoot, FOUNDRY_VERSION_CHECKER)
@@ -100,5 +108,5 @@ export function assertTronToolchainOrThrow(options?: {
       }`
     )
 
-  toolchainConfirmed = true
+  confirmedRoots.add(repoRoot)
 }

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -50,6 +50,7 @@ import {
   TRON_SAFE_PROXY_FACTORY_ABI,
   TRON_SAFE_SETUP_ABI,
 } from './constants.js'
+import { assertTronDeploymentRecordable } from './tronUtils.js'
 import type { ITronSafeTemp } from './types.js'
 
 function readTronSafeTemp(): ITronSafeTemp | null {
@@ -486,6 +487,12 @@ async function run(options: {
     // 1) Deploy Safe implementation (no constructor)
     if (!existingSingleton) {
       consola.info('Deploying Safe implementation...')
+      assertTronDeploymentRecordable(
+        safeArtifact,
+        [],
+        'SafeSingleton',
+        TRON_DEPLOY_NETWORK
+      )
       const safeResult = await deployer.deployContract(safeArtifact, [])
       singletonAddress = safeResult.contractAddress
       consola.success(`Safe implementation: ${singletonAddress}`)
@@ -502,6 +509,12 @@ async function run(options: {
     // 2) Deploy SafeProxyFactory(singleton)
     if (!existingFactory) {
       consola.info('Deploying SafeProxyFactory...')
+      assertTronDeploymentRecordable(
+        factoryArtifact,
+        [singletonAddress],
+        'SafeProxyFactory',
+        TRON_DEPLOY_NETWORK
+      )
       const factoryResult = await deployer.deployContract(factoryArtifact, [
         singletonAddress,
       ])

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -41,6 +41,7 @@ import { sleep } from '../../utils/delay'
 import { getEnvVar } from '../../utils/utils'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
+import { assertTronToolchainOrThrow } from './assertTronToolchain.js'
 import {
   CREATE_PROXY_SAFETY_MARGIN,
   TRON_DEPLOY_NETWORK,
@@ -50,7 +51,6 @@ import {
   TRON_SAFE_PROXY_FACTORY_ABI,
   TRON_SAFE_SETUP_ABI,
 } from './constants.js'
-import { assertTronDeploymentRecordable } from './tronUtils.js'
 import type { ITronSafeTemp } from './types.js'
 
 function readTronSafeTemp(): ITronSafeTemp | null {
@@ -487,12 +487,14 @@ async function run(options: {
     // 1) Deploy Safe implementation (no constructor)
     if (!existingSingleton) {
       consola.info('Deploying Safe implementation...')
-      assertTronDeploymentRecordable(
-        safeArtifact,
-        [],
-        'SafeSingleton',
-        TRON_DEPLOY_NETWORK
-      )
+      // The toolchain check, not `assertTronDeploymentRecordable`: these are
+      // third-party Safe artifacts built separately by `forge build -C
+      // safe/london` and never written to the deployment log, so recordability
+      // is not the applicable question — and that assert validates constructor
+      // args against the artifact ABI, which for the committed
+      // SafeProxyFactory build declares none while its source declares one. It
+      // refused every run, environment-independently.
+      assertTronToolchainOrThrow()
       const safeResult = await deployer.deployContract(safeArtifact, [])
       singletonAddress = safeResult.contractAddress
       consola.success(`Safe implementation: ${singletonAddress}`)
@@ -509,12 +511,7 @@ async function run(options: {
     // 2) Deploy SafeProxyFactory(singleton)
     if (!existingFactory) {
       consola.info('Deploying SafeProxyFactory...')
-      assertTronDeploymentRecordable(
-        factoryArtifact,
-        [singletonAddress],
-        'SafeProxyFactory',
-        TRON_DEPLOY_NETWORK
-      )
+      assertTronToolchainOrThrow()
       const factoryResult = await deployer.deployContract(factoryArtifact, [
         singletonAddress,
       ])

--- a/script/deploy/tron/tronUtils.ts
+++ b/script/deploy/tron/tronUtils.ts
@@ -42,6 +42,7 @@ import {
 import { getContractVersion } from '../shared/getContractVersion'
 import { isRateLimitError } from '../shared/rateLimit'
 
+import { assertTronToolchainOrThrow } from './assertTronToolchain'
 import { DIAMOND_CUT_ENERGY_MULTIPLIER } from './constants'
 import {
   assertRecordedArgsMatchAbi,
@@ -184,6 +185,11 @@ export async function deployContractWithLogging(
   network: SupportedChain = 'tron'
 ): Promise<IDeploymentResult> {
   try {
+    // Ahead of the artifact load so a drifted toolchain is reported as such, rather than as
+    // a stale or missing artifact. The same call also guards every deploy site from inside
+    // assertTronDeploymentRecordable; it runs the checker once per process either way.
+    assertTronToolchainOrThrow()
+
     const artifact = await loadForgeArtifact(contractName)
     const version = await getContractVersion(contractName)
 
@@ -249,19 +255,24 @@ const tronAbiEncoder =
     )
 
 /**
- * Checks that a deployment will be recordable, before anything is broadcast.
+ * Checks that a deployment will be recordable and that its artifact came from the pinned
+ * toolchain, before anything is broadcast.
  *
  * Call this immediately before deploying. Everything it checks is pure — the
  * artifact's ABI and the values — so failing here costs nothing, while the same
  * failure after `deployer.deployContract` leaves a contract on chain that
  * cannot be recorded, and TRX already spent.
  *
+ * The toolchain pre-flight lives here because every Tron deploy site calls this immediately
+ * before its `deployer.deployContract`, so a new deploy site cannot reach a chain without
+ * passing it. It costs one checker run per process, not one per contract.
+ *
  * @param artifact - The Forge artifact about to be deployed.
  * @param constructorArgs - Exactly the values the constructor will receive.
  * @param contractName - Named in every message.
  * @param network - Network whose codec will encode the values.
- * @throws When the ABI is unreadable, the arity disagrees, or the values cannot
- * be encoded.
+ * @throws When the local forge does not match the pin, the ABI is unreadable, the arity
+ * disagrees, or the values cannot be encoded.
  */
 export function assertTronDeploymentRecordable(
   artifact: { abi?: unknown },
@@ -269,6 +280,8 @@ export function assertTronDeploymentRecordable(
   contractName: string,
   network: SupportedChain
 ): void {
+  assertTronToolchainOrThrow()
+
   const types = constructorInputTypes(artifact?.abi, contractName)
   const encoded = encodeWithTypes(
     tronAbiEncoder(network),

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -16,34 +16,11 @@ NETWORKS_JSON_FILE_PATH="config/networks.json"
 GLOBAL_FILE_PATH="config/global.json"
 source script/universalCast.sh
 source script/deploy/shared/assertFoundryVersion.sh
+source script/utils/zkToolchainPins.sh
+source script/deploy/shared/assertZkToolchain.sh
 
 ZERO_ADDRESS=0x0000000000000000000000000000000000000000
 TRON_ZERO_ADDRESS_BASE58=T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb
-
-# getZkToolchainPin: Reads a version pin from the [external.zksync] section of foundry.toml.
-# Vanilla forge ignores [external.*] sections without warning, so the pins can live in
-# foundry.toml even though only our scripts consume them.
-#
-# Usage: getZkToolchainPin KEY
-#   KEY - Pin name, e.g. "zksolc" or "foundry_zksync"
-#
-# Returns: The pinned version string (empty if not found)
-# Example: getZkToolchainPin "zksolc"
-function getZkToolchainPin() {
-  local KEY="$1"
-  # default covers .env files that don't define FOUNDRY_TOML_FILE_PATH
-  local FOUNDRY_TOML="${FOUNDRY_TOML_FILE_PATH:-foundry.toml}"
-
-  if [[ ! -f "$FOUNDRY_TOML" ]]; then
-    return 1
-  fi
-
-  awk -v key="$KEY" '
-    /^\[external\.zksync\]/ { IN_SECTION = 1; next }
-    /^\[/ { IN_SECTION = 0 }
-    IN_SECTION && $1 == key && $2 == "=" { gsub(/["'\'']/, "", $3); print $3; exit }
-  ' "$FOUNDRY_TOML"
-}
 
 # zksolc version pin for foundry-zksync, defined in foundry.toml [external.zksync].
 # Passed to foundry-zksync via env because a real `zksync` key in any profile makes
@@ -2132,6 +2109,10 @@ function ensureStandardArtifactForSalt() {
 
   if checkIfFileExists "$ARTIFACT_PATH" >/dev/null; then
     return 0
+  fi
+
+  if ! assertFoundryVersionOrFail; then
+    return 1
   fi
 
   echo "[info] standard artifact $ARTIFACT_PATH not found - running 'forge build --skip test' to derive the deploy salt"
@@ -5219,12 +5200,11 @@ function executeAndParse() {
   local ON_ERROR_ACTION="${4:-return}"
 
   # Every deploy-path `forge script` is a COMMAND passed to this function, which is why a
-  # toolchain check lives in a generic executor. Direct `forge build` call sites do not
-  # pass through here; the EXSC-932 deploy entry points gate their own, and several others
-  # (scriptMaster.sh, deployGroupingHelpers.sh, deployContractToNetworks.sh,
-  # proposeContractToNetworks.sh) remain ungated. The result globals are reset because
-  # callers that ignore the status read the verdict out of them via handleForgeScriptError,
-  # where a previous call's success payload would read as a completed forge run.
+  # toolchain check lives in a generic executor. Direct `forge build` call sites do not pass
+  # through here and carry their own; zkEVM builds are gated in install_foundry_zksync. The
+  # result globals are reset because callers that ignore the status read the verdict out of
+  # them via handleForgeScriptError, where a previous call's success payload would read as a
+  # completed forge run.
   if ! assertFoundryVersionOrFail; then
     RAW_RETURN_DATA=""
     STDERR_CONTENT="refused: could not confirm the local foundry matches .foundry-version"
@@ -5632,7 +5612,7 @@ function updateDiamondLogs() {
   fi
 }
 
-# Function: install_foundry_zksync
+# Function: installFoundryZksyncBinary
 # Description: Downloads and installs the zkSync version of foundry tools (forge and cast).
 # Idempotent: returns immediately if the installed binary already matches the expected
 # version; on mismatch the binaries are removed and re-downloaded.
@@ -5649,7 +5629,7 @@ function updateDiamondLogs() {
 # Returns:
 #   0 - Success
 #   1 - Failure (with error message)
-install_foundry_zksync() {
+installFoundryZksyncBinary() {
   # env override takes precedence over the pin in foundry.toml [external.zksync]
   local EXPECTED_VERSION="${FOUNDRY_ZKSYNC_VERSION:-$(getZkToolchainPin "foundry_zksync")}"
   # Allow custom installation directory or use default
@@ -5796,6 +5776,19 @@ install_foundry_zksync() {
   echo "Installation completed successfully"
   echo "Binaries are executable and ready to use"
   return 0
+}
+
+# install_foundry_zksync: Installs the pinned foundry-zksync, then refuses unless the
+# toolchain that will compile matches the pins in foundry.toml [external.zksync].
+#
+# Every zkEVM build and every zkEVM forge script installs through here first, so the pin
+# check cannot be missed by a future caller the way a per-call-site check could.
+#
+# Arguments and env overrides: see installFoundryZksyncBinary.
+# Returns: 0 when the toolchain is installed and pinned, 1 otherwise.
+install_foundry_zksync() {
+  installFoundryZksyncBinary "$@" || return 1
+  assertZkToolchainOrFail "${1:-./foundry-zksync}" || return 1
 }
 
 # Function: getContractDeploymentStatusSummary

--- a/script/scriptMaster.sh
+++ b/script/scriptMaster.sh
@@ -43,6 +43,9 @@ scriptMaster() {
 
   # make sure that all compiled artifacts are current
   if [[ "$COMPILE_ON_STARTUP" == "true" ]]; then
+    if ! assertFoundryVersionOrFail; then
+      return 1
+    fi
     forge build
   fi
 
@@ -146,7 +149,10 @@ scriptMaster() {
       # Use zksync specific scripts
       DEPLOY_SCRIPT_DIRECTORY="script/deploy/zksync/"
       # Check if the foundry-zksync binaries exist, if not fetch them
-      install_foundry_zksync
+      if ! install_foundry_zksync; then
+        error "failed to install or verify foundry-zksync"
+        return 1
+      fi
       # get user-selected deploy script and contract from list
       SCRIPT=$(ls -1 "$DEPLOY_SCRIPT_DIRECTORY" | sed -e 's/\.zksync.s.sol$//' | grep 'Deploy' | gum filter --placeholder "Deploy Script")
     else

--- a/script/tasks/diamondUpdateFacet.sh
+++ b/script/tasks/diamondUpdateFacet.sh
@@ -139,7 +139,10 @@ diamondUpdateFacet() {
   if isZkEvmNetwork "$NETWORK"; then
     SCRIPT_PATH="script/deploy/zksync/$SCRIPT.zksync.s.sol"
     # Check if the foundry-zksync binaries exist, if not fetch them
-    install_foundry_zksync
+    if ! install_foundry_zksync; then
+      error "failed to install or verify foundry-zksync"
+      return 1
+    fi
   else
     SCRIPT_PATH=$DEPLOY_SCRIPT_DIRECTORY"$SCRIPT.s.sol"
   fi

--- a/script/utils/verify-zk-toolchain.sh
+++ b/script/utils/verify-zk-toolchain.sh
@@ -10,6 +10,15 @@
 # zksolc cannot be pinned through a foundry profile, so the only thing that pins it is the
 # FOUNDRY_ZKSYNC env var script/helperFunctions.sh exports. An unset var therefore means
 # zksolc falls back to whatever the binary defaults to, which is why that case fails here.
+#
+# What the two legs prove is not the same thing. The foundry-zksync leg is an observation:
+# it runs the installed binary and reads its version. The zksolc leg is not — it checks the
+# request, because FOUNDRY_ZKSYNC is built from this same foundry.toml line by
+# helperFunctions.sh, so on the deploy path it compares the pin against itself. It catches a
+# hand-set or unset value in a shell a human drives (docs/DiamondCutRecomputation.md tells
+# the reader to run ./foundry-zksync/forge directly), and it cannot catch foundry-zksync
+# resolving the pinned zksolc to something else. Reading the compiler out of zkout/ metadata
+# after the build is what would make that leg an observation too.
 set -euo pipefail
 
 GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -73,7 +82,10 @@ if [ -z "${FOUNDRY_ZKSYNC:-}" ]; then
   exit 1
 fi
 
-if [[ "${FOUNDRY_ZKSYNC}" != *"$ZKSOLC_PIN"* ]]; then
+# Anchored on the closing quote of the value helperFunctions.sh exports
+# (`{ zksolc = "X.Y.Z" }`). A bare substring test passes pin 1.5.15 against a 1.5.155
+# toolchain — a false green in the one check that decides the compiler is the pinned one.
+if [[ "${FOUNDRY_ZKSYNC}" != *"\"$ZKSOLC_PIN\""* ]]; then
   printf '\033[31m✗ FOUNDRY_ZKSYNC does not name the pinned zksolc\033[0m\n' >&2
   printf '   pinned:   %s\n' "$ZKSOLC_PIN" >&2
   printf '   actual:   %s\n' "${FOUNDRY_ZKSYNC}" >&2
@@ -105,5 +117,8 @@ if [ "$ZK_FOUNDRY_ACTUAL" != "$ZK_FOUNDRY_PIN" ]; then
 fi
 
 if [ "$QUIET" != "true" ]; then
-  printf '\033[32m✓ foundry-zksync %s, zksolc %s\033[0m\n' "$ZK_FOUNDRY_ACTUAL" "$ZKSOLC_PIN"
+  # foundry-zksync is what the binary reported; zksolc is what was requested of it. The
+  # labels are the difference between the two legs, so the line cannot be read as having
+  # observed a compiler nothing here runs.
+  printf '\033[32m✓ foundry-zksync %s observed, zksolc %s requested\033[0m\n' "$ZK_FOUNDRY_ACTUAL" "$ZKSOLC_PIN"
 fi

--- a/script/utils/verify-zk-toolchain.sh
+++ b/script/utils/verify-zk-toolchain.sh
@@ -82,13 +82,26 @@ if [ -z "${FOUNDRY_ZKSYNC:-}" ]; then
   exit 1
 fi
 
-# Anchored on the closing quote of the value helperFunctions.sh exports
-# (`{ zksolc = "X.Y.Z" }`). A bare substring test passes pin 1.5.15 against a 1.5.155
-# toolchain — a false green in the one check that decides the compiler is the pinned one.
-if [[ "${FOUNDRY_ZKSYNC}" != *"\"$ZKSOLC_PIN\""* ]]; then
+# Parsed, not searched. A substring test passed pin 1.5.15 against a 1.5.155 toolchain, and
+# anchoring on the value's quotes still accepted the pin appearing anywhere in the string —
+# `{ zksolc = "9.9.9", other = "1.5.15" }` read as pinned. This leg exists to catch a value a
+# human set by hand (docs/DiamondCutRecomputation.md tells the reader to drive the zk forge
+# directly), which is exactly where a decorated value comes from.
+ZKSOLC_KEYS="$(printf '%s' "${FOUNDRY_ZKSYNC}" | grep -o 'zksolc[[:space:]]*=' | wc -l | tr -d ' ')"
+if [ "$ZKSOLC_KEYS" != "1" ]; then
+  printf '\033[31m✗ FOUNDRY_ZKSYNC does not carry exactly one zksolc key\033[0m\n' >&2
+  printf '   found:    %s\n' "$ZKSOLC_KEYS" >&2
+  printf '   actual:   %s\n' "${FOUNDRY_ZKSYNC}" >&2
+  printf '   fix:      unset FOUNDRY_ZKSYNC and source script/helperFunctions.sh\n' >&2
+  exit 1
+fi
+
+ZKSOLC_ACTUAL="$(printf '%s' "${FOUNDRY_ZKSYNC}" | sed -n 's/.*zksolc[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p')"
+if [ "$ZKSOLC_ACTUAL" != "$ZKSOLC_PIN" ]; then
   printf '\033[31m✗ FOUNDRY_ZKSYNC does not name the pinned zksolc\033[0m\n' >&2
   printf '   pinned:   %s\n' "$ZKSOLC_PIN" >&2
-  printf '   actual:   %s\n' "${FOUNDRY_ZKSYNC}" >&2
+  printf '   actual:   %s\n' "${ZKSOLC_ACTUAL:-<unparseable>}" >&2
+  printf '   from:     %s\n' "${FOUNDRY_ZKSYNC}" >&2
   exit 1
 fi
 
@@ -120,5 +133,5 @@ if [ "$QUIET" != "true" ]; then
   # foundry-zksync is what the binary reported; zksolc is what was requested of it. The
   # labels are the difference between the two legs, so the line cannot be read as having
   # observed a compiler nothing here runs.
-  printf '\033[32m✓ foundry-zksync %s observed, zksolc %s requested\033[0m\n' "$ZK_FOUNDRY_ACTUAL" "$ZKSOLC_PIN"
+  printf '\033[32m✓ foundry-zksync %s observed, zksolc %s requested\033[0m\n' "$ZK_FOUNDRY_ACTUAL" "$ZKSOLC_ACTUAL"
 fi

--- a/script/utils/verify-zk-toolchain.sh
+++ b/script/utils/verify-zk-toolchain.sh
@@ -84,10 +84,11 @@ fi
 
 # Parsed, not searched. A substring test passed pin 1.5.15 against a 1.5.155 toolchain, and
 # anchoring on the value's quotes still accepted the pin appearing anywhere in the string —
-# `{ zksolc = "9.9.9", other = "1.5.15" }` read as pinned. This leg exists to catch a value a
+# `{ zksolc = "9.9.9", other = "1.5.15" }` read as pinned. The key itself is token-bounded:
+# `{ notzksolc = "<pin>" }` is not a zksolc request. This leg exists to catch a value a
 # human set by hand (docs/DiamondCutRecomputation.md tells the reader to drive the zk forge
 # directly), which is exactly where a decorated value comes from.
-ZKSOLC_KEYS="$(printf '%s' "${FOUNDRY_ZKSYNC}" | grep -o 'zksolc[[:space:]]*=' | wc -l | tr -d ' ')"
+ZKSOLC_KEYS="$(printf '%s' "${FOUNDRY_ZKSYNC}" | grep -oE '(^|[^[:alnum:]_])zksolc[[:space:]]*=' | wc -l | tr -d ' ')" || true
 if [ "$ZKSOLC_KEYS" != "1" ]; then
   printf '\033[31m✗ FOUNDRY_ZKSYNC does not carry exactly one zksolc key\033[0m\n' >&2
   printf '   found:    %s\n' "$ZKSOLC_KEYS" >&2
@@ -96,7 +97,11 @@ if [ "$ZKSOLC_KEYS" != "1" ]; then
   exit 1
 fi
 
-ZKSOLC_ACTUAL="$(printf '%s' "${FOUNDRY_ZKSYNC}" | sed -n 's/.*zksolc[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p')"
+ZKSOLC_KEY_RE='(^|[^[:alnum:]_])zksolc[[:space:]]*=[[:space:]]*"([^"]*)"'
+ZKSOLC_ACTUAL=""
+if [[ "${FOUNDRY_ZKSYNC}" =~ $ZKSOLC_KEY_RE ]]; then
+  ZKSOLC_ACTUAL="${BASH_REMATCH[2]}"
+fi
 if [ "$ZKSOLC_ACTUAL" != "$ZKSOLC_PIN" ]; then
   printf '\033[31m✗ FOUNDRY_ZKSYNC does not name the pinned zksolc\033[0m\n' >&2
   printf '   pinned:   %s\n' "$ZKSOLC_PIN" >&2

--- a/script/utils/verify-zk-toolchain.sh
+++ b/script/utils/verify-zk-toolchain.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Verify that the zkEVM toolchain about to compile matches the pins committed in
+# foundry.toml [external.zksync]: the foundry-zksync binary release and the zksolc
+# version it drives. Exits 0 on a full match, 1 otherwise.
+#
+# Usage: verify-zk-toolchain.sh [--quiet] [--dir INSTALL_DIR]
+#   --quiet          suppress the success line
+#   --dir            foundry-zksync install directory (default: ./foundry-zksync)
+#
+# zksolc cannot be pinned through a foundry profile, so the only thing that pins it is the
+# FOUNDRY_ZKSYNC env var script/helperFunctions.sh exports. An unset var therefore means
+# zksolc falls back to whatever the binary defaults to, which is why that case fails here.
+set -euo pipefail
+
+GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$GIT_ROOT"
+
+QUIET="false"
+INSTALL_DIR="./foundry-zksync"
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --quiet)
+    QUIET="true"
+    shift
+    ;;
+  --dir)
+    if [ $# -lt 2 ]; then
+      printf '\033[31m✗ --dir needs a value\033[0m\n' >&2
+      exit 1
+    fi
+    INSTALL_DIR="$2"
+    shift 2
+    ;;
+  *)
+    printf '\033[31m✗ unknown argument: %s\033[0m\n' "$1" >&2
+    exit 1
+    ;;
+  esac
+done
+
+PIN_READER="$GIT_ROOT/script/utils/zkToolchainPins.sh"
+if [ ! -f "$PIN_READER" ]; then
+  printf '\033[31m✗ %s not found\033[0m\n' "$PIN_READER" >&2
+  exit 1
+fi
+# shellcheck source=script/utils/zkToolchainPins.sh
+source "$PIN_READER"
+
+ZKSOLC_PIN="$(getZkToolchainPin zksolc || true)"
+ZK_FOUNDRY_PIN="$(getZkToolchainPin foundry_zksync || true)"
+
+if [ -z "$ZKSOLC_PIN" ] || [ -z "$ZK_FOUNDRY_PIN" ]; then
+  printf '\033[31m✗ zk toolchain pins missing from foundry.toml [external.zksync]\033[0m\n' >&2
+  printf '   zksolc:          %s\n' "${ZKSOLC_PIN:-<empty>}" >&2
+  printf '   foundry_zksync:  %s\n' "${ZK_FOUNDRY_PIN:-<empty>}" >&2
+  exit 1
+fi
+
+# The override exists so a new release can be tried out; on a build whose bytecode has to
+# reproduce later, taking it would silently detach the artifact from the committed pin.
+if [ -n "${FOUNDRY_ZKSYNC_VERSION:-}" ] && [ "${FOUNDRY_ZKSYNC_VERSION}" != "$ZK_FOUNDRY_PIN" ]; then
+  printf '\033[31m✗ FOUNDRY_ZKSYNC_VERSION overrides the committed foundry-zksync pin\033[0m\n' >&2
+  printf '   pinned:   %s\n' "$ZK_FOUNDRY_PIN" >&2
+  printf '   override: %s\n' "${FOUNDRY_ZKSYNC_VERSION}" >&2
+  printf '   fix:      unset FOUNDRY_ZKSYNC_VERSION, or change the pin in foundry.toml\n' >&2
+  exit 1
+fi
+
+if [ -z "${FOUNDRY_ZKSYNC:-}" ]; then
+  printf '\033[31m✗ FOUNDRY_ZKSYNC is not set, so zksolc is unpinned\033[0m\n' >&2
+  printf '   expected it to carry zksolc %s\n' "$ZKSOLC_PIN" >&2
+  printf '   fix:      source script/helperFunctions.sh before building\n' >&2
+  exit 1
+fi
+
+if [[ "${FOUNDRY_ZKSYNC}" != *"$ZKSOLC_PIN"* ]]; then
+  printf '\033[31m✗ FOUNDRY_ZKSYNC does not name the pinned zksolc\033[0m\n' >&2
+  printf '   pinned:   %s\n' "$ZKSOLC_PIN" >&2
+  printf '   actual:   %s\n' "${FOUNDRY_ZKSYNC}" >&2
+  exit 1
+fi
+
+if [ ! -x "${INSTALL_DIR}/forge" ]; then
+  printf '\033[31m✗ no executable foundry-zksync forge at %s/forge\033[0m\n' "$INSTALL_DIR" >&2
+  printf '   fix:      install_foundry_zksync (script/helperFunctions.sh)\n' >&2
+  exit 1
+fi
+
+# Same shape install_foundry_zksync compares against, covering both the vX.Y.Z and the
+# nightly-<sha> release tags.
+ZK_FOUNDRY_ACTUAL="$("${INSTALL_DIR}/forge" --version 2>/dev/null | grep -oE 'foundry-zksync-[^[:space:]]+' | sed 's/^foundry-zksync-//' | head -1 || true)"
+
+if [ -z "$ZK_FOUNDRY_ACTUAL" ]; then
+  # shellcheck disable=SC2016 # the backticks quote a command name for the reader, not a substitution
+  printf '\033[31m✗ could not parse the foundry-zksync version from `%s/forge --version`\033[0m\n' "$INSTALL_DIR" >&2
+  exit 1
+fi
+
+if [ "$ZK_FOUNDRY_ACTUAL" != "$ZK_FOUNDRY_PIN" ]; then
+  printf '\033[31m✗ foundry-zksync version mismatch\033[0m\n' >&2
+  printf '   expected: %s\n' "$ZK_FOUNDRY_PIN" >&2
+  printf '   actual:   %s\n' "$ZK_FOUNDRY_ACTUAL" >&2
+  printf '   fix:      install_foundry_zksync (script/helperFunctions.sh)\n' >&2
+  exit 1
+fi
+
+if [ "$QUIET" != "true" ]; then
+  printf '\033[32m✓ foundry-zksync %s, zksolc %s\033[0m\n' "$ZK_FOUNDRY_ACTUAL" "$ZKSOLC_PIN"
+fi

--- a/script/utils/zkToolchainPins.sh
+++ b/script/utils/zkToolchainPins.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# getZkToolchainPin: Reads a version pin from the [external.zksync] section of foundry.toml.
+# Vanilla forge ignores [external.*] sections without warning, so the pins can live in
+# foundry.toml even though only our scripts consume them.
+#
+# Usage: getZkToolchainPin KEY
+#   KEY - Pin name, e.g. "zksolc" or "foundry_zksync"
+#
+# Returns: The pinned version string (empty if not found)
+# Example: getZkToolchainPin "zksolc"
+function getZkToolchainPin() {
+  local KEY="$1"
+  # default covers .env files that don't define FOUNDRY_TOML_FILE_PATH
+  local FOUNDRY_TOML="${FOUNDRY_TOML_FILE_PATH:-foundry.toml}"
+
+  if [[ ! -f "$FOUNDRY_TOML" ]]; then
+    return 1
+  fi
+
+  awk -v key="$KEY" '
+    /^\[external\.zksync\]/ { IN_SECTION = 1; next }
+    /^\[/ { IN_SECTION = 0 }
+    IN_SECTION && $1 == key && $2 == "=" { gsub(/["'\'']/, "", $3); print $3; exit }
+  ' "$FOUNDRY_TOML"
+}


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-933](https://linear.app/lifi-linear/issue/EXSC-933/toolchain-gate-residuals-zk-pin-ungated-forge-build-sites-tron-deploy) — the named residual of EXSC-932 / #2325.

# Why did I implement it this way?

#2325 gated the EVM toolchain at `executeAndParse`, the seam every `forge script` passes
through. Four build paths do not pass through it. This closes them.

**zkEVM (a).** `foundry.toml [external.zksync]` already pins both `foundry_zksync` and
`zksolc`, but nothing enforced them where a deploy can see it, and the one mechanism that
pins zksolc at all — the `FOUNDRY_ZKSYNC` env var `helperFunctions.sh` exports — was
exported conditionally, so a lost pin silently fell back to the toolchain's default
compiler. `FOUNDRY_ZKSYNC_VERSION` also overrode the committed release with no trace: the
installer compares the binary against the *override*, so an override plus a matching binary
read as a clean install.

New `script/utils/verify-zk-toolchain.sh` is the single verdict, and
`assertZkToolchainOrFail` (`script/deploy/shared/assertZkToolchain.sh`) is the bash seam
that delegates to it and fails closed when it cannot run — the same shape as
`assertFoundryVersion.sh`.

It is wired **inside** `install_foundry_zksync` rather than beside each build. Every one of
the six scripts that reaches for `./foundry-zksync/forge` installs through that function
first, so the check cannot be missed by a future caller. The existing body was renamed to
`installFoundryZksyncBinary` and `install_foundry_zksync` is now install-then-verify, so no
call site changed. Two of those call sites — `scriptMaster.sh` and `diamondUpdateFacet.sh` —
called it bare and discarded its status; they now abort on it.

**Ungated `forge build` sites (b).** Measured rather than taken from the ticket: three of
the five reported lines were the zk builds now covered by (a), and two more were unreported.
Gated with `assertFoundryVersionOrFail`: `scriptMaster.sh`'s startup compile,
`updateFoundryTomlForGroup` (ahead of the `sed`, so a refusal cannot leave `foundry.toml`
rewritten for a group whose build never ran), and `ensureStandardArtifactForSalt`.
`deployAndStoreCREATE3Factory.sh`'s fallback build is deliberately **not** given a second
gate: it is only reachable when the preceding `executeAndParse` left a chain-unsupported
message in `STDERR_CONTENT`, and the seam's refusal replaces that message, so a refused run
cannot enter the branch. There is a test asserting exactly that, rather than a comment
claiming it.

**Tron (c).** The ticket's premise is half stale: `assertTronDeploymentRecordable` already
exists, so recordability is covered. The toolchain was not. Tron deploys pre-built Forge
artifacts through `loadForgeArtifact`, so the bytecode that reaches chain is whatever the
operator's last `forge build` produced. `assertTronToolchainOrThrow` delegates to the *same*
`verify-foundry-version.sh` and sits inside `assertTronDeploymentRecordable`, which every
Tron deploy site already calls immediately before its `deployer.deployContract` — so a new
deploy site cannot reach a chain without passing it. The shared `deployContractWithLogging`
seam also calls it ahead of the artifact load, so a drifted toolchain is reported as such
rather than as a stale artifact; it is the same memoized call, one checker run per process.

It resolves the checker against the working directory, not against this file, so the
`contracts-tron` checkout gates itself with its own pin — verified against that checkout at
`ca21417ad`, which carries both `.foundry-version` and the checker.

## Known follow-ups (not this PR)

- **zksolc is still ceremonial.** This gate compares the `foundry.toml` pin to the env the installer just exported, not the compiler that wrote `zkout/`. A later PR should read artifact metadata.
- **Tron checks the live `forge`, not the artifact's compiler.** Building with a drifted forge, then `foundryup` back to the pin, still deploys. Same class as the zksolc gap.
- **Production Tron cuts run from `contracts-tron`.** This file is not there yet; schedule the sync. The working-directory resolution above is why that checkout can gate itself once the pin and checker land.

**Smoke-test filter (d).** Confirmed: the filter listed `script/deploy/**`,
`script/utils/**`, `script/tasks/**` and `script/resources/**` but not
`script/helperFunctions.sh` — the chokepoint every deploy passes through — nor
`script/scriptMaster.sh`. Added `script/*.sh`, which covers both and the other three
top-level shell files the pipeline sources.

## How the placement is proven

Not by classifying shell text — that was wrong four times on #2325. The zk gate's placement
is proven by running `script/deploy/deployContractToNetworks.sh Executor abstract` for real
inside a throwaway tree whose `./foundry-zksync/forge` records every argv it is handed.
With a diverging override the installer prints `Version matches expected v9.9.9` (so the
pre-existing check is satisfied and, without this gate, the run proceeds), the gate refuses,
and **no `build --zksync` appears in the argv log** — paired with a present-assertion that
the run did reach the installer, so a run that stopped earlier cannot pass the same case.
With the toolchain pinned, the identical drive is silent and the zk build does run.

`diamondUpdateFacet`, `updateFoundryTomlForGroup`, `ensureStandardArtifactForSalt`,
`scriptMaster`, `deployContractWithLogging` and `assertTronDeploymentRecordable` are each
driven the same way, every refusal paired with its benign counterpart. The Tron deploy CLIs
are driven at that chokepoint rather than spawned: they import the demo-script helpers,
which need generated typechain bindings CI does not build, so a CLI spawn fails at module
load in CI and would prove nothing — a first draft did exactly that and the no-`.env`
no-`forge` re-run is what caught it. Nothing reaches a chain: every
binary that could — `forge`, `cast`, `bun`, `curl`, `wget` — is a stub, and the tree's
`deployments/` is a copy so a drive cannot write a record into the checkout.

**21 mutations, all killed**, each by a named test: seven on the checker's individual
verdicts, two on the seam's fail-closed paths, six on the gate placements, one on the smoke
filter, and five on the Tron gate.

One real defect the mutation round surfaced in my own code: `bun`'s `spawnSync` snapshots
the environment it was started with, so a mutated `process.env.PATH` did not reach the
child and the Tron gate passed with no `forge` installed at all. `env` is now passed
explicitly.

## Checks

`bun test`: 2625 pass / 0 fail (2582 baseline), also green with no `.env`, no `typechain/`
and no `forge` on `PATH`. `bunx tsc --noEmit`: no new errors. eslint clean, `lint:md:fix`
0 errors.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

