### PR TITLE
feat(deploy): apply the Safe threshold floor to Tron deployments (EXSC-945)

### DIFF
--- a/script/deploy/safe/add-safe-owners-and-threshold.ts
+++ b/script/deploy/safe/add-safe-owners-and-threshold.ts
@@ -3,7 +3,7 @@
  *
  * Proposes Safe transactions to add owners (from `config/global.json:safeOwners`
  * and/or `--owners`) and, when current threshold differs, propose a change to
- * the expected value (`EXPECTED_THRESHOLD`).
+ * the expected value (`SAFE_THRESHOLD`).
  * Supports a single network (`--network <name>`) or every active EVM mainnet
  * (`--all-networks`, excludes `networks.json` entries with `type: "testnet"`).
  * Signs with a Ledger by default; falls back to a private
@@ -26,6 +26,7 @@ import {
 import globalConfig from '../../../config/global.json'
 import networksData from '../../../config/networks.json'
 import { getViemChainForNetworkName } from '../../utils/viemScriptHelpers'
+import { SAFE_THRESHOLD } from '../shared/constants'
 
 import type { ILedgerAccountResult } from './ledger'
 import { assertTicketPresent } from './proposal-intent'
@@ -39,8 +40,6 @@ import {
   storeTransactionInMongoDB,
   type ISafeTxDocument,
 } from './safe-utils'
-
-const EXPECTED_THRESHOLD = 3
 
 const ansi = (code: string, text: string) => `\x1b[${code}m${text}\x1b[0m`
 const green = (text: string) => ansi('32', text)
@@ -88,7 +87,7 @@ interface ICheckResult {
 const main = defineCommand({
   meta: {
     name: 'add-safe-owners-and-threshold',
-    description: `Proposes transactions to add SAFE owners from global.json (and/or --owners) and sets threshold to ${EXPECTED_THRESHOLD}. Single network via --network; --all-networks skips networks where type is testnet.`,
+    description: `Proposes transactions to add SAFE owners from global.json (and/or --owners) and sets threshold to ${SAFE_THRESHOLD}. Single network via --network; --all-networks skips networks where type is testnet.`,
   },
   args: {
     network: {
@@ -155,16 +154,12 @@ const main = defineCommand({
       ) as Address[]
 
       consola.info(
-        `Checking ${networks.length} network(s) against ${expectedOwners.length} expected owner(s) + threshold=${EXPECTED_THRESHOLD}`
+        `Checking ${networks.length} network(s) against ${expectedOwners.length} expected owner(s) + threshold=${SAFE_THRESHOLD}`
       )
 
       const checkResults: ICheckResult[] = []
       for (const network of networks) {
-        const r = await checkNetwork(
-          network,
-          expectedOwners,
-          EXPECTED_THRESHOLD
-        )
+        const r = await checkNetwork(network, expectedOwners, SAFE_THRESHOLD)
         checkResults.push(r)
       }
 
@@ -417,7 +412,7 @@ async function processNetwork(
 
     let thresholdNewlyProposed = false
     let thresholdAlreadyProposed = false
-    if (currentThreshold !== EXPECTED_THRESHOLD) {
+    if (currentThreshold !== SAFE_THRESHOLD) {
       // Existing proposals will add their owners when executed, so include
       // both newly proposed and already-proposed addOwners in the projection.
       const updatedOwnerCount =
@@ -425,16 +420,16 @@ async function processNetwork(
         addOwnerNewlyProposed +
         addOwnerAlreadyProposed
 
-      if (updatedOwnerCount < EXPECTED_THRESHOLD)
+      if (updatedOwnerCount < SAFE_THRESHOLD)
         throw new Error(
-          `Cannot set threshold to ${EXPECTED_THRESHOLD} when only ${updatedOwnerCount} owner(s) would exist (would lock the Safe)`
+          `Cannot set threshold to ${SAFE_THRESHOLD} when only ${updatedOwnerCount} owner(s) would exist (would lock the Safe)`
         )
 
       consola.info(
-        `Now proposing to change threshold from ${currentThreshold} to ${EXPECTED_THRESHOLD}`
+        `Now proposing to change threshold from ${currentThreshold} to ${SAFE_THRESHOLD}`
       )
       const changeThresholdTx = await safe.createChangeThresholdTx(
-        EXPECTED_THRESHOLD,
+        SAFE_THRESHOLD,
         { nonce: nextNonce }
       )
       const signedThresholdTx = await safe.signTransaction(changeThresholdTx)
@@ -463,7 +458,7 @@ async function processNetwork(
       }
     } else
       consola.success(
-        `Threshold is already set to ${EXPECTED_THRESHOLD} - no action required`
+        `Threshold is already set to ${SAFE_THRESHOLD} - no action required`
       )
 
     const summaryParts: string[] = []
@@ -473,10 +468,9 @@ async function processNetwork(
       summaryParts.push(`${addOwnerAlreadyProposed} addOwner already proposed`)
     if (ownersAlreadyOnChain > 0)
       summaryParts.push(`${ownersAlreadyOnChain} already on-chain`)
-    if (thresholdNewlyProposed)
-      summaryParts.push(`threshold→${EXPECTED_THRESHOLD}`)
+    if (thresholdNewlyProposed) summaryParts.push(`threshold→${SAFE_THRESHOLD}`)
     else if (thresholdAlreadyProposed)
-      summaryParts.push(`threshold→${EXPECTED_THRESHOLD} already proposed`)
+      summaryParts.push(`threshold→${SAFE_THRESHOLD} already proposed`)
     if (!summaryParts.length) summaryParts.push('no changes')
 
     return { proposalsCreated, summary: summaryParts.join(', ') }
@@ -588,7 +582,7 @@ function printCheckTable(results: ICheckResult[]): void {
     const th =
       r.threshold !== undefined
         ? `threshold=${
-            r.threshold === EXPECTED_THRESHOLD
+            r.threshold === SAFE_THRESHOLD
               ? green(String(r.threshold))
               : red(String(r.threshold))
           }`

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -110,23 +110,21 @@ describe('what the CLI hands the floor check', () => {
     expect(source).not.toContain('parseInt(args.threshold')
   })
 
-  it('keeps a fraction the guard has to judge, rather than rounding it down', () => {
-    // `parseInt` turned 5.9 into 5 — a Safe weaker than the one asked for, with
-    // nothing said, since 5 clears the floor.
-    expect(Number('5.9')).toBe(5.9)
-    expect(Number.isInteger(Number('5.9'))).toBe(false)
-  })
-
-  it('refuses a value with trailing rubbish that truncation used to accept', () => {
-    // `parseInt('3abc', 10)` is 3, so the old parse accepted it silently.
-    expect(Number.isNaN(Number('3abc'))).toBe(true)
-  })
-
-  it('still refuses the forms the existing guard covers', () => {
-    for (const raw of ['', '-1', 'abc']) {
-      const parsed = Number(raw)
-      expect(Number.isNaN(parsed) || parsed < 1, raw).toBe(true)
-    }
+  it('never truncates the threshold anywhere between the CLI and the guard', () => {
+    // A source scan, deliberately, and the reason is worth stating: the only
+    // behavioural proof would call the exported `run()` — but a mutation that
+    // disables the floor guard turns such a test into a real Tron deployment
+    // with the production key, so the test would manufacture the very blast
+    // radius it exists to prevent. This scan is the strongest assertion that is
+    // safe to make here; the durable fix is for the guard to hand back a
+    // validated threshold that the deploy path must consume, so an unvalidated
+    // number cannot reach it at all (EXSC-945).
+    expect(source).not.toMatch(/Math\.(?:trunc|floor|round)\s*\(\s*threshold/u)
+    expect(source).not.toMatch(/parseInt\s*\(\s*(?:args\.)?threshold/u)
+    expect(source).not.toMatch(/threshold\s*\|\s*0/u)
+    // Paired presence: the value that reaches the guard is the parsed one, so
+    // this is not passing on a file that never parses a threshold at all.
+    expect(source).toContain('const threshold = Number(args.threshold)')
   })
 })
 

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The threshold floor on the Tron Safe deployment, judged against the network
+ * and configuration the script itself feeds the guard.
+ *
+ * `safe-deploy-guards.test.ts` covers what the guard decides. What this adds is
+ * the pair of things only the call site can be wrong about: the inputs
+ * `deploy-safe-tron.ts` supplies, and where in `run()` the refusal happens.
+ *
+ * The script is never executed here, not even to be refused: its default path
+ * deploys a Safe with the production key, so the ordering claim is read off the
+ * source and every anchor it matches is asserted unique — a rename breaks this
+ * file rather than quietly satisfying it.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import globalConfig from '../../../config/global.json'
+import networks from '../../../config/networks.json'
+import { isTestnetNetwork } from '../../utils/viemScriptHelpers'
+import {
+  assertSafeThresholdFloor,
+  evaluateSafeThresholdFloor,
+} from '../safe/safe-deploy-guards'
+import { SAFE_THRESHOLD } from '../shared/constants'
+
+import { TRON_DEPLOY_NETWORK } from './constants'
+
+const configOwners = globalConfig.safeOwners as string[]
+
+const tronEntry = (
+  networks as Record<string, { type?: string; safeAddress?: string }>
+)[TRON_DEPLOY_NETWORK]
+
+const source = readFileSync(
+  join(import.meta.dir, 'deploy-safe-tron.ts'),
+  'utf8'
+)
+
+const soleIndex = (needle: string): number => {
+  const first = source.indexOf(needle)
+  expect(first, `${needle} appears in deploy-safe-tron.ts`).toBeGreaterThan(-1)
+  expect(
+    source.indexOf(needle, first + 1),
+    `${needle} appears exactly once`
+  ).toBe(-1)
+  return first
+}
+
+describe('the committed config the Tron floor is judged against', () => {
+  it('types the Tron deploy target as a mainnet carrying a live Safe', () => {
+    expect(tronEntry?.type).toBe('mainnet')
+    expect(isTestnetNetwork(TRON_DEPLOY_NETWORK)).toBe(false)
+    expect(tronEntry?.safeAddress?.length).toBeGreaterThan(0)
+  })
+
+  it('declares more Safe owners than the floor requires', () => {
+    expect(configOwners.length).toBeGreaterThan(SAFE_THRESHOLD)
+  })
+})
+
+describe('the floor applied to the Tron deploy target', () => {
+  it('refuses every threshold the owner-count check would have allowed', () => {
+    for (let threshold = 1; threshold < SAFE_THRESHOLD; threshold++) {
+      const verdict = evaluateSafeThresholdFloor({
+        network: TRON_DEPLOY_NETWORK,
+        threshold,
+        isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+      })
+      expect(verdict.allowed, `--threshold ${threshold}`).toBe(false)
+      expect(verdict.floor).toBe(SAFE_THRESHOLD)
+      expect(verdict.refusal).toContain(TRON_DEPLOY_NETWORK)
+    }
+  })
+
+  it('allows the threshold the CLI defaults to, and the full owner set', () => {
+    for (const threshold of [SAFE_THRESHOLD, configOwners.length]) {
+      const verdict = assertSafeThresholdFloor({
+        network: TRON_DEPLOY_NETWORK,
+        threshold,
+        isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+      })
+      expect(verdict, `--threshold ${threshold}`).toEqual({
+        allowed: true,
+        floor: SAFE_THRESHOLD,
+      })
+    }
+  })
+
+  it('holds the CLI default at the floor rather than below it', () => {
+    const defaultThreshold = Number(
+      /threshold:[\s\S]{0,200}?default: '(\d+)'/.exec(source)?.[1]
+    )
+    expect(defaultThreshold).toBeGreaterThanOrEqual(SAFE_THRESHOLD)
+  })
+})
+
+describe('where the Tron floor check sits in run()', () => {
+  const guard = () => soleIndex('assertSafeThresholdFloor({')
+
+  it('reads the testnet answer from repo config, not from a literal', () => {
+    expect(source).toContain(
+      'isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),'
+    )
+  })
+
+  it('refuses before the production key is read', () => {
+    expect(guard()).toBeLessThan(
+      soleIndex("getEnvVar('PRIVATE_KEY_PRODUCTION')")
+    )
+  })
+
+  it('refuses before the setup-only path, which sets a threshold of its own', () => {
+    expect(guard()).toBeLessThan(soleIndex('if (options.setupOnly) {'))
+  })
+
+  it('leaves the owner-count check its own refusals, ahead of the floor', () => {
+    expect(soleIndex('Threshold must be between 1 and')).toBeLessThan(guard())
+  })
+})

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -7,9 +7,9 @@
  * `deploy-safe-tron.ts` supplies, and where in `run()` the refusal happens.
  *
  * The script is never executed here, not even to be refused: its default path
- * deploys a Safe with the production key, so the ordering claim is read off the
- * source and every anchor it matches is asserted unique — a rename breaks this
- * file rather than quietly satisfying it.
+ * deploys a Safe with the production key. So the ordering claim is read off the
+ * source, and every anchor is asserted to occur exactly once, so a rename
+ * fails this file loudly instead of silently satisfying it.
  */
 
 import { readFileSync } from 'fs'
@@ -117,7 +117,7 @@ describe('where the Tron floor check sits in run()', () => {
     )
   })
 
-  it('refuses before the setup-only path, which sets a threshold of its own', () => {
+  it('refuses before the setup-only path, which calls setup() with it', () => {
     expect(guard()).toBeLessThan(soleIndex('if (options.setupOnly) {'))
   })
 

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -102,6 +102,34 @@ describe('the floor applied to the Tron deploy target', () => {
   })
 })
 
+describe('what the CLI hands the floor check', () => {
+  // The refusal for a non-whole threshold is only reachable if the CLI stops
+  // truncating before the guard sees the value.
+  it('parses the threshold without truncating it', () => {
+    expect(source).toContain('const threshold = Number(args.threshold)')
+    expect(source).not.toContain('parseInt(args.threshold')
+  })
+
+  it('keeps a fraction the guard has to judge, rather than rounding it down', () => {
+    // `parseInt` turned 5.9 into 5 — a Safe weaker than the one asked for, with
+    // nothing said, since 5 clears the floor.
+    expect(Number('5.9')).toBe(5.9)
+    expect(Number.isInteger(Number('5.9'))).toBe(false)
+  })
+
+  it('refuses a value with trailing rubbish that truncation used to accept', () => {
+    // `parseInt('3abc', 10)` is 3, so the old parse accepted it silently.
+    expect(Number.isNaN(Number('3abc'))).toBe(true)
+  })
+
+  it('still refuses the forms the existing guard covers', () => {
+    for (const raw of ['', '-1', 'abc']) {
+      const parsed = Number(raw)
+      expect(Number.isNaN(parsed) || parsed < 1, raw).toBe(true)
+    }
+  })
+})
+
 describe('where the Tron floor check sits in run()', () => {
   const guard = () => soleIndex('assertSafeThresholdFloor({')
 

--- a/script/deploy/tron/deploy-safe-tron-threshold.test.ts
+++ b/script/deploy/tron/deploy-safe-tron-threshold.test.ts
@@ -119,12 +119,23 @@ describe('what the CLI hands the floor check', () => {
     // safe to make here; the durable fix is for the guard to hand back a
     // validated threshold that the deploy path must consume, so an unvalidated
     // number cannot reach it at all (EXSC-945).
+    // The assignment is matched WHOLE, not by substring: `| 0`, `>> 0` and
+    // `Math.trunc(...)` all truncate as a suffix, so a `toContain` on the
+    // prefix passes while the value is rounded down after it.
+    const assignments = (
+      source.match(/^\s*const threshold = .*$/gmu) ?? []
+    ).map((line) => line.trim())
+    // Both, and in order: `run()` takes the number it was handed, the CLI
+    // parses the argument. Asserting the whole set means a third assignment
+    // cannot appear unnoticed either.
+    expect(assignments).toEqual([
+      'const threshold = options.threshold',
+      'const threshold = Number(args.threshold)',
+    ])
+
+    // And nothing truncates it on the way to the guard either.
     expect(source).not.toMatch(/Math\.(?:trunc|floor|round)\s*\(\s*threshold/u)
-    expect(source).not.toMatch(/parseInt\s*\(\s*(?:args\.)?threshold/u)
-    expect(source).not.toMatch(/threshold\s*\|\s*0/u)
-    // Paired presence: the value that reaches the guard is the parsed one, so
-    // this is not passing on a file that never parses a threshold at all.
-    expect(source).toContain('const threshold = Number(args.threshold)')
+    expect(source).not.toMatch(/threshold(?:\s*\)?)*\s*(?:\||>>>?)\s*0/u)
   })
 })
 

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -718,7 +718,11 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    const threshold = parseInt(args.threshold, 10)
+    // `Number`, not `parseInt`: `parseInt` truncates, so `--threshold 5.9`
+    // would reach the floor check as 5 and deploy a Safe weaker than the one
+    // the operator asked for, with nothing said. `Number` keeps the fraction so
+    // the whole-number refusal below can see it.
+    const threshold = Number(args.threshold)
     if (isNaN(threshold) || threshold < 1) {
       consola.error('Invalid --threshold; must be a positive integer.')
       process.exit(1)

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -718,10 +718,6 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
-    // `Number`, not `parseInt`: `parseInt` truncates, so `--threshold 5.9`
-    // would reach the floor check as 5 and deploy a Safe weaker than the one
-    // the operator asked for, with nothing said. `Number` keeps the fraction so
-    // the whole-number refusal below can see it.
     const threshold = Number(args.threshold)
     if (isNaN(threshold) || threshold < 1) {
       consola.error('Invalid --threshold; must be a positive integer.')

--- a/script/deploy/tron/deploy-safe-tron.ts
+++ b/script/deploy/tron/deploy-safe-tron.ts
@@ -39,6 +39,8 @@ import globalConfig from '../../../config/global.json'
 import networks from '../../../config/networks.json'
 import { sleep } from '../../utils/delay'
 import { getEnvVar } from '../../utils/utils'
+import { isTestnetNetwork } from '../../utils/viemScriptHelpers'
+import { assertSafeThresholdFloor } from '../safe/safe-deploy-guards'
 import { retryWithRateLimit } from '../shared/rateLimit.js'
 
 import {
@@ -362,6 +364,15 @@ async function run(options: {
       `Threshold must be between 1 and ${ownersEvm.length} (number of owners)`
     )
   }
+
+  const thresholdFloor = assertSafeThresholdFloor({
+    network: TRON_DEPLOY_NETWORK,
+    threshold,
+    isTestnet: isTestnetNetwork(TRON_DEPLOY_NETWORK),
+  })
+  consola.info(
+    `Threshold ${threshold} clears the ${thresholdFloor.floor}-confirmation floor for ${TRON_DEPLOY_NETWORK}`
+  )
 
   const privateKey = getEnvVar('PRIVATE_KEY_PRODUCTION')
   const tvmKey = TRON_DEPLOY_NETWORK as TronTvmNetworkName


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-945](https://linear.app/lifi-linear/issue/EXSC-945) — **part (a) only**. Part (b), the hand-typed Safe address in `script/deploy/safe/deploy-safe.ts`, is out of scope here and being handled separately; this PR does not touch that file.

**Stacked on #2338 (`feat/exsc-944-safe-deploy-guards`) and must merge after it** — it reuses `script/deploy/safe/safe-deploy-guards.ts`, which lands there.

# Why did I implement it this way?

`script/deploy/tron/deploy-safe-tron.ts` checked only `threshold < 1 || threshold > ownersEvm.length`, so `--threshold 1` produced a 1-of-6 Safe on Tron mainnet, where `config/networks.json` names a live governance Safe. `script/deploy/healthCheckInvariants.ts` is the only other `SAFE_THRESHOLD` consumer and is EVM-only, so Tron's threshold was floor-checked neither at deploy time nor in the daily sweep.

**Reuse, not a second constant.** The Tron script now calls `assertSafeThresholdFloor` from `safe-deploy-guards`, the same function `deploy-safe.ts` calls, judged against the same `SAFE_THRESHOLD`.

**Placement.** The floor sits after the owner-count range check and before both `getEnvVar('PRIVATE_KEY_PRODUCTION')` and the `--setupOnly` dispatch. After the range check so nothing is swallowed: the range check keeps every input it already refused (`0`, and anything above the owner count), and the floor only refuses inputs that previously passed. Before the key read and the setup-only branch so a refusal happens before any credential is loaded and on both paths, since `--setupOnly` calls `setup()` with the same threshold.

**Tron testnet.** `TRON_DEPLOY_NETWORK` is the compile-time constant `'tron'`, and `config/networks.json` types it `mainnet`, so the exemption is unreachable today — `tronshasta` exists but is `type: "testnet"`, `status: "inactive"`, and is not what this script targets. The answer is still read from repo config via `isTestnetNetwork` rather than hardcoded `false`: retargeting the script is one edit to that constant, and the floor must follow config rather than a literal that would then be wrong. No env var is involved.

**One source for the threshold.** `script/deploy/safe/add-safe-owners-and-threshold.ts` carried its own `EXPECTED_THRESHOLD = 3` beside `SAFE_THRESHOLD = 3` in `script/deploy/shared/constants.ts`. The local const is gone and its 13 references now read `SAFE_THRESHOLD`; the value and behaviour are unchanged. This collapse has no test that can distinguish it — it is a rename onto an identical value — so it rests on review.

**Tests.** `safe-deploy-guards.test.ts` already covers what the guard decides; `script/deploy/tron/deploy-safe-tron-threshold.test.ts` covers the two things only the call site can get wrong — the inputs the Tron script feeds the guard (read from committed `config/networks.json` and `config/global.json`, not fixtures) and where in `run()` the refusal happens. Every refusal is paired with the real current configuration still passing, so none of it is satisfied by a blanket refusal.

The script is never executed, not even with `--help`: its default path deploys a Safe with the production key. The ordering claims are therefore read off the source, with each anchor asserted to occur exactly once so a rename fails the file loudly.

Run it with:

```bash
bun test script/deploy/tron/deploy-safe-tron-threshold.test.ts script/deploy/safe/safe-deploy-guards.test.ts
bun test script/
bunx tsc-files --noEmit script/deploy/tron/deploy-safe-tron.ts script/deploy/tron/deploy-safe-tron-threshold.test.ts script/deploy/safe/add-safe-owners-and-threshold.ts
```

Eight mutations of the call site and of the floor itself — deleting the guard, moving it after the key read, moving it after the setup-only dispatch, hardcoding `isTestnet: true`, downgrading the assert to a discarded evaluate, lowering the CLI default, flattening the floor to 1, and excluding the floor from its own comparison — were each killed with the test total held constant. Harness and per-mutation counts are in the review thread rather than the body, since a score in a body goes stale.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
