### PR TITLE
feat(safe): sanitise every stored field in the signer's transaction detail block (EXSC-948)

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -19,7 +19,6 @@ import { type Address, type Hex } from 'viem'
 import networksData from '../../../config/networks.json'
 import { buildExplorerAddressUrl } from '../../utils/viemScriptHelpers'
 import { createDefaultCache } from '../shared/deployment-cache'
-import { sanitizeProvenanceText } from '../shared/git-provenance'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import { readBooleanFlag, readValueFlag } from './cli-flags'
@@ -50,12 +49,12 @@ import {
   LEDGER_FLEX_WRAP_NOTE,
   renderLedgerFlexFlow,
 } from './ledger-flex-preview'
-import { formatProvenanceLines } from './provenance-display'
 import { reconcileAllSubmittedSafeTxs } from './reconcile'
 import {
   formatDecodedTxDataForDisplay,
   getTargetName,
 } from './safe-decode-utils'
+import { buildSafeTxDetailLines } from './safe-tx-detail-display'
 import {
   parseAccountIndex,
   canExecuteWithNonceStatus,
@@ -399,48 +398,30 @@ const processTxs = async (
         ? ` \u001b[33m⚠ on-chain nonce is ${expectedNonce} — cannot execute yet\u001b[0m`
         : ''
 
-    const detailLines = [
-      'Safe Transaction Details:',
-      `    Nonce:           \u001b[${nonceColor}m${tx.safeTx.data.nonce}\u001b[0m${nonceWarning}`,
-      `    To:              \u001b[32m${toDisplay}${toExplorerSuffix}\u001b[0m`,
-      `    Value:           \u001b[32m${tx.safeTx.data.value}\u001b[0m`,
-      `    Operation:       \u001b[32m${
+    const detailLines = buildSafeTxDetailLines({
+      nonce: tx.safeTx.data.nonce,
+      nonceColor,
+      nonceWarning,
+      toDisplay,
+      toExplorerSuffix,
+      value: tx.safeTx.data.value,
+      operationLabel:
         tx.safeTransaction.data.operation === 0
           ? 'Call'
           : tx.safeTransaction.data.operation === 1
           ? 'DelegateCall'
           : `not Call (${describeOperationValue(
               tx.safeTransaction.data.operation
-            )})`
-      }\u001b[0m`,
-      `    Data:            \u001b[32m${tx.safeTx.data.data}\u001b[0m`,
-      `    Proposer:        \u001b[32m${proposerDisplay}\u001b[0m`,
-      `    Safe Tx Hash:    \u001b[36m${tx.safeTxHash}\u001b[0m`,
-      `    Signatures:      \u001b[32m${tx.safeTransaction.signatures.size}/${tx.threshold}\u001b[0m required`,
-      `    Execution Ready: \u001b[${tx.canExecute ? '32m✓' : '31m✗'}\u001b[0m`,
-    ]
-
-    // Deferred diamond-cleanup: if parked facet removals were folded into this
-    // proposal, show the originating deprecation PR(s) so the signer sees WHY each
-    // facet is being removed (DeferredDiamondCleanupQueue.md §6). Plain strings,
-    // outside the shared decode formatter (rule 201 untouched).
-    if (tx.parkedTaskRefs && tx.parkedTaskRefs.length > 0) {
-      detailLines.push('    Parked cleanup — origin PRs:')
-      for (const ref of tx.parkedTaskRefs)
-        detailLines.push(`        [32m${ref.facet}[0m → [36m${ref.prUrl}[0m`)
-    }
-
-    // Belt-and-braces around a total function: no shape of stored row may cost
-    // the operator the rest of the networks in this run.
-    try {
-      detailLines.push(...formatProvenanceLines(tx.provenance))
-    } catch (error) {
-      detailLines.push(
-        `    Provenance:      \u001b[33mUNKNOWN — could not be rendered: ${sanitizeProvenanceText(
-          error instanceof Error ? error.message : error
-        )}\u001b[0m`
-      )
-    }
+            )})`,
+      data: tx.safeTx.data.data,
+      proposer: proposerDisplay,
+      safeTxHash: tx.safeTxHash,
+      signatureCount: tx.safeTransaction.signatures.size,
+      threshold: tx.threshold,
+      canExecute: tx.canExecute,
+      parkedTaskRefs: tx.parkedTaskRefs,
+      provenance: tx.provenance,
+    })
 
     consola.info(detailLines.join('\n'))
 

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -381,7 +381,9 @@ const processTxs = async (
       buildExplorerAddressUrl(network.toLowerCase(), address as Address) ?? ''
 
     // Looked up on the sanitised address: the record keys are repository
-    // configuration, so a match names a contract this repo deployed.
+    // configuration, so a match names a contract this repo deployed. The block
+    // decides whether to show the name — it refuses for an address it had to
+    // repair, since sanitising a corrupt one can yield a valid one.
     const targetName = await getTargetName(
       sanitizeProvenanceText(tx.safeTx.data.to) as Address,
       network
@@ -443,7 +445,7 @@ const processTxs = async (
         const filmstrip = renderLedgerFlexFlow({
           chainId: chain.id,
           verifyingContract: safeAddress,
-          to: sanitizeProvenanceText(tx.safeTx.data.to) as Address,
+          to: tx.safeTransaction.data.to,
           value: String(tx.safeTx.data.value),
           data: tx.safeTx.data.data as Hex,
         })

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -19,6 +19,7 @@ import { type Address, type Hex } from 'viem'
 import networksData from '../../../config/networks.json'
 import { buildExplorerAddressUrl } from '../../utils/viemScriptHelpers'
 import { createDefaultCache } from '../shared/deployment-cache'
+import { sanitizeProvenanceText } from '../shared/git-provenance'
 import { tronHexSuffix } from '../tron/helpers/tronHexSuffix'
 
 import { readBooleanFlag, readValueFlag } from './cli-flags'
@@ -369,24 +370,30 @@ const processTxs = async (
         network,
       })
 
+    // Sanitised before anything renders it: the checks upstream of here skip
+    // whitespace rather than refusing it, so a `\r` in the stored address
+    // reaches this line and rewinds it over the label.
+    const toAddress = sanitizeProvenanceText(tx.safeTx.data.to) as Address
+
     // Get target name for display
-    const targetName = await getTargetName(tx.safeTx.data.to, network)
+    const targetName = await getTargetName(toAddress, network)
     const toAddrDisplay = `${formatAddressForNetworkCliDisplay(
       network,
-      tx.safeTx.data.to
-    )}${tronHexSuffix(network, tx.safeTx.data.to)}`
+      toAddress
+    )}${tronHexSuffix(network, toAddress)}`
     const toDisplay = targetName
       ? `${toAddrDisplay} \u001b[33m${targetName}\u001b[0m`
       : toAddrDisplay
     const toExplorerUrl = buildExplorerAddressUrl(
       network.toLowerCase(),
-      tx.safeTx.data.to
+      toAddress
     )
     const toExplorerSuffix = toExplorerUrl ? ` [36m${toExplorerUrl}[0m` : ''
