### PR TITLE
feat(deploy): bound the deployer key's power to a documented inventory (EXSC-878)

### DIFF
--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -43,6 +43,39 @@ Status: **current state**, verified against the repo. Author: Daniel B. (SC).
 | Executor (Safe leg) | Any owner may execute once the threshold is met, but in practice the **deployer wallet** broadcasts: it is the only owner funded on every chain, whereas the signer hardware wallets are not | The "…With Deployer" execute variants inside `bun confirm-safe-tx`, which broadcast with `PRIVATE_KEY_PRODUCTION` |
 | Executor (timelock leg) | The **"Timelock Auto Execution" GitHub cron** (`.github/workflows/runPendingTimelockTXs.yml`), every 10 minutes, gated on repo var `ENABLE_TIMELOCK_AUTO_EXECUTION` | `script/deploy/safe/execute-pending-timelock-tx.ts --executeAll`, signing with `TIMELOCK_EXECUTOR_PRIVATE_KEY` — a pure gas-payer EOA with no protocol authority (`EXECUTOR_ROLE` is open). Manual fallback: `bun execute-timelock` |
 
+### 2.1 What the deployer key can do
+
+The deployer wallet (`config/global.json` `deployerWallet`, key
+`PRIVATE_KEY_PRODUCTION`) is the only key that appears at every stage: it
+deploys, writes the deployment record, creates the proposal, holds one of the
+Safe owner slots, and holds `CANCELLER_ROLE` on every timelock. Its power is
+nevertheless bounded to **DoS and griefing** on production mainnets — it cannot
+schedule or push a bad operation, because both need the Safe threshold, and it
+holds one signature of `SAFE_THRESHOLD` (`script/deploy/shared/constants.ts`).
+
+`bun deployer-key-power` prints the full inventory and refuses if the config
+grants the wallet anything outside the documented set. The check walks the whole
+of `config/global.json` and `config/networks.json` rather than a list of known
+field names, so a newly added field pointing at the deployer is caught too, and
+it runs in `bun test:ts` (whose path filter includes `config/**`).
+
+Two scoped exceptions are part of the inventory rather than hidden by it. On
+**testnet and staging** the deployer owns the diamond outright — those networks
+have no Safe or timelock — so the bound above is a production-mainnet claim.
+And during **production bring-up** the deployer owns the diamond between
+`transferOwnership(timelock)` and the Safe-executed `confirmOwnershipTransfer()`;
+a network left in that state is reported unhealthy by the `diamond-owner`
+invariant.
+
+Timelock execution is **not** a deployer power today: `EXECUTOR_ROLE` is granted
+to `address(0)`, so execution is permissionless. It becomes one when the F7
+executor restriction lands (EXSC-872), and the inventory carries it as `pending`
+until then.
+
+The Tron and EVM deployer identities are the same key
+(`tronWallets.deployerWallet` decodes to `deployerWallet`), so there is one
+deployer key, not two.
+
 ## 3. Architecture
 
 Two MongoDB clusters with different trust profiles:

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -78,7 +78,10 @@ This is not bring-up-only. What bounds it is **detection**, not prevention: the
 directions, so an owner the config does not declare is reported (PR #2337,
 EXSC-943). The inventory carries the power in
 `ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS`, and an integrity power that no
-disclosure names a detection for refuses.
+disclosure names a detection for refuses. An empty map is the target state:
+detection is weaker than removal, so each entry also names the work that retires
+it — here EXSC-944, which defaults `allowOverride` to `false` and refuses a
+production threshold below `SAFE_THRESHOLD`.
 
 Two further scoped exceptions are part of the inventory rather than hidden by it.
 On **testnets** the deployer owns the diamond outright, in every environment —

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -48,24 +48,49 @@ Status: **current state**, verified against the repo. Author: Daniel B. (SC).
 The deployer wallet (`config/global.json` `deployerWallet`, key
 `PRIVATE_KEY_PRODUCTION`) is the only key that appears at every stage: it
 deploys, writes the deployment record, creates the proposal, holds one of the
-Safe owner slots, and holds `CANCELLER_ROLE` on every timelock. Its power is
-nevertheless bounded to **DoS and griefing** on production mainnets — it cannot
-schedule or push a bad operation, because both need the Safe threshold, and it
-holds one signature of `SAFE_THRESHOLD` (`script/deploy/shared/constants.ts`).
+Safe owner slots, and holds `CANCELLER_ROLE` on every timelock. Against an
+**already-deployed** governance Safe its power is bounded to **DoS and
+griefing** — it cannot schedule or push a bad operation, because both need the
+Safe threshold, and it holds one signature of `SAFE_THRESHOLD`
+(`script/deploy/shared/constants.ts`). Deploying the Safe itself is the one
+exception, below.
 
 `bun deployer-key-power` prints the full inventory and refuses if the config
 grants the wallet anything outside the documented set. The check walks the whole
 of `config/global.json` and `config/networks.json` rather than a list of known
-field names, so a newly added field pointing at the deployer is caught too, and
-it runs in `bun test:ts` (whose path filter includes `config/**`).
+field names — matching addresses used as values and as object keys, and the
+`41`-prefixed TronWeb hex form as well as the EVM hex form — so a newly added
+field pointing at the deployer is caught too, and it runs in `bun test:ts`
+(whose path filter includes `config/**`).
 
-Two scoped exceptions are part of the inventory rather than hidden by it. On
-**testnet and staging** the deployer owns the diamond outright — those networks
-have no Safe or timelock — so the bound above is a production-mainnet claim.
-And during **production bring-up** the deployer owns the diamond between
-`transferOwnership(timelock)` and the Safe-executed `confirmOwnershipTransfer()`;
-a network left in that state is reported unhealthy by the `diamond-owner`
-invariant.
+One production-mainnet **integrity** power is disclosed rather than bounded away:
+the deployer can deploy the governance Safe and choose its owner set and
+threshold. `script/deploy/safe/deploy-safe.ts` unions `--owners` into
+`globalConfig.safeOwners`, accepts any `--threshold` of 1 or more, defaults
+`allowOverride` to `true` so the "Safe already deployed on …" guard does not fire
+without a flag, signs with `PRIVATE_KEY_PRODUCTION`, and rewrites
+`config/networks.json` with the resulting `safeAddress`. Its own on-chain
+verification compares `getOwners()` and `getThreshold()` against the same
+expanded arguments it was handed, so it confirms "deployed as asked", not "as
+configured". `script/deploy/tron/deploy-safe-tron.ts` is the Tron equivalent.
+This is not bring-up-only. What bounds it is **detection**, not prevention: the
+`safe-config` health-check invariant asserts the Safe owner set in both
+directions, so an owner the config does not declare is reported (PR #2337,
+EXSC-943). The inventory carries the power in
+`ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS`, and an integrity power that no
+disclosure names a detection for refuses.
+
+Two further scoped exceptions are part of the inventory rather than hidden by it.
+On **testnets** the deployer owns the diamond outright, in every environment —
+those networks have no Safe or timelock. Staging on a mainnet network is a
+different key, not a deployer power: `getPrivateKey` in
+`script/helperFunctions.sh` returns `PRIVATE_KEY` for a staging environment, and
+`script/deploy/healthCheck.ts` resolves `ctx.deployerWallet` to
+`globalConfig.devWallet` there; the `diamond-owner` invariant skips staging
+entirely. And during **production bring-up** the deployer owns the diamond
+between `transferOwnership(timelock)` and the Safe-executed
+`confirmOwnershipTransfer()`; a network left in that state is reported unhealthy
+by the `diamond-owner` invariant.
 
 Timelock execution is **not** a deployer power today: `EXECUTOR_ROLE` is granted
 to `address(0)`, so execution is permissionless. It becomes one when the F7

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "safe:tunnel": "bash script/deploy/safe/with-safe-tunnel.sh",
     "deploy-safe": "bunx tsx ./script/deploy/safe/deploy-safe.ts",
     "coverage": "rm -rf coverage && rm -f lcov-filtered.info && rm -f lcov.info && forge coverage --report lcov --evm-version 'cancun' --ir-minimum && bun script/utils/filter_lcov.ts lcov.info lcov-filtered.info 'test/' 'script/' && genhtml lcov-filtered.info --ignore-errors inconsistent,corrupt --branch-coverage --output-dir coverage && open coverage/index.html",
