### PR TITLE
fix: whitelist Composer VM proxy on Plasma diamond allowlist

### DIFF
--- a/config/composerWhitelist.json
+++ b/config/composerWhitelist.json
@@ -474,6 +474,17 @@
       ]
     }
   ],
+  "plasma": [
+    {
+      "address": "0xA9076E5FD4b9D553af8956Fd5F580De7F6f055CE",
+      "functionSelectors": [
+        {
+          "selector": "0x00a32e6c",
+          "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+        }
+      ]
+    }
+  ],
   "plume": [
     {
       "address": "0x125d9e76cDAF61B352548e39567382a2AAa1d378",

--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -9514,6 +9514,16 @@
             "signature": "validateNativeOutput(uint256,address)"
           }
         ]
+      },
+      {
+        "name": "Composer",
+        "address": "0xA9076E5FD4b9D553af8956Fd5F580De7F6f055CE",
+        "selectors": [
+          {
+            "selector": "0x00a32e6c",
+            "signature": "runVM((uint8,bytes32)[],(bytes[]))"
+          }
+        ]
       }
     ],
     "plume": [


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[COM-1675](https://linear.app/lifi-linear/issue/COM-1675) — [Folks Finance] Composer VM proxy not whitelisted on Plasma Diamond

# Why did I implement it this way?

Composer routes on Plasma (9745) reverted `ContractCallNotAllowed()` for every integrator and both directions. The Composer VM proxy `0xA9076E5FD4b9D553af8956Fd5F580De7F6f055CE` (owner = the Plasma diamond `0x026F252016A7C47CDEf1F05a3Fc9E20C92a49C37`) was missing from the diamond allowlist, so the `runVM` swap step was rejected. `config/composerWhitelist.json` covered 24 chains and `plasma` was not one of them.

This is the same one-line-per-chain fix as #2081 (Pharos) and #1675 (Linea):

- add the `plasma` entry to `config/composerWhitelist.json`
- regenerate the periphery section with `bun run update-whitelist-periphery --environment production`, which appends the `Composer` entry to `PERIPHERY.plasma` in `config/whitelist.json`

The generator reproduced the entry byte for byte, so the diff is exactly the two config additions.

## Verification (anvil fork of Plasma)

Real integrator calldata from the LI.FI API (`allowExchanges=smartDeposits`, USDe → aPlaUSDe, 100 USDe, `to` = diamond, payload contains `runVM` `0x00a32e6c` against the Composer VM proxy), replayed against an anvil fork of Plasma:

| Stage | Result |
| --- | --- |
| Pre-fix, `isContractSelectorWhitelisted(proxy, 0x00a32e6c)` | `false` |
| Pre-fix, send the quote calldata | reverts `0x94539804` = `ContractCallNotAllowed()` |
| Whitelist applied by the diamond owner (timelock `0x707F90…6c47`) | `getWhitelistedSelectorsForContract(proxy)` → `[0x00a32e6c]` |
| Post-fix, send the same calldata | `status 0x1`, gas 700 115 |
| Balances | 100 USDe → 0, aPlaUSDe 0 → 99.749999999999999999 |

So the failing route succeeds once the allowlist entry exists, with no other change.

## Deployment

`config/whitelist.json` is the source of truth for the on-chain allowlist; the Plasma diamond still needs `diamondSyncWhitelist` run after merge for the fix to take effect on-chain.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug — config-only change, verified on an anvil fork as above; matches the Pharos and Linea precedent
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation — none required

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

Reviewer note: the whitelisted address is a `MinimalProxy` whose `owner()` is the Plasma diamond itself and whose `fallback` is `onlyOwnerOrFactory`, so only the diamond and the ProxyFactory `0xe174D02351656a883f6626497C86684e849efB35` can drive it. Only the `runVM` selector is whitelisted.