+    const proposerAddress = sanitizeProvenanceText(tx.proposer) as Address
     const proposerDisplay = `${formatAddressForNetworkCliDisplay(
       network,
-      tx.proposer
-    )}${tronHexSuffix(network, tx.proposer)}`
+      proposerAddress
+    )}${tronHexSuffix(network, proposerAddress)}`
 
     const nonceColor =
       nonceStatus === 'current' ? '32' : nonceStatus === 'stale' ? '31' : '33'
@@ -442,7 +449,7 @@ const processTxs = async (
         const filmstrip = renderLedgerFlexFlow({
           chainId: chain.id,
           verifyingContract: safeAddress,
-          to: tx.safeTx.data.to,
+          to: toAddress,
           value: String(tx.safeTx.data.value),
           data: tx.safeTx.data.data as Hex,
         })
@@ -587,10 +594,10 @@ const processTxs = async (
       consola.error('✗  STALE PROPOSAL — THIS TRANSACTION WILL REVERT')
       consola.error('='.repeat(80))
       consola.error(
-        `  This proposal has nonce \u001b[31m${tx.safeTx.data.nonce}\u001b[0m but the Safe's on-chain nonce is already \u001b[31m${expectedNonce}\u001b[0m.`
+        `  This proposal has nonce \u001b[31m${txNonce}\u001b[0m but the Safe's on-chain nonce is already \u001b[31m${expectedNonce}\u001b[0m.`
       )
       consola.error(
-        `  Nonce ${tx.safeTx.data.nonce} was already used — this proposal is stale and cannot be executed.`
+        `  Nonce ${txNonce} was already used — this proposal is stale and cannot be executed.`
       )
       consola.error(
         `  Likely cause: the RPC returned a stale nonce when the proposal was created.`
@@ -620,7 +627,7 @@ const processTxs = async (
         consola.warn('⚠  GS026 — THIS TRANSACTION WILL REVERT')
         consola.warn('='.repeat(80))
         consola.warn(
-          `  This transaction has nonce \u001b[33m${tx.safeTx.data.nonce}\u001b[0m but the Safe's current on-chain nonce is \u001b[33m${expectedNonce}\u001b[0m.`
+          `  This transaction has nonce \u001b[33m${txNonce}\u001b[0m but the Safe's current on-chain nonce is \u001b[33m${expectedNonce}\u001b[0m.`
         )
         consola.warn(
           `  The Safe requires nonce ${expectedNonce} to be executed first — executing this will revert with GS026.`
@@ -661,7 +668,7 @@ const processTxs = async (
       consola.warn('⚠  NONCE GAP — EXECUTING BY OPERATOR OVERRIDE')
       consola.warn('='.repeat(80))
       consola.warn(
-        `  This transaction has nonce \u001b[33m${tx.safeTx.data.nonce}\u001b[0m but the configured RPC reports on-chain nonce \u001b[33m${expectedNonce}\u001b[0m.`
+        `  This transaction has nonce \u001b[33m${txNonce}\u001b[0m but the configured RPC reports on-chain nonce \u001b[33m${expectedNonce}\u001b[0m.`
       )
       consola.warn(
         '  ALLOW_FUTURE_NONCE_EXECUTION=true — proceeding on the assumption that the RPC nonce is out of date.'

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -370,30 +370,22 @@ const processTxs = async (
         network,
       })
 
-    // Sanitised before anything renders it: the checks upstream of here skip
-    // whitespace rather than refusing it, so a `\r` in the stored address
-    // reaches this line and rewinds it over the label.
-    const toAddress = sanitizeProvenanceText(tx.safeTx.data.to) as Address
+    // The block sanitises the stored addresses itself, so it can report a row
+    // that needed it. These only decide how a clean address is displayed.
+    const formatAddress = (address: string): string =>
+      `${formatAddressForNetworkCliDisplay(
+        network,
+        address as Address
+      )}${tronHexSuffix(network, address as Address)}`
+    const explorerUrlFor = (address: string): string =>
+      buildExplorerAddressUrl(network.toLowerCase(), address as Address) ?? ''
 
-    // Get target name for display
-    const targetName = await getTargetName(toAddress, network)
-    const toAddrDisplay = `${formatAddressForNetworkCliDisplay(
-      network,
-      toAddress
-    )}${tronHexSuffix(network, toAddress)}`
-    const toDisplay = targetName
-      ? `${toAddrDisplay} \u001b[33m${targetName}\u001b[0m`
-      : toAddrDisplay
-    const toExplorerUrl = buildExplorerAddressUrl(
-      network.toLowerCase(),
-      toAddress
+    // Looked up on the sanitised address: the record keys are repository
+    // configuration, so a match names a contract this repo deployed.
+    const targetName = await getTargetName(
+      sanitizeProvenanceText(tx.safeTx.data.to) as Address,
+      network
     )
-    const toExplorerSuffix = toExplorerUrl ? ` [36m${toExplorerUrl}[0m` : ''
-    const proposerAddress = sanitizeProvenanceText(tx.proposer) as Address
-    const proposerDisplay = `${formatAddressForNetworkCliDisplay(
-      network,
-      proposerAddress
-    )}${tronHexSuffix(network, proposerAddress)}`
 
     const nonceColor =
       nonceStatus === 'current' ? '32' : nonceStatus === 'stale' ? '31' : '33'
@@ -409,8 +401,10 @@ const processTxs = async (
       nonce: tx.safeTx.data.nonce,
       nonceColor,
       nonceWarning,
-      toDisplay,
-      toExplorerSuffix,
+      to: tx.safeTx.data.to,
+      toTargetName: targetName,
+      formatAddress,
+      explorerUrlFor,
       value: tx.safeTx.data.value,
       operationLabel:
         tx.safeTransaction.data.operation === 0
@@ -421,7 +415,7 @@ const processTxs = async (
               tx.safeTransaction.data.operation
             )})`,
       data: tx.safeTx.data.data,
-      proposer: proposerDisplay,
+      proposer: tx.proposer,
       safeTxHash: tx.safeTxHash,
       signatureCount: tx.safeTransaction.signatures.size,
       threshold: tx.threshold,
@@ -449,7 +443,7 @@ const processTxs = async (
         const filmstrip = renderLedgerFlexFlow({
           chainId: chain.id,
           verifyingContract: safeAddress,
-          to: toAddress,
+          to: sanitizeProvenanceText(tx.safeTx.data.to) as Address,
           value: String(tx.safeTx.data.value),
           data: tx.safeTx.data.data as Hex,
         })

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -446,7 +446,7 @@ const processTxs = async (
           chainId: chain.id,
           verifyingContract: safeAddress,
           to: tx.safeTransaction.data.to,
-          value: String(tx.safeTx.data.value),
+          value: String(tx.safeTransaction.data.value),
           data: tx.safeTx.data.data as Hex,
         })
         consola.info(

--- a/script/deploy/safe/safe-tx-detail-display-placement.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display-placement.test.ts
@@ -1,18 +1,24 @@
 /**
- * That the CLI still hands the block its stored values unrendered.
+ * A smoke check on the shape of one call. It proves nothing about safety.
  *
- * This is a tripwire, not the guarantee. The guarantee is that
- * `buildSafeTxDetailLines` sanitises every stored value it is given, which
- * `safe-tx-detail-display.test.ts` proves by executing it. What execution
- * cannot reach is `confirm-safe-tx.ts` itself — it is a CLI with `runMain` at
- * module scope — so the one thing asserted here is the shape of the call.
+ * Read that literally. Every assertion here is `toContain` over the file's
+ * text, which a comment anywhere in the file satisfies and a duplicate object
+ * key defeats — measured, not supposed. It catches an accidental rewrite and
+ * an adversary walks past it.
  *
- * Two earlier versions of this file tried to prove the property by scanning
- * the source for unsafe interpolations. Both were defeated by rewrites that
- * changed nothing about the behaviour: a `const d = tx.safeTx.data` alias, an
- * `include`-based exclusion that a trailing comment satisfied, bracket access,
- * optional chaining, string concatenation. A scanner cannot decide where a
- * value came from, so it is not asked to any more.
+ * The property that matters — no stored value reaches a printed line
+ * unsanitised — is held by `buildSafeTxDetailLines`, which takes every stored
+ * value unrendered and is exercised directly in
+ * `safe-tx-detail-display.test.ts`. That is the file to read and to extend.
+ * `confirm-safe-tx.ts` is a CLI with `runMain` at module scope and cannot be
+ * imported, which is why the composition was moved out of it rather than
+ * scanned inside it.
+ *
+ * Three versions of this file tried to prove the property by scanning, and all
+ * three were defeated by rewrites that changed no behaviour: a
+ * `const d = tx.safeTx.data` alias, an `includes` exclusion a trailing comment
+ * satisfied, bracket access, optional chaining, concatenation, a `}` inside a
+ * string literal. A scanner cannot decide where a value came from.
  */
 
 import { readFileSync } from 'fs'
@@ -30,8 +36,8 @@ const CONFIRM = readFileSync(
   'utf8'
 )
 
-describe('the CLI hands the detail block its stored values unrendered', () => {
-  it('passes the target and proposer straight off the row', () => {
+describe('smoke check: the shape of the call into the detail block', () => {
+  it('appears to pass the target and proposer straight off the row', () => {
     // Pre-sanitising either one here would not be safer, it would be worse:
     // the block compares what it was given against what it can print to decide
     // whether to warn, so a value cleaned on the way in is a value it reports

--- a/script/deploy/safe/safe-tx-detail-display-placement.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display-placement.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Where the detail block is built, not what it renders —
+ * `safe-tx-detail-display.test.ts` covers the rendering by executing it.
+ *
+ * `confirm-safe-tx.ts` cannot be imported as the CLI (`runMain` at module
+ * scope), so placement is asserted on the source, shaped so a field added back
+ * into a colour code raw fails the suite.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+/* eslint-disable no-template-curly-in-string -- every `${...}` below is a source pattern this file matches, never a template of its own */
+
+const CONFIRM = readFileSync(
+  join(import.meta.dir, 'confirm-safe-tx.ts'),
+  'utf8'
+)
+
+/**
+ * A stored field interpolated directly inside an SGR colour code — the shape
+ * that lets a row's own content recolour or repaint the line printing it.
+ *
+ * Matches the escape as the source spells it and as a literal ESC byte, so
+ * switching spelling does not slip past.
+ */
+// eslint-disable-next-line no-control-regex -- matching the escape sequences is the point
+const RAW_IN_COLOUR = /(?:\\u001b|\u001b)\[[^\]]{0,20}?m\$\{\s*(tx\.[^}]*)\}/gs
+
+const storedFieldsInColour = (source: string): string[] =>
+  [...source.matchAll(RAW_IN_COLOUR)].map((match) => match[1] ?? '')
+
+describe('the signing prompt builds its detail block through the sanitiser', () => {
+  it('prints the array the builder returns, and builds it nowhere else', () => {
+    expect(CONFIRM).toContain('const detailLines = buildSafeTxDetailLines({')
+    expect(CONFIRM).toContain("consola.info(detailLines.join('\\n'))")
+    // An inline `detailLines.push` would put a line into the block without
+    // passing through the builder.
+    expect(CONFIRM).not.toContain('detailLines.push')
+  })
+
+  it('leaves no stored field but the nonce inside a colour code', () => {
+    // The nonce is the one exemption: `BigInt(tx.safeTx.data.nonce)` runs
+    // unwrapped earlier in the same loop, so a row whose nonce is not numeric
+    // throws before any of these lines is reached.
+    expect(CONFIRM).toContain('const txNonce = BigInt(tx.safeTx.data.nonce)')
+    expect(
+      CONFIRM.indexOf('const txNonce = BigInt(tx.safeTx.data.nonce)')
+    ).toBeLessThan(CONFIRM.lastIndexOf('${tx.safeTx.data.nonce}'))
+
+    for (const field of storedFieldsInColour(CONFIRM))
+      expect(field).toBe('tx.safeTx.data.nonce')
+  })
+
+  it('flags the shape it exists to catch', () => {
+    // Without this the rule above passes on a file that simply stopped using
+    // template literals, which is the same bug wearing a different syntax.
+    const reintroduced = [
+      '`    Data:            \\u001b[32m${tx.safeTx.data.data}\\u001b[0m`',
+      '`    Safe Tx Hash:    \\u001b[36m${tx.safeTxHash}\\u001b[0m`',
+    ].join('\n')
+
+    expect(storedFieldsInColour(reintroduced)).toEqual([
+      'tx.safeTx.data.data',
+      'tx.safeTxHash',
+    ])
+  })
+})

--- a/script/deploy/safe/safe-tx-detail-display-placement.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display-placement.test.ts
@@ -1,10 +1,16 @@
 /**
  * A smoke check on the shape of one call. It proves nothing about safety.
  *
- * Read that literally. Every assertion here is `toContain` over the file's
- * text, which a comment anywhere in the file satisfies and a duplicate object
- * key defeats — measured, not supposed. It catches an accidental rewrite and
- * an adversary walks past it.
+ * Read that literally. The positive assertions are `toContain` over the file's
+ * text, which a comment anywhere in the file satisfies and a spread override
+ * defeats — measured, not supposed. They catch an accidental rewrite and an
+ * adversary walks past them.
+ *
+ * The `not.toContain` pair is the half worth keeping: it fails conservatively,
+ * catching an inline `detailLines.push` or the raw nonce being interpolated
+ * again. Its cost is the mirror image — a comment or string literal elsewhere
+ * in `confirm-safe-tx.ts` that merely mentions either turns this suite red for
+ * no behavioural reason.
  *
  * The property that matters — no stored value reaches a printed line
  * unsanitised — is held by `buildSafeTxDetailLines`, which takes every stored

--- a/script/deploy/safe/safe-tx-detail-display-placement.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display-placement.test.ts
@@ -1,13 +1,18 @@
 /**
- * Where the signing prompt's values come from, not what they render to —
- * `safe-tx-detail-display.test.ts` covers the rendering by executing it.
+ * That the CLI still hands the block its stored values unrendered.
  *
- * `confirm-safe-tx.ts` cannot be imported as the CLI (`runMain` at module
- * scope), so this is asserted on the source. The rule is deliberately not
- * "no stored field inside a colour code": a value that rewinds a line does so
- * wherever it is printed, and the parked-cleanup fields are reached through
- * `ref.` rather than `tx.`, so a colour-code rule keyed on one receiver would
- * not see them.
+ * This is a tripwire, not the guarantee. The guarantee is that
+ * `buildSafeTxDetailLines` sanitises every stored value it is given, which
+ * `safe-tx-detail-display.test.ts` proves by executing it. What execution
+ * cannot reach is `confirm-safe-tx.ts` itself — it is a CLI with `runMain` at
+ * module scope — so the one thing asserted here is the shape of the call.
+ *
+ * Two earlier versions of this file tried to prove the property by scanning
+ * the source for unsafe interpolations. Both were defeated by rewrites that
+ * changed nothing about the behaviour: a `const d = tx.safeTx.data` alias, an
+ * `include`-based exclusion that a trailing comment satisfied, bracket access,
+ * optional chaining, string concatenation. A scanner cannot decide where a
+ * value came from, so it is not asked to any more.
  */
 
 import { readFileSync } from 'fs'
@@ -20,107 +25,34 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-/* eslint-disable no-template-curly-in-string -- every `${...}` below is a source pattern this file matches, never a template of its own */
-
 const CONFIRM = readFileSync(
   join(import.meta.dir, 'confirm-safe-tx.ts'),
   'utf8'
 )
 
-/** Receivers carrying a value read out of the stored proposal row. */
-const STORED_RECEIVER =
-  /\b(?:tx\.|ref\.|proposerDisplay|toDisplay|toAddrDisplay)/u
-
-/**
- * Every `${...}` in the source, brace-counted rather than pattern-matched, so
- * an expression containing a nested template literal is still seen whole.
- */
-function interpolations(source: string): string[] {
-  const found: string[] = []
-  for (let i = 0; i < source.length - 1; i++) {
-    if (source[i] !== '$' || source[i + 1] !== '{') continue
-    let depth = 1
-    let j = i + 2
-    for (; j < source.length && depth > 0; j++)
-      if (source[j] === '{') depth++
-      else if (source[j] === '}') depth--
-    if (depth === 0) found.push(source.slice(i + 2, j - 1))
-  }
-  return found
-}
-
-const storedInterpolations = (source: string): string[] =>
-  interpolations(source)
-    .filter((expression) => STORED_RECEIVER.test(expression))
-    .map((expression) => expression.replace(/\s+/gu, ' ').trim())
-
-/**
- * The only stored values allowed to reach a printed line without going through
- * `buildSafeTxDetailLines`. Both are sanitised before they get here, and the
- * assertions below pin that rather than take it on trust.
- */
-const ALLOWED = [
-  'describeOperationValue( tx.safeTransaction.data.operation )',
-  'toAddrDisplay',
-]
-
-describe('the signing prompt prints no stored value it has not sanitised', () => {
-  it('interpolates only the stored expressions that are already safe', () => {
-    expect(storedInterpolations(CONFIRM).sort()).toEqual([...ALLOWED].sort())
+describe('the CLI hands the detail block its stored values unrendered', () => {
+  it('passes the target and proposer straight off the row', () => {
+    // Pre-sanitising either one here would not be safer, it would be worse:
+    // the block compares what it was given against what it can print to decide
+    // whether to warn, so a value cleaned on the way in is a value it reports
+    // as clean.
+    expect(CONFIRM).toContain('to: tx.safeTx.data.to,')
+    expect(CONFIRM).toContain('proposer: tx.proposer,')
   })
 
-  it('sanitises the target and proposer addresses before rendering them', () => {
-    expect(CONFIRM).toContain(
-      'const toAddress = sanitizeProvenanceText(tx.safeTx.data.to) as Address'
-    )
-    expect(CONFIRM).toContain(
-      'const proposerAddress = sanitizeProvenanceText(tx.proposer) as Address'
-    )
-    // Every other read of those two fields would be a second, ungated route.
-    for (const raw of ['tx.safeTx.data.to', 'tx.proposer'])
-      expect(
-        CONFIRM.split('\n').filter(
-          (line) =>
-            line.includes(raw) && !line.includes('sanitizeProvenanceText')
-        )
-      ).toEqual([])
-  })
-
-  it('prints the parsed nonce, never the stored string', () => {
-    // `BigInt()` skips whitespace instead of refusing it — `BigInt('31\r')` is
-    // 31n — so having been parsed does not make the stored string safe.
-    expect(CONFIRM).not.toContain('${tx.safeTx.data.nonce}')
-    expect(CONFIRM).toContain('const txNonce = BigInt(tx.safeTx.data.nonce)')
-  })
-
-  it('builds the detail block in one place and prints what it returns', () => {
+  it('builds the block in one place and prints what it returns', () => {
     expect(CONFIRM).toContain('const detailLines = buildSafeTxDetailLines({')
     expect(CONFIRM).toContain("consola.info(detailLines.join('\\n'))")
     // An inline push would add a line without passing through the builder.
     expect(CONFIRM).not.toContain('detailLines.push')
   })
 
-  it('flags every shape it exists to catch', () => {
-    // Each of these passed the colour-code rule this replaced. Without them
-    // the suite cannot tell a rule that holds from one that matches nothing.
-    const reintroduced = [
-      '`    Data:            \\u001b[32m${tx.safeTx.data.data}\\u001b[0m`',
-      '`        ${GREEN}${ref.facet}${RESET} → ${CYAN}${ref.prUrl}${RESET}`',
-      '`  Nonce ${tx.safeTx.data.nonce} was already used`',
-      '`${nested ? `${tx.safeTxHash}` : ""}`',
-      '`    Proposer:        ${proposerDisplay}`',
-    ].join('\n')
-
-    expect(storedInterpolations(reintroduced)).toEqual([
-      'tx.safeTx.data.data',
-      'ref.facet',
-      'ref.prUrl',
-      'tx.safeTx.data.nonce',
-      'nested ? `${tx.safeTxHash}` : ""',
-      // The scanner reports the inner interpolation too, so nesting hides
-      // nothing from it.
-      'tx.safeTxHash',
-      'proposerDisplay',
-    ])
+  it('prints the parsed nonce in the mismatch warnings', () => {
+    // Those warnings are outside the block. `txNonce` is a `bigint`, so no
+    // string can reach them at all — the compiler holds this one, and this
+    // assertion only catches the field being swapped back in wholesale.
+    // eslint-disable-next-line no-template-curly-in-string -- a source pattern, not a template
+    expect(CONFIRM).not.toContain('${tx.safeTx.data.nonce}')
+    expect(CONFIRM).toContain('const txNonce = BigInt(tx.safeTx.data.nonce)')
   })
 })

--- a/script/deploy/safe/safe-tx-detail-display-placement.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display-placement.test.ts
@@ -1,10 +1,13 @@
 /**
- * Where the detail block is built, not what it renders —
+ * Where the signing prompt's values come from, not what they render to —
  * `safe-tx-detail-display.test.ts` covers the rendering by executing it.
  *
  * `confirm-safe-tx.ts` cannot be imported as the CLI (`runMain` at module
- * scope), so placement is asserted on the source, shaped so a field added back
- * into a colour code raw fails the suite.
+ * scope), so this is asserted on the source. The rule is deliberately not
+ * "no stored field inside a colour code": a value that rewinds a line does so
+ * wherever it is printed, and the parked-cleanup fields are reached through
+ * `ref.` rather than `tx.`, so a colour-code rule keyed on one receiver would
+ * not see them.
  */
 
 import { readFileSync } from 'fs'
@@ -24,52 +27,100 @@ const CONFIRM = readFileSync(
   'utf8'
 )
 
+/** Receivers carrying a value read out of the stored proposal row. */
+const STORED_RECEIVER =
+  /\b(?:tx\.|ref\.|proposerDisplay|toDisplay|toAddrDisplay)/u
+
 /**
- * A stored field interpolated directly inside an SGR colour code — the shape
- * that lets a row's own content recolour or repaint the line printing it.
- *
- * Matches the escape as the source spells it and as a literal ESC byte, so
- * switching spelling does not slip past.
+ * Every `${...}` in the source, brace-counted rather than pattern-matched, so
+ * an expression containing a nested template literal is still seen whole.
  */
-// eslint-disable-next-line no-control-regex -- matching the escape sequences is the point
-const RAW_IN_COLOUR = /(?:\\u001b|\u001b)\[[^\]]{0,20}?m\$\{\s*(tx\.[^}]*)\}/gs
+function interpolations(source: string): string[] {
+  const found: string[] = []
+  for (let i = 0; i < source.length - 1; i++) {
+    if (source[i] !== '$' || source[i + 1] !== '{') continue
+    let depth = 1
+    let j = i + 2
+    for (; j < source.length && depth > 0; j++)
+      if (source[j] === '{') depth++
+      else if (source[j] === '}') depth--
+    if (depth === 0) found.push(source.slice(i + 2, j - 1))
+  }
+  return found
+}
 
-const storedFieldsInColour = (source: string): string[] =>
-  [...source.matchAll(RAW_IN_COLOUR)].map((match) => match[1] ?? '')
+const storedInterpolations = (source: string): string[] =>
+  interpolations(source)
+    .filter((expression) => STORED_RECEIVER.test(expression))
+    .map((expression) => expression.replace(/\s+/gu, ' ').trim())
 
-describe('the signing prompt builds its detail block through the sanitiser', () => {
-  it('prints the array the builder returns, and builds it nowhere else', () => {
+/**
+ * The only stored values allowed to reach a printed line without going through
+ * `buildSafeTxDetailLines`. Both are sanitised before they get here, and the
+ * assertions below pin that rather than take it on trust.
+ */
+const ALLOWED = [
+  'describeOperationValue( tx.safeTransaction.data.operation )',
+  'toAddrDisplay',
+]
+
+describe('the signing prompt prints no stored value it has not sanitised', () => {
+  it('interpolates only the stored expressions that are already safe', () => {
+    expect(storedInterpolations(CONFIRM).sort()).toEqual([...ALLOWED].sort())
+  })
+
+  it('sanitises the target and proposer addresses before rendering them', () => {
+    expect(CONFIRM).toContain(
+      'const toAddress = sanitizeProvenanceText(tx.safeTx.data.to) as Address'
+    )
+    expect(CONFIRM).toContain(
+      'const proposerAddress = sanitizeProvenanceText(tx.proposer) as Address'
+    )
+    // Every other read of those two fields would be a second, ungated route.
+    for (const raw of ['tx.safeTx.data.to', 'tx.proposer'])
+      expect(
+        CONFIRM.split('\n').filter(
+          (line) =>
+            line.includes(raw) && !line.includes('sanitizeProvenanceText')
+        )
+      ).toEqual([])
+  })
+
+  it('prints the parsed nonce, never the stored string', () => {
+    // `BigInt()` skips whitespace instead of refusing it — `BigInt('31\r')` is
+    // 31n — so having been parsed does not make the stored string safe.
+    expect(CONFIRM).not.toContain('${tx.safeTx.data.nonce}')
+    expect(CONFIRM).toContain('const txNonce = BigInt(tx.safeTx.data.nonce)')
+  })
+
+  it('builds the detail block in one place and prints what it returns', () => {
     expect(CONFIRM).toContain('const detailLines = buildSafeTxDetailLines({')
     expect(CONFIRM).toContain("consola.info(detailLines.join('\\n'))")
-    // An inline `detailLines.push` would put a line into the block without
-    // passing through the builder.
+    // An inline push would add a line without passing through the builder.
     expect(CONFIRM).not.toContain('detailLines.push')
   })
 
-  it('leaves no stored field but the nonce inside a colour code', () => {
-    // The nonce is the one exemption: `BigInt(tx.safeTx.data.nonce)` runs
-    // unwrapped earlier in the same loop, so a row whose nonce is not numeric
-    // throws before any of these lines is reached.
-    expect(CONFIRM).toContain('const txNonce = BigInt(tx.safeTx.data.nonce)')
-    expect(
-      CONFIRM.indexOf('const txNonce = BigInt(tx.safeTx.data.nonce)')
-    ).toBeLessThan(CONFIRM.lastIndexOf('${tx.safeTx.data.nonce}'))
-
-    for (const field of storedFieldsInColour(CONFIRM))
-      expect(field).toBe('tx.safeTx.data.nonce')
-  })
-
-  it('flags the shape it exists to catch', () => {
-    // Without this the rule above passes on a file that simply stopped using
-    // template literals, which is the same bug wearing a different syntax.
+  it('flags every shape it exists to catch', () => {
+    // Each of these passed the colour-code rule this replaced. Without them
+    // the suite cannot tell a rule that holds from one that matches nothing.
     const reintroduced = [
       '`    Data:            \\u001b[32m${tx.safeTx.data.data}\\u001b[0m`',
-      '`    Safe Tx Hash:    \\u001b[36m${tx.safeTxHash}\\u001b[0m`',
+      '`        ${GREEN}${ref.facet}${RESET} → ${CYAN}${ref.prUrl}${RESET}`',
+      '`  Nonce ${tx.safeTx.data.nonce} was already used`',
+      '`${nested ? `${tx.safeTxHash}` : ""}`',
+      '`    Proposer:        ${proposerDisplay}`',
     ].join('\n')
 
-    expect(storedFieldsInColour(reintroduced)).toEqual([
+    expect(storedInterpolations(reintroduced)).toEqual([
       'tx.safeTx.data.data',
+      'ref.facet',
+      'ref.prUrl',
+      'tx.safeTx.data.nonce',
+      'nested ? `${tx.safeTxHash}` : ""',
+      // The scanner reports the inner interpolation too, so nesting hides
+      // nothing from it.
       'tx.safeTxHash',
+      'proposerDisplay',
     ])
   })
 })

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -124,7 +124,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     )
     const plain = lineStartingWith(linesFor({ data: '0x12' }), 'Data:')
 
-    expect(zeroWidth).toContain('stored 5, shown 4')
+    expect(zeroWidth).toContain('stored 5, printable 4')
     expect(plain).not.toContain('sanitised for display')
     // The visible renderings are identical; only the marker separates them.
     expect(stripOwnColours(plain).trimEnd()).toContain('0x12')
@@ -159,7 +159,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
         }),
         label
       )
-      expect(line).toContain('stored 5, shown 4')
+      expect(line).toContain('stored 5, printable 4')
       expect(line).toContain('(0x41…)')
     }
   })
@@ -173,13 +173,64 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(line).toContain('invisible character')
   })
 
-  it('names a value that stringifies to nothing but was not a string', () => {
-    // `String([])` is '', which would otherwise render as an ordinary blank
-    // field indistinguishable from a stored empty string.
-    expect(lineStartingWith(linesFor({ data: [] }), 'Data:')).toContain(
-      'empty array'
+  it('sanitises what a display callback returns, not only what it is given', () => {
+    // The callbacks receive a sanitised address, but what reaches the line is
+    // their return value, so one that reached for the stored row instead would
+    // render it raw.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        formatAddress: () => '0xBAD\u001b[2J\u001b[Hfake',
+        explorerUrlFor: () => 'https://x/\u001b[2Jevil',
+      }),
+      'To:'
     )
-    expect(lineStartingWith(linesFor({ data: '' }), 'Data:')).not.toContain('⚠')
+
+    expect(stripOwnColours(line).match(TERMINAL_DRIVING)).toBeNull()
+    expect(line).toContain('fake')
+  })
+
+  it('resolves no name and no link for an address it had to repair', () => {
+    // Sanitising a corrupt address can yield a valid one — a zero-width space
+    // inside the hex just disappears — and naming that would present a corrupt
+    // row as a known contract with a working link.
+    const repaired = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        to: '0x11f1022cA6AdEF6400e5677528a80\u200bd49a069C00c',
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+      }),
+      'To:'
+    )
+
+    expect(repaired).not.toContain('(LiFiDiamond)')
+    expect(repaired).not.toContain('etherscan')
+    expect(repaired).toContain('sanitised for display')
+
+    // The same row without the zero-width space keeps both.
+    const clean = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+      }),
+      'To:'
+    )
+    expect(clean).toContain('(LiFiDiamond)')
+    expect(clean).toContain('etherscan')
+  })
+
+  it('puts the notice outside the colour on the address lines too', () => {
+    for (const [field, label] of [
+      ['to', 'To:'],
+      ['proposer', 'Proposer:'],
+    ] as const) {
+      const line = lineStartingWith(linesFor({ [field]: '0x1\u00072' }), label)
+      expect(line.indexOf('\u001b[0m')).toBeLessThan(
+        line.indexOf('sanitised for display')
+      )
+    }
   })
 
   it('keeps a missing field visibly missing', () => {
@@ -210,7 +261,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       linesFor({ data: '\u{1f600}\u{1f600}\u0007' }),
       'Data:'
     )
-    expect(line).toContain('stored 3, shown 2')
+    expect(line).toContain('stored 3, printable 2')
   })
 
   it('says so when a field renders to nothing at all', () => {

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -715,6 +715,30 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       expect(rendered).not.toContain('block could not be rendered')
     }
 
+    // And the nesting one level deeper: describing the thrown value is itself
+    // a coercion, so a value whose `toString` throws something unstringifiable
+    // defeats the describing too. The last catch before the network loop
+    // cannot be allowed to fail.
+    const nested = (): string[] =>
+      buildSafeTxDetailLines({
+        ...benign,
+        provenance: {
+          get proposerHandle(): string {
+            // A non-Error thrown value is the whole point: a row can produce one.
+            // eslint-disable-next-line no-throw-literal
+            throw {
+              toString() {
+                throw Object.create(null)
+              },
+            }
+          },
+        } as never,
+      })
+    expect(nested).not.toThrow()
+    expect(nested().join('\n')).toContain(
+      'an error that cannot itself be described'
+    )
+
     // The rest of the block survives a broken provenance row.
     expect(lines.some((line) => line.includes('Data:'))).toBe(true)
   })

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -62,8 +62,10 @@ const lineStartingWith = (lines: string[], label: string): string => {
 }
 
 describe('no proposer-controlled field can drive the signer’s terminal', () => {
+  // Named rather than `keyof ISafeTxDetailInput`: these are exactly the fields
+  // the block sanitises, and the wider type also admitted the two callbacks.
   const cases: {
-    field: keyof ISafeTxDetailInput
+    field: 'data' | 'safeTxHash' | 'proposer' | 'to' | 'nonce' | 'value'
     label: string
   }[] = [
     { field: 'data', label: 'Data:' },
@@ -136,12 +138,12 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     // still not what it looks like.
     for (const hidden of ['0x1\u200d2', '0x1\u31642', '0x1\uffa02'])
       expect(lineStartingWith(linesFor({ data: hidden }), 'Data:')).toContain(
-        '1 invisible character in a value of 5'
+        '1 invisible character among 5 printable'
       )
 
     expect(
       lineStartingWith(linesFor({ data: '0x1\u200d\u31642' }), 'Data:')
-    ).toContain('2 invisible characters in a value of 6')
+    ).toContain('2 invisible characters among 6 printable')
   })
 
   it('still marks a hostile value after the network formatter runs', () => {
@@ -221,6 +223,130 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(clean).toContain('etherscan')
   })
 
+  it('keeps the name and link when only surrounding whitespace was lost', () => {
+    // Trimming the ends cannot change which address this is, and the name is
+    // the strongest confirmation the signer gets that the target is the
+    // contract they expect.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        to: `  ${benign.to as string}  `,
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+      }),
+      'To:'
+    )
+
+    expect(line).toContain('(LiFiDiamond)')
+    expect(line).toContain('etherscan')
+    // The repair is still disclosed.
+    expect(line).toContain('sanitised for display')
+  })
+
+  it('drops the name and link for an invisible character the sanitiser keeps', () => {
+    // The stripped case is covered above; this is the branch where stored and
+    // printable have the same length, so a change-detector would miss it.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        to: `${benign.to as string}‍`,
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+      }),
+      'To:'
+    )
+
+    expect(line).not.toContain('(LiFiDiamond)')
+    expect(line).not.toContain('etherscan')
+    expect(line).toContain('invisible character')
+  })
+
+  it('drops the name and link for a target that cannot be coerced', () => {
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        to: {
+          toString() {
+            throw new Error('nope')
+          },
+        },
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+      }),
+      'To:'
+    )
+
+    expect(line).not.toContain('(LiFiDiamond)')
+    expect(line).not.toContain('etherscan')
+  })
+
+  it('resolves nothing for a target that was never a string', () => {
+    // `String(undefined)` is a word, not an address. Naming it would present a
+    // row with no target at all as a known contract.
+    for (const to of [undefined, 42, true])
+      expect(
+        lineStartingWith(
+          buildSafeTxDetailLines({
+            ...benign,
+            to,
+            toTargetName: '(LiFiDiamond)',
+            explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+          }),
+          'To:'
+        )
+      ).not.toContain('(LiFiDiamond)')
+  })
+
+  it('shows no name or link beside an address that would not render', () => {
+    // A formatter that throws used to yield an empty fragment, leaving the
+    // name and the link describing nothing at all.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        toTargetName: '(LiFiDiamond)',
+        explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+        formatAddress: () => {
+          throw new Error('no codec for this network')
+        },
+      }),
+      'To:'
+    )
+
+    expect(line).not.toContain('(LiFiDiamond)')
+    expect(line).not.toContain('etherscan')
+    expect(line).toContain('could not be rendered for this network')
+    // The stored address is still shown, unformatted, rather than nothing.
+    expect(line).toContain(benign.to as string)
+  })
+
+  it('sanitises the proposer formatter’s return value, not only its input', () => {
+    // `formattedAddressField` has its own call into the formatter; covering
+    // only the target's would leave this one unobserved.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        formatAddress: () => '0xP[2Jwiped',
+      }),
+      'Proposer:'
+    )
+
+    expect(stripOwnColours(line).match(TERMINAL_DRIVING)).toBeNull()
+    expect(line).toContain('wiped')
+  })
+
+  it('sanitises the target name, which is a string the caller composes', () => {
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        toTargetName: '(LiFiDiamond)[2J',
+      }),
+      'To:'
+    )
+
+    expect(stripOwnColours(line).match(TERMINAL_DRIVING)).toBeNull()
+    expect(line).toContain('(LiFiDiamond)')
+  })
+
   it('puts the notice outside the colour on the address lines too', () => {
     for (const [field, label] of [
       ['to', 'To:'],
@@ -271,6 +397,66 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     )
 
     expect(line).toContain('no printable characters')
+  })
+
+  it('names a stored value that is not a string, whatever it renders as', () => {
+    // Says only what it knows: `[' ']` renders as nothing while holding an
+    // element, so "empty" would be a false claim about the container.
+    for (const [value, expected] of [
+      [[], 'stored as an array, not a string'],
+      [[' '], 'stored as an array, not a string'],
+      [{}, 'stored as an object, not a string'],
+      [new Date(0), 'stored as an object, not a string'],
+    ] as const)
+      expect(
+        lineStartingWith(linesFor({ data: value as never }), 'Data:')
+      ).toContain(expected)
+
+    // `typeof null` is 'object'; a stored null renders as "null" and is not a
+    // malformed container.
+    expect(lineStartingWith(linesFor({ data: null }), 'Data:')).not.toContain(
+      'not a string'
+    )
+    // A stored empty string is legitimate and stays unremarked.
+    expect(lineStartingWith(linesFor({ data: '' }), 'Data:')).not.toContain('⚠')
+  })
+
+  it('separates two remarks so neither reads as part of the other', () => {
+    const line = lineStartingWith(linesFor({ data: ['0x1‍'] }), 'Data:')
+
+    expect(line).toContain('; ')
+    expect(line).toContain('stored as an array, not a string')
+    expect(line).toContain('invisible character')
+  })
+
+  it('counts invisibles among the printable text, not the stored value', () => {
+    // U+200B is stripped, so reporting it as surviving would be a false alarm
+    // about a character the reader is not being shown.
+    expect(
+      lineStartingWith(linesFor({ data: '0x1​2' }), 'Data:')
+    ).not.toContain('invisible character')
+    // And in code points: two emoji plus a joiner is three characters.
+    expect(
+      lineStartingWith(linesFor({ data: '\u{1f600}\u{1f600}‍' }), 'Data:')
+    ).toContain('among 3 printable')
+  })
+
+  it('marks a value that cannot be coerced at all', () => {
+    const line = lineStartingWith(
+      linesFor({
+        data: {
+          toString() {
+            throw new Error('nope')
+          },
+        },
+      }),
+      'Data:'
+    )
+
+    expect(line).toContain('unrenderable')
+    // Without the notice this is indistinguishable from a row storing the
+    // literal string "unrenderable".
+    expect(line).toContain('value cannot be shown')
   })
 
   it('leaves a benign field unmarked', () => {

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -10,6 +10,20 @@ import {
   type ISafeTxDetailInput,
 } from './safe-tx-detail-display'
 
+/**
+ * Exact renderings for hostile input. The structural assertions below strip the
+ * module's own SGR codes before looking for control characters, which cannot
+ * distinguish a row-supplied `ESC[31m` from one this module wrote — so the
+ * property that no escape survives from the row is pinned here, byte for byte,
+ * where a sanitiser that started passing SGR through would fail.
+ */
+const HOSTILE_GOLDENS: Record<string, string> = {
+  'Data:':
+    '    Data:            \u001b[32m[2J[H[32mfake\u001b[0m\u001b[33m ⚠ sanitised for display — stored 16, printable 13\u001b[0m',
+  'Proposer:':
+    '    Proposer:        \u001b[32m[2J[H[32mfake\u001b[0m\u001b[33m ⚠ sanitised for display — stored 16, printable 13\u001b[0m',
+}
+
 /** Anything outside the colour codes this module writes itself. */
 const TERMINAL_DRIVING = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu
 // eslint-disable-next-line no-control-regex -- matching the escape sequences is the point
@@ -86,6 +100,15 @@ describe('no proposer-controlled field can drive the signer’s terminal', () =>
       // Paired present: the field is still rendered, not silently dropped.
       expect(line).toContain('fake line')
     })
+
+  it('lets no escape from the row survive, byte for byte', () => {
+    // An SGR payload specifically: the structural checks cannot see one.
+    const sgr = '\u001b[2J\u001b[H\u001b[32mfake'
+    for (const [label, expected] of Object.entries(HOSTILE_GOLDENS)) {
+      const field = label === 'Data:' ? 'data' : 'proposer'
+      expect(lineStartingWith(linesFor({ [field]: sgr }), label)).toBe(expected)
+    }
+  })
 
   it('strips them from a parked-cleanup facet and PR link', () => {
     const lines = linesFor({
@@ -209,6 +232,21 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(repaired).not.toContain('(LiFiDiamond)')
     expect(repaired).not.toContain('etherscan')
     expect(repaired).toContain('sanitised for display')
+    // And the omission is stated: a bare address otherwise reads as "not a
+    // known contract", which is the opposite of what happened.
+    expect(repaired).toContain('target name withheld')
+
+    // Nothing is claimed when there was no name to withhold.
+    expect(
+      lineStartingWith(
+        buildSafeTxDetailLines({
+          ...benign,
+          to: `${benign.to as string}\u200d`,
+          toTargetName: '',
+        }),
+        'To:'
+      )
+    ).not.toContain('withheld')
 
     // The same row without the zero-width space keeps both.
     const clean = lineStartingWith(
@@ -325,7 +363,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     const line = lineStartingWith(
       buildSafeTxDetailLines({
         ...benign,
-        formatAddress: () => '0xP[2Jwiped',
+        formatAddress: () => '0xP\u001b[2Jwiped',
       }),
       'Proposer:'
     )
@@ -338,7 +376,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     const line = lineStartingWith(
       buildSafeTxDetailLines({
         ...benign,
-        toTargetName: '(LiFiDiamond)[2J',
+        toTargetName: '(LiFiDiamond)\u001b[2J',
       }),
       'To:'
     )

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -127,6 +127,51 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(stripOwnColours(plain).trimEnd()).toContain('0x12')
   })
 
+  it('marks a value hiding zero-width characters the sanitiser keeps', () => {
+    // U+200D is preserved by design and U+3164 is a printable letter, so
+    // neither is stripped and the stored/shown lengths agree — the value is
+    // still not what it looks like.
+    for (const hidden of ['0x1\u200d2', '0x1\u31642', '0x1\uffa02'])
+      expect(lineStartingWith(linesFor({ data: hidden }), 'Data:')).toContain(
+        '1 invisible character in a value of 5'
+      )
+
+    expect(
+      lineStartingWith(linesFor({ data: '0x1\u200d\u31642' }), 'Data:')
+    ).toContain('2 invisible characters in a value of 6')
+  })
+
+  it('keeps a missing field visibly missing', () => {
+    // Rendering it blank would make a row with no `data` — still cast to Hex
+    // and signed — read exactly like one carrying `0x`.
+    expect(lineStartingWith(linesFor({ data: undefined }), 'Data:')).toContain(
+      'undefined'
+    )
+    expect(lineStartingWith(linesFor({ data: null }), 'Data:')).toContain(
+      'null'
+    )
+  })
+
+  it('puts the notice outside the value\u2019s colour, never inside it', () => {
+    // Inside, a notice would render in the value's green and read as part of
+    // the value rather than as a warning about it.
+    const line = lineStartingWith(linesFor({ data: HOSTILE }), 'Data:')
+    expect(line.indexOf('\u001b[0m')).toBeLessThan(
+      line.indexOf('sanitised for display')
+    )
+    expect(line).toContain('\u001b[33m \u26a0')
+  })
+
+  it('counts length in code points, not UTF-16 units', () => {
+    // A two-emoji value is two characters to a reader and four units to
+    // `.length`; the number exists for the reader.
+    const line = lineStartingWith(
+      linesFor({ data: '\u{1f600}\u{1f600}\u0007' }),
+      'Data:'
+    )
+    expect(line).toContain('stored 3, shown 2')
+  })
+
   it('says so when a field renders to nothing at all', () => {
     const line = lineStartingWith(
       linesFor({ proposer: '\u001b\u0007\u009b' }),

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -314,7 +314,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
 
     expect(line).not.toContain('(LiFiDiamond)')
     expect(line).not.toContain('etherscan')
-    expect(line).toContain('could not be rendered for this network')
+    expect(line).toContain('shown unformatted')
     // The stored address is still shown, unformatted, rather than nothing.
     expect(line).toContain(benign.to as string)
   })
@@ -361,7 +361,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       'Proposer:'
     )
 
-    expect(line).toContain('could not be rendered for this network')
+    expect(line).toContain('shown unformatted')
     // The stored address is still shown rather than blanked.
     expect(line).toContain(benign.proposer as string)
   })
@@ -375,7 +375,7 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       ['proposer', 'Proposer:'],
     ] as const)
       expect(lineStartingWith(linesFor({ [field]: '' }), label)).not.toContain(
-        'could not be rendered'
+        'shown unformatted'
       )
   })
 
@@ -388,14 +388,84 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       buildSafeTxDetailLines({
         ...benign,
         to: padded,
-        formatAddress: (address: string) => `len${address.length}`,
-        explorerUrlFor: (address: string) => `https://x/len${address.length}`,
+        formatAddress: (address: string) => `fmt${address.length}`,
+        explorerUrlFor: (address: string) => `https://x/url${address.length}`,
       }),
       'To:'
     )
 
-    expect(line).toContain(`len${(benign.to as string).length}`)
-    expect(line).not.toContain(`len${padded.length}`)
+    // Distinct markers, or the formatter's output alone satisfies both halves
+    // and nothing constrains what the explorer was handed.
+    expect(line).toContain(`fmt${(benign.to as string).length}`)
+    expect(line).toContain(`url${(benign.to as string).length}`)
+    expect(line).not.toContain(`fmt${padded.length}`)
+    expect(line).not.toContain(`url${padded.length}`)
+  })
+
+  it('hands the proposer formatter the sanitised text as well', () => {
+    // The target line's version of this is above; sharing one helper between
+    // the two call sites does not mean both are observed.
+    const padded = `  ${benign.proposer as string}  `
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        proposer: padded,
+        formatAddress: (address: string) => `fmt${address.length}`,
+      }),
+      'Proposer:'
+    )
+
+    expect(line).toContain(`fmt${(benign.proposer as string).length}`)
+    expect(line).not.toContain(`fmt${padded.length}`)
+  })
+
+  it('survives a callback whose return value throws on coercion', () => {
+    // The sanitiser coerces what the callback returns, so it can throw where
+    // the callback did not. Escaping here costs every remaining network in the
+    // run, because the caller has no per-network catch.
+    const throwing = {
+      toString() {
+        throw new Error('boom')
+      },
+    } as unknown as string
+
+    for (const overrides of [
+      { formatAddress: () => throwing },
+      { explorerUrlFor: () => throwing },
+      { toTargetName: throwing },
+    ])
+      expect(() =>
+        buildSafeTxDetailLines({ ...benign, ...overrides })
+      ).not.toThrow()
+  })
+
+  it('renders no explorer link for a target that sanitises to nothing', () => {
+    const line = lineStartingWith(
+      linesFor({
+        to: ' ',
+        explorerUrlFor: () => 'https://etherscan.io/address/',
+      }),
+      'To:'
+    )
+
+    expect(line).not.toContain('etherscan')
+  })
+
+  it('keeps the unformatted-address warning outside the value\u2019s colour', () => {
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        formatAddress: () => {
+          throw new Error('no codec')
+        },
+      }),
+      'To:'
+    )
+
+    expect(line).toContain('\u001b[33m \u26a0 shown unformatted')
+    expect(line.indexOf('\u001b[0m')).toBeLessThan(
+      line.indexOf('shown unformatted')
+    )
   })
 
   it('puts the notice outside the colour on the address lines too', () => {
@@ -611,6 +681,27 @@ describe('the block is total — no row shape costs the operator the run', () =>
     )
 
     expect(line).toContain('unrenderable')
+  })
+
+  it('renders a parked-refs field that is not an array', () => {
+    // A stored document with a `length` satisfies a length check and then
+    // throws on `for...of`, which would escape the builder entirely.
+    for (const parkedTaskRefs of [
+      { length: 2 } as never,
+      { length: 1, 0: {} } as never,
+      5 as never,
+      'abc' as never,
+    ])
+      expect(() =>
+        buildSafeTxDetailLines({ ...benign, parkedTaskRefs })
+      ).not.toThrow()
+
+    expect(
+      buildSafeTxDetailLines({
+        ...benign,
+        parkedTaskRefs: { length: 2 } as never,
+      }).some((line) => line.includes('Parked cleanup'))
+    ).toBe(false)
   })
 
   it('renders a parked ref that is not an object', () => {

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -29,8 +29,10 @@ const benign: ISafeTxDetailInput = {
   nonce: '31',
   nonceColor: '32',
   nonceWarning: '',
-  toDisplay: '0x11f1022cA6AdEF6400e5677528a80d49a069C00c',
-  toExplorerSuffix: '',
+  to: '0x11f1022cA6AdEF6400e5677528a80d49a069C00c',
+  toTargetName: '',
+  formatAddress: (address: string) => address,
+  explorerUrlFor: () => '',
   value: '0',
   operationLabel: 'Call',
   data: '0xdeadbeef',
@@ -67,6 +69,7 @@ describe('no proposer-controlled field can drive the signer’s terminal', () =>
     { field: 'data', label: 'Data:' },
     { field: 'safeTxHash', label: 'Safe Tx Hash:' },
     { field: 'proposer', label: 'Proposer:' },
+    { field: 'to', label: 'To:' },
     { field: 'nonce', label: 'Nonce:' },
     { field: 'value', label: 'Value:' },
   ]
@@ -141,6 +144,44 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     ).toContain('2 invisible characters in a value of 6')
   })
 
+  it('still marks a hostile value after the network formatter runs', () => {
+    // The formatter is applied to the sanitised text, so a value that needed
+    // sanitising must still say so on the address lines.
+    for (const [field, label] of [
+      ['to', 'To:'],
+      ['proposer', 'Proposer:'],
+    ] as const) {
+      const line = lineStartingWith(
+        buildSafeTxDetailLines({
+          ...benign,
+          [field]: '0x1\u200b2',
+          formatAddress: (address: string) => `${address} (0x41…)`,
+        }),
+        label
+      )
+      expect(line).toContain('stored 5, shown 4')
+      expect(line).toContain('(0x41…)')
+    }
+  })
+
+  it('reports a stripped character and a surviving invisible one together', () => {
+    // Either alone is disclosed; a value carrying both must not have the
+    // second silenced by the first.
+    const line = lineStartingWith(linesFor({ data: '0x1\r\u200d2' }), 'Data:')
+
+    expect(line).toContain('sanitised for display')
+    expect(line).toContain('invisible character')
+  })
+
+  it('names a value that stringifies to nothing but was not a string', () => {
+    // `String([])` is '', which would otherwise render as an ordinary blank
+    // field indistinguishable from a stored empty string.
+    expect(lineStartingWith(linesFor({ data: [] }), 'Data:')).toContain(
+      'empty array'
+    )
+    expect(lineStartingWith(linesFor({ data: '' }), 'Data:')).not.toContain('⚠')
+  })
+
   it('keeps a missing field visibly missing', () => {
     // Rendering it blank would make a row with no `data` — still cast to Hex
     // and signed — read exactly like one carrying `0x`.
@@ -211,7 +252,7 @@ describe('a normal proposal renders exactly as it does today', () => {
       ...benign,
       nonceColor: '31',
       nonceWarning: ' \u001b[31m✗ STALE\u001b[0m',
-      toExplorerSuffix: ' \u001b[36mhttps://etherscan.io/address/0x11\u001b[0m',
+      explorerUrlFor: () => 'https://etherscan.io/address/0x11',
       canExecute: true,
     })
 
@@ -223,6 +264,21 @@ describe('a normal proposal renders exactly as it does today', () => {
     )
     expect(lineStartingWith(lines, 'Execution Ready:')).toBe(
       '    Execution Ready: \u001b[32m✓\u001b[0m'
+    )
+  })
+
+  it('places the target name and explorer link inside the target colour', () => {
+    expect(
+      lineStartingWith(
+        buildSafeTxDetailLines({
+          ...benign,
+          toTargetName: '(LiFiDiamond)',
+          explorerUrlFor: () => 'https://etherscan.io/address/0x11',
+        }),
+        'To:'
+      )
+    ).toBe(
+      '    To:              \u001b[32m0x11f1022cA6AdEF6400e5677528a80d49a069C00c \u001b[33m(LiFiDiamond)\u001b[0m \u001b[36mhttps://etherscan.io/address/0x11\u001b[0m\u001b[0m'
     )
   })
 

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -1,0 +1,235 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  buildSafeTxDetailLines,
+  type ISafeTxDetailInput,
+} from './safe-tx-detail-display'
+
+/** Anything outside the colour codes this module writes itself. */
+const TERMINAL_DRIVING = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu
+// eslint-disable-next-line no-control-regex -- matching the escape sequences is the point
+const OWN_COLOUR_CODES = /\u001b\[\d+m/gu
+
+const stripOwnColours = (line: string): string =>
+  line.replace(OWN_COLOUR_CODES, '')
+
+/** Asserted per line: joining them would introduce a newline of the test's own. */
+const expectNoTerminalControl = (lines: string[]): void => {
+  for (const line of lines)
+    expect(stripOwnColours(line).match(TERMINAL_DRIVING)).toBeNull()
+}
+
+/** A row with nothing hostile in it. Every field is the shape Mongo stores. */
+const benign: ISafeTxDetailInput = {
+  nonce: '31',
+  nonceColor: '32',
+  nonceWarning: '',
+  toDisplay: '0x11f1022cA6AdEF6400e5677528a80d49a069C00c',
+  toExplorerSuffix: '',
+  value: '0',
+  operationLabel: 'Call',
+  data: '0xdeadbeef',
+  proposer: '0x5c19DE04c40f9F8Ed9F0Fe6a5cEb84E5C8a5b31E',
+  safeTxHash:
+    '0x7c6d5e4f3a2b1908172635445362718091a2b3c4d5e6f708192a3b4c5d6e7f80',
+  signatureCount: 1,
+  threshold: 3,
+  canExecute: false,
+}
+
+/**
+ * One payload carrying each escape family the ticket names: CSI (ESC + '['),
+ * a bare C1 CSI and OSC, an OSC-8 hyperlink, and a line separator.
+ */
+const HOSTILE =
+  '\u001b[2J\u001b[H\u009b31m\u009d0;evil\u0007\u001b]8;;https://evil.example\u0007click\u001b]8;;\u0007\u2028fake line'
+
+const linesFor = (overrides: Partial<ISafeTxDetailInput>): string[] =>
+  buildSafeTxDetailLines({ ...benign, ...overrides })
+
+const lineStartingWith = (lines: string[], label: string): string => {
+  const found = lines.find((line) => line.trimStart().startsWith(label))
+  if (!found)
+    throw new Error(`no line labelled ${label} in:\n${lines.join('\n')}`)
+  return found
+}
+
+describe('no proposer-controlled field can drive the signer’s terminal', () => {
+  const cases: {
+    field: keyof ISafeTxDetailInput
+    label: string
+  }[] = [
+    { field: 'data', label: 'Data:' },
+    { field: 'safeTxHash', label: 'Safe Tx Hash:' },
+    { field: 'proposer', label: 'Proposer:' },
+    { field: 'nonce', label: 'Nonce:' },
+    { field: 'value', label: 'Value:' },
+  ]
+
+  for (const { field, label } of cases)
+    it(`strips every terminal-driving character from ${String(field)}`, () => {
+      const line = lineStartingWith(linesFor({ [field]: HOSTILE }), label)
+
+      // The colour codes this module writes are the only escapes permitted;
+      // anything the row contributed has to be gone from what is left.
+      expect(stripOwnColours(line).match(TERMINAL_DRIVING)).toBeNull()
+      // Paired present: the field is still rendered, not silently dropped.
+      expect(line).toContain('fake line')
+    })
+
+  it('strips them from a parked-cleanup facet and PR link', () => {
+    const lines = linesFor({
+      parkedTaskRefs: [{ facet: HOSTILE, prUrl: HOSTILE }],
+    })
+    const parked = lines.filter((line) => line.startsWith('        '))
+
+    expect(parked).toHaveLength(1)
+    expect(stripOwnColours(parked[0] ?? '').match(TERMINAL_DRIVING)).toBeNull()
+    expect(parked[0]).toContain('fake line')
+  })
+
+  it('leaves no terminal-driving character anywhere in the block', () => {
+    const lines = linesFor({
+      data: HOSTILE,
+      safeTxHash: HOSTILE,
+      proposer: HOSTILE,
+      nonce: HOSTILE,
+      value: HOSTILE,
+      parkedTaskRefs: [{ facet: HOSTILE, prUrl: HOSTILE }],
+    })
+
+    expectNoTerminalControl(lines)
+  })
+})
+
+describe('a hostile row is disclosed, not quietly cleaned', () => {
+  it('marks a field whose stored value is not what is shown', () => {
+    const line = lineStartingWith(linesFor({ data: HOSTILE }), 'Data:')
+
+    expect(line).toContain('sanitised for display')
+  })
+
+  it('reports both lengths, so two rows that render alike stay distinct', () => {
+    const zeroWidth = lineStartingWith(
+      linesFor({ data: '0x1\u200b2' }),
+      'Data:'
+    )
+    const plain = lineStartingWith(linesFor({ data: '0x12' }), 'Data:')
+
+    expect(zeroWidth).toContain('stored 5, shown 4')
+    expect(plain).not.toContain('sanitised for display')
+    // The visible renderings are identical; only the marker separates them.
+    expect(stripOwnColours(plain).trimEnd()).toContain('0x12')
+  })
+
+  it('says so when a field renders to nothing at all', () => {
+    const line = lineStartingWith(
+      linesFor({ proposer: '\u001b\u0007\u009b' }),
+      'Proposer:'
+    )
+
+    expect(line).toContain('no printable characters')
+  })
+
+  it('leaves a benign field unmarked', () => {
+    for (const line of buildSafeTxDetailLines(benign))
+      expect(line).not.toContain('sanitised for display')
+  })
+})
+
+describe('a normal proposal renders exactly as it does today', () => {
+  it('is byte-identical to the block the signer already reads', () => {
+    expect(buildSafeTxDetailLines(benign).join('\n')).toBe(
+      [
+        'Safe Transaction Details:',
+        '    Nonce:           \u001b[32m31\u001b[0m',
+        '    To:              \u001b[32m0x11f1022cA6AdEF6400e5677528a80d49a069C00c\u001b[0m',
+        '    Value:           \u001b[32m0\u001b[0m',
+        '    Operation:       \u001b[32mCall\u001b[0m',
+        '    Data:            \u001b[32m0xdeadbeef\u001b[0m',
+        '    Proposer:        \u001b[32m0x5c19DE04c40f9F8Ed9F0Fe6a5cEb84E5C8a5b31E\u001b[0m',
+        '    Safe Tx Hash:    \u001b[36m0x7c6d5e4f3a2b1908172635445362718091a2b3c4d5e6f708192a3b4c5d6e7f80\u001b[0m',
+        '    Signatures:      \u001b[32m1/3\u001b[0m required',
+        '    Execution Ready: \u001b[31m✗\u001b[0m',
+        '    Provenance:      \u001b[33m— not recorded (proposal predates provenance capture) —\u001b[0m',
+      ].join('\n')
+    )
+  })
+
+  it('keeps the nonce warning, explorer suffix and ready mark verbatim', () => {
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      nonceColor: '31',
+      nonceWarning: ' \u001b[31m✗ STALE\u001b[0m',
+      toExplorerSuffix: ' \u001b[36mhttps://etherscan.io/address/0x11\u001b[0m',
+      canExecute: true,
+    })
+
+    expect(lineStartingWith(lines, 'Nonce:')).toBe(
+      '    Nonce:           \u001b[31m31\u001b[0m \u001b[31m✗ STALE\u001b[0m'
+    )
+    expect(lineStartingWith(lines, 'To:')).toBe(
+      '    To:              \u001b[32m0x11f1022cA6AdEF6400e5677528a80d49a069C00c \u001b[36mhttps://etherscan.io/address/0x11\u001b[0m\u001b[0m'
+    )
+    expect(lineStartingWith(lines, 'Execution Ready:')).toBe(
+      '    Execution Ready: \u001b[32m✓\u001b[0m'
+    )
+  })
+
+  it('renders the parked-cleanup block in its existing shape', () => {
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      parkedTaskRefs: [
+        { facet: 'AcrossFacetV3', prUrl: 'https://github.com/x/y/pull/1' },
+      ],
+    })
+
+    expect(lines).toContain('    Parked cleanup — origin PRs:')
+    expect(lines).toContain(
+      '        \u001b[32mAcrossFacetV3\u001b[0m → \u001b[36mhttps://github.com/x/y/pull/1\u001b[0m'
+    )
+  })
+})
+
+describe('the block is total — no row shape costs the operator the run', () => {
+  it('renders a row whose fields are absent', () => {
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      data: undefined,
+      safeTxHash: undefined,
+      proposer: undefined,
+    })
+
+    expect(lines.length).toBeGreaterThan(0)
+    expectNoTerminalControl(lines)
+  })
+
+  it('renders a row whose field throws on coercion', () => {
+    const throwing = {
+      toString() {
+        throw new Error('nope')
+      },
+    }
+
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({ ...benign, data: throwing }),
+      'Data:'
+    )
+
+    expect(line).toContain('unrenderable')
+  })
+
+  it('renders a parked ref that is not an object', () => {
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      parkedTaskRefs: [undefined as never, 'not an object' as never],
+    })
+
+    expectNoTerminalControl(lines)
+  })
+})

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -347,6 +347,57 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(line).toContain('(LiFiDiamond)')
   })
 