+    "deployer-key-power": "bunx tsx ./script/deploy/deployer-key-power.ts",
     "detect-evm-version": "bunx tsx ./script/deploy/detect-evm-version.ts",
     "execute": "node ./_scripts.js run",
     "execute-timelock": "bash script/deploy/safe/with-safe-tunnel.sh && bun typechain && bunx tsx ./script/deploy/safe/execute-pending-timelock-tx.ts",

--- a/script/deploy/deployer-key-power.test.ts
+++ b/script/deploy/deployer-key-power.test.ts
@@ -14,6 +14,7 @@ import globalConfig from '../../config/global.json'
 import networksConfig from '../../config/networks.json'
 
 import {
+  ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS,
   assertDeployerKeyPowerBounded,
   DEPLOYER_KEY_POWERS,
   DOCUMENTED_DEPLOYER_CONFIG_SLOTS,
@@ -116,7 +117,7 @@ describe('deployer key power — a widened config refuses', () => {
     widened.safeOwners.push(globalConfig.deployerWallet)
     expectRefusal(
       () => assertDeployerKeyPowerBounded(widened, networksConfig),
-      /occupies 2 safeOwners slots, expected exactly 1/
+      /occupies 2 safeOwners slots, expected at most 1/
     )
   })
 
@@ -173,11 +174,15 @@ describe('deployer key power — the integrity bound', () => {
     )
   })
 
-  it('accepts the shipped inventory, whose integrity powers are all out of production steady state', () => {
+  it('accepts the shipped inventory, whose integrity powers are either out of production steady state or disclosed', () => {
     const integrity = DEPLOYER_KEY_POWERS.filter((p) => p.class === 'integrity')
     expect(integrity.length).toBeGreaterThan(0)
     for (const power of integrity)
-      expect(power.scope).not.toBe('production-mainnet')
+      if (power.scope === 'production-mainnet' && power.status === 'current')
+        expect(
+          ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.get(power.id)
+        ).toBeTruthy()
+    expect(integrity.some((p) => p.scope !== 'production-mainnet')).toBe(true)
     expect(() =>
       assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
         powers: DEPLOYER_KEY_POWERS,
@@ -191,5 +196,131 @@ describe('deployer key power — the F7 executor row', () => {
     const pending = DEPLOYER_KEY_POWERS.filter((p) => p.status === 'pending')
     expect(pending.map((p) => p.id)).toEqual(['timelock-execute'])
     expect(pending[0]?.note).toMatch(/EXSC-872/)
+  })
+})
+
+describe('deployer key power — the two config files are both required', () => {
+  for (const [label, networks] of [
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty object', {}],
+  ] as const)
+    it(`refuses ${label} as config/networks.json rather than walking one file`, () => {
+      expectRefusal(
+        () => assertDeployerKeyPowerBounded(globalConfig, networks),
+        /networks config must be a non-empty object/
+      )
+    })
+
+  it('refuses a global config that declares no deployerWallet, even with the Tron identity present', () => {
+    const stripped = clone(globalConfig) as Record<string, unknown>
+    delete stripped.deployerWallet
+    expect(
+      (stripped.tronWallets as Record<string, string>).deployerWallet
+    ).toBeTruthy()
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(stripped, networksConfig),
+      /config\/global\.json declares no deployerWallet/
+    )
+  })
+})
+
+describe('deployer key power — identity forms the walk resolves', () => {
+  const body = globalConfig.deployerWallet.slice(2)
+
+  for (const [label, form] of [
+    ['the TronWeb 41-prefixed hex form', `41${body}`],
+    ['the 0x41-prefixed hex form', `0x41${body}`],
+  ] as const)
+    it(`refuses ${label} pasted into another Tron slot`, () => {
+      const widened = clone(globalConfig)
+      widened.tronWallets.pauserWallet = form
+      expectRefusal(
+        () => assertDeployerKeyPowerBounded(widened, networksConfig),
+        /undocumented grant: global\.json:tronWallets\.pauserWallet/
+      )
+    })
+
+  it('refuses the deployer used as an object key, the shape a grant table takes', () => {
+    const widened = clone(globalConfig) as Record<string, unknown>
+    widened.roleGrants = { [globalConfig.deployerWallet]: 'CANCELLER_ROLE' }
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /undocumented grant: global\.json:roleGrants\./
+    )
+  })
+
+  it('does not match the base58 Tron form of the EVM identity, the disclosed residual', () => {
+    const slots = findDeployerConfigSlots(globalConfig, networksConfig)
+    expect(slots.map((s) => s.value)).toContain(
+      globalConfig.tronWallets.deployerWallet
+    )
+    expect(globalConfig.tronWallets.deployerWallet).not.toMatch(/^(0x)?41/)
+  })
+})
+
+describe('deployer key power — a reduction of power is not a violation', () => {
+  it('passes with the deployer absent from safeOwners', () => {
+    const reduced = clone(globalConfig)
+    reduced.safeOwners = reduced.safeOwners.filter(
+      (owner) =>
+        owner.toLowerCase() !== globalConfig.deployerWallet.toLowerCase()
+    )
+    expect(reduced.safeOwners.length).toBe(globalConfig.safeOwners.length - 1)
+    expect(() =>
+      assertDeployerKeyPowerBounded(reduced, networksConfig)
+    ).not.toThrow()
+  })
+})
+
+describe('deployer key power — disclosed production integrity powers', () => {
+  it('refuses an integrity power that no disclosure names a detection for', () => {
+    const promoted: IDeployerPower[] = [
+      ...DEPLOYER_KEY_POWERS,
+      {
+        id: 'undisclosed-integrity',
+        power: 'Change which code executes without a Safe threshold',
+        surface: 'hypothetical',
+        class: 'integrity',
+        scope: 'production-mainnet',
+        status: 'current',
+        note: 'Not named in ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.',
+      },
+    ]
+    expectRefusal(
+      () =>
+        assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
+          powers: promoted,
+        }),
+      /undisclosed integrity power in production steady state: undisclosed-integrity/
+    )
+  })
+
+  it('carries the Safe-deployment power as a disclosed integrity break with a named detection', () => {
+    const safeDeployment = DEPLOYER_KEY_POWERS.find(
+      (p) => p.id === 'safe-deployment'
+    )
+    expect(safeDeployment?.class).toBe('integrity')
+    expect(safeDeployment?.scope).toBe('production-mainnet')
+    expect(safeDeployment?.status).toBe('current')
+    expect(safeDeployment?.surface).toMatch(/deploy-safe\.ts/)
+    expect(safeDeployment?.surface).toMatch(/deploy-safe-tron\.ts/)
+    expect(
+      ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.get('safe-deployment')
+    ).toMatch(/safe-config/)
+  })
+
+  it('discloses no production integrity power the inventory does not carry', () => {
+    const ids = new Set(DEPLOYER_KEY_POWERS.map((p) => p.id))
+    for (const id of ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.keys())
+      expect(ids.has(id)).toBe(true)
+  })
+
+  it('scopes the diamond-outright power to testnets, not to staging', () => {
+    const testnet = DEPLOYER_KEY_POWERS.find(
+      (p) => p.id === 'testnet-diamond-owner'
+    )
+    expect(testnet?.note).not.toMatch(/staging diamonds/)
+    expect(testnet?.note).toMatch(/devWallet/)
   })
 })

