### PR TITLE
fix(health-check): safe-config asserts the Safe owner set both ways (EXSC-943)

### DIFF
--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -3022,3 +3022,156 @@ describe('periphery-registered scheduled-registration coverage', () => {
     expect(ctx.errors).toHaveLength(1)
   })
 })
+
+/**
+ * `safe-config` asserts the owner set in **both** directions.
+ *
+ * The one-directional version could only see a configured owner that had been
+ * removed on chain. An owner *added* to the Safe left every configured owner in
+ * place and the threshold at or above its floor, so the invariant named for the
+ * governance Safe's owners passed while the signer set had been widened — which
+ * is the failure these tests exist to keep closed. So the assertions come in
+ * pairs: each refusal is matched by the configuration that must still pass,
+ * because a check that refused every owner set would satisfy the refusals alone.
+ */
+const SAFE = '0x1111111111111111111111111111111111111111'
+const OWNER_A = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'
+const OWNER_B = '0xBbBbBBBb00000000000000000000000000000001'
+const OWNER_C = '0xcCcCcCCc00000000000000000000000000000002'
+const INTRUDER = '0xdDdDddDd00000000000000000000000000000003'
+
+function makeSafeCtx(stub: {
+  configured: string[]
+  onChain: string[]
+  threshold?: bigint
+  safeAddress?: string | undefined
+}): IHealthCheckContext {
+  const ctx = makeCtx()
+  Object.assign(ctx, {
+    globalConfig: { safeOwners: stub.configured },
+    networkConfig: {
+      safeAddress: 'safeAddress' in stub ? stub.safeAddress : SAFE,
+    },
+    publicClient: {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (functionName === 'getOwners') return stub.onChain
+        if (functionName === 'getThreshold') return stub.threshold ?? BigInt(3)
+        return BigInt(7)
+      },
+    },
+  })
+  return ctx
+}
+
+describe('safe-config asserts the owner set both ways', () => {
+  it('passes when the on-chain owners are exactly the configured ones', async () => {
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, OWNER_B, OWNER_C],
+      onChain: [OWNER_A, OWNER_B, OWNER_C],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toEqual([])
+  })
+
+  it('fails on an owner added to the Safe but absent from config', async () => {
+    // The gap: every configured owner is still an owner and the threshold is
+    // untouched, so the one-directional check saw nothing.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, OWNER_B, OWNER_C],
+      onChain: [OWNER_A, OWNER_B, OWNER_C, INTRUDER],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain(getAddress(INTRUDER))
+    expect(ctx.errors[0]).toContain('NOT in config/global.json')
+  })
+
+  it('still fails on a configured owner removed from the Safe', async () => {
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, OWNER_B, OWNER_C],
+      onChain: [OWNER_A, OWNER_B],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain(getAddress(OWNER_C))
+    expect(ctx.errors[0]).toContain('NOT an owner')
+  })
+
+  it('says which side each direction is missing from', async () => {
+    // Both messages name a set and a side. The pre-existing message read "not
+    // in SAFE configuration" for an owner that *was* configured and missing on
+    // chain, which points a responder at the wrong file.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, OWNER_C],
+      onChain: [OWNER_A, INTRUDER],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(2)
+    const configuredSideMissing = ctx.errors.find((e) =>
+      e.includes(getAddress(OWNER_C))
+    )
+    const chainSideExtra = ctx.errors.find((e) =>
+      e.includes(getAddress(INTRUDER))
+    )
+    expect(configuredSideMissing).toContain('is in config/global.json')
+    expect(configuredSideMissing).toContain('NOT an owner')
+    expect(chainSideExtra).toContain('on chain')
+    expect(chainSideExtra).toContain('NOT in config/global.json')
+  })
+
+  it('compares checksummed, so a lowercased config entry is not a mismatch', async () => {
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A.toLowerCase(), OWNER_B.toLowerCase()],
+      onChain: [getAddress(OWNER_A), getAddress(OWNER_B)],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toEqual([])
+  })
+
+  it('refuses rather than reports when config lists no owners', async () => {
+    // An empty expected set is a subset of every on-chain set there is, so both
+    // directions would pass while nothing had been compared.
+    const ctx = makeSafeCtx({ configured: [], onChain: [OWNER_A, INTRUDER] })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('lists no safeOwners')
+  })
+
+  it('says the added-owner check could not run when a config entry is malformed', async () => {
+    // A typo in config would otherwise make every on-chain owner it fails to
+    // match look like an intruder. The check reports that it could not compare
+    // instead of naming an owner that may well be configured.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, '0xnot-an-address'],
+      onChain: [getAddress(OWNER_A), getAddress(OWNER_B)],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors.join('\n')).toContain('not a valid address')
+    expect(ctx.errors.join('\n')).toContain('0xnot-an-address')
+    // Never named as unexpected on the strength of an incomplete config set.
+    expect(ctx.errors.join('\n')).not.toContain(
+      `${getAddress(OWNER_B)} is an owner`
+    )
+  })
+
+  it('keeps failing a threshold below the floor', async () => {
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A],
+      onChain: [OWNER_A],
+      threshold: BigInt(1),
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('threshold')
+  })
+
+  it('does not read the Safe when no address is configured', async () => {
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A],
+      onChain: [INTRUDER],
+      safeAddress: undefined,
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toEqual([])
+  })
+})

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -4,6 +4,7 @@ import {
   it,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
+import { consola } from 'consola'
 import { getAddress, type Address, type Hex, type PublicClient } from 'viem'
 
 import globalConfig from '../../config/global.json'
@@ -3026,13 +3027,11 @@ describe('periphery-registered scheduled-registration coverage', () => {
 /**
  * `safe-config` asserts the owner set in **both** directions.
  *
- * The one-directional version could only see a configured owner that had been
- * removed on chain. An owner *added* to the Safe left every configured owner in
- * place and the threshold at or above its floor, so the invariant named for the
- * governance Safe's owners passed while the signer set had been widened — which
- * is the failure these tests exist to keep closed. So the assertions come in
- * pairs: each refusal is matched by the configuration that must still pass,
- * because a check that refused every owner set would satisfy the refusals alone.
+ * An owner added to the Safe leaves every configured owner in place and the
+ * threshold at or above its floor, so only the on-chain direction can see it.
+ * The assertions come in pairs: each refusal is matched by the configuration
+ * that must still pass, because a check that refused every owner set would
+ * satisfy the refusals alone.
  */
 const SAFE = '0x1111111111111111111111111111111111111111'
 const OWNER_A = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa'
@@ -3074,8 +3073,8 @@ describe('safe-config asserts the owner set both ways', () => {
   })
 
   it('fails on an owner added to the Safe but absent from config', async () => {
-    // The gap: every configured owner is still an owner and the threshold is
-    // untouched, so the one-directional check saw nothing.
+    // Every configured owner is still an owner and the threshold is untouched,
+    // so nothing but the on-chain direction can reach this.
     const ctx = makeSafeCtx({
       configured: [OWNER_A, OWNER_B, OWNER_C],
       onChain: [OWNER_A, OWNER_B, OWNER_C, INTRUDER],
@@ -3098,9 +3097,8 @@ describe('safe-config asserts the owner set both ways', () => {
   })
 
   it('says which side each direction is missing from', async () => {
-    // Both messages name a set and a side. The pre-existing message read "not
-    // in SAFE configuration" for an owner that *was* configured and missing on
-    // chain, which points a responder at the wrong file.
+    // Both messages name a set and a side, so a responder knows which file to
+    // open.
     const ctx = makeSafeCtx({
       configured: [OWNER_A, OWNER_C],
       onChain: [OWNER_A, INTRUDER],
@@ -3129,8 +3127,8 @@ describe('safe-config asserts the owner set both ways', () => {
   })
 
   it('refuses rather than reports when config lists no owners', async () => {
-    // An empty expected set is a subset of every on-chain set there is, so both
-    // directions would pass while nothing had been compared.
+    // An empty expected set is a subset of every on-chain set there is, so a
+    // comparison against it agrees with anything.
     const ctx = makeSafeCtx({ configured: [], onChain: [OWNER_A, INTRUDER] })
     await invariant('safe-config').run(ctx)
     expect(ctx.errors).toHaveLength(1)
@@ -3138,9 +3136,9 @@ describe('safe-config asserts the owner set both ways', () => {
   })
 
   it('says the added-owner check could not run when a config entry is malformed', async () => {
-    // A typo in config would otherwise make every on-chain owner it fails to
-    // match look like an intruder. The check reports that it could not compare
-    // instead of naming an owner that may well be configured.
+    // An incomplete configured set would make an on-chain owner it cannot match
+    // look like an intruder, so the check reports that it could not compare
+    // rather than naming an owner that may well be configured.
     const ctx = makeSafeCtx({
       configured: [OWNER_A, '0xnot-an-address'],
       onChain: [getAddress(OWNER_A), getAddress(OWNER_B)],
@@ -3154,6 +3152,84 @@ describe('safe-config asserts the owner set both ways', () => {
     )
   })
 
+  it('treats a blank config entry as unusable, not as one to skip', async () => {
+    // A dropped entry is an incomplete configured set, so the comparison would
+    // name a legitimate signer as an unexpected owner of the Safe and send the
+    // responder to the Safe instead of to the blank config line.
+    for (const blank of ['', null, undefined] as unknown as string[]) {
+      const ctx = makeSafeCtx({
+        configured: [OWNER_A, blank],
+        onChain: [getAddress(OWNER_A), getAddress(OWNER_B)],
+      })
+      await invariant('safe-config').run(ctx)
+      const joined = ctx.errors.join('\n')
+
+      expect(joined).toContain('not a valid address')
+      expect(joined).not.toContain(`${getAddress(OWNER_B)} is an owner`)
+    }
+  })
+
+  it('refuses a duplicated config entry, which set equality cannot see', async () => {
+    // The two sets agree — config just claims one more owner than the Safe has.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, OWNER_A, OWNER_B],
+      onChain: [getAddress(OWNER_A), getAddress(OWNER_B)],
+    })
+    await invariant('safe-config').run(ctx)
+    expect(ctx.errors).toHaveLength(1)
+    expect(ctx.errors[0]).toContain('duplicate')
+  })
+
+  it('does not print the match line when the comparison could not run', async () => {
+    // The refusal and a "matches config" line together would read as a check
+    // that ran and agreed. Asserted on the rendered output because that is
+    // where the two can contradict each other.
+    const printed: string[] = []
+    const success = consola.success
+    consola.success = ((message: unknown) => {
+      printed.push(String(message))
+    }) as typeof consola.success
+    try {
+      await invariant('safe-config').run(
+        makeSafeCtx({ configured: [], onChain: [OWNER_A] })
+      )
+    } finally {
+      consola.success = success
+    }
+
+    expect(printed.join('\n')).not.toContain('owner set matches')
+    // Paired presence: the line does appear when the comparison does run, so
+    // this is not passing on a call that printed nothing at all.
+    const printedOnPass: string[] = []
+    consola.success = ((message: unknown) => {
+      printedOnPass.push(String(message))
+    }) as typeof consola.success
+    try {
+      await invariant('safe-config').run(
+        makeSafeCtx({ configured: [OWNER_A], onChain: [getAddress(OWNER_A)] })
+      )
+    } finally {
+      consola.success = success
+    }
+
+    expect(printedOnPass.join('\n')).toContain('owner set matches')
+  })
+
+  it('reaches the run summary when no Safe address is configured', async () => {
+    // A skipped check must not read like a passing one: the summary counts what
+    // the context collected, so a raw `consola.warn` would be invisible there.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A],
+      onChain: [INTRUDER],
+      safeAddress: undefined,
+    })
+    await invariant('safe-config').run(ctx)
+
+    expect(ctx.errors).toEqual([])
+    expect(ctx.warnings).toHaveLength(1)
+    expect(ctx.warnings[0]).toContain('No SAFE address configured')
+  })
+
   it('keeps failing a threshold below the floor', async () => {
     const ctx = makeSafeCtx({
       configured: [OWNER_A],
@@ -3163,15 +3239,5 @@ describe('safe-config asserts the owner set both ways', () => {
     await invariant('safe-config').run(ctx)
     expect(ctx.errors).toHaveLength(1)
     expect(ctx.errors[0]).toContain('threshold')
-  })
-
-  it('does not read the Safe when no address is configured', async () => {
-    const ctx = makeSafeCtx({
-      configured: [OWNER_A],
-      onChain: [INTRUDER],
-      safeAddress: undefined,
-    })
-    await invariant('safe-config').run(ctx)
-    expect(ctx.errors).toEqual([])
   })
 })

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -3195,6 +3195,22 @@ describe('safe-config asserts the owner set both ways', () => {
     }
   })
 
+  it('strips control characters out of an unusable entry', async () => {
+    // The description reaches an operator's terminal and a job log, so an entry
+    // carrying an escape sequence must not be interpolated raw.
+    const esc = String.fromCharCode(27)
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, `${esc}[31mRED`],
+      onChain: [getAddress(OWNER_A)],
+    })
+    await invariant('safe-config').run(ctx)
+    const joined = ctx.errors.join('\n')
+
+    expect(joined).not.toContain(esc)
+    // Paired presence: the entry is still described, not silently dropped.
+    expect(joined).toContain('RED')
+  })
+
   it('distinguishes two unusable entries that render identically', async () => {
     // The whole point of carrying position and length: without them these two
     // are the same text in the operator's terminal.

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -3169,16 +3169,46 @@ describe('safe-config asserts the owner set both ways', () => {
     }
   })
 
-  it('renders an unusable entry that has no printable characters', async () => {
-    // Sanitising is lossy, so a whitespace-only entry would otherwise reach the
-    // operator as an invisible gap between two commas.
+  it('identifies an unusable entry that renders to nothing visible', async () => {
+    // Sanitising strips most invisible characters but not all: a zero-width
+    // joiner and a Hangul filler both survive it at zero width, so a rendering
+    // alone cannot name the line to fix. Position and length can.
+    const cases: Array<[string, string]> = [
+      ['whitespace', '   '],
+      ['zero-width space', '\u200b'],
+      ['zero-width joiner', '\u200d'],
+      ['Hangul filler', '\u3164'],
+    ]
+
+    for (const [name, value] of cases) {
+      const ctx = makeSafeCtx({
+        configured: [OWNER_A, value],
+        onChain: [getAddress(OWNER_A)],
+      })
+      await invariant('safe-config').run(ctx)
+      const joined = ctx.errors.join('\n')
+
+      expect(joined, name).toContain('entry 1')
+      expect(joined, name).toContain(
+        `${value.length} char${value.length === 1 ? '' : 's'}`
+      )
+    }
+  })
+
+  it('distinguishes two unusable entries that render identically', async () => {
+    // The whole point of carrying position and length: without them these two
+    // are the same text in the operator's terminal.
     const ctx = makeSafeCtx({
-      configured: [OWNER_A, '   '],
+      configured: ['\u200d', '\u200d\u200d', OWNER_A],
       onChain: [getAddress(OWNER_A)],
     })
     await invariant('safe-config').run(ctx)
+    const joined = ctx.errors.join('\n')
 
-    expect(ctx.errors.join('\n')).toContain('(no printable characters)')
+    expect(joined).toContain('entry 0')
+    expect(joined).toContain('entry 1')
+    expect(joined).toContain('1 char')
+    expect(joined).toContain('2 chars')
   })
 
   it('refuses a duplicated config entry, which set equality cannot see', async () => {

--- a/script/deploy/healthCheckInvariants.test.ts
+++ b/script/deploy/healthCheckInvariants.test.ts
@@ -3153,9 +3153,9 @@ describe('safe-config asserts the owner set both ways', () => {
   })
 
   it('treats a blank config entry as unusable, not as one to skip', async () => {
-    // A dropped entry is an incomplete configured set, so the comparison would
-    // name a legitimate signer as an unexpected owner of the Safe and send the
-    // responder to the Safe instead of to the blank config line.
+    // An incomplete configured set names a legitimate signer as an unexpected
+    // owner of the Safe, sending the responder to the Safe instead of to the
+    // blank config line.
     for (const blank of ['', null, undefined] as unknown as string[]) {
       const ctx = makeSafeCtx({
         configured: [OWNER_A, blank],
@@ -3169,6 +3169,18 @@ describe('safe-config asserts the owner set both ways', () => {
     }
   })
 
+  it('renders an unusable entry that has no printable characters', async () => {
+    // Sanitising is lossy, so a whitespace-only entry would otherwise reach the
+    // operator as an invisible gap between two commas.
+    const ctx = makeSafeCtx({
+      configured: [OWNER_A, '   '],
+      onChain: [getAddress(OWNER_A)],
+    })
+    await invariant('safe-config').run(ctx)
+
+    expect(ctx.errors.join('\n')).toContain('(no printable characters)')
+  })
+
   it('refuses a duplicated config entry, which set equality cannot see', async () => {
     // The two sets agree — config just claims one more owner than the Safe has.
     const ctx = makeSafeCtx({
@@ -3180,39 +3192,60 @@ describe('safe-config asserts the owner set both ways', () => {
     expect(ctx.errors[0]).toContain('duplicate')
   })
 
-  it('does not print the match line when the comparison could not run', async () => {
-    // The refusal and a "matches config" line together would read as a check
-    // that ran and agreed. Asserted on the rendered output because that is
+  it('does not print the match line on any route that could not compare', async () => {
+    // A refusal and a "matches config" line together read as a check that ran
+    // and agreed. Every refusal route has to suppress it, not just one, so this
+    // is driven over all three. Asserted on rendered output because that is
     // where the two can contradict each other.
-    const printed: string[] = []
-    const success = consola.success
-    consola.success = ((message: unknown) => {
-      printed.push(String(message))
-    }) as typeof consola.success
-    try {
-      await invariant('safe-config').run(
-        makeSafeCtx({ configured: [], onChain: [OWNER_A] })
-      )
-    } finally {
-      consola.success = success
+    const capture = async (ctx: IHealthCheckContext): Promise<string> => {
+      const printed: string[] = []
+      const success = consola.success
+      consola.success = ((message: unknown) => {
+        printed.push(String(message))
+      }) as typeof consola.success
+      try {
+        await invariant('safe-config').run(ctx)
+      } finally {
+        consola.success = success
+      }
+      return printed.join('\n')
     }
 
-    expect(printed.join('\n')).not.toContain('owner set matches')
+    const routes: Array<[string, IHealthCheckContext]> = [
+      [
+        'no configured owners',
+        makeSafeCtx({ configured: [], onChain: [OWNER_A] }),
+      ],
+      [
+        'an unusable entry',
+        makeSafeCtx({
+          configured: [OWNER_A, '0xnot-an-address'],
+          onChain: [getAddress(OWNER_A)],
+        }),
+      ],
+      [
+        'a duplicated entry',
+        makeSafeCtx({
+          configured: [OWNER_A, OWNER_A],
+          onChain: [getAddress(OWNER_A)],
+        }),
+      ],
+    ]
+
+    for (const [route, ctx] of routes) {
+      const printed = await capture(ctx)
+      expect(printed, route).not.toContain('owner set matches')
+      expect(ctx.errors.length, route).toBeGreaterThan(0)
+    }
+
     // Paired presence: the line does appear when the comparison does run, so
-    // this is not passing on a call that printed nothing at all.
-    const printedOnPass: string[] = []
-    consola.success = ((message: unknown) => {
-      printedOnPass.push(String(message))
-    }) as typeof consola.success
-    try {
-      await invariant('safe-config').run(
-        makeSafeCtx({ configured: [OWNER_A], onChain: [getAddress(OWNER_A)] })
-      )
-    } finally {
-      consola.success = success
-    }
-
-    expect(printedOnPass.join('\n')).toContain('owner set matches')
+    // none of the above passes on a call that printed nothing at all.
+    const clean = makeSafeCtx({
+      configured: [OWNER_A],
+      onChain: [getAddress(OWNER_A)],
+    })
+    expect(await capture(clean)).toContain('owner set matches')
+    expect(clean.errors).toEqual([])
   })
 
   it('reaches the run summary when no Safe address is configured', async () => {

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -3298,7 +3298,10 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
     },
     run: async (ctx) => {
       if (!ctx.networkConfig.safeAddress) {
-        consola.warn('SAFE address not configured')
+        // `ctx.logWarn`, not `consola`: the run summary counts only what the
+        // context collected, so a raw warn makes a network that skipped this
+        // check read as one that passed it.
+        ctx.logWarn(`No SAFE address configured, cannot check the owner set`)
         return
       }
       if (!ctx.publicClient) return
@@ -3317,13 +3320,23 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         // `getOwners()` returns whatever the node encodes and the config file is
         // hand-written.
         const configured = new Set<string>()
-        const unparseable: string[] = []
+        const unusable: string[] = []
+        let duplicates = 0
         for (const entry of safeOwners) {
-          if (!entry) continue
+          // A blank or absent entry is an incomplete configured set by exactly
+          // the argument that governs an unparseable one, so it takes the same
+          // route rather than being dropped: skipping it quietly leaves the
+          // comparison naming a legitimate owner as unexpected.
+          if (!entry) {
+            unusable.push(entry === '' ? '(empty string)' : String(entry))
+            continue
+          }
           try {
-            configured.add(getAddress(entry))
+            const normalised = getAddress(entry)
+            if (configured.has(normalised)) duplicates += 1
+            configured.add(normalised)
           } catch {
-            unparseable.push(entry)
+            unusable.push(entry)
           }
         }
 
@@ -3342,38 +3355,42 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
               `SAFE owner ${safeOwner} is in config/global.json but is NOT an owner of ${safeAddress} on chain`
             )
 
-        if (unparseable.length > 0)
-          // Reported instead of comparing, never alongside a verdict: with an
-          // entry that would not normalise, the configured set is incomplete,
-          // so an on-chain owner it omits would be named as unexpected when it
-          // may be configured and merely mistyped.
+        if (unusable.length > 0)
+          // Reported instead of compared: an incomplete configured set would
+          // name an on-chain owner as unexpected when it may be configured and
+          // merely mistyped.
           report(
             `Cannot check ${safeAddress} for unexpected owners: ${
-              unparseable.length
+              unusable.length
             } entr${
-              unparseable.length === 1 ? 'y' : 'ies'
+              unusable.length === 1 ? 'y' : 'ies'
             } in config/global.json safeOwners ${
-              unparseable.length === 1 ? 'is' : 'are'
-            } not a valid address (${unparseable.join(
+              unusable.length === 1 ? 'is' : 'are'
+            } not a valid address (${unusable.join(
               ', '
-            )}). Fix the config and re-run — an owner added to the Safe is invisible until this check can compare the full set.`
+            )}). An owner added to the Safe stays invisible until the full set can be compared.`
           )
         else if (configured.size === 0)
           // An empty expected set agrees with every on-chain set there is.
           report(
             `Cannot check ${safeAddress} for unexpected owners: config/global.json lists no safeOwners`
           )
-        // The direction the configured-owner loop cannot see. An added owner
-        // leaves every configured owner in place and the threshold at or above
-        // its floor, so without this the widening is silent — and three of
-        // seven signatures is a weaker Safe than three of six, with the added
-        // key among the seven.
         else
           for (const safeOwner of onChain)
             if (!configured.has(safeOwner))
               report(
                 `SAFE owner ${safeOwner} is an owner of ${safeAddress} on chain but is NOT in config/global.json`
               )
+
+        // Set equality pins the distinct owners, not the entry count, so a
+        // duplicated entry is outside it: the sets agree while config claims
+        // one more owner than the Safe has.
+        if (duplicates > 0)
+          report(
+            `config/global.json safeOwners lists ${duplicates} duplicate entr${
+              duplicates === 1 ? 'y' : 'ies'
+            }, so its owner count does not match ${safeAddress}`
+          )
 
         if (mismatches === 0)
           consola.success(

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -54,6 +54,7 @@ import {
   loadCompiledFacetSelectors,
   resolveLiveFacets,
 } from './shared/facetPeripheryCouplings'
+import { sanitizeProvenanceText } from './shared/git-provenance'
 import { getCorePeriphery } from './shared/globalContractLists'
 import {
   collectImmutableBindingChecks,
@@ -1761,6 +1762,18 @@ async function resolvePendingRegistrations(
  * output; earlier invariants may populate mutable context fields (e.g. `onChainFacets`)
  * that later ones reuse.
  */
+/**
+ * Renders a `safeOwners` entry that cannot be used, for an operator to read.
+ *
+ * Sanitised because the raw value reaches a terminal and a job log; the fallback
+ * distinguishes an entry that rendered to nothing from one that was never there, which a
+ * bare empty string in the middle of a comma-joined list cannot.
+ * @param entry - the unusable entry, whatever it held
+ * @returns A control-character-free rendering, never empty
+ */
+const describeConfigEntry = (entry: unknown): string =>
+  sanitizeProvenanceText(String(entry)) || '(no printable characters)'
+
 export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
   {
     name: 'diamond-deployed',
@@ -3323,12 +3336,12 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         const unusable: string[] = []
         let duplicates = 0
         for (const entry of safeOwners) {
-          // A blank or absent entry is an incomplete configured set by exactly
-          // the argument that governs an unparseable one, so it takes the same
-          // route rather than being dropped: skipping it quietly leaves the
-          // comparison naming a legitimate owner as unexpected.
+          // A blank entry leaves the configured set incomplete by exactly the
+          // argument that governs an unparseable one, so it takes the same
+          // route: comparing against a partial set names a legitimate owner as
+          // unexpected.
           if (!entry) {
-            unusable.push(entry === '' ? '(empty string)' : String(entry))
+            unusable.push(describeConfigEntry(entry))
             continue
           }
           try {
@@ -3336,7 +3349,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
             if (configured.has(normalised)) duplicates += 1
             configured.add(normalised)
           } catch {
-            unusable.push(entry)
+            unusable.push(describeConfigEntry(entry))
           }
         }
 
@@ -3389,7 +3402,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           report(
             `config/global.json safeOwners lists ${duplicates} duplicate entr${
               duplicates === 1 ? 'y' : 'ies'
-            }, so its owner count does not match ${safeAddress}`
+            }, so it names fewer distinct owners than it has entries`
           )
 
         if (mismatches === 0)

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1758,11 +1758,6 @@ async function resolvePendingRegistrations(
 }
 
 /**
- * Ordered registry of every health-check invariant. The order matches historical log
- * output; earlier invariants may populate mutable context fields (e.g. `onChainFacets`)
- * that later ones reuse.
- */
-/**
  * Renders a `safeOwners` entry that cannot be used, for an operator to read.
  *
  * Sanitised because the raw value reaches a terminal and a job log; the fallback
@@ -1774,6 +1769,11 @@ async function resolvePendingRegistrations(
 const describeConfigEntry = (entry: unknown): string =>
   sanitizeProvenanceText(String(entry)) || '(no printable characters)'
 
+/**
+ * Ordered registry of every health-check invariant. The order matches historical log
+ * output; earlier invariants may populate mutable context fields (e.g. `onChainFacets`)
+ * that later ones reuse.
+ */
 export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
   {
     name: 'diamond-deployed',
@@ -3396,8 +3396,8 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
               )
 
         // Set equality pins the distinct owners, not the entry count, so a
-        // duplicated entry is outside it: the sets agree while config claims
-        // one more owner than the Safe has.
+        // duplicated entry is outside it: the sets agree while config names
+        // fewer distinct owners than it has entries.
         if (duplicates > 0)
           report(
             `config/global.json safeOwners lists ${duplicates} duplicate entr${

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -1758,16 +1758,25 @@ async function resolvePendingRegistrations(
 }
 
 /**
- * Renders a `safeOwners` entry that cannot be used, for an operator to read.
+ * Names a `safeOwners` entry that cannot be used, for an operator to read.
  *
- * Sanitised because the raw value reaches a terminal and a job log; the fallback
- * distinguishes an entry that rendered to nothing from one that was never there, which a
- * bare empty string in the middle of a comma-joined list cannot.
+ * Carries the position and the length rather than relying on the rendering being visible:
+ * sanitising strips most invisible characters but not all of them (a zero-width joiner and
+ * a Hangul filler both survive it and occupy no width), and a value that renders blank is
+ * indistinguishable from the next one inside a comma-joined list. Position and length
+ * identify the line to fix whatever the characters are.
  * @param entry - the unusable entry, whatever it held
- * @returns A control-character-free rendering, never empty
+ * @param index - its position in `safeOwners`, as an operator counts them
+ * @returns A control-character-free description that identifies the entry
  */
-const describeConfigEntry = (entry: unknown): string =>
-  sanitizeProvenanceText(String(entry)) || '(no printable characters)'
+const describeConfigEntry = (entry: unknown, index: number): string => {
+  const raw = String(entry)
+  const size = `${raw.length} char${raw.length === 1 ? '' : 's'}`
+  const rendered = sanitizeProvenanceText(raw)
+  return rendered === ''
+    ? `entry ${index} (nothing printable, ${size})`
+    : `entry ${index} "${rendered}" (${size})`
+}
 
 /**
  * Ordered registry of every health-check invariant. The order matches historical log
@@ -3335,13 +3344,13 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
         const configured = new Set<string>()
         const unusable: string[] = []
         let duplicates = 0
-        for (const entry of safeOwners) {
+        for (const [index, entry] of safeOwners.entries()) {
           // A blank entry leaves the configured set incomplete by exactly the
           // argument that governs an unparseable one, so it takes the same
           // route: comparing against a partial set names a legitimate owner as
           // unexpected.
           if (!entry) {
-            unusable.push(describeConfigEntry(entry))
+            unusable.push(describeConfigEntry(entry, index))
             continue
           }
           try {
@@ -3349,7 +3358,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
             if (configured.has(normalised)) duplicates += 1
             configured.add(normalised)
           } catch {
-            unusable.push(describeConfigEntry(entry))
+            unusable.push(describeConfigEntry(entry, index))
           }
         }
 

--- a/script/deploy/healthCheckInvariants.ts
+++ b/script/deploy/healthCheckInvariants.ts
@@ -3303,7 +3303,7 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
       }
       if (!ctx.publicClient) return
 
-      const safeOwners = ctx.globalConfig.safeOwners
+      const safeOwners = ctx.globalConfig.safeOwners ?? []
       const safeAddress = ctx.networkConfig.safeAddress
 
       try {
@@ -3313,18 +3313,72 @@ export const HEALTH_CHECK_INVARIANTS: IHealthCheckInvariant[] = [
           safeAddress as Address
         )
 
-        for (const o in safeOwners) {
-          const safeOwnerAddr = safeOwners[o]
-          if (!safeOwnerAddr) continue
-          const safeOwner = getAddress(safeOwnerAddr)
-          const isOwner = safeInfo.owners.some(
-            (owner) => getAddress(owner) === safeOwner
-          )
-          if (!isOwner)
-            ctx.logError(`SAFE owner ${safeOwner} not in SAFE configuration`)
-          else
-            consola.success(`SAFE owner ${safeOwner} is in SAFE configuration`)
+        // Checksummed on both sides, because the two sources disagree on case:
+        // `getOwners()` returns whatever the node encodes and the config file is
+        // hand-written.
+        const configured = new Set<string>()
+        const unparseable: string[] = []
+        for (const entry of safeOwners) {
+          if (!entry) continue
+          try {
+            configured.add(getAddress(entry))
+          } catch {
+            unparseable.push(entry)
+          }
         }
+
+        const onChain = new Set<string>()
+        for (const owner of safeInfo.owners) onChain.add(getAddress(owner))
+
+        let mismatches = 0
+        const report = (message: string): void => {
+          mismatches += 1
+          ctx.logError(message)
+        }
+
+        for (const safeOwner of configured)
+          if (!onChain.has(safeOwner))
+            report(
+              `SAFE owner ${safeOwner} is in config/global.json but is NOT an owner of ${safeAddress} on chain`
+            )
+
+        if (unparseable.length > 0)
+          // Reported instead of comparing, never alongside a verdict: with an
+          // entry that would not normalise, the configured set is incomplete,
+          // so an on-chain owner it omits would be named as unexpected when it
+          // may be configured and merely mistyped.
+          report(
+            `Cannot check ${safeAddress} for unexpected owners: ${
+              unparseable.length
+            } entr${
+              unparseable.length === 1 ? 'y' : 'ies'
+            } in config/global.json safeOwners ${
+              unparseable.length === 1 ? 'is' : 'are'
+            } not a valid address (${unparseable.join(
+              ', '
+            )}). Fix the config and re-run — an owner added to the Safe is invisible until this check can compare the full set.`
+          )
+        else if (configured.size === 0)
+          // An empty expected set agrees with every on-chain set there is.
+          report(
+            `Cannot check ${safeAddress} for unexpected owners: config/global.json lists no safeOwners`
+          )
+        // The direction the configured-owner loop cannot see. An added owner
+        // leaves every configured owner in place and the threshold at or above
+        // its floor, so without this the widening is silent — and three of
+        // seven signatures is a weaker Safe than three of six, with the added
+        // key among the seven.
+        else
+          for (const safeOwner of onChain)
+            if (!configured.has(safeOwner))
+              report(
+                `SAFE owner ${safeOwner} is an owner of ${safeAddress} on chain but is NOT in config/global.json`
+              )
+
+        if (mismatches === 0)
+          consola.success(
+            `SAFE owner set matches config/global.json (${onChain.size} owner(s))`
+          )
 
         if (safeInfo.threshold < BigInt(SAFE_THRESHOLD))
           ctx.logError(


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-943](https://linear.app/lifi-linear/issue/EXSC-943/the-safe-config-health-check-cannot-see-an-added-safe-owner)

# Why did I implement it this way?

`safe-config` — "Governance Safe has the expected owners and threshold", severity
`error`, production EVM — compared the two owner sets in one direction only:
every owner in `config/global.json` had to be an owner of the Safe. It never
iterated `getOwners()`.

So **an owner added to the production Safe passed the daily health check
silently.** Every configured owner was still present, and the threshold check is
a floor (`< 3` fails), which an addition does not move. With six owners and a
threshold of 3 you need three of six; with an added seventh you need three of
seven, and the added key is one of them.

Both directions are now asserted, which pins the *distinct* owner set. That is
not quite an owner-count assertion: config entries dedupe, so three entries
against two on-chain owners would agree. Duplicated entries are therefore
reported separately.

Two ways the comparison can be *unable* to run are reported as errors rather
than rendered as agreement:

- **an empty `safeOwners` list** — it is a subset of every on-chain set there
  is, so both directions would pass having compared nothing;
- **a config entry that does not normalise to an address** — the configured set
  is then incomplete, and an on-chain owner it fails to match would be named as
  an intruder when it may be configured and merely mistyped. The check says it
  could not compare instead of naming an owner on the strength of a partial set.

The pre-existing direction's message is corrected. It read `SAFE owner X not in
SAFE configuration` for an owner that *was* configured and missing on chain,
which points a responder at the wrong file. Both messages now name a set and a
side.

The per-owner success chatter is replaced by one line naming the count, since
what is now checked is the set as a whole rather than each owner independently.

`getSafeInfoFromContract` already returned `owners`, so there is no new RPC read.

## Falsification

Every new assertion was mutated and killed (`bun test
script/deploy/healthCheckInvariants.test.ts`):

| Mutation | Killed by |
|---|---|
| reverse direction removed | added-owner test, side-naming test |
| empty-config branch tolerated | "refuses rather than reports when config lists no owners" |
| malformed entry silently dropped | "says the added-owner check could not run…" |
| config side not checksummed | 6 tests |
| on-chain side not checksummed | 4 tests |
| threshold floor removed | "keeps failing a threshold below the floor" |
| falsy `safeOwners` entry skipped | "treats a blank config entry as unusable" |
| duplicate check disabled | "refuses a duplicated config entry" |
| `ctx.logWarn` reverted to a raw `consola.warn` | "reaches the run summary when no Safe address is configured" |
| `mismatches` counter deleted | "does not print the match line on any route that could not compare" |
| `report` → `ctx.logError` on the unusable route | same |
| `report` → `ctx.logError` on the duplicate route | same |
| sanitizer, and its fallback, removed | "renders an unusable entry that has no printable characters" |

One mutation survives and is **equivalent, not a gap**: `configured.size === 0` →
`safeOwners.length === 0`. That branch is reachable only when `unusable` is empty,
and every `continue` and every throw in the loop pushes to `unusable`, so reaching
it means every entry parsed — where the two predicates agree.

Reverting the implementation to its pre-PR form fails 5 of the new tests,
including the added-owner case.

Driven once against the **real** `config/global.json` owner list (6 owners,
threshold 3) with a stubbed `getOwners()`:

- on-chain set == config → passes, so the check is not a blanket refusal;
- config + 1 unexpected owner → refuses, naming that address and the side it is
  on;
- config − 1 owner → refuses on the other direction, naming the configured
  address.


## The fleet cannot go red on this

Asserting the reverse direction is only safe if `config/global.json` `safeOwners`
really is the owner set of *every* production EVM Safe. It is:

- `safeOwners` is the single owner source in the repo — no per-network owner map,
  override, or exception list exists, and `HEALTH_CHECK_EXCLUSIONS` is empty.
- `script/deploy/safe/add-safe-owners-and-threshold.ts --check` has required both
  `missingOwners` and `extraOwners` to be empty since #1758, over this same
  network set. This PR moves an expectation that already exists into the daily
  check.
- Read directly, read-only, from all **65** production EVM Safes: every one holds
  exactly the 6 configured owners, with threshold ≥ 3. Zero extra owners, zero
  missing, zero low thresholds. That also settles the one residual — `deploy-safe`
  has an undocumented `--owners` flag that merges extra owners in at creation, and
  no production chain shows a trace of it having been used.

## Gate round

Two rounds. The first, on `4ceca867c`, found four things, fixed in `93403c3fa`:

- **A blank or absent `safeOwners` entry was dropped** by `if (!entry) continue` —
  a second route to the incomplete configured set the unparseable branch exists to
  refuse, which skipped that branch. Blanking one config line would have turned
  every network red naming a *legitimate* signer as an unexpected owner. Falsy
  entries now take the same route as unparseable ones.
- **Duplicated config entries** were outside set equality (above).
- **The "no SAFE address configured" exit used a raw `consola.warn`**, so a network
  that skipped the check reached the run summary looking like one that passed. Now
  `ctx.logWarn`, as the 25 other warn sites in the file do.
- **Two guards were untested**: deleting the falsy-entry skip and deleting the
  `mismatches` counter both survived. Both are now killed; the counter's test
  asserts on rendered output, since that is where a refusal and a "matches config"
  line can contradict each other.

A second round on `93403c3fa` found that the counter suppressing the "owner set
matches" line was asserted on **one of its three refusal routes** — mutating the
other two left the suite green while both printed a refusal and the match line
together. It also found the duplicate refusal's message claimed "so its owner count
does not match", which is false whenever the counts still agree. Both fixed in
`2a5eb51f5`, along with rendering unusable entries through `sanitizeProvenanceText`
so a whitespace-only entry is not an invisible gap between two commas.

Both rounds came back clean on the fleet-wide question, on double-counting through
`executeInvariant`'s re-verify, and on the `!ctx.publicClient` exit (unreachable in
scope — `healthCheck.ts` always builds a client or throws, and `chains: 'evm-only'`
excludes Tron).

Tron's Safe is out of this invariant's scope (`chains: 'evm-only'`).

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

No Solidity changes: this is a read-only health-check invariant, no new
contract and no privileged call.