+  it('says so when the proposer address will not render either', () => {
+    // The same branch as the target's, one call site over — the gap that let
+    // the silent-blank behaviour survive on this line after it was fixed on
+    // the other.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        formatAddress: () => {
+          throw new Error('no codec for this network')
+        },
+      }),
+      'Proposer:'
+    )
+
+    expect(line).toContain('could not be rendered for this network')
+    // The stored address is still shown rather than blanked.
+    expect(line).toContain(benign.proposer as string)
+  })
+
+  it('blames nothing for a field that is blank because it is empty', () => {
+    // An empty stored value renders empty because it is empty; a renderer
+    // notice there would name the wrong cause and add a line the display
+    // never had.
+    for (const [field, label] of [
+      ['to', 'To:'],
+      ['proposer', 'Proposer:'],
+    ] as const)
+      expect(lineStartingWith(linesFor({ [field]: '' }), label)).not.toContain(
+        'could not be rendered'
+      )
+  })
+
+  it('hands the formatter and the explorer the sanitised text, not the row', () => {
+    // Both are given `text`. Passing the stored value instead would put the
+    // unsanitised string on the line as the address, under a notice still
+    // claiming it had been sanitised.
+    const padded = `  ${benign.to as string}  `
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        to: padded,
+        formatAddress: (address: string) => `len${address.length}`,
+        explorerUrlFor: (address: string) => `https://x/len${address.length}`,
+      }),
+      'To:'
+    )
+
+    expect(line).toContain(`len${(benign.to as string).length}`)
+    expect(line).not.toContain(`len${padded.length}`)
+  })
+
   it('puts the notice outside the colour on the address lines too', () => {
     for (const [field, label] of [
       ['to', 'To:'],

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -624,15 +624,21 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       } as never,
     })
 
-    expect(lines.join('\n')).toContain('dblaecker')
-    expect(lines.join('\n')).not.toContain('not recorded')
+    const block = lines.join('\n')
+    // Each element the commit message names as at risk, or a mutation keeping
+    // the first line and dropping the rest passes.
+    expect(block).toContain('dblaecker')
+    expect(block).toContain('a1b2c3d4e5f6')
+    expect(block).toContain('feat/thing')
+    expect(block).toContain('clean')
+    expect(block).not.toContain('not recorded')
   })
 
   it('degrades to a line for a half-migrated provenance row', () => {
-    // The degradation is `formatProvenanceLines`' own — it is total, which is
-    // why the builder's try around it cannot be observed and a mutation
-    // removing that try survives. What is asserted here is the visible
-    // property: a broken block costs one line, not the whole prompt.
+    // Two containment layers, and the messages name which one fired:
+    // `formatProvenanceLines` says "block could not be rendered", this module's
+    // own catch says "could not be rendered". A plain thrown Error is handled
+    // there; the shapes below are not.
     const lines = buildSafeTxDetailLines({
       ...benign,
       provenance: {
@@ -642,8 +648,37 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       } as never,
     })
 
-    expect(lines.join('\n')).toContain('could not be rendered')
-    expect(lines.length).toBeGreaterThan(1)
+    // Handled by `formatProvenanceLines` itself.
+    expect(lines.join('\n')).toContain('block could not be rendered')
+
+    // And these are not: it stringifies what was thrown to build that message,
+    // so an unstringifiable value makes its handler throw again. Only this
+    // module's catch stops them, and a mutation deleting it lets them escape.
+    for (const thrown of [
+      () => Object.create(null) as unknown,
+      () => ({
+        toString() {
+          throw new Error('inner')
+        },
+      }),
+    ]) {
+      const build = (): string[] =>
+        buildSafeTxDetailLines({
+          ...benign,
+          provenance: {
+            get proposerHandle(): string {
+              throw thrown()
+            },
+          } as never,
+        })
+      expect(build).not.toThrow()
+      const rendered = build().join('\n')
+      expect(rendered).toContain('could not be rendered')
+      expect(rendered).not.toContain('block could not be rendered')
+    }
+
+    // The rest of the block survives a broken provenance row.
+    expect(lines.some((line) => line.includes('Data:'))).toBe(true)
   })
 
   it('leaves a benign field unmarked', () => {

--- a/script/deploy/safe/safe-tx-detail-display.test.ts
+++ b/script/deploy/safe/safe-tx-detail-display.test.ts
@@ -437,6 +437,15 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
       expect(() =>
         buildSafeTxDetailLines({ ...benign, ...overrides })
       ).not.toThrow()
+
+    // And the block still renders — swallowing the line would pass the
+    // assertions above while losing the field the signer is checking.
+    expect(
+      lineStartingWith(
+        buildSafeTxDetailLines({ ...benign, formatAddress: () => throwing }),
+        'To:'
+      )
+    ).toContain(benign.to as string)
   })
 
   it('renders no explorer link for a target that sanitises to nothing', () => {
@@ -580,6 +589,63 @@ describe('a hostile row is disclosed, not quietly cleaned', () => {
     expect(line).toContain('value cannot be shown')
   })
 
+  it('keeps the unformatted-address warning outside the proposer colour too', () => {
+    // The target line's placement is asserted above; one shared constant does
+    // not mean both call sites emit it in the right place.
+    const line = lineStartingWith(
+      buildSafeTxDetailLines({
+        ...benign,
+        formatAddress: () => {
+          throw new Error('no codec')
+        },
+      }),
+      'Proposer:'
+    )
+
+    expect(line.indexOf('\u001b[0m')).toBeLessThan(
+      line.indexOf('shown unformatted')
+    )
+  })
+
+  it('renders the provenance it is given, not a fresh absence', () => {
+    // `formatProvenanceLines` has its own suite; what is unobserved here is the
+    // wiring. Dropping the argument would make every proposal read "not
+    // recorded" and hide the commit, branch and dirty-tree disclosure.
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      provenance: {
+        proposerHandle: 'dblaecker',
+        actor: 'human',
+        gitCommit: 'a1b2c3d4e5f6a7b8c9d0',
+        gitBranch: 'feat/thing',
+        dirtyTreeScoped: [],
+        captureErrors: [],
+        commitOnRemote: true,
+      } as never,
+    })
+
+    expect(lines.join('\n')).toContain('dblaecker')
+    expect(lines.join('\n')).not.toContain('not recorded')
+  })
+
+  it('degrades to a line for a half-migrated provenance row', () => {
+    // The degradation is `formatProvenanceLines`' own — it is total, which is
+    // why the builder's try around it cannot be observed and a mutation
+    // removing that try survives. What is asserted here is the visible
+    // property: a broken block costs one line, not the whole prompt.
+    const lines = buildSafeTxDetailLines({
+      ...benign,
+      provenance: {
+        get proposerHandle(): string {
+          throw new Error('half-migrated row')
+        },
+      } as never,
+    })
+
+    expect(lines.join('\n')).toContain('could not be rendered')
+    expect(lines.length).toBeGreaterThan(1)
+  })
+
   it('leaves a benign field unmarked', () => {
     for (const line of buildSafeTxDetailLines(benign))
       expect(line).not.toContain('sanitised for display')
@@ -652,6 +718,18 @@ describe('a normal proposal renders exactly as it does today', () => {
     expect(lines).toContain(
       '        \u001b[32mAcrossFacetV3\u001b[0m → \u001b[36mhttps://github.com/x/y/pull/1\u001b[0m'
     )
+
+    // Every ref, not just the first: dropping the tail would hide deprecation
+    // context for the facets after it.
+    const both = buildSafeTxDetailLines({
+      ...benign,
+      parkedTaskRefs: [
+        { facet: 'AcrossFacetV3', prUrl: 'https://github.com/x/y/pull/1' },
+        { facet: 'AmarokFacet', prUrl: 'https://github.com/x/y/pull/2' },
+      ],
+    })
+    expect(both.filter((line) => line.startsWith('        '))).toHaveLength(2)
+    expect(both.join('\n')).toContain('AmarokFacet')
   })
 })
 