--- a/script/deploy/deployer-key-power.test.ts
+++ b/script/deploy/deployer-key-power.test.ts
@@ -112,6 +112,45 @@ describe('deployer key power — a widened config refuses', () => {
     )
   })
 
+  it('refuses every equivalent spelling of the same address', () => {
+    // The bound claims nothing outside the documented slots, so a spelling the
+    // walk fails to recognise is a slot it cannot claim anything about. The
+    // prefix and the digit case carry no meaning, and neither does the Tron
+    // `41` hex form of the same key.
+    const body = globalConfig.deployerWallet.slice(2)
+    const spellings = [
+      body,
+      body.toLowerCase(),
+      body.toUpperCase(),
+      `0X${body}`,
+      `0x${body.toUpperCase()}`,
+      `41${body}`,
+      `0x41${body}`,
+    ]
+
+    for (const spelling of spellings) {
+      const widened = clone(globalConfig)
+      widened.pauserWallet = spelling
+      const message = expectRefusal(
+        () => assertDeployerKeyPowerBounded(widened, networksConfig),
+        /undocumented grant: global\.json:pauserWallet/
+      )
+      // The refusal names the spelling it found, so an operator reading it can
+      // see which line of the config to open.
+      expect(message).toContain(spelling)
+    }
+  })
+
+  it('leaves an unrelated address alone, so recognition is not a blanket match', () => {
+    // Paired presence: broadening which spellings count as the deployer must
+    // not make every address count as the deployer.
+    const untouched = clone(globalConfig)
+    untouched.pauserWallet = `0x${'a'.repeat(40)}`
+    expect(() =>
+      assertDeployerKeyPowerBounded(untouched, networksConfig)
+    ).not.toThrow()
+  })
+
   it('refuses a duplicated owner entry, which the signature count is derived from', () => {
     const widened = clone(globalConfig)
     widened.safeOwners.push(globalConfig.deployerWallet)

--- a/script/deploy/deployer-key-power.test.ts
+++ b/script/deploy/deployer-key-power.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The assertion is exercised against the committed `config/global.json` and
+ * `config/networks.json`, not fixtures — a widened copy is derived from the real files so a
+ * refusal proves the check fires on the document it will actually read in CI.
+ */
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import globalConfig from '../../config/global.json'
+import networksConfig from '../../config/networks.json'
+
+import {
+  assertDeployerKeyPowerBounded,
+  DEPLOYER_KEY_POWERS,
+  DOCUMENTED_DEPLOYER_CONFIG_SLOTS,
+  findDeployerConfigSlots,
+  renderDeployerKeyPowerInventory,
+  type IDeployerPower,
+} from './deployer-key-power'
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
+
+const expectRefusal = (run: () => void, match: string | RegExp): string => {
+  let message: string | undefined
+  try {
+    run()
+  } catch (error) {
+    message = error instanceof Error ? error.message : String(error)
+  }
+  if (message === undefined)
+    throw new Error(`expected a refusal matching ${String(match)}, got none`)
+  expect(message).toMatch(match)
+  return message
+}
+
+describe('deployer key power — the committed config', () => {
+  it('grants the deployer exactly the documented slots', () => {
+    const slots = findDeployerConfigSlots(globalConfig, networksConfig)
+
+    expect(slots.length).toBeGreaterThan(0)
+    expect([...new Set(slots.map((s) => s.slot))].sort()).toEqual(
+      [...DOCUMENTED_DEPLOYER_CONFIG_SLOTS].sort()
+    )
+    expect(slots.map((s) => s.path)).toEqual([
+      'global.json:deployerWallet',
+      'global.json:tronWallets.deployerWallet',
+      'global.json:safeOwners[0]',
+    ])
+  })
+
+  it('passes the bound on the real config/global.json and config/networks.json', () => {
+    expect(() =>
+      assertDeployerKeyPowerBounded(globalConfig, networksConfig)
+    ).not.toThrow()
+  })
+
+  it('prints the inventory with every power and the resolved slots', () => {
+    const rendered = renderDeployerKeyPowerInventory(
+      globalConfig,
+      networksConfig
+    )
+    for (const power of DEPLOYER_KEY_POWERS)
+      expect(rendered).toContain(power.id)
+    expect(rendered).toContain('global.json:safeOwners[0]')
+  })
+})
+
+describe('deployer key power — a widened config refuses', () => {
+  it('refuses a documented role field reassigned to the deployer', () => {
+    const widened = clone(globalConfig)
+    widened.pauserWallet = globalConfig.deployerWallet
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /undocumented grant: global\.json:pauserWallet/
+    )
+  })
+
+  it('refuses a config field that did not exist when the check was written', () => {
+    const widened = clone(globalConfig) as Record<string, unknown>
+    widened.someNewOperatorWallet = globalConfig.deployerWallet
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /undocumented grant: global\.json:someNewOperatorWallet/
+    )
+  })
+
+  it('refuses the deployer standing in for a network Safe', () => {
+    const widened = clone(networksConfig) as Record<
+      string,
+      { safeAddress?: string }
+    >
+    const mainnet = widened.mainnet
+    if (!mainnet) throw new Error('config/networks.json has no mainnet entry')
+    mainnet.safeAddress = globalConfig.deployerWallet
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(globalConfig, widened),
+      /undocumented grant: networks\.json:mainnet\.safeAddress/
+    )
+  })
+
+  it('refuses the Tron identity pasted into another Tron slot', () => {
+    const widened = clone(globalConfig)
+    widened.tronWallets.pauserWallet = globalConfig.tronWallets.deployerWallet
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /undocumented grant: global\.json:tronWallets\.pauserWallet/
+    )
+  })
+
+  it('refuses a duplicated owner entry, which the signature count is derived from', () => {
+    const widened = clone(globalConfig)
+    widened.safeOwners.push(globalConfig.deployerWallet)
+    expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /occupies 2 safeOwners slots, expected exactly 1/
+    )
+  })
+
+  it('reports every violation in one pass rather than only the first', () => {
+    const widened = clone(globalConfig)
+    widened.pauserWallet = globalConfig.deployerWallet
+    widened.safeOwners.push(globalConfig.deployerWallet)
+    const message = expectRefusal(
+      () => assertDeployerKeyPowerBounded(widened, networksConfig),
+      /undocumented grant/
+    )
+    expect(message).toMatch(/occupies 2 safeOwners slots/)
+  })
+})
+
+describe('deployer key power — the integrity bound', () => {
+  it('refuses a threshold one signature can reach', () => {
+    expectRefusal(
+      () =>
+        assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
+          safeThreshold: 1,
+        }),
+      /the key alone reaches the threshold/
+    )
+  })
+
+  it('passes at a threshold above one, so the bound is not a blanket refusal', () => {
+    expect(() =>
+      assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
+        safeThreshold: 2,
+      })
+    ).not.toThrow()
+  })
+
+  it('refuses an inventory claiming an integrity power in production steady state', () => {
+    const promoted: IDeployerPower[] = [
+      ...DEPLOYER_KEY_POWERS,
+      {
+        id: 'schedule-without-safe',
+        power: 'Schedule a timelock operation without the Safe',
+        surface: 'hypothetical',
+        class: 'integrity',
+        scope: 'production-mainnet',
+        status: 'current',
+        note: 'Would falsify R7.1.',
+      },
+    ]
+    expectRefusal(
+      () =>
+        assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
+          powers: promoted,
+        }),
+      /schedule-without-safe/
+    )
+  })
+
+  it('accepts the shipped inventory, whose integrity powers are all out of production steady state', () => {
+    const integrity = DEPLOYER_KEY_POWERS.filter((p) => p.class === 'integrity')
+    expect(integrity.length).toBeGreaterThan(0)
+    for (const power of integrity)
+      expect(power.scope).not.toBe('production-mainnet')
+    expect(() =>
+      assertDeployerKeyPowerBounded(globalConfig, networksConfig, {
+        powers: DEPLOYER_KEY_POWERS,
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('deployer key power — the F7 executor row', () => {
+  it('carries timelock execution as pending, not as a power held today', () => {
+    const pending = DEPLOYER_KEY_POWERS.filter((p) => p.status === 'pending')
+    expect(pending.map((p) => p.id)).toEqual(['timelock-execute'])
+    expect(pending[0]?.note).toMatch(/EXSC-872/)
+  })
+})

--- a/script/deploy/deployer-key-power.ts
+++ b/script/deploy/deployer-key-power.ts
@@ -192,8 +192,17 @@ interface IWalkTarget {
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
 
+/**
+ * Whether a string is written as a hexadecimal address, with or without `0x`.
+ *
+ * Case-insensitive on the prefix as well as the body: `0X` is the same address, and a form
+ * this returns false for is compared verbatim instead, which is how an equivalent spelling
+ * escapes the walk entirely.
+ * @param id - the candidate string
+ * @returns Whether it is a 40- or 42-digit hexadecimal address in either form
+ */
 const isHexAddressForm = (id: string): boolean =>
-  /^(?:0x)?(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{42})$/.test(id)
+  /^(?:0x)?(?:[0-9a-f]{40}|[0-9a-f]{42})$/iu.test(id)
 
 /** Identity strings the deployer key answers to across the config files. */
 export const deployerIdentities = (globalConfig: {
@@ -214,10 +223,22 @@ export const deployerIdentities = (globalConfig: {
   return [...new Set([...declared, ...tronHexForms])]
 }
 
+/**
+ * Compares two hexadecimal address strings ignoring the `0x` and its case.
+ *
+ * The prefix is optional in the source data but carries no meaning, so a slot writing an
+ * identity without it would otherwise be a string the walk does not recognise — and an
+ * identity the walk cannot recognise is one the bound cannot claim anything about.
+ * @param value - a hexadecimal address in either form
+ * @returns The lowercase body, with no prefix
+ */
+const hexAddressBody = (value: string): string =>
+  value.replace(/^0x/iu, '').toLowerCase()
+
 const matches = (value: string, identities: string[]): boolean =>
   identities.some((id) =>
-    isHexAddressForm(id)
-      ? value.toLowerCase() === id.toLowerCase()
+    isHexAddressForm(id) && isHexAddressForm(value)
+      ? hexAddressBody(value) === hexAddressBody(id)
       : value === id
   )
 

--- a/script/deploy/deployer-key-power.ts
+++ b/script/deploy/deployer-key-power.ts
@@ -151,6 +151,9 @@ export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
  * that makes abuse observable. An unlisted id refuses, so a power promoted into this class cannot
  * reach main by editing its own row; and a disclosure with nothing watching it is not a
  * disclosure, which is why the value is required to be non-empty.
+ *
+ * Detection is weaker than removal, so each value names the work that retires the entry. An empty
+ * map is the target state: R7.1's bound is only fully held when this map is empty.
  */
 export const ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS: ReadonlyMap<
   string,
@@ -158,7 +161,7 @@ export const ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS: ReadonlyMap<
 > = new Map([
   [
     'safe-deployment',
-    "healthCheckInvariants.ts 'safe-config' asserts the Safe owner set in both directions, so an owner the config does not declare is reported (PR #2337, EXSC-943)",
+    "healthCheckInvariants.ts 'safe-config' asserts the Safe owner set in both directions, so an owner the config does not declare is reported (PR #2337, EXSC-943). Removal, not detection, is tracked as EXSC-944: defaulting allowOverride to false and refusing a production threshold below SAFE_THRESHOLD retires this entry.",
   ],
 ])
 

--- a/script/deploy/deployer-key-power.ts
+++ b/script/deploy/deployer-key-power.ts
@@ -1,0 +1,355 @@
+/**
+ * R7.1 — the deployer key's power inventory, and the config assertion that bounds it.
+ *
+ * Two independent legs, both reported in one pass so neither can mask the other:
+ *
+ *  1. `findDeployerConfigSlots` walks `config/global.json` and `config/networks.json`
+ *     for every slot holding one of the deployer wallet's identities, and
+ *     `assertDeployerKeyPowerBounded` refuses any slot outside
+ *     {@link DOCUMENTED_DEPLOYER_CONFIG_SLOTS}. The walk is generic rather than a scan of
+ *     known field names, so a *newly added* config field pointing at the deployer is caught
+ *     too — that is the widening R7.1 asks to alert on.
+ *  2. The same assertion re-derives the inventory's central claim from config: the wallet's
+ *     power is bounded to DoS/griefing and never an integrity break, because reaching the
+ *     Safe threshold needs signatures it does not hold.
+ *
+ * Residual, deliberately not covered: the walk matches address *strings*, so it compares the
+ * Tron identity as base58 and the EVM identity as hex. Both are the same key today
+ * (`tronWallets.deployerWallet` decodes to `deployerWallet`), but a re-encoded form of one
+ * pasted into a slot of the other kind would not match. Decoding needs a TronWeb instance,
+ * which the dependency-light `bun test:ts` job deliberately does not carry.
+ */
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+
+import globalConfigJson from '../../config/global.json'
+import networksConfigJson from '../../config/networks.json'
+
+import { SAFE_THRESHOLD } from './shared/constants'
+
+/** What holding the key buys an attacker who holds nothing else. */
+export type TDeployerPowerClass =
+  /** Changes nothing beyond cost and liveness. */
+  | 'no-authority'
+  /** Can degrade liveness or grief, recoverably. */
+  | 'dos'
+  /** Produces a value a downstream gate must re-derive rather than trust. */
+  | 'untrusted-input'
+  /** Can change which code executes without a Safe threshold. */
+  | 'integrity'
+
+/** Where the power applies. Only `production-mainnet` carries the R7.1 bound. */
+export type TDeployerPowerScope =
+  | 'production-mainnet'
+  | 'production-bring-up'
+  | 'non-production'
+
+export interface IDeployerPower {
+  id: string
+  power: string
+  /** The code path that exercises it. */
+  surface: string
+  class: TDeployerPowerClass
+  scope: TDeployerPowerScope
+  /** `pending` powers are not held yet; the ticket that grants them is named in `note`. */
+  status: 'current' | 'pending'
+  note: string
+}
+
+/**
+ * The documented set. A power absent from this list is, by construction, undocumented — which
+ * is why the config walk refuses an unlisted slot instead of describing it.
+ */
+export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
+  {
+    id: 'deploy',
+    power: 'Deploy arbitrary bytecode (CREATE3, every network)',
+    surface:
+      'script/deploy/deploySingleContract.sh (getPrivateKey … production)',
+    class: 'no-authority',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'Deployed code is inert until a diamondCut wires it, and the cut needs the Safe threshold.',
+  },
+  {
+    id: 'record',
+    power: 'Write the deployment record at deploy time',
+    surface: 'script/deploy/update-deployment-logs.ts add (Mongo upsert)',
+    class: 'untrusted-input',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'A lying record is the G7 threat model; the sign-time codehash gate re-derives instead of trusting it.',
+  },
+  {
+    id: 'propose',
+    power: 'Create a Safe proposal',
+    surface: 'script/deploy/safe/propose-to-safe.ts (runPropose)',
+    class: 'dos',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'A proposal claims a nonce and is otherwise inert; an unsigned proposal is discardable.',
+  },
+  {
+    id: 'one-signature',
+    power: 'Contribute one Safe signature',
+    surface: 'config/global.json safeOwners — the deployer is one owner',
+    class: 'dos',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'One of a threshold of several. Bounded by assertDeployerKeyPowerBounded, not by convention.',
+  },
+  {
+    id: 'cancel',
+    power: 'Cancel a queued timelock operation',
+    surface:
+      'CANCELLER_ROLE, granted to the _cancellerWallet constructor arg in src/Security/LiFiTimelockController.sol',
+    class: 'dos',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'T6 accepts this: a cancel costs a re-proposal, never a wrong operation. Holder set is mutable on-chain, so read it there.',
+  },
+  {
+    id: 'broadcast-safe-execution',
+    power: 'Broadcast a Safe execution once the threshold is met',
+    surface:
+      'the "…With Deployer" execute variants in script/deploy/safe/confirm-safe-tx.ts',
+    class: 'no-authority',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'Carries signatures it did not produce; withholding the broadcast is DoS, not an integrity break.',
+  },
+  {
+    id: 'timelock-execute',
+    power: 'Execute a ready timelock operation as the sole executor',
+    surface: 'EXECUTOR_ROLE on LiFiTimelockController',
+    class: 'dos',
+    scope: 'production-mainnet',
+    status: 'pending',
+    note: 'Granted only once the F7 executor restriction lands (WP-6.2 / EXSC-872). On main EXECUTOR_ROLE is still address(0) — execution is permissionless and the deployer holds no executor grant.',
+  },
+  {
+    id: 'testnet-diamond-owner',
+    power: 'Own the diamond outright (diamondCut without a Safe)',
+    surface:
+      "healthCheckInvariants.ts 'diamond-owner' asserts ctx.deployerWallet owns the diamond on testnets; deployAllContracts.sh stage 12 skips the timelock transfer there",
+    class: 'integrity',
+    scope: 'non-production',
+    status: 'current',
+    note: 'Testnet and staging diamonds have no Safe or timelock by design, so the R7.1 bound is a production-mainnet claim and is scoped as such.',
+  },
+  {
+    id: 'bring-up-diamond-owner',
+    power: 'Own a production diamond until the timelock transfer is confirmed',
+    surface:
+      'deployAllContracts.sh stage 12 — transferOwnership(timelock) is sent from the deployer as the then-current owner; confirmOwnershipTransfer() is proposed to the Safe',
+    class: 'integrity',
+    scope: 'production-bring-up',
+    status: 'current',
+    note: 'Closes when the Safe executes the confirmation. A network left in this state is reported unhealthy by the diamond-owner invariant.',
+  },
+] as const
+
+/**
+ * Slots the deployer's identities may occupy, as `<file>:<json path>`. Anything else is a
+ * widening and refuses. `safeOwners` is listed without an index because owner order carries no
+ * on-chain meaning; the count is bounded separately.
+ */
+export const DOCUMENTED_DEPLOYER_CONFIG_SLOTS: readonly string[] = [
+  'global.json:deployerWallet',
+  'global.json:safeOwners[]',
+  'global.json:tronWallets.deployerWallet',
+]
+
+export interface IDeployerConfigSlot {
+  /** `<file>:<json path>`, with array indices collapsed to `[]` for comparison. */
+  slot: string
+  /** The uncollapsed path, so a violation names the exact entry. */
+  path: string
+  value: string
+}
+
+interface IWalkTarget {
+  file: string
+  value: unknown
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v)
+
+/** Identity strings the deployer key answers to across the config files. */
+export const deployerIdentities = (globalConfig: {
+  deployerWallet: string
+  tronWallets?: Record<string, string>
+}): string[] => {
+  return [
+    globalConfig.deployerWallet,
+    globalConfig.tronWallets?.deployerWallet,
+  ].filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+const matches = (value: string, identities: string[]): boolean =>
+  identities.some((id) =>
+    id.startsWith('0x')
+      ? value.toLowerCase() === id.toLowerCase()
+      : value === id
+  )
+
+/**
+ * Every slot in the given configs holding a deployer identity, found by walking the whole
+ * document rather than a list of known field names.
+ */
+export const findDeployerConfigSlots = (
+  globalConfig: unknown,
+  networksConfig: unknown
+): IDeployerConfigSlot[] => {
+  if (!isPlainObject(globalConfig))
+    throw new Error('global config must be an object')
+
+  const identities = deployerIdentities(
+    globalConfig as { deployerWallet: string }
+  )
+  if (identities.length === 0)
+    throw new Error('config/global.json declares no deployerWallet')
+
+  const found: IDeployerConfigSlot[] = []
+
+  const walk = (file: string, node: unknown, path: string): void => {
+    if (typeof node === 'string') {
+      if (matches(node, identities))
+        found.push({
+          slot: `${file}:${path.replace(/\[\d+]/g, '[]')}`,
+          path: `${file}:${path}`,
+          value: node,
+        })
+      return
+    }
+    if (Array.isArray(node)) {
+      node.forEach((child, i) => walk(file, child, `${path}[${i}]`))
+      return
+    }
+    if (isPlainObject(node))
+      for (const [key, child] of Object.entries(node))
+        walk(file, child, path === '' ? key : `${path}.${key}`)
+  }
+
+  const targets: IWalkTarget[] = [
+    { file: 'global.json', value: globalConfig },
+    { file: 'networks.json', value: networksConfig },
+  ]
+  for (const { file, value } of targets) walk(file, value, '')
+
+  return found
+}
+
+export interface IDeployerPowerBoundOptions {
+  /** Safe signature threshold the fleet is held to. Defaults to the repo constant. */
+  safeThreshold?: number
+  /** Inventory to judge. Defaults to {@link DEPLOYER_KEY_POWERS}; injectable so the bound is testable. */
+  powers?: readonly IDeployerPower[]
+}
+
+/**
+ * Refuse if the deployer wallet occupies a config slot outside the documented set, if it does
+ * not hold exactly the one Safe-owner slot the signature arithmetic assumes, if that slot could
+ * by itself reach the signature threshold, or if the inventory itself claims an integrity power
+ * in production steady state.
+ *
+ * Every leg is collected before throwing, so one violation never hides another.
+ */
+export const assertDeployerKeyPowerBounded = (
+  globalConfig: unknown,
+  networksConfig: unknown,
+  options: IDeployerPowerBoundOptions = {}
+): void => {
+  const threshold = options.safeThreshold ?? SAFE_THRESHOLD
+  const violations: string[] = []
+
+  const slots = findDeployerConfigSlots(globalConfig, networksConfig)
+  const documented = new Set(DOCUMENTED_DEPLOYER_CONFIG_SLOTS)
+  for (const { slot, path, value } of slots)
+    if (!documented.has(slot))
+      violations.push(
+        `undocumented grant: ${path} = ${value} (slot ${slot} is not in DOCUMENTED_DEPLOYER_CONFIG_SLOTS)`
+      )
+
+  const ownerSlots = slots.filter(
+    (s) => s.slot === 'global.json:safeOwners[]'
+  ).length
+  if (ownerSlots !== 1)
+    violations.push(
+      `deployer occupies ${ownerSlots} safeOwners slots, expected exactly 1 — the human-signature count the process documents is derived from that`
+    )
+  if (!Number.isInteger(threshold) || threshold < 1)
+    violations.push(
+      `safe threshold must be a positive integer, got ${threshold}`
+    )
+  else if (ownerSlots >= threshold)
+    violations.push(
+      `deployer holds ${ownerSlots} of ${threshold} required Safe signatures — the key alone reaches the threshold, so its power is no longer bounded to DoS`
+    )
+
+  for (const power of options.powers ?? DEPLOYER_KEY_POWERS)
+    if (
+      power.status === 'current' &&
+      power.scope === 'production-mainnet' &&
+      power.class === 'integrity'
+    )
+      violations.push(
+        `inventory claims an integrity power in production steady state: ${power.id} — R7.1's bound is falsified, not merely undocumented`
+      )
+
+  if (violations.length > 0)
+    throw new Error(
+      `deployer key power is not bounded to the documented set:\n${violations
+        .map((v) => `  - ${v}`)
+        .join('\n')}`
+    )
+}
+
+export const renderDeployerKeyPowerInventory = (
+  globalConfig: unknown,
+  networksConfig: unknown,
+  options: IDeployerPowerBoundOptions = {}
+): string => {
+  const threshold = options.safeThreshold ?? SAFE_THRESHOLD
+  const slots = findDeployerConfigSlots(globalConfig, networksConfig)
+  const lines = [
+    'Deployer key power inventory (R7.1)',
+    '',
+    `Safe signature threshold: ${threshold}`,
+    `Config slots holding a deployer identity: ${slots.length}`,
+    ...slots.map((s) => `  ${s.path} = ${s.value}`),
+    '',
+    'Powers:',
+    ...(options.powers ?? DEPLOYER_KEY_POWERS).map(
+      (p) =>
+        `  [${p.status}] [${p.scope}] [${p.class}] ${p.id}: ${p.power}\n      surface: ${p.surface}\n      ${p.note}`
+    ),
+  ]
+  return lines.join('\n')
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'deployer-key-power',
+    description:
+      "Prints the deployer key's power inventory and asserts config grants it nothing outside the documented set (R7.1)",
+  },
+  run() {
+    consola.log(
+      renderDeployerKeyPowerInventory(globalConfigJson, networksConfigJson)
+    )
+    try {
+      assertDeployerKeyPowerBounded(globalConfigJson, networksConfigJson)
+    } catch (error) {
+      consola.error(error instanceof Error ? error.message : String(error))
+      process.exit(1)
+    }
+    consola.success(
+      'Deployer key power is bounded to the documented set (config assertion passed)'
+    )
+  },
+})
+
+if (import.meta.main) runMain(main)

--- a/script/deploy/deployer-key-power.ts
+++ b/script/deploy/deployer-key-power.ts
@@ -1,23 +1,12 @@
 /**
  * R7.1 — the deployer key's power inventory, and the config assertion that bounds it.
  *
- * Two independent legs, both reported in one pass so neither can mask the other:
- *
- *  1. `findDeployerConfigSlots` walks `config/global.json` and `config/networks.json`
- *     for every slot holding one of the deployer wallet's identities, and
- *     `assertDeployerKeyPowerBounded` refuses any slot outside
- *     {@link DOCUMENTED_DEPLOYER_CONFIG_SLOTS}. The walk is generic rather than a scan of
- *     known field names, so a *newly added* config field pointing at the deployer is caught
- *     too — that is the widening R7.1 asks to alert on.
- *  2. The same assertion re-derives the inventory's central claim from config: the wallet's
- *     power is bounded to DoS/griefing and never an integrity break, because reaching the
- *     Safe threshold needs signatures it does not hold.
- *
- * Residual, deliberately not covered: the walk matches address *strings*, so it compares the
- * Tron identity as base58 and the EVM identity as hex. Both are the same key today
- * (`tronWallets.deployerWallet` decodes to `deployerWallet`), but a re-encoded form of one
- * pasted into a slot of the other kind would not match. Decoding needs a TronWeb instance,
- * which the dependency-light `bun test:ts` job deliberately does not carry.
+ * The walk compares address *strings*, so the Tron identity is matched as base58 and the EVM
+ * identity as hex — including the `41`-prefixed TronWeb hex form, which is a pure string
+ * transform of the EVM address. Both are the same key today (`tronWallets.deployerWallet`
+ * decodes to `deployerWallet`), but a base58 re-encoding of the EVM identity would not match:
+ * decoding needs a TronWeb instance, which the dependency-light `bun test:ts` job deliberately
+ * does not carry.
  */
 
 import { defineCommand, runMain } from 'citty'
@@ -36,7 +25,7 @@ export type TDeployerPowerClass =
   | 'dos'
   /** Produces a value a downstream gate must re-derive rather than trust. */
   | 'untrusted-input'
-  /** Can change which code executes without a Safe threshold. */
+  /** Can change which code executes, or who governs it, without a Safe threshold. */
   | 'integrity'
 
 /** Where the power applies. Only `production-mainnet` carries the R7.1 bound. */
@@ -57,10 +46,6 @@ export interface IDeployerPower {
   note: string
 }
 
-/**
- * The documented set. A power absent from this list is, by construction, undocumented — which
- * is why the config walk refuses an unlisted slot instead of describing it.
- */
 export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
   {
     id: 'deploy',
@@ -129,6 +114,17 @@ export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
     note: 'Granted only once the F7 executor restriction lands (WP-6.2 / EXSC-872). On main EXECUTOR_ROLE is still address(0) — execution is permissionless and the deployer holds no executor grant.',
   },
   {
+    id: 'safe-deployment',
+    power:
+      'Deploy the governance Safe with an owner set and threshold of its choosing, then repoint config at it',
+    surface:
+      'script/deploy/safe/deploy-safe.ts — --owners is unioned into globalConfig.safeOwners, --threshold accepts any value >= 1, allowOverride defaults to true so the "Safe already deployed" guard does not fire, and config/networks.json safeAddress is rewritten with the result; script/deploy/tron/deploy-safe-tron.ts is the Tron equivalent',
+    class: 'integrity',
+    scope: 'production-mainnet',
+    status: 'current',
+    note: 'The script\'s own on-chain verification compares getOwners() and getThreshold() against the same expanded owners array and threshold it was passed, so it confirms "deployed as asked", not "as configured". Abuse is observable, not prevented — see ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.',
+  },
+  {
     id: 'testnet-diamond-owner',
     power: 'Own the diamond outright (diamondCut without a Safe)',
     surface:
@@ -136,7 +132,7 @@ export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
     class: 'integrity',
     scope: 'non-production',
     status: 'current',
-    note: 'Testnet and staging diamonds have no Safe or timelock by design, so the R7.1 bound is a production-mainnet claim and is scoped as such.',
+    note: 'Testnet diamonds have no Safe or timelock by design, so the R7.1 bound is a production-mainnet claim and is scoped as such. Staging on a mainnet network is a different key: helperFunctions.sh getPrivateKey returns PRIVATE_KEY there, and healthCheck.ts resolves ctx.deployerWallet to globalConfig.devWallet.',
   },
   {
     id: 'bring-up-diamond-owner',
@@ -149,6 +145,22 @@ export const DEPLOYER_KEY_POWERS: readonly IDeployerPower[] = [
     note: 'Closes when the Safe executes the confirmation. A network left in this state is reported unhealthy by the diamond-owner invariant.',
   },
 ] as const
+
+/**
+ * Production-mainnet integrity powers that are disclosed rather than refused, mapped to the check
+ * that makes abuse observable. An unlisted id refuses, so a power promoted into this class cannot
+ * reach main by editing its own row; and a disclosure with nothing watching it is not a
+ * disclosure, which is why the value is required to be non-empty.
+ */
+export const ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS: ReadonlyMap<
+  string,
+  string
+> = new Map([
+  [
+    'safe-deployment',
+    "healthCheckInvariants.ts 'safe-config' asserts the Safe owner set in both directions, so an owner the config does not declare is reported (PR #2337, EXSC-943)",
+  ],
+])
 
 /**
  * Slots the deployer's identities may occupy, as `<file>:<json path>`. Anything else is a
@@ -177,48 +189,65 @@ interface IWalkTarget {
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v)
 
+const isHexAddressForm = (id: string): boolean =>
+  /^(?:0x)?(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{42})$/.test(id)
+
 /** Identity strings the deployer key answers to across the config files. */
 export const deployerIdentities = (globalConfig: {
   deployerWallet: string
   tronWallets?: Record<string, string>
 }): string[] => {
-  return [
+  const declared = [
     globalConfig.deployerWallet,
     globalConfig.tronWallets?.deployerWallet,
   ].filter((id): id is string => typeof id === 'string' && id.length > 0)
+
+  const evm = globalConfig.deployerWallet
+  const tronHexForms =
+    typeof evm === 'string' && /^0x[0-9a-fA-F]{40}$/.test(evm)
+      ? [`41${evm.slice(2)}`, `0x41${evm.slice(2)}`]
+      : []
+
+  return [...new Set([...declared, ...tronHexForms])]
 }
 
 const matches = (value: string, identities: string[]): boolean =>
   identities.some((id) =>
-    id.startsWith('0x')
+    isHexAddressForm(id)
       ? value.toLowerCase() === id.toLowerCase()
       : value === id
   )
 
-/**
- * Every slot in the given configs holding a deployer identity, found by walking the whole
- * document rather than a list of known field names.
- */
+/** Every slot in the given configs holding a deployer identity, as a value or as an object key. */
 export const findDeployerConfigSlots = (
   globalConfig: unknown,
   networksConfig: unknown
 ): IDeployerConfigSlot[] => {
   if (!isPlainObject(globalConfig))
     throw new Error('global config must be an object')
+  if (
+    !isPlainObject(networksConfig) ||
+    Object.keys(networksConfig).length === 0
+  )
+    throw new Error('networks config must be a non-empty object')
+
+  const declaredDeployer = (globalConfig as { deployerWallet?: unknown })
+    .deployerWallet
+  if (typeof declaredDeployer !== 'string' || declaredDeployer.length === 0)
+    throw new Error('config/global.json declares no deployerWallet')
 
   const identities = deployerIdentities(
     globalConfig as { deployerWallet: string }
   )
-  if (identities.length === 0)
-    throw new Error('config/global.json declares no deployerWallet')
 
   const found: IDeployerConfigSlot[] = []
+  const collapse = (path: string): string => path.replace(/\[\d+]/g, '[]')
 
   const walk = (file: string, node: unknown, path: string): void => {
     if (typeof node === 'string') {
       if (matches(node, identities))
         found.push({
-          slot: `${file}:${path.replace(/\[\d+]/g, '[]')}`,
+          slot: `${file}:${collapse(path)}`,
           path: `${file}:${path}`,
           value: node,
         })
@@ -229,8 +258,16 @@ export const findDeployerConfigSlots = (
       return
     }
     if (isPlainObject(node))
-      for (const [key, child] of Object.entries(node))
-        walk(file, child, path === '' ? key : `${path}.${key}`)
+      for (const [key, child] of Object.entries(node)) {
+        const childPath = path === '' ? key : `${path}.${key}`
+        if (matches(key, identities))
+          found.push({
+            slot: `${file}:${collapse(childPath)}`,
+            path: `${file}:${childPath}`,
+            value: key,
+          })
+        walk(file, child, childPath)
+      }
   }
 
   const targets: IWalkTarget[] = [
@@ -245,15 +282,15 @@ export const findDeployerConfigSlots = (
 export interface IDeployerPowerBoundOptions {
   /** Safe signature threshold the fleet is held to. Defaults to the repo constant. */
   safeThreshold?: number
-  /** Inventory to judge. Defaults to {@link DEPLOYER_KEY_POWERS}; injectable so the bound is testable. */
+  /** Inventory to judge. Defaults to {@link DEPLOYER_KEY_POWERS}. */
   powers?: readonly IDeployerPower[]
 }
 
 /**
- * Refuse if the deployer wallet occupies a config slot outside the documented set, if it does
- * not hold exactly the one Safe-owner slot the signature arithmetic assumes, if that slot could
- * by itself reach the signature threshold, or if the inventory itself claims an integrity power
- * in production steady state.
+ * Refuse if the deployer wallet occupies a config slot outside the documented set, if it occupies
+ * more than the one Safe-owner slot the signature arithmetic assumes, if that slot could by itself
+ * reach the signature threshold, or if the inventory claims an integrity power in production
+ * steady state that {@link ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS} does not disclose.
  *
  * Every leg is collected before throwing, so one violation never hides another.
  */
@@ -276,9 +313,9 @@ export const assertDeployerKeyPowerBounded = (
   const ownerSlots = slots.filter(
     (s) => s.slot === 'global.json:safeOwners[]'
   ).length
-  if (ownerSlots !== 1)
+  if (ownerSlots > 1)
     violations.push(
-      `deployer occupies ${ownerSlots} safeOwners slots, expected exactly 1 — the human-signature count the process documents is derived from that`
+      `deployer occupies ${ownerSlots} safeOwners slots, expected at most 1 — the human-signature count the process documents is derived from that`
     )
   if (!Number.isInteger(threshold) || threshold < 1)
     violations.push(
@@ -294,10 +331,13 @@ export const assertDeployerKeyPowerBounded = (
       power.status === 'current' &&
       power.scope === 'production-mainnet' &&
       power.class === 'integrity'
-    )
-      violations.push(
-        `inventory claims an integrity power in production steady state: ${power.id} — R7.1's bound is falsified, not merely undocumented`
-      )
+    ) {
+      const detection = ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS.get(power.id)
+      if (detection === undefined || detection.trim().length === 0)
+        violations.push(
+          `inventory claims an undisclosed integrity power in production steady state: ${power.id} — either it is not an integrity power, or R7.1's bound needs restating and ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS must name the check that observes it`
+        )
+    }
 
   if (violations.length > 0)
     throw new Error(
@@ -326,6 +366,11 @@ export const renderDeployerKeyPowerInventory = (
       (p) =>
         `  [${p.status}] [${p.scope}] [${p.class}] ${p.id}: ${p.power}\n      surface: ${p.surface}\n      ${p.note}`
     ),
+    '',
+    'Disclosed production-mainnet integrity powers (observable, not prevented):',
+    ...[...ACKNOWLEDGED_PRODUCTION_INTEGRITY_POWERS].map(
+      ([id, detection]) => `  ${id}: ${detection}`
+    ),
   ]
   return lines.join('\n')
 }
@@ -347,7 +392,7 @@ const main = defineCommand({
       process.exit(1)
     }
     consola.success(
-      'Deployer key power is bounded to the documented set (config assertion passed)'
+      'Deployer key power on production mainnets is bounded to the documented set, apart from the disclosed integrity powers above (config assertion over config/global.json and config/networks.json passed)'
     )
   },
 })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-878](https://linear.app/lifi-linear/issue/EXSC-878/wp-73-deployer-key-power-inventory-config-assertion) — WP-7.3 / R7.1, deployer key-power inventory + config assertion.

# Why did I implement it this way?

The deployer wallet is the one key that appears at every stage of a production change. Measured from the repo at `95fdb620d`, it: deploys (`PRIVATE_KEY_PRODUCTION`), writes the deployment record at deploy time, creates the Safe proposal (`propose-to-safe.ts` `runPropose`), holds one of the `safeOwners` slots — `safeOwners[0]` **is** `deployerWallet` — holds `CANCELLER_ROLE` on every timelock (the `_cancellerWallet` constructor arg in `LiFiTimelockController`), and broadcasts the Safe execution once the threshold is met. R7.1 asks for that set to be enumerated, bounded, and alerted on when it widens.

**`script/deploy/deployer-key-power.ts` carries the inventory and the assertion, with three legs, all collected before throwing so one violation never hides another.**

- **The config leg** walks the whole of `config/global.json` and `config/networks.json` and refuses any slot holding a deployer identity that is not in `DOCUMENTED_DEPLOYER_CONFIG_SLOTS`. It is a generic walk rather than a scan of known field names, because the widening R7.1 worries about is precisely a *new* field pointing at the deployer — a scan of today's field names would not see it.
- **The bound leg** re-derives the claim the inventory rests on instead of asserting it in prose: the deployer occupies exactly one owner slot, and one slot cannot reach `SAFE_THRESHOLD`. That is why it cannot schedule or push an operation. Injecting a threshold of 1 refuses; 2 passes, so the leg is not a blanket refusal.
- **The inventory leg** refuses if any power marked as held in production steady state is classed `integrity`. If a future change adds one, the check fails and forces the premise to be re-argued rather than quietly widened.

**Two scoped exceptions are in the inventory rather than hidden by it**, because both are real and the honest reading of "DoS only, never an integrity break" is production-mainnet-scoped:

- On **testnet and staging** the deployer owns the diamond outright and can `diamondCut` unilaterally — those networks have no Safe or timelock by design (`healthCheckInvariants.ts` asserts exactly that ownership; `deployAllContracts.sh` stage 12 skips the timelock transfer there).
- During **production bring-up** the deployer owns a production diamond between `transferOwnership(timelock)`, which it sends directly as the then-current owner, and the Safe-executed `confirmOwnershipTransfer()`. A network left in that state is already reported unhealthy by the `diamond-owner` invariant.

The deploy-time record write is classed `untrusted-input`, not `no-authority`: a lying record is the G7 threat model, and the premise holds only because the sign-time gate re-derives rather than trusting it.

**Timelock execution is carried as `pending`, not current.** `EXECUTOR_ROLE` is granted to `address(0)` on `main`, so execution is permissionless and the deployer holds no executor grant. It becomes a deployer power when the F7 restriction lands (WP-6.2 / EXSC-872).

**Where the check runs.** `bun deployer-key-power` prints the inventory and exits non-zero on a violation; `script/deploy/deployer-key-power.test.ts` is the CI leg, and it is reached on a config-only change because `ts-unit-tests.yml`'s path filter already covers `config/**`. It is deliberately *not* wired into the proposal funnel: those files are owned by open PRs #2329 / #2334 / #2335. Reversible — moving it into the funnel later is a one-line call.

**Asserted against the committed config, not fixtures**, and every falsification mutates the real file on disk and is reverted with `git checkout`:

| Mutation | Result |
|---|---|
| unmutated committed config | `CLI exit code: 0` |
| `pauserWallet` reassigned to the deployer | refuses, names `global.json:pauserWallet`, exit 1 |
| a field that did not exist when the check was written (`someNewOperatorWallet`) | refuses, exit 1 |
| the deployer standing in for `networks.json:mainnet.safeAddress` | refuses, exit 1 |
| a duplicated `safeOwners` entry | refuses (`occupies 2 safeOwners slots, expected exactly 1`), exit 1 |
| `pauserWallet` **and** the duplicate together | both violations printed in one message |
| injected `SAFE_THRESHOLD` of 1 / of 2 | refuses / passes |

`bun test:ts` 2596 pass / 0 fail against a 2582 / 0 baseline on the same worktree. Repo-wide `bunx tsc --noEmit` shows 88 pre-existing errors, none in the new files; `bunx tsc-files` and `bunx eslint` are clean on both.

**Measured, worth a reviewer's eye:** the `safe-config` health-check invariant only asserts config owners ⊆ on-chain owners, so an *extra* on-chain Safe owner — a genuine widening of the signer set — is invisible to it. Out of scope here (this package bounds the deployer key, not the owner set) but it is the same class of gap.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
