### PR TITLE
feat(deploy): gate Safe deployment on config, not on its own arguments (EXSC-944)

### DIFF
--- a/script/deploy/safe/add-safe-owners-and-threshold.ts
+++ b/script/deploy/safe/add-safe-owners-and-threshold.ts
@@ -3,7 +3,7 @@
  *
  * Proposes Safe transactions to add owners (from `config/global.json:safeOwners`
  * and/or `--owners`) and, when current threshold differs, propose a change to
- * the expected value (`EXPECTED_THRESHOLD`).
+ * the expected value (`SAFE_THRESHOLD`).
  * Supports a single network (`--network <name>`) or every active EVM mainnet
  * (`--all-networks`, excludes `networks.json` entries with `type: "testnet"`).
  * Signs with a Ledger by default; falls back to a private
@@ -26,6 +26,7 @@ import {
 import globalConfig from '../../../config/global.json'
 import networksData from '../../../config/networks.json'
 import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
+import { SAFE_THRESHOLD } from '../shared/constants'
 
 import type { ILedgerAccountResult } from './ledger'
 import { assertTicketPresent } from './proposal-intent'
@@ -39,8 +40,6 @@ import {
   storeTransactionInMongoDB,
   type ISafeTxDocument,
 } from './safe-utils'
-
-const EXPECTED_THRESHOLD = 3
 
 const ansi = (code: string, text: string) => `\x1b[${code}m${text}\x1b[0m`
 const green = (text: string) => ansi('32', text)
@@ -88,7 +87,7 @@ interface ICheckResult {
 const main = defineCommand({
   meta: {
     name: 'add-safe-owners-and-threshold',
-    description: `Proposes transactions to add SAFE owners from global.json (and/or --owners) and sets threshold to ${EXPECTED_THRESHOLD}. Single network via --network; --all-networks skips networks where type is testnet.`,
+    description: `Proposes transactions to add SAFE owners from global.json (and/or --owners) and sets threshold to ${SAFE_THRESHOLD}. Single network via --network; --all-networks skips networks where type is testnet.`,
   },
   args: {
     network: {
@@ -155,16 +154,12 @@ const main = defineCommand({
       ) as Address[]
 
       consola.info(
-        `Checking ${networks.length} network(s) against ${expectedOwners.length} expected owner(s) + threshold=${EXPECTED_THRESHOLD}`
+        `Checking ${networks.length} network(s) against ${expectedOwners.length} expected owner(s) + threshold=${SAFE_THRESHOLD}`
       )
 
       const checkResults: ICheckResult[] = []
       for (const network of networks) {
-        const r = await checkNetwork(
-          network,
-          expectedOwners,
-          EXPECTED_THRESHOLD
-        )
+        const r = await checkNetwork(network, expectedOwners, SAFE_THRESHOLD)
         checkResults.push(r)
       }
 
@@ -417,7 +412,7 @@ async function processNetwork(
 
     let thresholdNewlyProposed = false
     let thresholdAlreadyProposed = false
-    if (currentThreshold !== EXPECTED_THRESHOLD) {
+    if (currentThreshold !== SAFE_THRESHOLD) {
       // Existing proposals will add their owners when executed, so include
       // both newly proposed and already-proposed addOwners in the projection.
       const updatedOwnerCount =
@@ -425,16 +420,16 @@ async function processNetwork(
         addOwnerNewlyProposed +
         addOwnerAlreadyProposed
 
-      if (updatedOwnerCount < EXPECTED_THRESHOLD)
+      if (updatedOwnerCount < SAFE_THRESHOLD)
         throw new Error(
-          `Cannot set threshold to ${EXPECTED_THRESHOLD} when only ${updatedOwnerCount} owner(s) would exist (would lock the Safe)`
+          `Cannot set threshold to ${SAFE_THRESHOLD} when only ${updatedOwnerCount} owner(s) would exist (would lock the Safe)`
         )
 
       consola.info(
-        `Now proposing to change threshold from ${currentThreshold} to ${EXPECTED_THRESHOLD}`
+        `Now proposing to change threshold from ${currentThreshold} to ${SAFE_THRESHOLD}`
       )
       const changeThresholdTx = await safe.createChangeThresholdTx(
-        EXPECTED_THRESHOLD,
+        SAFE_THRESHOLD,
         { nonce: nextNonce }
       )
       const signedThresholdTx = await safe.signTransaction(changeThresholdTx)
@@ -463,7 +458,7 @@ async function processNetwork(
       }
     } else
       consola.success(
-        `Threshold is already set to ${EXPECTED_THRESHOLD} - no action required`
+        `Threshold is already set to ${SAFE_THRESHOLD} - no action required`
       )
 
     const summaryParts: string[] = []
@@ -473,10 +468,9 @@ async function processNetwork(
       summaryParts.push(`${addOwnerAlreadyProposed} addOwner already proposed`)
     if (ownersAlreadyOnChain > 0)
       summaryParts.push(`${ownersAlreadyOnChain} already on-chain`)
-    if (thresholdNewlyProposed)
-      summaryParts.push(`threshold→${EXPECTED_THRESHOLD}`)
+    if (thresholdNewlyProposed) summaryParts.push(`threshold→${SAFE_THRESHOLD}`)
     else if (thresholdAlreadyProposed)
-      summaryParts.push(`threshold→${EXPECTED_THRESHOLD} already proposed`)
+      summaryParts.push(`threshold→${SAFE_THRESHOLD} already proposed`)
     if (!summaryParts.length) summaryParts.push('no changes')
 
     return { proposalsCreated, summary: summaryParts.join(', ') }
@@ -588,7 +582,7 @@ function printCheckTable(results: ICheckResult[]): void {
     const th =
       r.threshold !== undefined
         ? `threshold=${
-            r.threshold === EXPECTED_THRESHOLD
+            r.threshold === SAFE_THRESHOLD
               ? green(String(r.threshold))
               : red(String(r.threshold))
           }`

--- a/script/deploy/safe/deploy-safe.ts
+++ b/script/deploy/safe/deploy-safe.ts
@@ -86,7 +86,15 @@ import {
 import { setupEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
 import { sleep } from '../../utils/delay'
 import { getFoundryDefaultEvmVersion } from '../../utils/utils'
+import { isTestnetNetwork } from '../../utils/viemScriptHelpers'
 import { EVM_VERSIONS } from '../shared/constants'
+
+import {
+  assertSafeAddressOverrideAllowed,
+  assertSafeThresholdFloor,
+  compareOwnerSets,
+  describeOwnerSetDivergence,
+} from './safe-deploy-guards'
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
@@ -278,9 +286,9 @@ const main = defineCommand({
     allowOverride: {
       type: 'boolean',
       description:
-        'Whether to allow overriding existing Safe address in networks.json (default: true)',
+        'Whether to allow overriding existing Safe address in networks.json (default: false)',
       required: false,
-      default: true,
+      default: false,
     },
     rpcUrl: {
       type: 'string',
@@ -336,9 +344,14 @@ const main = defineCommand({
     // validate network & existing
     const networkName = args.network as SupportedChain
     const existing = networks[networkName]?.safeAddress
-    if (existing && existing !== zeroAddress && !args.allowOverride)
-      throw new Error(
-        `Safe already deployed on ${networkName} @ ${existing}. Use --allowOverride flag to force redeployment.`
+    const override = assertSafeAddressOverrideAllowed({
+      network: networkName,
+      existing,
+      allowOverride: args.allowOverride,
+    })
+    if (override.occupied)
+      consola.warn(
+        `--allowOverride: this run replaces the Safe at ${existing} that config/networks.json names for ${networkName}`
       )
 
     // parse & validate threshold + owners
@@ -346,6 +359,15 @@ const main = defineCommand({
     const threshold = Number(args.threshold)
     if (isNaN(threshold) || threshold < 1)
       throw new Error('Threshold must be a positive integer')
+
+    const thresholdFloor = assertSafeThresholdFloor({
+      network: networkName,
+      threshold,
+      isTestnet: isTestnetNetwork(networkName),
+    })
+    consola.info(
+      `Threshold ${threshold} clears the ${thresholdFloor.floor}-confirmation floor for ${networkName}`
+    )
 
     if (isDefaultThreshold)
       consola.info('ℹ Using default threshold of 3 required confirmations')
@@ -525,6 +547,7 @@ const main = defineCommand({
     // verify on-chain owners & threshold
     consola.info('🔍 Verifying Safe on-chain state…')
 
+    let ownerDivergence: string[] = []
     try {
       const [actualOwners, actualThreshold] = await Promise.all([
         publicClient.readContract({
@@ -558,6 +581,16 @@ const main = defineCommand({
         )
         throw new Error('Threshold verification failed')
       } else consola.success('✔ Threshold matches expected')
+
+      ownerDivergence = describeOwnerSetDivergence({
+        network: networkName,
+        safeAddress,
+        comparison: compareOwnerSets(ownersFromConfig, actual),
+      })
+      if (ownerDivergence.length) {
+        consola.warn('⚠ CONFIG DIVERGENCE')
+        for (const line of ownerDivergence) consola.warn(line)
+      } else consola.success('✔ Owners match config/global.json safeOwners')
     } catch (error) {
       consola.error('❌ Verification failed with error:', error)
       consola.error(`Safe address: ${safeAddress}`)
@@ -569,19 +602,16 @@ const main = defineCommand({
 
     // update networks.json
     try {
-      if (args.allowOverride) {
-        ;(networks as any)[networkName] = {
-          ...networks[networkName],
-          safeAddress,
-        }
-        writeFileSync(
-          join(__dirname, '../../../config/networks.json'),
-          `${JSON.stringify(networks, null, 2)}\n`,
-          'utf8'
-        )
-        consola.success(`✔ networks.json updated with Safe @ ${safeAddress}`)
-      } else
-        consola.info(`ℹ Skipping networks.json update (--allowOverride=false)`)
+      ;(networks as any)[networkName] = {
+        ...networks[networkName],
+        safeAddress,
+      }
+      writeFileSync(
+        join(__dirname, '../../../config/networks.json'),
+        `${JSON.stringify(networks, null, 2)}\n`,
+        'utf8'
+      )
+      consola.success(`✔ networks.json updated with Safe @ ${safeAddress}`)
     } catch (error) {
       consola.error('❌ Failed to update networks.json:', error)
       consola.error(
@@ -594,6 +624,10 @@ const main = defineCommand({
       consola.info('-'.repeat(80))
       consola.info('🎉 Deployment complete!')
       consola.info(`Safe Address: \u001b[32m${safeAddress}\u001b[0m`)
+      if (ownerDivergence.length) {
+        consola.warn('⚠ CONFIG DIVERGENCE')
+        for (const line of ownerDivergence) consola.warn(line)
+      }
       const explorerUrl = chain.blockExplorers?.default?.url
       if (explorerUrl)
         consola.info(

--- a/script/deploy/safe/deploy-safe.ts
+++ b/script/deploy/safe/deploy-safe.ts
@@ -355,7 +355,9 @@ const main = defineCommand({
       )
 
     // parse & validate threshold + owners
-    const isDefaultThreshold = !process.argv.includes('--threshold')
+    const isDefaultThreshold = !process.argv.some(
+      (arg) => arg === '--threshold' || arg.startsWith('--threshold=')
+    )
     const threshold = Number(args.threshold)
     if (isNaN(threshold) || threshold < 1)
       throw new Error('Threshold must be a positive integer')
@@ -565,6 +567,21 @@ const main = defineCommand({
       const expected = owners.map((o) => o.toLowerCase())
       const actual = (actualOwners as Address[]).map((o) => o.toLowerCase())
 
+      // Against config first, because the requested-vs-actual check below throws
+      // unless the two sets are equal — so anything read after it can only
+      // restate the arguments this run supplied. The Safe's address is not
+      // always one this run derived: the no-`ProxyCreation` fallback takes it
+      // from an operator's keyboard.
+      ownerDivergence = describeOwnerSetDivergence({
+        network: networkName,
+        safeAddress,
+        comparison: compareOwnerSets(ownersFromConfig, actual),
+      })
+      if (ownerDivergence.length) {
+        consola.warn('⚠ CONFIG DIVERGENCE')
+        for (const line of ownerDivergence) consola.warn(line)
+      } else consola.success('✔ Owners match config/global.json safeOwners')
+
       const missing = expected.filter((o) => !actual.includes(o))
       const extra = actual.filter((o) => !expected.includes(o))
 
@@ -581,16 +598,6 @@ const main = defineCommand({
         )
         throw new Error('Threshold verification failed')
       } else consola.success('✔ Threshold matches expected')
-
-      ownerDivergence = describeOwnerSetDivergence({
-        network: networkName,
-        safeAddress,
-        comparison: compareOwnerSets(ownersFromConfig, actual),
-      })
-      if (ownerDivergence.length) {
-        consola.warn('⚠ CONFIG DIVERGENCE')
-        for (const line of ownerDivergence) consola.warn(line)
-      } else consola.success('✔ Owners match config/global.json safeOwners')
     } catch (error) {
       consola.error('❌ Verification failed with error:', error)
       consola.error(`Safe address: ${safeAddress}`)

--- a/script/deploy/safe/safe-deploy-guards.test.ts
+++ b/script/deploy/safe/safe-deploy-guards.test.ts
@@ -250,6 +250,53 @@ describe('assertSafeThresholdFloor', () => {
   })
 })
 
+describe('the normalisers that decide what counts as no Safe', () => {
+  // `config/networks.json` is hand-edited, so these forms are reachable by a
+  // typo rather than by an attack. Each one denotes *no Safe*, so reading it as
+  // occupied would refuse a legitimate first deployment.
+  it('reads an upper-case or padded zero address as no Safe', () => {
+    for (const existing of [
+      '0X0000000000000000000000000000000000000000',
+      '  0x0000000000000000000000000000000000000000  ',
+      '0x0000000000000000000000000000000000000000',
+    ]) {
+      const verdict = evaluateSafeAddressOverride({
+        network: sampleNetwork,
+        existing,
+        allowOverride: false,
+      })
+
+      expect(verdict.occupied, existing).toBe(false)
+      expect(verdict.allowed, existing).toBe(true)
+    }
+  })
+
+  it('still reads a real address as occupied, however it is spelled', () => {
+    // Paired presence: leniency about the zero address must not make a Safe
+    // that exists look absent.
+    for (const existing of [
+      '0xE3C8121DF9b1c5A7d383Ab4923fF848a6510F357',
+      '0xe3c8121df9b1c5a7d383ab4923ff848a6510f357',
+      '  0xE3C8121DF9b1c5A7d383Ab4923fF848a6510F357  ',
+      `0x${'0'.repeat(39)}1`,
+    ]) {
+      const verdict = evaluateSafeAddressOverride({
+        network: sampleNetwork,
+        existing,
+        allowOverride: false,
+      })
+
+      expect(verdict.occupied, existing).toBe(true)
+      expect(verdict.allowed, existing).toBe(false)
+    }
+  })
+
+  it('does not treat surrounding whitespace as an owner difference', () => {
+    const owner = '0xE3C8121DF9b1c5A7d383Ab4923fF848a6510F357'
+    expect(compareOwnerSets([owner], [`  ${owner}  `]).matchesConfig).toBe(true)
+  })
+})
+
 describe('compareOwnerSets', () => {
   it('matches the committed owner set against itself', () => {
     expect(compareOwnerSets(configOwners, configOwners)).toEqual({

--- a/script/deploy/safe/safe-deploy-guards.test.ts
+++ b/script/deploy/safe/safe-deploy-guards.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for the Safe deployment guards (safe-deploy-guards.ts).
+ *
+ * Every refusal is exercised twice: once against the committed
+ * `config/global.json` / `config/networks.json` so it is shown to fire on the
+ * data a real invocation reads, and once against the configuration the fleet
+ * actually runs so none of them is a blanket refusal.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import globalConfig from '../../../config/global.json'
+import networks from '../../../config/networks.json'
+import { SAFE_THRESHOLD } from '../shared/constants'
+
+import {
+  assertSafeAddressOverrideAllowed,
+  assertSafeThresholdFloor,
+  compareOwnerSets,
+  describeOwnerSetDivergence,
+  evaluateSafeAddressOverride,
+  evaluateSafeThresholdFloor,
+} from './safe-deploy-guards'
+
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+const configOwners = globalConfig.safeOwners as string[]
+
+const networkEntries = Object.entries(
+  networks as Record<string, { safeAddress?: string; type?: string }>
+)
+
+const mainnetWithSafe = networkEntries.filter(
+  ([, entry]) =>
+    entry.type !== 'testnet' &&
+    typeof entry.safeAddress === 'string' &&
+    entry.safeAddress.length > 0 &&
+    entry.safeAddress !== ZERO
+)
+
+const testnets = networkEntries.filter(([, entry]) => entry.type === 'testnet')
+
+const required = <T>(value: T | undefined, what: string): T => {
+  if (value === undefined)
+    throw new Error(`committed config carries no ${what}`)
+  return value
+}
+
+const [sampleNetwork, sampleEntry] = required(
+  mainnetWithSafe[0],
+  'mainnet with a Safe address'
+)
+const sampleSafeAddress = required(
+  sampleEntry.safeAddress,
+  'sample Safe address'
+)
+const firstConfigOwner = required(configOwners[0], 'configured Safe owner')
+
+describe('committed config the guards are judged against', () => {
+  it('declares more owners than the threshold floor requires', () => {
+    expect(configOwners.length).toBeGreaterThan(SAFE_THRESHOLD)
+  })
+
+  it('names a live Safe on every mainnet, and on no testnet', () => {
+    const mainnets = networkEntries.filter(
+      ([, entry]) => entry.type !== 'testnet'
+    )
+    expect(mainnetWithSafe.length).toBe(mainnets.length)
+    expect(mainnetWithSafe.length).toBeGreaterThan(0)
+    expect(testnets.length).toBeGreaterThan(0)
+    for (const [, entry] of testnets)
+      expect(entry.safeAddress === undefined || entry.safeAddress === '').toBe(
+        true
+      )
+  })
+})
+
+describe('evaluateSafeAddressOverride', () => {
+  it('refuses every mainnet in committed config when the flag is absent', () => {
+    for (const [network, entry] of mainnetWithSafe) {
+      const verdict = evaluateSafeAddressOverride({
+        network,
+        existing: entry.safeAddress,
+        allowOverride: false,
+      })
+      expect(verdict.occupied).toBe(true)
+      expect(verdict.allowed).toBe(false)
+      expect(verdict.refusal).toContain(entry.safeAddress as string)
+      expect(verdict.refusal).toContain('--allowOverride')
+    }
+  })
+
+  it('allows the same mainnets once the flag is stated', () => {
+    for (const [network, entry] of mainnetWithSafe) {
+      const verdict = evaluateSafeAddressOverride({
+        network,
+        existing: entry.safeAddress,
+        allowOverride: true,
+      })
+      expect(verdict.occupied).toBe(true)
+      expect(verdict.allowed).toBe(true)
+      expect(verdict.refusal).toBeUndefined()
+    }
+  })
+
+  it('allows bring-up on every network committed config leaves empty', () => {
+    for (const [network, entry] of testnets) {
+      const verdict = evaluateSafeAddressOverride({
+        network,
+        existing: entry.safeAddress,
+        allowOverride: false,
+      })
+      expect(verdict.occupied).toBe(false)
+      expect(verdict.allowed).toBe(true)
+    }
+  })
+
+  it('treats an explicit zero address as unoccupied', () => {
+    const verdict = evaluateSafeAddressOverride({
+      network: 'mainnet',
+      existing: ZERO,
+      allowOverride: false,
+    })
+    expect(verdict.occupied).toBe(false)
+    expect(verdict.allowed).toBe(true)
+  })
+
+  it('treats a checksummed and a lowercase address alike', () => {
+    expect(
+      evaluateSafeAddressOverride({
+        network: 'mainnet',
+        existing: sampleSafeAddress.toLowerCase(),
+        allowOverride: false,
+      }).allowed
+    ).toBe(false)
+  })
+})
+
+describe('assertSafeAddressOverrideAllowed', () => {
+  it('throws for a mainnet from committed config without the flag', () => {
+    expect(() =>
+      assertSafeAddressOverrideAllowed({
+        network: sampleNetwork,
+        existing: sampleSafeAddress,
+        allowOverride: false,
+      })
+    ).toThrow(sampleSafeAddress)
+  })
+
+  it('returns the verdict when the flag is stated', () => {
+    expect(
+      assertSafeAddressOverrideAllowed({
+        network: sampleNetwork,
+        existing: sampleSafeAddress,
+        allowOverride: true,
+      }).occupied
+    ).toBe(true)
+  })
+})
+
+describe('evaluateSafeThresholdFloor', () => {
+  it('refuses every threshold under the floor on a mainnet', () => {
+    for (let threshold = 1; threshold < SAFE_THRESHOLD; threshold++) {
+      const verdict = evaluateSafeThresholdFloor({
+        network: sampleNetwork,
+        threshold,
+        isTestnet: false,
+      })
+      expect(verdict.allowed).toBe(false)
+      expect(verdict.floor).toBe(SAFE_THRESHOLD)
+      expect(verdict.refusal).toContain(`--threshold ${threshold}`)
+      expect(verdict.refusal).toContain(sampleNetwork)
+    }
+  })
+
+  it('allows the floor itself and anything above it on every mainnet', () => {
+    for (const [network] of mainnetWithSafe)
+      for (const threshold of [SAFE_THRESHOLD, configOwners.length]) {
+        const verdict = evaluateSafeThresholdFloor({
+          network,
+          threshold,
+          isTestnet: false,
+        })
+        expect(verdict.allowed).toBe(true)
+        expect(verdict.refusal).toBeUndefined()
+      }
+  })
+
+  it('allows a single confirmation on a testnet but not on a mainnet', () => {
+    const [testnet] = required(testnets[0], 'testnet')
+    expect(
+      evaluateSafeThresholdFloor({
+        network: testnet,
+        threshold: 1,
+        isTestnet: true,
+      })
+    ).toEqual({ allowed: true, floor: 1 })
+    expect(
+      evaluateSafeThresholdFloor({
+        network: testnet,
+        threshold: 1,
+        isTestnet: false,
+      }).allowed
+    ).toBe(false)
+  })
+})
+
+describe('assertSafeThresholdFloor', () => {
+  it('throws for one confirmation on a mainnet from committed config', () => {
+    expect(() =>
+      assertSafeThresholdFloor({
+        network: sampleNetwork,
+        threshold: 1,
+        isTestnet: false,
+      })
+    ).toThrow(`below the ${SAFE_THRESHOLD} confirmations`)
+  })
+
+  it('returns the floor for the threshold the script defaults to', () => {
+    expect(
+      assertSafeThresholdFloor({
+        network: sampleNetwork,
+        threshold: SAFE_THRESHOLD,
+        isTestnet: false,
+      })
+    ).toEqual({ allowed: true, floor: SAFE_THRESHOLD })
+  })
+})
+
+describe('compareOwnerSets', () => {
+  it('matches the committed owner set against itself', () => {
+    expect(compareOwnerSets(configOwners, configOwners)).toEqual({
+      matchesConfig: true,
+      absent: [],
+      beyondConfig: [],
+    })
+  })
+
+  it('matches across checksum casing and reordering', () => {
+    const deployed = [...configOwners]
+      .reverse()
+      .map((owner) => owner.toUpperCase().replace('0X', '0x'))
+    expect(compareOwnerSets(configOwners, deployed).matchesConfig).toBe(true)
+  })
+
+  it('reports an owner the committed config does not declare', () => {
+    const intruder = '0x00000000000000000000000000000000000000ff'
+    const comparison = compareOwnerSets(configOwners, [
+      ...configOwners,
+      intruder,
+    ])
+    expect(comparison.matchesConfig).toBe(false)
+    expect(comparison.beyondConfig).toEqual([intruder])
+    expect(comparison.absent).toEqual([])
+  })
+
+  it('reports a configured owner the Safe does not have', () => {
+    const comparison = compareOwnerSets(configOwners, configOwners.slice(1))
+    expect(comparison.matchesConfig).toBe(false)
+    expect(comparison.absent).toEqual([firstConfigOwner.toLowerCase()])
+    expect(comparison.beyondConfig).toEqual([])
+  })
+
+  it('reports both directions at once', () => {
+    const intruder = '0x00000000000000000000000000000000000000ff'
+    const comparison = compareOwnerSets(configOwners, [
+      ...configOwners.slice(1),
+      intruder,
+    ])
+    expect(comparison.absent).toEqual([firstConfigOwner.toLowerCase()])
+    expect(comparison.beyondConfig).toEqual([intruder])
+  })
+
+  it('reports a Safe that kept one configured owner and added three', () => {
+    const attackers = [
+      '0x00000000000000000000000000000000000000a1',
+      '0x00000000000000000000000000000000000000a2',
+      '0x00000000000000000000000000000000000000a3',
+    ]
+    const comparison = compareOwnerSets(configOwners, [
+      firstConfigOwner,
+      ...attackers,
+    ])
+    expect(comparison.beyondConfig).toEqual(attackers)
+    expect(comparison.absent).toEqual(
+      configOwners.slice(1).map((owner) => owner.toLowerCase())
+    )
+  })
+})
+
+describe('describeOwnerSetDivergence', () => {
+  it('says nothing when the deployed owners are the committed ones', () => {
+    expect(
+      describeOwnerSetDivergence({
+        network: sampleNetwork,
+        safeAddress: sampleSafeAddress,
+        comparison: compareOwnerSets(configOwners, configOwners),
+      })
+    ).toEqual([])
+  })
+
+  it('names the network, the Safe and each undeclared owner', () => {
+    const intruder = '0x00000000000000000000000000000000000000ff'
+    const lines = describeOwnerSetDivergence({
+      network: sampleNetwork,
+      safeAddress: sampleSafeAddress,
+      comparison: compareOwnerSets(configOwners, [...configOwners, intruder]),
+    })
+    const report = lines.join('\n')
+    expect(lines.length).toBe(3)
+    expect(report).toContain(sampleNetwork)
+    expect(report).toContain(sampleSafeAddress)
+    expect(report).toContain(intruder)
+    expect(report).toContain('deliberate override')
+    expect(report).not.toContain('does not have')
+  })
+
+  it('names a configured owner that is missing', () => {
+    const lines = describeOwnerSetDivergence({
+      network: sampleNetwork,
+      safeAddress: sampleSafeAddress,
+      comparison: compareOwnerSets(configOwners, configOwners.slice(1)),
+    })
+    const report = lines.join('\n')
+    expect(lines.length).toBe(3)
+    expect(report).toContain(firstConfigOwner.toLowerCase())
+    expect(report).toContain('does not have')
+    expect(report).not.toContain('does not declare')
+  })
+
+  it('names both directions on one report', () => {
+    const intruder = '0x00000000000000000000000000000000000000ff'
+    const lines = describeOwnerSetDivergence({
+      network: sampleNetwork,
+      safeAddress: sampleSafeAddress,
+      comparison: compareOwnerSets(configOwners, [
+        ...configOwners.slice(1),
+        intruder,
+      ]),
+    })
+    expect(lines.length).toBe(4)
+    expect(lines.join('\n')).toContain(intruder)
+    expect(lines.join('\n')).toContain(firstConfigOwner.toLowerCase())
+  })
+})

--- a/script/deploy/safe/safe-deploy-guards.test.ts
+++ b/script/deploy/safe/safe-deploy-guards.test.ts
@@ -292,8 +292,12 @@ describe('the normalisers that decide what counts as no Safe', () => {
   })
 
   it('does not treat surrounding whitespace as an owner difference', () => {
+    // Both sides, because either one can carry the padding: the config side is
+    // hand-edited and the deployed side is whatever the node encodes.
     const owner = '0xE3C8121DF9b1c5A7d383Ab4923fF848a6510F357'
+
     expect(compareOwnerSets([owner], [`  ${owner}  `]).matchesConfig).toBe(true)
+    expect(compareOwnerSets([`  ${owner}  `], [owner]).matchesConfig).toBe(true)
   })
 })
 

--- a/script/deploy/safe/safe-deploy-guards.test.ts
+++ b/script/deploy/safe/safe-deploy-guards.test.ts
@@ -1,10 +1,9 @@
 /**
- * Tests for the Safe deployment guards (safe-deploy-guards.ts).
+ * The Safe deployment guards.
  *
- * Every refusal is exercised twice: once against the committed
- * `config/global.json` / `config/networks.json` so it is shown to fire on the
- * data a real invocation reads, and once against the configuration the fleet
- * actually runs so none of them is a blanket refusal.
+ * Each refusal is paired with the configuration that must still pass, because a
+ * guard that refused every deployment would satisfy the refusals alone — and
+ * the command cannot be run to find out.
  */
 
 import {
@@ -219,6 +218,25 @@ describe('assertSafeThresholdFloor', () => {
         isTestnet: false,
       })
     ).toThrow(`below the ${SAFE_THRESHOLD} confirmations`)
+  })
+
+  it('refuses a threshold that is not a whole number, and says so', () => {
+    // These compare above the floor while being no count of signatures at all.
+    // The refusal names that, rather than telling the operator their value is
+    // below a floor it in fact exceeds.
+    // `1e100` is deliberately absent: it *is* a whole number, and an absurdly
+    // large one is refused downstream by `threshold > owners.length`.
+    for (const threshold of [3.5, 2.5, Infinity, -Infinity, NaN]) {
+      expect(
+        () =>
+          assertSafeThresholdFloor({
+            network: sampleNetwork,
+            threshold,
+            isTestnet: false,
+          }),
+        String(threshold)
+      ).toThrow('not a whole number')
+    }
   })
 
   it('returns the floor for the threshold the script defaults to', () => {

--- a/script/deploy/safe/safe-deploy-guards.ts
+++ b/script/deploy/safe/safe-deploy-guards.ts
@@ -1,0 +1,187 @@
+/**
+ * Decides whether a Safe deployment may proceed and whether the Safe it
+ * produced matches repo config.
+ *
+ * Imported by `deploy-safe.ts`. The three decisions are pure so each refusal
+ * can be exercised against the committed `config/global.json` and
+ * `config/networks.json` without running a deployment.
+ */
+
+import { SAFE_THRESHOLD } from '../shared/constants'
+
+/** Whether a deployment may replace the Safe address config already names. */
+export interface ISafeOverrideVerdict {
+  /** Whether config already names a non-zero Safe for this network. */
+  occupied: boolean
+  allowed: boolean
+  /** Set exactly when `allowed` is false. */
+  refusal?: string
+}
+
+/** Whether a threshold clears the fleet-wide floor. */
+export interface ISafeThresholdVerdict {
+  allowed: boolean
+  floor: number
+  /** Set exactly when `allowed` is false. */
+  refusal?: string
+}
+
+/** How a deployed owner set relates to the one config declares. */
+export interface IOwnerSetComparison {
+  matchesConfig: boolean
+  /** Configured owners the deployed Safe does not have, lowercase. */
+  absent: string[]
+  /** Deployed owners config does not declare, lowercase. */
+  beyondConfig: string[]
+}
+
+const isZeroAddress = (address: string): boolean =>
+  /^0x0{40}$/i.test(address.trim())
+
+/**
+ * Judges a deployment against the Safe address config already names.
+ * @param input.network - target network name, named in the refusal
+ * @param input.existing - `safeAddress` config currently names, if any
+ * @param input.allowOverride - whether the operator asked to replace it
+ * @returns Whether config is occupied and whether the deployment may proceed
+ */
+export const evaluateSafeAddressOverride = (input: {
+  network: string
+  existing?: string
+  allowOverride: boolean
+}): ISafeOverrideVerdict => {
+  const occupied =
+    typeof input.existing === 'string' &&
+    input.existing.length > 0 &&
+    !isZeroAddress(input.existing)
+
+  if (!occupied || input.allowOverride) return { occupied, allowed: true }
+
+  return {
+    occupied,
+    allowed: false,
+    refusal: `${input.network} already has a Safe at ${input.existing}. Deploying another one and repointing config/networks.json at it moves governance of every contract this Safe owns to a Safe nobody has reviewed. Pass --allowOverride to state that this is what you intend.`,
+  }
+}
+
+/**
+ * Judges a threshold against {@link SAFE_THRESHOLD}.
+ *
+ * Testnets are exempt: they carry no Safe at all in committed config, their
+ * diamonds are EOA-owned, and a Safe brought up there is a rehearsal that no
+ * production contract obeys.
+ * @param input.network - target network name, named in the refusal
+ * @param input.threshold - confirmations the deployment would set
+ * @param input.isTestnet - whether config types this network as a testnet
+ * @returns Whether the threshold is allowed, and the floor it is judged against
+ */
+export const evaluateSafeThresholdFloor = (input: {
+  network: string
+  threshold: number
+  isTestnet: boolean
+}): ISafeThresholdVerdict => {
+  const floor = input.isTestnet ? 1 : SAFE_THRESHOLD
+
+  if (input.threshold >= floor) return { allowed: true, floor }
+
+  return {
+    allowed: false,
+    floor,
+    refusal: `--threshold ${input.threshold} is below the ${floor} confirmations required on ${input.network}. A Safe deployed under the floor can act on fewer signatures than the fleet's governance assumes.`,
+  }
+}
+
+/**
+ * Relates a deployed owner set to the one config declares.
+ *
+ * Comparison is by lowercase address, so a checksum difference between an
+ * on-chain read and config is not divergence.
+ * @param configured - owners `config/global.json` declares
+ * @param deployed - owners the Safe reports
+ * @returns The two directions of difference, each empty on a match
+ */
+export const compareOwnerSets = (
+  configured: readonly string[],
+  deployed: readonly string[]
+): IOwnerSetComparison => {
+  const configuredSet = new Set(configured.map((o) => o.trim().toLowerCase()))
+  const deployedSet = new Set(deployed.map((o) => o.trim().toLowerCase()))
+
+  const absent = [...configuredSet].filter((o) => !deployedSet.has(o))
+  const beyondConfig = [...deployedSet].filter((o) => !configuredSet.has(o))
+
+  return {
+    matchesConfig: absent.length === 0 && beyondConfig.length === 0,
+    absent,
+    beyondConfig,
+  }
+}
+
+/**
+ * Renders an owner set that diverges from config as lines an operator reading a
+ * deploy log cannot skim past.
+ * @param input.network - network the Safe was deployed on
+ * @param input.safeAddress - Safe whose owners were read
+ * @param input.comparison - result of {@link compareOwnerSets}
+ * @returns One line per finding, empty when the owner set matches config
+ */
+export const describeOwnerSetDivergence = (input: {
+  network: string
+  safeAddress: string
+  comparison: IOwnerSetComparison
+}): string[] => {
+  if (input.comparison.matchesConfig) return []
+
+  const lines = [
+    `Owner set of the Safe deployed on ${input.network} (${input.safeAddress}) does not match config/global.json safeOwners.`,
+  ]
+  if (input.comparison.beyondConfig.length)
+    lines.push(
+      `  • Owners config does not declare: ${input.comparison.beyondConfig.join(
+        ', '
+      )}`
+    )
+  if (input.comparison.absent.length)
+    lines.push(
+      `  • Configured owners this Safe does not have: ${input.comparison.absent.join(
+        ', '
+      )}`
+    )
+  lines.push(
+    'Treat this as a deliberate override: it is only correct if you meant to deploy a Safe whose owners differ from the fleet configuration.'
+  )
+
+  return lines
+}
+
+/**
+ * Applies {@link evaluateSafeAddressOverride} before anything is deployed.
+ * @param input - network, the Safe address config names, and the operator's flag
+ * @returns The verdict, so the caller can see whether config names a Safe
+ * @throws If config names a Safe and the override is not stated
+ */
+export const assertSafeAddressOverrideAllowed = (input: {
+  network: string
+  existing?: string
+  allowOverride: boolean
+}): ISafeOverrideVerdict => {
+  const verdict = evaluateSafeAddressOverride(input)
+  if (!verdict.allowed) throw new Error(verdict.refusal)
+  return verdict
+}
+
+/**
+ * Applies {@link evaluateSafeThresholdFloor} before anything is deployed.
+ * @param input - network, requested threshold, and whether it is a testnet
+ * @returns The verdict, so the caller can report the floor it cleared
+ * @throws If the threshold is below the floor for this network
+ */
+export const assertSafeThresholdFloor = (input: {
+  network: string
+  threshold: number
+  isTestnet: boolean
+}): ISafeThresholdVerdict => {
+  const verdict = evaluateSafeThresholdFloor(input)
+  if (!verdict.allowed) throw new Error(verdict.refusal)
+  return verdict
+}

--- a/script/deploy/safe/safe-deploy-guards.ts
+++ b/script/deploy/safe/safe-deploy-guards.ts
@@ -2,9 +2,9 @@
  * Decides whether a Safe deployment may proceed and whether the Safe it
  * produced matches repo config.
  *
- * Imported by `deploy-safe.ts`. The three decisions are pure so each refusal
- * can be exercised against the committed `config/global.json` and
- * `config/networks.json` without running a deployment.
+ * Pure by necessity rather than by taste: the command these guard deploys a
+ * Safe with the production key, so a refusal that could only be exercised by
+ * running it could not be exercised at all.
  */
 
 import { SAFE_THRESHOLD } from '../shared/constants'
@@ -81,6 +81,16 @@ export const evaluateSafeThresholdFloor = (input: {
   isTestnet: boolean
 }): ISafeThresholdVerdict => {
   const floor = input.isTestnet ? 1 : SAFE_THRESHOLD
+
+  // `3.5` and `Infinity` both compare above 3 while being no threshold at all,
+  // and they get their own refusal: telling an operator who passed 1 that it is
+  // not a whole number describes a value that is not the one in front of them.
+  if (!Number.isInteger(input.threshold))
+    return {
+      allowed: false,
+      floor,
+      refusal: `--threshold ${input.threshold} is not a whole number of confirmations. A Safe's threshold is a count of signatures, so anything else is a typo rather than a weaker policy.`,
+    }
 
   if (input.threshold >= floor) return { allowed: true, floor }
 

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The threshold floor on the Tron Safe deployment, judged against the network
+ * and configuration the script itself feeds the guard.
+ *
+ * `safe-deploy-guards.test.ts` covers what the guard decides. What this adds is
+ * the pair of things only the call site can be wrong about: the inputs
+ * `deploy-safe-tron.ts` supplies, and where in `run()` the refusal happens.
+ *
+ * The script is never executed here, not even to be refused: its default path
+ * deploys a Safe with the production key. So the ordering claim is read off the
+ * source, and every anchor is asserted to occur exactly once, so a rename
+ * fails this file loudly instead of silently satisfying it.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import globalConfig from '../../../config/global.json'
+import networks from '../../../config/networks.json'
+import { isTestnetNetwork } from '../../utils/viemScriptHelpers'
+import {
+  assertSafeThresholdFloor,
+  evaluateSafeThresholdFloor,
+} from '../safe/safe-deploy-guards'
+import { SAFE_THRESHOLD } from '../shared/constants'
+
+import { TRON_DEPLOY_NETWORK } from './constants'
+
+const configOwners = globalConfig.safeOwners as string[]
+
+const tronEntry = (
+  networks as Record<string, { type?: string; safeAddress?: string }>
+)[TRON_DEPLOY_NETWORK]
+
+const source = readFileSync(
+  join(import.meta.dir, 'deploy-safe-tron.ts'),
+  'utf8'
+)
+
+const soleIndex = (needle: string): number => {
+  const first = source.indexOf(needle)
+  expect(first, `${needle} appears in deploy-safe-tron.ts`).toBeGreaterThan(-1)
+  expect(
+    source.indexOf(needle, first + 1),
+    `${needle} appears exactly once`
+  ).toBe(-1)
+  return first
+}
+
+describe('the committed config the Tron floor is judged against', () => {
+  it('types the Tron deploy target as a mainnet carrying a live Safe', () => {
+    expect(tronEntry?.type).toBe('mainnet')
+    expect(isTestnetNetwork(TRON_DEPLOY_NETWORK)).toBe(false)
+    expect(tronEntry?.safeAddress?.length).toBeGreaterThan(0)
+  })
+
+  it('declares more Safe owners than the floor requires', () => {
+    expect(configOwners.length).toBeGreaterThan(SAFE_THRESHOLD)
+  })
+})
+
+describe('the floor applied to the Tron deploy target', () => {
+  it('refuses every threshold the owner-count check would have allowed', () => {
+    for (let threshold = 1; threshold < SAFE_THRESHOLD; threshold++) {
+      const verdict = evaluateSafeThresholdFloor({
+        network: TRON_DEPLOY_NETWORK,
+        threshold,
+        isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+      })
+      expect(verdict.allowed, `--threshold ${threshold}`).toBe(false)
+      expect(verdict.floor).toBe(SAFE_THRESHOLD)
+      expect(verdict.refusal).toContain(TRON_DEPLOY_NETWORK)
+    }
+  })
+
+  it('allows the threshold the CLI defaults to, and the full owner set', () => {
+    for (const threshold of [SAFE_THRESHOLD, configOwners.length]) {
+      const verdict = assertSafeThresholdFloor({
+        network: TRON_DEPLOY_NETWORK,
+        threshold,
+        isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+      })
+      expect(verdict, `--threshold ${threshold}`).toEqual({
+        allowed: true,
+        floor: SAFE_THRESHOLD,
+      })
+    }
+  })
+
+  it('holds the CLI default at the floor rather than below it', () => {
+    const defaultThreshold = Number(
+      /threshold:[\s\S]{0,200}?default: '(\d+)'/.exec(source)?.[1]
+    )
+    expect(defaultThreshold).toBeGreaterThanOrEqual(SAFE_THRESHOLD)
+  })
+})
+
+describe('what the CLI hands the floor check', () => {
+  // The refusal for a non-whole threshold is only reachable if the CLI stops
+  // truncating before the guard sees the value.
+  it('parses the threshold without truncating it', () => {
+    expect(source).toContain('const threshold = Number(args.threshold)')
+    expect(source).not.toContain('parseInt(args.threshold')
+  })
+
+  it('never truncates the threshold anywhere between the CLI and the guard', () => {
+    // A source scan, deliberately, and the reason is worth stating: the only
+    // behavioural proof would call the exported `run()` — but a mutation that
+    // disables the floor guard turns such a test into a real Tron deployment
+    // with the production key, so the test would manufacture the very blast
+    // radius it exists to prevent. This scan is the strongest assertion that is
+    // safe to make here; the durable fix is for the guard to hand back a
+    // validated threshold that the deploy path must consume, so an unvalidated
+    // number cannot reach it at all (EXSC-945).
+    // The assignment is matched WHOLE, not by substring: `| 0`, `>> 0` and
+    // `Math.trunc(...)` all truncate as a suffix, so a `toContain` on the
+    // prefix passes while the value is rounded down after it.
+    const assignments = (
+      source.match(/^\s*const threshold = .*$/gmu) ?? []
+    ).map((line) => line.trim())
+    // Both, and in order: `run()` takes the number it was handed, the CLI
+    // parses the argument. Asserting the whole set means a third assignment
+    // cannot appear unnoticed either.
+    expect(assignments).toEqual([
+      'const threshold = options.threshold',
+      'const threshold = Number(args.threshold)',
+    ])
+
+    // And nothing truncates it on the way to the guard either.
+    expect(source).not.toMatch(/Math\.(?:trunc|floor|round)\s*\(\s*threshold/u)
+    expect(source).not.toMatch(/threshold(?:\s*\)?)*\s*(?:\||>>>?)\s*0/u)
+  })
+})
+
+describe('where the Tron floor check sits in run()', () => {
+  const guard = () => soleIndex('assertSafeThresholdFloor({')
+
+  it('reads the testnet answer from repo config, not from a literal', () => {
+    expect(source).toContain(
+      'isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),'
+    )
+  })
+
+  it('refuses before the production key is read', () => {
+    expect(guard()).toBeLessThan(
+      soleIndex("getEnvVar('PRIVATE_KEY_PRODUCTION')")
+    )
+  })
+
+  it('refuses before the setup-only path, which calls setup() with it', () => {
+    expect(guard()).toBeLessThan(soleIndex('if (options.setupOnly) {'))
+  })
+
+  it('leaves the owner-count check its own refusals, ahead of the floor', () => {
+    expect(soleIndex('Threshold must be between 1 and')).toBeLessThan(guard())
+  })
+})

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -135,7 +135,7 @@ describe('what the CLI hands the floor check', () => {
 
     // And nothing truncates it on the way to the guard either.
     expect(source).not.toMatch(/Math\.(?:trunc|floor|round)\s*\(\s*threshold/u)
-    expect(source).not.toMatch(/threshold(?:\s*\)?)*\s*(?:\||>>>?)\s*0/u)
+    expect(source).not.toMatch(/threshold[\s)]*(?:\||>>>?)\s*0/u)
   })
 })
 

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -39,6 +39,8 @@ import globalConfig from '../../../config/global.json'
 import networks from '../../../config/networks.json'
 import { sleep } from '../../utils/delay'
 import { getEnvVar } from '../../utils/utils'
+import { isTestnetNetwork } from '../../utils/viemScriptHelpers'
+import { assertSafeThresholdFloor } from '../safe/safe-deploy-guards'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
 import { assertTronToolchainOrThrow } from './assertTronToolchain.js'
@@ -363,6 +365,15 @@ async function run(options: {
       `Threshold must be between 1 and ${ownersEvm.length} (number of owners)`
     )
   }
+
+  const thresholdFloor = assertSafeThresholdFloor({
+    network: TRON_DEPLOY_NETWORK,
+    threshold,
+    isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+  })
+  consola.info(
+    `Threshold ${threshold} clears the ${thresholdFloor.floor}-confirmation floor for ${TRON_DEPLOY_NETWORK}`
+  )
 
   const privateKey = getEnvVar('PRIVATE_KEY_PRODUCTION')
   const tvmKey = TRON_DEPLOY_NETWORK as TronTvmNetworkName
@@ -717,7 +728,7 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    const threshold = parseInt(args.threshold, 10)
+    const threshold = Number(args.threshold)
     if (isNaN(threshold) || threshold < 1) {
       consola.error('Invalid --threshold; must be a positive integer.')
       process.exit(1)


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-944](https://linear.app/lifi-linear/issue/EXSC-944) — items 1-3 of its scope. Sub-issue of [EXSC-686](https://linear.app/lifi-linear/issue/EXSC-686).

# Why did I implement it this way?

`script/deploy/safe/deploy-safe.ts` decided everything from its own arguments. Three changes, all in one new pure module (`script/deploy/safe/safe-deploy-guards.ts`) so each refusal is provable without running a deployment.

**1. `allowOverride` defaults to `false`.** The option declared `default: true` while the file's own header documented `false`; the code moves to match the header, so the guard at the top of `run()` can actually fire. `config/networks.json` names a Safe on all 66 mainnets and on none of the 7 testnets, so this refuses a replacement on every network that has a live governance Safe and blocks no bring-up. `script/deploy/tron/deploy-safe-tron.ts` already defaults this to `false` — the EVM script was the outlier.

Consequence worth reviewing: the `networks.json` write at the end of the script was gated on the same `args.allowOverride`, so flipping the default alone would have stopped a first-time bring-up from recording the address it just deployed. The write is now unconditional, reached only after the override guard has passed — occupied config implies the flag was stated.

**2. A threshold below `SAFE_THRESHOLD` refuses.** Reuses `script/deploy/shared/constants.ts`; no second constant. **Testnets are exempt** (floor of 1): committed config gives them no `safeAddress` at all, their diamonds are EOA-owned, and `script/deploy/deployAllContracts.sh` skips Safe deployment for them entirely, so a Safe brought up on a testnet governs nothing. Mainnets get the floor of 3. The exemption is read from `networks.json` `type` via `isTestnetNetwork`, the same source the production deploy gate uses, not from an environment variable.

Both refusals sit before `setupEnvironment`, so nothing is signed, no RPC client is built and no key is read before they fire.

**3. The post-deploy check now also compares against config.** It kept its requested-vs-actual comparison (that one catches a Safe that did not initialise as asked) and gained a comparison of `getOwners()` against `config/global.json` `safeOwners`. A divergent owner set is named — each undeclared owner, each configured owner the Safe lacks — as a warning block printed twice: at verification time and again in the final summary, so it cannot be scrolled past.

**Item 3 ships as detection and reporting only, deliberately.** Whether a config-divergent owner set should refuse outright or require a typed confirmation is items 4-5 of EXSC-944 and is not pre-empted here.

Not touched: `--owners` still exists for production (EXSC-944 item 4, open), the Tron sibling's missing threshold floor, and the health check's blindness to a *changed* `safeAddress` (item 5). #2337 makes an owner added to an existing Safe visible to the daily `safe-config` check; it still reads whatever address config names, so a replaced Safe stays invisible to it.

## Verification

- `bun test script/` and `bun test script/deploy/safe/safe-deploy-guards.test.ts` both green; `bunx tsc-files --noEmit` and `bunx eslint` clean on all three changed files (the 9 `no-explicit-any` warnings in `deploy-safe.ts` are pre-existing).
- `bunx tsc-files --noEmit` on all three changed files — clean.
- `bunx eslint` on all three — exit 0 (the 9 pre-existing `no-explicit-any` warnings in `deploy-safe.ts` are untouched).
- Each refusal was run against the committed `config/global.json` and `config/networks.json` and shown to fire, paired with the real configuration passing (threshold 3, the six configured owners, an empty testnet `safeAddress`).
- Mutation-tested, each mutation syntactically valid and with the test total held constant. Killed: an always-allow override, an override that ignores the flag, an `occupied` that is never true, the zero address counted as occupied, a refusal that drops the address, a floor of 1 everywhere, an off-by-one floor, a blanket floor refusal, an inverted testnet exemption, either divergence direction suppressed, `matchesConfig` always true, an empty divergence report, a case-sensitive comparison, both `assert*` throws stripped, and the integrality check removed.
- **A gate round found three survivors I had not tried**, all in the normalisers: dropping the `/i` from the zero-address match, and dropping `.trim()` from that match and from the owner comparison. Each is a real behaviour change on a value `config/networks.json` does not currently hold — and it is hand-edited, which is how such a value would arrive. Pinned in `cb8067b50`, both directions (a lenient reading of the zero address must not make an existing Safe look absent), and all three now die.
- `citty` parses the flag correctly at the new default (absent → `false`, `--allowOverride` → `true`, `--allowOverride=false` → `false`, `--no-allowOverride` → `false`), checked with a throwaway command carrying the same arg spec.


## After the gate round

- **The config comparison was vacuous where it mattered.** It ran *after* the pre-existing
  requested-vs-actual check, which throws unless the on-chain set equals the arguments this run
  supplied — so its "owner config does not declare" direction was unreachable, and the other
  direction only restated the `--owners` argument, a value known before any deployment. It now runs
  first, which also makes it meaningful for the one path where the address is not derived from this
  run: the no-`ProxyCreation` fallback takes the Safe address from an operator's keyboard.
- **The floor now requires a whole number.** `3.5` and `Infinity` compared above 3 while being no
  count of signatures. They get their own refusal, because telling an operator who passed `1` that
  their value is not a whole number describes a value that is not the one in front of them. `1e100`
  is still allowed here on purpose — it *is* a whole number, and an absurdly large threshold is
  refused downstream by `threshold > owners.length`.
- `isDefaultThreshold` matched only the space-separated `--threshold`, so `--threshold=5` printed
  "Using default threshold of 3" two lines below the new line correctly reporting 5. Pre-existing,
  but the diff put the two together.

## Two gaps this does NOT close, now tracked on EXSC-944

- `deploy-safe.ts:~861` — the no-`ProxyCreation` fallback asks the operator to **type** the deployed
  Safe address and accepts any `^0x[a-fA-F0-9]{40}$`. The config comparison catches a careless typo
  (a non-Safe reverts the read; a differently-owned Safe trips verification) but not a substituted,
  correctly-configured Safe: anyone can deploy one carrying the six config owners at threshold 3.
  Binding the pointer to the transaction — a counterfactual CREATE2 address, or matching
  `ProxyCreation` in the receipt's block — is the real fix.
- `deploy-safe-tron.ts` has **no `SAFE_THRESHOLD` floor** (`threshold < 1 || threshold >
  owners.length` only), and Tron's Safe threshold is floor-checked nowhere, at deploy time or in the
  daily sweep. It already defaults `allowOverride: false` and has no `--owners` flag at all.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] Not applicable: no new contract in this PR — it changes a deploy script and adds a TypeScript module, so there is nothing to audit

