### PR TITLE
fix(test): skip selector FFI cases without out/ artifacts (EXSC-946)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,9 @@ fs_permissions = [
   { access = "read", path = "./config/" },
   { access = "read-write", path = "./test/logs/" },
   { access = "read", path = "./zkout/" },
+  # Lets a test check whether the build artifact the selector FFI reads is on disk. `forge coverage`
+  # never writes that tree, so the FFI-backed cases have to detect its absence and self-skip.
+  { access = "read", path = "./out/" },
 ]
 ffi = true
 libs = ["node_modules", "lib"]

--- a/test/solidity/script/UpdateScriptBase.t.sol
+++ b/test/solidity/script/UpdateScriptBase.t.sol
@@ -226,6 +226,7 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
     bytes4 internal constant WITHDRAW = WithdrawFacet.withdraw.selector;
 
     uint256 internal constant MAINNET_CHAIN_ID = 1;
+    string internal constant ARTIFACTS_DIR = "./out";
     string internal constant BOGUS_ARTIFACTS_DIR =
         "./out/nonexistent-artifacts";
 
@@ -238,6 +239,22 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
     address internal newOwnershipFacet;
     address internal attestedOwnershipFacet;
     address internal withdrawFacet;
+
+    /// @dev Every case that computes real cut calldata reaches `contract-selectors.sh` through
+    ///      `vm.ffi`, and that script reads the facet's `methodIdentifiers` off the build artifact
+    ///      in `out/`. `forge build` and `forge test` write that tree, but `forge coverage` compiles
+    ///      instrumented sources through a pipeline that never does, so under coverage the artifact
+    ///      is absent and the FFI can only fail. Skipping keeps the weekly coverage run reporting
+    ///      instead of red; the PR path still runs every case, because there `out/` is populated.
+    ///
+    ///      The guard deliberately lives here and not in `UpdateScriptBase.getSelectors`: on a real
+    ///      deploy a missing artifact must keep failing loudly, since an empty selector list would
+    ///      otherwise encode as a valid no-op diamond cut.
+    modifier whenSelectorArtifactExists(string memory _facetName) {
+        if (!vm.isFile(_artifactPath(_facetName))) vm.skip(true);
+
+        _;
+    }
 
     function setUp() public {
         vm.chainId(MAINNET_CHAIN_ID);
@@ -279,7 +296,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         vm.setEnv("DIAMOND_STATE_BLOCK", vm.toString(block.number));
     }
 
-    function test_EnvVarsDriveCutOptions() public {
+    function test_EnvVarsDriveCutOptions()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         EnvDrivenHarness harness = new EnvDrivenHarness();
 
         (, bytes memory cutData) = harness.runUpdate("OwnershipFacet");
@@ -298,7 +318,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         );
     }
 
-    function testRevert_SelectorArtifactsDirFromEnv() public {
+    function testRevert_SelectorArtifactsDirFromEnv()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         EnvDrivenHarness envHarness = new EnvDrivenHarness();
         UpdateScriptBaseHarness harness = new UpdateScriptBaseHarness();
 
@@ -319,7 +342,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         );
     }
 
-    function test_ReplaceCutMatchesGoldenCalldata() public {
+    function test_ReplaceCutMatchesGoldenCalldata()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         DefaultCutOptionsHarness harness = new DefaultCutOptionsHarness();
 
         (, bytes memory cutData) = harness.runUpdate("OwnershipFacet");
@@ -334,7 +360,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         );
     }
 
-    function test_AddCutMatchesGoldenCalldata() public {
+    function test_AddCutMatchesGoldenCalldata()
+        public
+        whenSelectorArtifactExists("WithdrawFacet")
+    {
         DefaultCutOptionsHarness harness = new DefaultCutOptionsHarness();
 
         (, bytes memory cutData) = harness.runUpdate("WithdrawFacet");
@@ -353,7 +382,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         );
     }
 
-    function test_RemoveCutMatchesGoldenCalldata() public {
+    function test_RemoveCutMatchesGoldenCalldata()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         _registerStaleSelectorsOnOwnershipFacet();
 
         DefaultCutOptionsHarness harness = new DefaultCutOptionsHarness();
@@ -381,7 +413,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         assertEq(cutData, _encodeCut(expectedCut));
     }
 