@@ -691,17 +769,17 @@ describe('the block is total — no row shape costs the operator the run', () =>
       { length: 1, 0: {} } as never,
       5 as never,
       'abc' as never,
-    ])
-      expect(() =>
+    ]) {
+      const build = (): string[] =>
         buildSafeTxDetailLines({ ...benign, parkedTaskRefs })
-      ).not.toThrow()
-
-    expect(
-      buildSafeTxDetailLines({
-        ...benign,
-        parkedTaskRefs: { length: 2 } as never,
-      }).some((line) => line.includes('Parked cleanup'))
-    ).toBe(false)
+      expect(build).not.toThrow()
+      // Every shape, not just the first: a guard that accepted an iterable
+      // with a length would render `undefined → undefined` rows under a real
+      // header for a stored string.
+      expect(build().some((line) => line.includes('Parked cleanup'))).toBe(
+        false
+      )
+    }
   })
 
   it('renders a parked ref that is not an object', () => {

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -1,0 +1,191 @@
+/**
+ * Safe transaction detail block
+ *
+ * Builds the lines a signer reads immediately before the sign prompt in
+ * `confirm-safe-tx.ts`. Every value in the block comes off a MongoDB proposal
+ * row, and the rows are not all written by this repository, so each one is
+ * rendered through the sanitiser rather than interpolated into the colour
+ * codes raw: a field whose own content carries an escape sequence can recolour,
+ * erase or repaint the lines around it, and repaint a fabricated block showing
+ * a benign target above the prompt that asks whether to sign.
+ *
+ * `value`, `nonce` and `to` reach the block already gated: they pass through
+ * `BigInt()` and `normalizeAddressForNetwork` in `initializeSafeTransaction`,
+ * which throw on a row that is not numeric or not an address. `data` goes
+ * through the same function cast to `Hex` with nothing checking it. Sanitising
+ * is applied to all of them anyway, because that gate is in another module and
+ * a guarantee this block depends on but does not make is one it cannot keep.
+ */
+
+import { sanitizeProvenanceText } from '../shared/git-provenance'
+
+import { formatProvenanceLines } from './provenance-display'
+import { type IProposalProvenance } from './safe-utils'
+
+const GREEN = '\u001b[32m'
+const RED = '\u001b[31m'
+const YELLOW = '\u001b[33m'
+const CYAN = '\u001b[36m'
+const RESET = '\u001b[0m'
+
+/** Width of the label column shared with the provenance lines. */
+const LABEL_WIDTH = 17
+
+const color = (code: string, text: string): string => `${code}${text}${RESET}`
+
+const detailLine = (label: string, value: string): string =>
+  `    ${`${label}:`.padEnd(LABEL_WIDTH)}${value}`
+
+/** One parked facet removal folded into this proposal. */
+export interface IParkedTaskRef {
+  readonly facet: unknown
+  readonly prUrl: unknown
+}
+
+/**
+ * What the block renders.
+ *
+ * The `unknown` fields are read straight off the stored row and are sanitised
+ * here. The `string` fields are fragments the caller has already rendered,
+ * including this module's own colour codes, so they are interpolated as-is —
+ * never pass a stored value through one of those.
+ */
+export interface ISafeTxDetailInput {
+  readonly nonce: unknown
+  /** SGR parameter for the nonce, chosen by the caller from nonce status. */
+  readonly nonceColor: string
+  /** Pre-rendered warning appended after the nonce, or empty. */
+  readonly nonceWarning: string
+  /** Pre-rendered target: address, optional Tron suffix, optional name. */
+  readonly toDisplay: string
+  /** Pre-rendered explorer link appended inside the target's colour. */
+  readonly toExplorerSuffix: string
+  readonly value: unknown
+  /** Pre-rendered operation, already sanitised by `describeOperationValue`. */
+  readonly operationLabel: string
+  readonly data: unknown
+  /** The proposer address as the caller formats it for this network. */
+  readonly proposer: unknown
+  readonly safeTxHash: unknown
+  readonly signatureCount: number
+  readonly threshold: number
+  readonly canExecute: boolean
+  readonly parkedTaskRefs?: readonly IParkedTaskRef[]
+  readonly provenance?: IProposalProvenance
+}
+
+/** A stored value reduced to something safe to print. */
+interface IRenderedField {
+  readonly text: string
+  /** Appended after the field; empty unless the value had to be changed. */
+  readonly notice: string
+}
+
+const asPrintable = (value: unknown): IRenderedField => {
+  // `String()` throws on a value with no `toString` or one that throws its
+  // own; the block still has to render, because the signer needs the rest of
+  // it to decide.
+  let stored: string
+  try {
+    stored = String(value ?? '')
+  } catch {
+    return {
+      text: 'unrenderable',
+      notice: color(YELLOW, ' ⚠ sanitised for display — value cannot be shown'),
+    }
+  }
+
+  const text = sanitizeProvenanceText(stored)
+  if (text === stored) return { text, notice: '' }
+
+  // Lengths in code points, the unit a reader counts: two rows that render
+  // identically differ only in this number, which is the whole reason it is
+  // printed. Reporting UTF-16 units instead would call a two-emoji value four
+  // characters.
+  const storedLength = [...stored].length
+  const shownLength = [...text].length
+  const detail =
+    text === ''
+      ? 'no printable characters'
+      : `stored ${storedLength}, shown ${shownLength}`
+
+  return { text, notice: color(YELLOW, ` ⚠ sanitised for display — ${detail}`) }
+}
+
+/** Renders a stored field inside `code`, with its notice outside the colour. */
+const storedField = (value: unknown, code: string): string => {
+  const { text, notice } = asPrintable(value)
+  return `${color(code, text)}${notice}`
+}
+
+/**
+ * Shows the deprecation PR behind each parked facet removal folded into this
+ * proposal, so the signer sees why a facet is being removed
+ * (DeferredDiamondCleanupQueue.md §6).
+ */
+function parkedLines(refs: readonly IParkedTaskRef[]): string[] {
+  const lines = ['    Parked cleanup — origin PRs:']
+  for (const ref of refs) {
+    // A ref that is not an object still has to print: the array is stored, so
+    // its element shapes are as proposer-controlled as their contents.
+    const facet = storedField(ref?.facet, GREEN)
+    const prUrl = storedField(ref?.prUrl, CYAN)
+    lines.push(`        ${facet} → ${prUrl}`)
+  }
+  return lines
+}
+
+/**
+ * Formats the Safe transaction detail block for the signing prompt.
+ * @param input - Stored row fields plus the fragments the caller pre-rendered.
+ * @returns The lines to print, in order.
+ */
+export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
+  const lines = [
+    'Safe Transaction Details:',
+    `${detailLine(
+      'Nonce',
+      storedField(input.nonce, `\u001b[${input.nonceColor}m`)
+    )}${input.nonceWarning}`,
+    detailLine(
+      'To',
+      color(GREEN, `${input.toDisplay}${input.toExplorerSuffix}`)
+    ),
+    detailLine('Value', storedField(input.value, GREEN)),
+    detailLine('Operation', color(GREEN, input.operationLabel)),
+    detailLine('Data', storedField(input.data, GREEN)),
+    detailLine('Proposer', storedField(input.proposer, GREEN)),
+    detailLine('Safe Tx Hash', storedField(input.safeTxHash, CYAN)),
+    detailLine(
+      'Signatures',
+      `${color(GREEN, `${input.signatureCount}/${input.threshold}`)} required`
+    ),
+    detailLine(
+      'Execution Ready',
+      input.canExecute ? color(GREEN, '✓') : color(RED, '✗')
+    ),
+  ]
+
+  if (input.parkedTaskRefs && input.parkedTaskRefs.length > 0)
+    lines.push(...parkedLines(input.parkedTaskRefs))
+
+  // Belt-and-braces around a total function: no shape of stored row may cost
+  // the operator the rest of the networks in this run.
+  try {
+    lines.push(...formatProvenanceLines(input.provenance))
+  } catch (error) {
+    lines.push(
+      detailLine(
+        'Provenance',
+        color(
+          YELLOW,
+          `UNKNOWN — could not be rendered: ${sanitizeProvenanceText(
+            error instanceof Error ? error.message : error
+          )}`
+        )
+      )
+    )
+  }
+
+  return lines
+}

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -62,18 +62,26 @@ export interface IParkedTaskRef {
  * pre-rendered by the caller, because a caller that sanitises them itself
  * leaves this block unable to tell that it did — and so unable to say so.
  *
- * The remaining `string` fields and the two callbacks are treated as untrusted
- * text all the same: their contents are sanitised where they are interpolated,
- * because a caller that composed one out of the stored row would otherwise
- * route straight past everything above. The exceptions are `nonceWarning` and
- * `operationLabel`, which carry colour codes of their own and so cannot be
- * sanitised without stripping them — both are built from values that cannot
- * hold a stored string.
+ * `toTargetName` and both callbacks are treated as untrusted text all the
+ * same: their contents are sanitised where they are interpolated, because a
+ * caller that composed one out of the stored row would otherwise route
+ * straight past everything above.
+ *
+ * Two fields are not, and cannot be: `nonceWarning` and `operationLabel` carry
+ * colour codes of their own, which sanitising would strip. Both are built from
+ * values that cannot hold a stored string — a chain-read `bigint` and a
+ * value already sanitised by `describeOperationValue`. `nonceColor` is typed
+ * as a closed set instead, being the only field that lands inside an escape
+ * sequence rather than beside one.
  */
 export interface ISafeTxDetailInput {
   readonly nonce: unknown
-  /** SGR parameter for the nonce, chosen by the caller from nonce status. */
-  readonly nonceColor: string
+  /**
+   * SGR parameter for the nonce. A closed set rather than a string: this is
+   * the one field interpolated *inside* an escape sequence rather than beside
+   * one, so a free-form value here would be a control sequence, not text.
+   */
+  readonly nonceColor: '31' | '32' | '33'
   /** Pre-rendered warning appended after the nonce, or empty. */
   readonly nonceWarning: string
   /** The target as stored. */
@@ -101,8 +109,11 @@ export interface ISafeTxDetailInput {
 /** A stored value reduced to something safe to print. */
 interface IRenderedField {
   readonly text: string
-  /** True when the stored value is not what the line will show. */
-  readonly altered: boolean
+  /**
+   * True when the printable text still identifies whatever the stored value
+   * identified — only leading and trailing whitespace was lost.
+   */
+  readonly identityPreserved: boolean
   /** Appended after the field; empty unless there is something to report. */
   readonly notice: string
 }
@@ -120,7 +131,7 @@ const asPrintable = (value: unknown): IRenderedField => {
   } catch {
     return {
       text: 'unrenderable',
-      altered: true,
+      identityPreserved: false,
       notice: color(YELLOW, ' ⚠ sanitised for display — value cannot be shown'),
     }
   }
@@ -142,14 +153,15 @@ const asPrintable = (value: unknown): IRenderedField => {
           }`
     )
 
-  // Reported even when nothing was stripped: these survive the sanitiser, so
-  // two values differing only by them render identically with no other sign.
+  // Counted on the printable text, not the stored value: a character the
+  // sanitiser removed is reported by the remark above, and repeating it here
+  // would claim it survived.
   const hidden = (text.match(DEFAULT_IGNORABLE) ?? []).length
   if (hidden > 0)
     remarks.push(
-      `${hidden} invisible character${hidden === 1 ? '' : 's'} in a value of ${
+      `${hidden} invisible character${hidden === 1 ? '' : 's'} among ${
         [...text].length
-      }`
+      } printable`
     )
 
   // Says only what it knows. An earlier version called these "empty", which is
@@ -164,7 +176,16 @@ const asPrintable = (value: unknown): IRenderedField => {
 
   return {
     text,
-    altered: remarks.length > 0,
+    // Each condition rules out a different way the glyphs a reader sees can
+    // fail to determine the stored value. Anything that was not a string was
+    // never an address, absent included — `String(undefined)` is a word, not a
+    // target. Trimming the ends is the one repair that cannot change which
+    // address this is; an edit inside it can, since a zero-width space between
+    // two hex digits simply vanishes. And a surviving invisible character is
+    // that same problem without the repair: the sanitiser keeps it by design,
+    // so the text and the glyphs disagree.
+    identityPreserved:
+      typeof value === 'string' && stored.trim() === text && hidden === 0,
     notice: remarks.length > 0 ? color(YELLOW, ` ⚠ ${remarks.join('; ')}`) : '',
   }
 }
@@ -182,14 +203,27 @@ const storedField = (value: unknown, code: string): string => {
  * their return value, so a caller that ignored its argument and reached for the
  * stored row would render it raw. Sanitising the result costs nothing on a real
  * address and removes that route.
+ *
+ * A renderer that throws or returns nothing yields `undefined` rather than an
+ * empty string. Silently dropping it would leave the decorations that were
+ * meant to describe it — a target name, an explorer link — standing beside no
+ * address at all, which reads as a stronger claim than the row supports.
  */
-const printableFragment = (produce: () => string): string => {
+const printableFragment = (produce: () => string): string | undefined => {
+  let produced: string
   try {
-    return sanitizeProvenanceText(produce())
+    produced = produce()
   } catch {
-    return ''
+    return undefined
   }
+  return sanitizeProvenanceText(produced) || undefined
 }
+
+/** Names a fragment that could not be rendered, in the notice's voice. */
+const FRAGMENT_UNRENDERABLE = color(
+  YELLOW,
+  ' ⚠ the address could not be rendered for this network'
+)
 
 /** Renders a stored address through the network's own display form. */
 function formattedAddressField(
@@ -197,36 +231,44 @@ function formattedAddressField(
   formatAddress: (address: string) => string
 ): string {
   const { text, notice } = asPrintable(value)
-  return `${color(
-    GREEN,
-    printableFragment(() => formatAddress(text))
-  )}${notice}`
+  const rendered = printableFragment(() => formatAddress(text))
+  return rendered === undefined
+    ? `${color(GREEN, text)}${notice}${FRAGMENT_UNRENDERABLE}`
+    : `${color(GREEN, rendered)}${notice}`
 }
 
 /**
  * The target, with its name from the deployment records and its explorer link.
  *
- * Neither is resolved for an address that had to be repaired. Sanitising a
- * corrupt address can produce a *valid* one — a zero-width space inside the hex
- * simply disappears — and looking that up would present a corrupt row as a
- * named, known contract with a working link, which is a stronger claim than the
- * row supports and a more convincing one than it made before.
+ * Neither is resolved unless the printable text still identifies the address
+ * that was stored. Sanitising a corrupt address can produce a *valid* one — a
+ * zero-width space between two hex digits simply disappears — and naming that
+ * would present a corrupt row as a known contract with a working link, a
+ * stronger claim than the row supports and a more convincing one than the same
+ * row made before this block existed. Trimmed whitespace is exempt: it cannot
+ * change which address this is.
+ *
+ * Both are dropped too when the address itself will not render, so a name and
+ * a link can never stand beside nothing.
  */
 function toLine(input: ISafeTxDetailInput): string {
-  const { text, altered, notice } = asPrintable(input.to)
-  const name =
-    !altered && input.toTargetName
-      ? ` ${color(
-          YELLOW,
-          printableFragment(() => input.toTargetName)
-        )}`
-      : ''
-  const url = altered ? '' : printableFragment(() => input.explorerUrlFor(text))
-  const link = url ? ` ${color(CYAN, url)}` : ''
-  return `${color(
-    GREEN,
-    `${printableFragment(() => input.formatAddress(text))}${name}${link}`
-  )}${notice}`
+  const { text, identityPreserved, notice } = asPrintable(input.to)
+  const address = printableFragment(() => input.formatAddress(text))
+  const resolvable = identityPreserved && address !== undefined
+
+  const targetName = resolvable
+    ? printableFragment(() => input.toTargetName)
+    : undefined
+  const name = targetName === undefined ? '' : ` ${color(YELLOW, targetName)}`
+
+  const url = resolvable
+    ? printableFragment(() => input.explorerUrlFor(text))
+    : undefined
+  const link = url === undefined ? '' : ` ${color(CYAN, url)}`
+
+  return address === undefined
+    ? `${color(GREEN, text)}${notice}${FRAGMENT_UNRENDERABLE}`
+    : `${color(GREEN, `${address}${name}${link}`)}${notice}`
 }
 
 /**

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -13,9 +13,12 @@
  * that look like they would — `BigInt()` on the nonce and value,
  * `normalizeAddressForNetwork` on the target — *skip* whitespace rather than
  * refusing it, so `\r`, `\n` and U+2028 survive both and reach a line they can
- * rewind. Every stored value this block prints is therefore sanitised here,
- * and the two fragments the caller assembles itself — the target and the nonce
- * warning — are sanitised there for the same reason.
+ * rewind.
+ *
+ * So the block takes every stored value unrendered and sanitises all of them
+ * here, including the addresses it composes itself. A caller that cleaned one
+ * first would leave this code unable to tell that it had, and so unable to say
+ * so — which is the whole of the disclosure below.
  */
 
 import { sanitizeProvenanceText } from '../shared/git-provenance'
@@ -59,9 +62,13 @@ export interface IParkedTaskRef {
  * pre-rendered by the caller, because a caller that sanitises them itself
  * leaves this block unable to tell that it did — and so unable to say so.
  *
- * The remaining `string` fields carry colour codes of their own and so cannot
- * be sanitised without stripping those. Each is either a constant or derived
- * from repository configuration; none may carry a stored value.
+ * The remaining `string` fields and the two callbacks are treated as untrusted
+ * text all the same: their contents are sanitised where they are interpolated,
+ * because a caller that composed one out of the stored row would otherwise
+ * route straight past everything above. The exceptions are `nonceWarning` and
+ * `operationLabel`, which carry colour codes of their own and so cannot be
+ * sanitised without stripping them — both are built from values that cannot
+ * hold a stored string.
  */
 export interface ISafeTxDetailInput {
   readonly nonce: unknown
@@ -94,7 +101,9 @@ export interface ISafeTxDetailInput {
 /** A stored value reduced to something safe to print. */
 interface IRenderedField {
   readonly text: string
-  /** Appended after the field; empty unless the value had to be changed. */
+  /** True when the stored value is not what the line will show. */
+  readonly altered: boolean
+  /** Appended after the field; empty unless there is something to report. */
   readonly notice: string
 }
 
@@ -111,6 +120,7 @@ const asPrintable = (value: unknown): IRenderedField => {
   } catch {
     return {
       text: 'unrenderable',
+      altered: true,
       notice: color(YELLOW, ' ⚠ sanitised for display — value cannot be shown'),
     }
   }
@@ -119,13 +129,15 @@ const asPrintable = (value: unknown): IRenderedField => {
   const remarks: string[] = []
 
   if (text !== stored)
-    // Lengths in code points, the unit a reader counts. They can be equal — a
-    // newline collapses to a space one for one — so the fact that the value
-    // was changed at all is stated separately from the counts.
+    // Counts describe the stored value and what survived sanitising, not the
+    // finished line: a network formatter may replace what it is given with an
+    // entirely different rendering. They can also be equal, since a newline
+    // collapses to a space one for one, which is why the fact of the change is
+    // stated separately from the numbers.
     remarks.push(
       text === ''
         ? 'no printable characters'
-        : `sanitised for display — stored ${[...stored].length}, shown ${
+        : `sanitised for display — stored ${[...stored].length}, printable ${
             [...text].length
           }`
     )
@@ -140,14 +152,19 @@ const asPrintable = (value: unknown): IRenderedField => {
       }`
     )
 
-  // An empty string is a legitimate stored value; an array or an object that
-  // stringifies to nothing is a malformed row that would otherwise render as
-  // an ordinary blank field.
-  if (text === '' && typeof value !== 'string' && value !== undefined)
-    remarks.push(`empty ${Array.isArray(value) ? 'array' : typeof value}`)
+  // Says only what it knows. An earlier version called these "empty", which is
+  // a claim about the container: `[' ']` and `[null]` both render as nothing
+  // while holding an element.
+  if (typeof value === 'object' && value !== null)
+    remarks.push(
+      `stored as ${
+        Array.isArray(value) ? 'an array' : 'an object'
+      }, not a string`
+    )
 
   return {
     text,
+    altered: remarks.length > 0,
     notice: remarks.length > 0 ? color(YELLOW, ` ⚠ ${remarks.join('; ')}`) : '',
   }
 }
@@ -159,28 +176,56 @@ const storedField = (value: unknown, code: string): string => {
 }
 
 /**
- * Renders a stored address through the network's own display form.
+ * What a caller-supplied renderer returned, reduced to printable text.
  *
- * Sanitised before formatting, not after: the formatter is a pass-through on
- * every network but Tron, and Tron's trims, so neither removes anything.
+ * The callbacks are handed a sanitised address, but what reaches the line is
+ * their return value, so a caller that ignored its argument and reached for the
+ * stored row would render it raw. Sanitising the result costs nothing on a real
+ * address and removes that route.
  */
+const printableFragment = (produce: () => string): string => {
+  try {
+    return sanitizeProvenanceText(produce())
+  } catch {
+    return ''
+  }
+}
+
+/** Renders a stored address through the network's own display form. */
 function formattedAddressField(
   value: unknown,
   formatAddress: (address: string) => string
 ): string {
   const { text, notice } = asPrintable(value)
-  return `${color(GREEN, formatAddress(text))}${notice}`
+  return `${color(
+    GREEN,
+    printableFragment(() => formatAddress(text))
+  )}${notice}`
 }
 
-/** The target, its name from the deployment records, and its explorer link. */
+/**
+ * The target, with its name from the deployment records and its explorer link.
+ *
+ * Neither is resolved for an address that had to be repaired. Sanitising a
+ * corrupt address can produce a *valid* one — a zero-width space inside the hex
+ * simply disappears — and looking that up would present a corrupt row as a
+ * named, known contract with a working link, which is a stronger claim than the
+ * row supports and a more convincing one than it made before.
+ */
 function toLine(input: ISafeTxDetailInput): string {
-  const { text, notice } = asPrintable(input.to)
-  const name = input.toTargetName ? ` ${color(YELLOW, input.toTargetName)}` : ''
-  const url = input.explorerUrlFor(text)
+  const { text, altered, notice } = asPrintable(input.to)
+  const name =
+    !altered && input.toTargetName
+      ? ` ${color(
+          YELLOW,
+          printableFragment(() => input.toTargetName)
+        )}`
+      : ''
+  const url = altered ? '' : printableFragment(() => input.explorerUrlFor(text))
   const link = url ? ` ${color(CYAN, url)}` : ''
   return `${color(
     GREEN,
-    `${input.formatAddress(text)}${name}${link}`
+    `${printableFragment(() => input.formatAddress(text))}${name}${link}`
   )}${notice}`
 }
 

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -9,11 +9,15 @@
  * erase or repaint the lines around it, and repaint a fabricated block showing
  * a benign target above the prompt that asks whether to sign.
  *
- * Nothing upstream can be relied on to have removed them first. The two checks
- * that look like they would — `BigInt()` on the nonce and value,
- * `normalizeAddressForNetwork` on the target — *skip* whitespace rather than
- * refusing it, so `\r`, `\n` and U+2028 survive both and reach a line they can
- * rewind.
+ * The two checks that look like they would remove such characters first —
+ * `BigInt()` on the nonce and value, `normalizeAddressForNetwork` on the target
+ * — *skip* whitespace rather than refusing it, so an `\r`, `\n` or U+2028 at
+ * either end of those fields survives both and reaches a line it can rewind.
+ * An escape in the *middle* of them does not: `getAddress` and `BigInt` throw
+ * on it in `initializeSafeTransaction`, before anything is displayed, so for
+ * those three fields that shape is a failed run rather than a spoofed prompt.
+ * `data`, `proposer`, `safeTxHash`, `provenance` and `parkedTaskRefs` have no
+ * such coercion anywhere and carry whatever the row holds.
  *
  * So the block takes every stored value unrendered and sanitises all of them
  * here, including the addresses it composes itself. A caller that cleaned one

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -346,8 +346,11 @@ export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
   if (Array.isArray(input.parkedTaskRefs) && input.parkedTaskRefs.length > 0)
     lines.push(...parkedLines(input.parkedTaskRefs))
 
-  // Belt-and-braces around a total function: no shape of stored row may cost
-  // the operator the rest of the networks in this run.
+  // Belt-and-braces around a total function, and unobservable for that reason:
+  // `formatProvenanceLines` catches its own failures, so nothing reaches this
+  // catch and a mutation deleting it survives the suite. Kept because the
+  // totality it relies on lives in another module. No shape of stored row may
+  // cost the operator the rest of the networks in this run.
   try {
     lines.push(...formatProvenanceLines(input.provenance))
   } catch (error) {

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -9,13 +9,13 @@
  * erase or repaint the lines around it, and repaint a fabricated block showing
  * a benign target above the prompt that asks whether to sign.
  *
- * Nothing upstream can be relied on to have removed them first. The checks
+ * Nothing upstream can be relied on to have removed them first. The two checks
  * that look like they would — `BigInt()` on the nonce and value,
- * `normalizeAddressForNetwork` on the target — both *skip* whitespace rather
- * than refusing it, so `\r`, `\n` and U+2028 pass through every one of them
- * and reach a line they can rewind. So every stored value this block prints is
- * sanitised here, at the point of printing, and the caller passes the target
- * address in raw rather than pre-rendered for that reason.
+ * `normalizeAddressForNetwork` on the target — *skip* whitespace rather than
+ * refusing it, so `\r`, `\n` and U+2028 survive both and reach a line they can
+ * rewind. Every stored value this block prints is therefore sanitised here,
+ * and the two fragments the caller assembles itself — the target and the nonce
+ * warning — are sanitised there for the same reason.
  */
 
 import { sanitizeProvenanceText } from '../shared/git-provenance'
@@ -53,9 +53,9 @@ export interface IParkedTaskRef {
  * What the block renders.
  *
  * The `unknown` fields are read straight off the stored row and are sanitised
- * here. The `string` fields are fragments the caller has already rendered,
- * including this module's own colour codes, so they are interpolated as-is —
- * never pass a stored value through one of those.
+ * here. The `string` fields already carry colour codes, so they cannot be
+ * sanitised without stripping those, and are interpolated as-is: a stored value
+ * may only reach one of them already sanitised by the caller.
  */
 export interface ISafeTxDetailInput {
   readonly nonce: unknown

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -30,8 +30,10 @@ const CYAN = '\u001b[36m'
 const RESET = '\u001b[0m'
 
 /**
- * Code points that render as zero width while counting as printable text —
- * U+200D and the Hangul fillers among them.
+ * Code points a renderer is meant to pass over rather than draw — U+200D and
+ * the Hangul fillers among them. The sanitiser keeps them because they are
+ * printable letters and separators, not control or formatting characters, so
+ * a value can differ from another only by these and print identically.
  */
 const DEFAULT_IGNORABLE = /\p{Default_Ignorable_Code_Point}/gu
 
@@ -52,10 +54,14 @@ export interface IParkedTaskRef {
 /**
  * What the block renders.
  *
- * The `unknown` fields are read straight off the stored row and are sanitised
- * here. The `string` fields already carry colour codes, so they cannot be
- * sanitised without stripping those, and are interpolated as-is: a stored value
- * may only reach one of them already sanitised by the caller.
+ * Every field carrying a value off the stored row is typed `unknown` and is
+ * sanitised here. The addresses are taken raw and composed here rather than
+ * pre-rendered by the caller, because a caller that sanitises them itself
+ * leaves this block unable to tell that it did — and so unable to say so.
+ *
+ * The remaining `string` fields carry colour codes of their own and so cannot
+ * be sanitised without stripping those. Each is either a constant or derived
+ * from repository configuration; none may carry a stored value.
  */
 export interface ISafeTxDetailInput {
   readonly nonce: unknown
@@ -63,15 +69,19 @@ export interface ISafeTxDetailInput {
   readonly nonceColor: string
   /** Pre-rendered warning appended after the nonce, or empty. */
   readonly nonceWarning: string
-  /** Pre-rendered target: address, optional Tron suffix, optional name. */
-  readonly toDisplay: string
-  /** Pre-rendered explorer link appended inside the target's colour. */
-  readonly toExplorerSuffix: string
+  /** The target as stored. */
+  readonly to: unknown
+  /** Name for the target from the repository's deployment records, or empty. */
+  readonly toTargetName: string
+  /** Renders an address the way this network displays it. */
+  readonly formatAddress: (address: string) => string
+  /** Explorer link for the sanitised target, or empty when there is none. */
+  readonly explorerUrlFor: (address: string) => string
   readonly value: unknown
   /** Pre-rendered operation, already sanitised by `describeOperationValue`. */
   readonly operationLabel: string
   readonly data: unknown
-  /** The proposer address as the caller formats it for this network. */
+  /** The proposer as stored. */
   readonly proposer: unknown
   readonly safeTxHash: unknown
   readonly signatureCount: number
@@ -106,47 +116,72 @@ const asPrintable = (value: unknown): IRenderedField => {
   }
 
   const text = sanitizeProvenanceText(stored)
+  const remarks: string[] = []
 
-  if (text !== stored) {
-    // Lengths in code points, the unit a reader counts: two rows that render
-    // identically differ only in this number, which is the whole reason it is
-    // printed. Reporting UTF-16 units instead would call a two-emoji value
-    // four characters.
-    const detail =
+  if (text !== stored)
+    // Lengths in code points, the unit a reader counts. They can be equal — a
+    // newline collapses to a space one for one — so the fact that the value
+    // was changed at all is stated separately from the counts.
+    remarks.push(
       text === ''
         ? 'no printable characters'
-        : `stored ${[...stored].length}, shown ${[...text].length}`
-    return {
-      text,
-      notice: color(YELLOW, ` ⚠ sanitised for display — ${detail}`),
-    }
-  }
+        : `sanitised for display — stored ${[...stored].length}, shown ${
+            [...text].length
+          }`
+    )
 
-  // Nothing needed stripping, and the value can still be hiding from the
-  // reader. These code points are printable letters and separators rather than
-  // control or formatting characters, so the sanitiser passes them through by
-  // design, yet they occupy no width — two rows carrying different values can
-  // print the same glyphs. Unicode names the class, so this is a defined set
-  // rather than a blocklist that has to be extended each time one is found.
+  // Reported even when nothing was stripped: these survive the sanitiser, so
+  // two values differing only by them render identically with no other sign.
   const hidden = (text.match(DEFAULT_IGNORABLE) ?? []).length
   if (hidden > 0)
-    return {
-      text,
-      notice: color(
-        YELLOW,
-        ` ⚠ ${hidden} invisible character${
-          hidden === 1 ? '' : 's'
-        } in a value of ${[...text].length}`
-      ),
-    }
+    remarks.push(
+      `${hidden} invisible character${hidden === 1 ? '' : 's'} in a value of ${
+        [...text].length
+      }`
+    )
 
-  return { text, notice: '' }
+  // An empty string is a legitimate stored value; an array or an object that
+  // stringifies to nothing is a malformed row that would otherwise render as
+  // an ordinary blank field.
+  if (text === '' && typeof value !== 'string' && value !== undefined)
+    remarks.push(`empty ${Array.isArray(value) ? 'array' : typeof value}`)
+
+  return {
+    text,
+    notice: remarks.length > 0 ? color(YELLOW, ` ⚠ ${remarks.join('; ')}`) : '',
+  }
 }
 
 /** Renders a stored field inside `code`, with its notice outside the colour. */
 const storedField = (value: unknown, code: string): string => {
   const { text, notice } = asPrintable(value)
   return `${color(code, text)}${notice}`
+}
+
+/**
+ * Renders a stored address through the network's own display form.
+ *
+ * Sanitised before formatting, not after: the formatter is a pass-through on
+ * every network but Tron, and Tron's trims, so neither removes anything.
+ */
+function formattedAddressField(
+  value: unknown,
+  formatAddress: (address: string) => string
+): string {
+  const { text, notice } = asPrintable(value)
+  return `${color(GREEN, formatAddress(text))}${notice}`
+}
+
+/** The target, its name from the deployment records, and its explorer link. */
+function toLine(input: ISafeTxDetailInput): string {
+  const { text, notice } = asPrintable(input.to)
+  const name = input.toTargetName ? ` ${color(YELLOW, input.toTargetName)}` : ''
+  const url = input.explorerUrlFor(text)
+  const link = url ? ` ${color(CYAN, url)}` : ''
+  return `${color(
+    GREEN,
+    `${input.formatAddress(text)}${name}${link}`
+  )}${notice}`
 }
 
 /**
@@ -178,14 +213,14 @@ export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
       'Nonce',
       storedField(input.nonce, `\u001b[${input.nonceColor}m`)
     )}${input.nonceWarning}`,
-    detailLine(
-      'To',
-      color(GREEN, `${input.toDisplay}${input.toExplorerSuffix}`)
-    ),
+    detailLine('To', toLine(input)),
     detailLine('Value', storedField(input.value, GREEN)),
     detailLine('Operation', color(GREEN, input.operationLabel)),
     detailLine('Data', storedField(input.data, GREEN)),
-    detailLine('Proposer', storedField(input.proposer, GREEN)),
+    detailLine(
+      'Proposer',
+      formattedAddressField(input.proposer, input.formatAddress)
+    ),
     detailLine('Safe Tx Hash', storedField(input.safeTxHash, CYAN)),
     detailLine(
       'Signatures',

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -286,9 +286,21 @@ function toLine(input: ISafeTxDetailInput): string {
     : undefined
   const link = url === undefined ? '' : ` ${color(CYAN, url)}`
 
+  // Saying nothing here inverts the meaning. The deployment records did match,
+  // and a bare address reads to a signer as "not a contract this repo
+  // deployed" — the opposite of what the code concluded, which is that it
+  // declined to vouch for a name it could otherwise have printed.
+  const withheld =
+    !resolvable && input.toTargetName
+      ? color(
+          YELLOW,
+          ' ⚠ target name withheld — the stored value is not what is shown'
+        )
+      : ''
+
   return `${color(GREEN, `${shown}${name}${link}`)}${notice}${
     failed ? FRAGMENT_UNRENDERABLE : ''
-  }`
+  }${withheld}`
 }
 
 /**

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -346,11 +346,12 @@ export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
   if (Array.isArray(input.parkedTaskRefs) && input.parkedTaskRefs.length > 0)
     lines.push(...parkedLines(input.parkedTaskRefs))
 
-  // Belt-and-braces around a total function, and unobservable for that reason:
-  // `formatProvenanceLines` catches its own failures, so nothing reaches this
-  // catch and a mutation deleting it survives the suite. Kept because the
-  // totality it relies on lives in another module. No shape of stored row may
-  // cost the operator the rest of the networks in this run.
+  // Load-bearing, not belt-and-braces. `formatProvenanceLines` handles its own
+  // failures by stringifying what was thrown, so a thrown value that cannot be
+  // stringified — a null-prototype object, one whose `toString` throws — makes
+  // its handler throw a second time and escape. This catch is the last thing
+  // before `processTxs`, which has no per-network catch, so an escape here
+  // costs the operator every network left in the run.
   try {
     lines.push(...formatProvenanceLines(input.provenance))
   } catch (error) {

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -176,8 +176,10 @@ const asPrintable = (value: unknown): IRenderedField => {
 
   return {
     text,
-    // Each condition rules out a different way the glyphs a reader sees can
-    // fail to determine the stored value. Anything that was not a string was
+    // A byte-level property, not a glyph-level one: it says the printable text
+    // is the stored text modulo trimming, which is what `getTargetName` and the
+    // explorer link are resolved from. Confusables and combining marks are not
+    // in scope here and are not claimed to be. Anything that was not a string was
     // never an address, absent included — `String(undefined)` is a word, not a
     // target. Trimming the ends is the one repair that cannot change which
     // address this is; an edit inside it can, since a zero-width space between
@@ -210,13 +212,15 @@ const storedField = (value: unknown, code: string): string => {
  * address at all, which reads as a stronger claim than the row supports.
  */
 const printableFragment = (produce: () => string): string | undefined => {
-  let produced: string
   try {
-    produced = produce()
+    // The coercion inside the sanitiser is as able to throw as the callback
+    // is — a returned object with a throwing `toString` reaches it — so both
+    // stay under the same guard. `processTxs` has no per-network catch, so an
+    // escape here costs the operator every remaining network in the run.
+    return sanitizeProvenanceText(produce()) || undefined
   } catch {
     return undefined
   }
-  return sanitizeProvenanceText(produced) || undefined
 }
 
 /** Names a fragment that could not be rendered, in the notice's voice. */
@@ -225,16 +229,30 @@ const FRAGMENT_UNRENDERABLE = color(
   ' ⚠ the address could not be rendered for this network'
 )
 
+/**
+ * How an address renders, and whether the renderer is the reason it is blank.
+ *
+ * An empty stored value renders empty because it is empty; saying the network
+ * could not render it would blame the wrong thing and add a line the original
+ * display never had.
+ */
+function renderAddress(
+  text: string,
+  formatAddress: (address: string) => string
+): { readonly shown: string; readonly failed: boolean } {
+  const rendered = printableFragment(() => formatAddress(text))
+  if (rendered !== undefined) return { shown: rendered, failed: false }
+  return { shown: text, failed: text !== '' }
+}
+
 /** Renders a stored address through the network's own display form. */
 function formattedAddressField(
   value: unknown,
   formatAddress: (address: string) => string
 ): string {
   const { text, notice } = asPrintable(value)
-  const rendered = printableFragment(() => formatAddress(text))
-  return rendered === undefined
-    ? `${color(GREEN, text)}${notice}${FRAGMENT_UNRENDERABLE}`
-    : `${color(GREEN, rendered)}${notice}`
+  const { shown, failed } = renderAddress(text, formatAddress)
+  return `${color(GREEN, shown)}${notice}${failed ? FRAGMENT_UNRENDERABLE : ''}`
 }
 
 /**
@@ -253,8 +271,8 @@ function formattedAddressField(
  */
 function toLine(input: ISafeTxDetailInput): string {
   const { text, identityPreserved, notice } = asPrintable(input.to)
-  const address = printableFragment(() => input.formatAddress(text))
-  const resolvable = identityPreserved && address !== undefined
+  const { shown, failed } = renderAddress(text, input.formatAddress)
+  const resolvable = identityPreserved && !failed && shown !== ''
 
   const targetName = resolvable
     ? printableFragment(() => input.toTargetName)
@@ -266,9 +284,9 @@ function toLine(input: ISafeTxDetailInput): string {
     : undefined
   const link = url === undefined ? '' : ` ${color(CYAN, url)}`
 
-  return address === undefined
-    ? `${color(GREEN, text)}${notice}${FRAGMENT_UNRENDERABLE}`
-    : `${color(GREEN, `${address}${name}${link}`)}${notice}`
+  return `${color(GREEN, `${shown}${name}${link}`)}${notice}${
+    failed ? FRAGMENT_UNRENDERABLE : ''
+  }`
 }
 
 /**

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -226,15 +226,17 @@ const printableFragment = (produce: () => string): string | undefined => {
 /** Names a fragment that could not be rendered, in the notice's voice. */
 const FRAGMENT_UNRENDERABLE = color(
   YELLOW,
-  ' ⚠ the address could not be rendered for this network'
+  ' ⚠ shown unformatted — this network produced nothing printable for it'
 )
 
 /**
- * How an address renders, and whether the renderer is the reason it is blank.
+ * How an address renders, and whether the renderer produced nothing printable
+ * when there was something to render. On failure the sanitised text is shown
+ * unformatted rather than dropped, so the line is never blank.
  *
- * An empty stored value renders empty because it is empty; saying the network
- * could not render it would blame the wrong thing and add a line the original
- * display never had.
+ * An empty stored value is not a failure: it renders empty because it is empty,
+ * and saying the network could not render it would blame the wrong thing and
+ * add a line the original display never had.
  */
 function renderAddress(
   text: string,
@@ -337,7 +339,11 @@ export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
     ),
   ]
 
-  if (input.parkedTaskRefs && input.parkedTaskRefs.length > 0)
+  // `Array.isArray`, not a length check: a stored document with a `length`
+  // property satisfies the latter and then throws on `for...of`, which escapes
+  // this function entirely — `processTxs` has no per-network catch, so it would
+  // cost the operator every network left in the run.
+  if (Array.isArray(input.parkedTaskRefs) && input.parkedTaskRefs.length > 0)
     lines.push(...parkedLines(input.parkedTaskRefs))
 
   // Belt-and-braces around a total function: no shape of stored row may cost

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -227,6 +227,25 @@ const printableFragment = (produce: () => string): string | undefined => {
   }
 }
 
+/**
+ * Describes a thrown value without being able to throw doing it.
+ *
+ * The last catch before `processTxs` cannot itself fail, and describing an
+ * error means coercing it: reading `.message` runs a getter, and the sanitiser
+ * coerces whatever it is given. A value whose `toString` throws something that
+ * is itself unstringifiable — a null-prototype object — defeats both, so the
+ * fallback is a constant rather than anything derived from the value.
+ */
+function describeThrown(error: unknown): string {
+  try {
+    return sanitizeProvenanceText(
+      error instanceof Error ? error.message : error
+    )
+  } catch {
+    return 'an error that cannot itself be described'
+  }
+}
+
 /** Names a fragment that could not be rendered, in the notice's voice. */
 const FRAGMENT_UNRENDERABLE = color(
   YELLOW,
@@ -376,9 +395,7 @@ export function buildSafeTxDetailLines(input: ISafeTxDetailInput): string[] {
         'Provenance',
         color(
           YELLOW,
-          `UNKNOWN — could not be rendered: ${sanitizeProvenanceText(
-            error instanceof Error ? error.message : error
-          )}`
+          `UNKNOWN — could not be rendered: ${describeThrown(error)}`
         )
       )
     )

--- a/script/deploy/safe/safe-tx-detail-display.ts
+++ b/script/deploy/safe/safe-tx-detail-display.ts
@@ -9,12 +9,13 @@
  * erase or repaint the lines around it, and repaint a fabricated block showing
  * a benign target above the prompt that asks whether to sign.
  *
- * `value`, `nonce` and `to` reach the block already gated: they pass through
- * `BigInt()` and `normalizeAddressForNetwork` in `initializeSafeTransaction`,
- * which throw on a row that is not numeric or not an address. `data` goes
- * through the same function cast to `Hex` with nothing checking it. Sanitising
- * is applied to all of them anyway, because that gate is in another module and
- * a guarantee this block depends on but does not make is one it cannot keep.
+ * Nothing upstream can be relied on to have removed them first. The checks
+ * that look like they would — `BigInt()` on the nonce and value,
+ * `normalizeAddressForNetwork` on the target — both *skip* whitespace rather
+ * than refusing it, so `\r`, `\n` and U+2028 pass through every one of them
+ * and reach a line they can rewind. So every stored value this block prints is
+ * sanitised here, at the point of printing, and the caller passes the target
+ * address in raw rather than pre-rendered for that reason.
  */
 
 import { sanitizeProvenanceText } from '../shared/git-provenance'
@@ -27,6 +28,12 @@ const RED = '\u001b[31m'
 const YELLOW = '\u001b[33m'
 const CYAN = '\u001b[36m'
 const RESET = '\u001b[0m'
+
+/**
+ * Code points that render as zero width while counting as printable text —
+ * U+200D and the Hangul fillers among them.
+ */
+const DEFAULT_IGNORABLE = /\p{Default_Ignorable_Code_Point}/gu
 
 /** Width of the label column shared with the provenance lines. */
 const LABEL_WIDTH = 17
@@ -87,7 +94,10 @@ const asPrintable = (value: unknown): IRenderedField => {
   // it to decide.
   let stored: string
   try {
-    stored = String(value ?? '')
+    // Not `value ?? ''`: an absent field has to stay visibly absent. Blanking
+    // it makes a row with no `data` — which is still cast to `Hex` and signed —
+    // indistinguishable from one carrying `0x`.
+    stored = String(value)
   } catch {
     return {
       text: 'unrenderable',
@@ -96,20 +106,41 @@ const asPrintable = (value: unknown): IRenderedField => {
   }
 
   const text = sanitizeProvenanceText(stored)
-  if (text === stored) return { text, notice: '' }
 
-  // Lengths in code points, the unit a reader counts: two rows that render
-  // identically differ only in this number, which is the whole reason it is
-  // printed. Reporting UTF-16 units instead would call a two-emoji value four
-  // characters.
-  const storedLength = [...stored].length
-  const shownLength = [...text].length
-  const detail =
-    text === ''
-      ? 'no printable characters'
-      : `stored ${storedLength}, shown ${shownLength}`
+  if (text !== stored) {
+    // Lengths in code points, the unit a reader counts: two rows that render
+    // identically differ only in this number, which is the whole reason it is
+    // printed. Reporting UTF-16 units instead would call a two-emoji value
+    // four characters.
+    const detail =
+      text === ''
+        ? 'no printable characters'
+        : `stored ${[...stored].length}, shown ${[...text].length}`
+    return {
+      text,
+      notice: color(YELLOW, ` ⚠ sanitised for display — ${detail}`),
+    }
+  }
 
-  return { text, notice: color(YELLOW, ` ⚠ sanitised for display — ${detail}`) }
+  // Nothing needed stripping, and the value can still be hiding from the
+  // reader. These code points are printable letters and separators rather than
+  // control or formatting characters, so the sanitiser passes them through by
+  // design, yet they occupy no width — two rows carrying different values can
+  // print the same glyphs. Unicode names the class, so this is a defined set
+  // rather than a blocklist that has to be extended each time one is found.
+  const hidden = (text.match(DEFAULT_IGNORABLE) ?? []).length
+  if (hidden > 0)
+    return {
+      text,
+      notice: color(
+        YELLOW,
+        ` ⚠ ${hidden} invisible character${
+          hidden === 1 ? '' : 's'
+        } in a value of ${[...text].length}`
+      ),
+    }
+
+  return { text, notice: '' }
 }
 
 /** Renders a stored field inside `code`, with its notice outside the colour. */


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-948](https://linear.app/lifi-linear/issue/EXSC-948/sanitise-every-proposer-controlled-field-in-the-signer-confirmation)

**Stacked on #2334** (EXSC-937), which added the sanitiser this extends to the rest of the block — review that one first. Note #2329, #2334 and this all touch `confirm-safe-tx.ts`, so whichever merges first forces a rebase on the others.

# Why did I implement it this way?

`confirm-safe-tx.ts` built the Safe detail block by interpolating fields straight off the MongoDB proposal row into its own colour codes. #2334 routed `operation` through a sanitiser and left its siblings raw. **A row could erase the screen and repaint a fabricated "Safe Transaction Details" block — benign target, `Operation: Call` — immediately above the prompt asking whether to sign.**

The block moves into `buildSafeTxDetailLines`, which takes every stored value unrendered and sanitises all of them at the point of printing.

**Sanitise at render, not at read.** `data` is the payload that gets signed, and `initializeSafeTransaction` casts it straight to `Hex`, so cleaning the stored copy would change what the signature covers. At render the row stays byte-identical for every consumer that hashes or compares it.

**Nothing upstream can be relied on.** The checks that look like they gate these fields do not: `normalizeAddressForNetwork` calls `.trim()` then `getAddress`, and `BigInt('31\r')` is `31n` — both *skip* whitespace rather than refusing it, so `\r`, `\n` and U+2028 reach a line they can rewind. The four nonce warnings print the parsed `txNonce` (a `bigint`) instead of the stored string.

**A repaired value is disclosed, not quietly cleaned.** A field whose printable text differs from what was stored carries `⚠ sanitised for display — stored N, printable M`; one carrying characters the sanitiser keeps by design (U+200D, the Hangul fillers) says so too, since stored and printable lengths agree there and the value is still not what it looks like. Silently cleaning a hostile row shows the signer a plausible line and hides the one fact that should stop them.

**The target's name and explorer link are withheld unless the printable text still identifies what was stored.** Sanitising a corrupt address can produce a *valid* one — a zero-width space between two hex digits vanishes — and naming that would present a corrupt row as a known contract with a working link. Trimmed whitespace is exempt: it cannot change which address it is, and I verified the exempted set is exactly the set that survives `normalizeAddressForNetwork`, so the name and link always describe the **signed** address.

# Where to look hardest

- `identityPreserved` (`safe-tx-detail-display.ts`) — three conjuncts, each ruling out a different way the printable text can stop identifying the stored value. It is a byte-level property; confusables are out of scope and not claimed.
- `renderAddress` / `printableFragment` — the callbacks are untrusted in both directions: sanitised going in, sanitised coming back, and a renderer that produces nothing printable takes the name and link with it rather than leaving them describing nothing.

# Evidence

Printed in full on the ticket.

**Terminal-driving characters.** One hostile row (CSI, bare C1 U+009B, OSC-8, line separator) contributed **7 escapes per line through the old template and 0 through the builder**, the old shape read out of the base commit rather than paraphrased. Twelve payloads that defeated an earlier revision — CR, LF, VT/FF, U+2028, NBSP, across the target and the nonce — all render clean.

**Byte-identity: 17/17 row shapes**, the old block transcribed from `02c6c7b81` and printed beside its own source so the transcription is checkable. An independent reviewer re-derived it across 27 shapes with zero differences.

**Mutation testing** on the display module: run `bash` over the harness in the ticket, or reproduce with any mutation of `safe-tx-detail-display.ts` — the last independent run scored 73 killed of 80 non-equivalent. Every mutant restores from a byte copy with the sha1 re-verified, never `git checkout`.

**Tests:** `bun test script/` on this branch and its base to compare; this adds two files.

# Known and not closed

- **No length cap.** A very long `data` renders as one line; capping it would break the byte-identity property above, so it needs its own decision.
- **The notice text is forgeable** in a captured log — a value may contain the literal notice string, distinguishable from a real one only by colour.
- **Confusables and combining marks** are not addressed, and unlike invisible characters they do not suppress the name and link.
- **A malformed `parkedTaskRefs`** is dropped silently rather than remarked on. It renders identically to omitting the field, so it defends against corruption rather than an adversary.
- **`formatDecodedTxDataForDisplay` and the Ledger filmstrip's `dataRows`** render the payload one screen above this block and are **not** covered here — both are in shared modules. Filed as [EXSC-949](https://linear.app/lifi-linear/issue/EXSC-949/the-decoded-calldata-display-renders-proposer-controlled-text-one).
- `describeOperationValue` in `delegatecall-gate.ts` keeps its own sanitise-and-clip; folding it onto this module's helper is worth doing once #2334 merges.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