-    function test_ExplicitDefaultOptionsProduceIdenticalCalldata() public {
+    function test_ExplicitDefaultOptionsProduceIdenticalCalldata()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         DefaultCutOptionsHarness baseline = new DefaultCutOptionsHarness();
         (, bytes memory baselineCutData) = baseline.runUpdate(
             "OwnershipFacet"
@@ -398,6 +433,7 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
 
     function test_FacetAddressOverrideTakesPrecedenceOverDeploymentsFile()
         public
+        whenSelectorArtifactExists("OwnershipFacet")
     {
         FacetAddressOverrideHarness harness = new FacetAddressOverrideHarness();
 
@@ -419,7 +455,10 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         assertTrue(harness.isNoBroadcast());
     }
 
-    function test_CutVerificationModeAcceptsPinnedBlock() public {
+    function test_CutVerificationModeAcceptsPinnedBlock()
+        public
+        whenSelectorArtifactExists("OwnershipFacet")
+    {
         PinnedVerificationHarness harness = new PinnedVerificationHarness();
 
         (, bytes memory cutData) = harness.runUpdate("OwnershipFacet");
@@ -527,6 +566,21 @@ contract UpdateScriptBaseTest is Test, DiamondTest {
         vm.prank(diamondOwner);
 
         DiamondCutFacet(address(diamond)).diamondCut(staleCut, address(0), "");
+    }
+
+    /// @dev Mirrors the layout `contract-selectors.sh` resolves: `<dir>/<name>.sol/<name>.json`.
+    function _artifactPath(
+        string memory _facetName
+    ) internal pure returns (string memory) {
+        return
+            string.concat(
+                ARTIFACTS_DIR,
+                "/",
+                _facetName,
+                ".sol/",
+                _facetName,
+                ".json"
+            );
     }
 
     function _ownershipSelectors()


### PR DESCRIPTION
# Which Linear task belongs to this PR?

https://linear.app/lifi-linear/issue/EXSC-946/weekly-coverage-run-fails-selector-ffi-tests-need-out-artifacts-forge

# Why did I implement it this way?

The weekly coverage report has been failing since the first run that included
`test/solidity/script/UpdateScriptBase.t.sol` (added in #2275, merged 2026-09-01 10:06 UTC — after
that morning's 06:54 UTC run). 8 of its 16 cases fail:

```
[FAIL: vm.ffi: ffi command ["script/deploy/facets/utils/contract-selectors.sh", "OwnershipFacet", "", "./out"]
 exited with code 1. stderr: contract-selectors.sh: no build artifact at ./out/OwnershipFacet.sol/OwnershipFacet.json
```

Those cases compute real cut calldata, which reaches `contract-selectors.sh` through `vm.ffi`; the
script reads the facet's `methodIdentifiers` off the build artifact in `out/`. `forge build` and
`forge test` write that tree, so the cases pass on the PR path. `forge coverage --ir-minimum`
compiles instrumented sources through a pipeline that never writes it, and the workflow also passes
`--force`, which clears it — after the CI coverage command `out/` does not exist at all. The failure
is therefore deterministic, so all 10 retries in the workflow fail identically, burning ~43 min
against ~5 min for a healthy run.

The fix guards the 8 artifact-dependent cases with a `whenSelectorArtifactExists` modifier that
skips when the artifact is not on disk, and grants `fs_permissions` read on `./out/` so the test can
make that check.

Two things I deliberately did not do:

- **The guard is not in `UpdateScriptBase.getSelectors`.** That is production deploy code, where a
  missing artifact must keep failing loudly — `contract-selectors.sh` fails hard for exactly this
  reason, since an empty selector list would otherwise encode as a valid no-op diamond cut.
- **I did not change the coverage command.** Making the 8 cases run under coverage instead needs a
  `forge build` step *and* dropping `--force` (I confirmed that combination works). That keeps the
  assertions live but trades away the clean-recompile guarantee `--force` provides, which is a
  bigger change than this reporting bug warrants. Noted on the ticket.

Scope note: the tests still run in full on every PR, where `out/` is populated. Only the weekly
coverage run skips them, and they cover a deploy helper rather than `src/`, so the reported coverage
number is unaffected.

Follow-up left on the ticket: `weeklyCoverageReport.yml` hardcodes "likely a transient RPC failure"
for every non-success outcome, which is what sent this deterministic test failure to Slack as an RPC
problem. That message should surface the actual coverage log tail.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
