### PR TITLE
feat(safe): route every Safe proposal through one blessed wrapper (EXSC-957)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,8 @@ module.exports = {
     'plugin:import/recommended', // provides the base import rules
     'plugin:import/typescript', // provides the typescript-specific import rules
     'prettier',
+    // Safe-proposal funnel fence; also run on its own by `bun lint:funnel`
+    './.eslintrc.funnel-fence.cjs',
   ],
   rules: {
     // General JavaScript rules

--- a/.eslintrc.funnel-fence.cjs
+++ b/.eslintrc.funnel-fence.cjs
@@ -33,6 +33,9 @@ const FENCE = [
   // that had only the two selectors above.
   { selector: `Literal[value='${FUNNEL}']`, message: MESSAGE },
   { selector: `TemplateElement[value.cooked='${FUNNEL}']`, message: MESSAGE },
+  // Not covered, deliberately: a name assembled by concatenation. No static
+  // selector can see it, and unlike the three above it is not a rewrite anyone
+  // reaches for by accident.
 ]
 
 module.exports = {

--- a/.eslintrc.funnel-fence.cjs
+++ b/.eslintrc.funnel-fence.cjs
@@ -13,7 +13,11 @@
  *
  * Extended by `.eslintrc.cjs` so a commit is checked by lint-staged, and run on
  * its own by `bun lint:funnel` (and `.github/workflows/enforceProposalFunnel.yml`)
- * so the fence does not depend on repo-wide lint being green.
+ * so the fence does not depend on repo-wide lint being green. That standalone run
+ * passes `--no-inline-config`, without which a file-level `eslint-disable` would
+ * turn the rule off, and sweeps every module extension the repo can hold — the
+ * repo-wide globs stop at `.ts`/`.js`/`.tsx`, so a `.mjs` or `.cts` route would
+ * otherwise be linted by nothing at all.
  */
 
 const FUNNEL = 'storeTransactionInMongoDB'
@@ -32,9 +36,11 @@ const FENCE = [
   // and as a template literal it is neither.
   { selector: `Literal[value='${FUNNEL}']`, message: MESSAGE },
   { selector: `TemplateElement[value.cooked='${FUNNEL}']`, message: MESSAGE },
-  // Not covered, deliberately: a name assembled by concatenation. No static
-  // selector can see it, and unlike the three above it is not a rewrite anyone
-  // reaches for by accident.
+  // Not covered, deliberately: a name assembled by concatenation, which no
+  // static selector can see, and an alias re-exported from an allowlisted file,
+  // which carries the funnel to a consumer under a name this rule never reads.
+  // Neither is a rewrite anyone reaches for by accident; the allowlisted files
+  // export no such alias today.
 ]
 
 module.exports = {
@@ -51,6 +57,8 @@ module.exports = {
   overrides: [
     {
       files: [
+        // names it to build the rule
+        '.eslintrc.funnel-fence.cjs',
         // declares it
         'script/deploy/safe/safe-utils.ts',
         // the blessed wrapper: the only caller

--- a/.eslintrc.funnel-fence.cjs
+++ b/.eslintrc.funnel-fence.cjs
@@ -1,0 +1,70 @@
+/**
+ * Safe-proposal funnel fence.
+ *
+ * `script/deploy/safe/propose-safe-tx.ts` is the blessed way to create a Safe
+ * proposal. Every check the signing process sites "in the funnel" only covers
+ * the paths that reach it, so this refuses any other file that names the
+ * storage function the funnel ends in.
+ *
+ * Keyed on the AST identifier rather than on the import declaration: an import
+ * restriction sees only `import`/`export … from`, so a namespace member access
+ * (`utils.storeTransactionInMongoDB`), a dynamic import or a computed lookup
+ * would reach the funnel unflagged. Every reference to the name is a node.
+ *
+ * Extended by `.eslintrc.cjs` so a commit is checked by lint-staged, and run on
+ * its own by `bun lint:funnel` (and `.github/workflows/enforceProposalFunnel.yml`)
+ * so the fence does not depend on repo-wide lint being green.
+ */
+
+const FUNNEL = 'storeTransactionInMongoDB'
+
+const MESSAGE =
+  `Safe proposals are created through proposeSafeTx() in ` +
+  `script/deploy/safe/propose-safe-tx.ts, which is where the funnel's checks ` +
+  `are sited. Naming ${FUNNEL} here would create a proposal route that ` +
+  `inherits none of them. If this file genuinely has to own its own storage ` +
+  `call, add it to the allowlist in .eslintrc.funnel-fence.cjs with a reason ` +
+  `and a ticket.`
+
+const FENCE = [
+  { selector: `Identifier[name='${FUNNEL}']`, message: MESSAGE },
+  // A computed lookup carries the name as a string, not as an identifier.
+  { selector: `Literal[value='${FUNNEL}']`, message: MESSAGE },
+]
+
+module.exports = {
+  // Enough to parse TypeScript; deliberately no `project`, so the standalone run
+  // needs no type information and stays a few seconds.
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  // Loaded so the repo's inline `eslint-disable` comments still name defined
+  // rules when this config runs on its own; none of their rules is enabled here.
+  plugins: ['@typescript-eslint', 'import'],
+  rules: {
+    'no-restricted-syntax': ['error', ...FENCE],
+  },
+  overrides: [
+    {
+      files: [
+        // declares it
+        'script/deploy/safe/safe-utils.ts',
+        // the blessed wrapper: the only caller
+        'script/deploy/safe/propose-safe-tx.ts',
+        // its unit tests
+        'script/deploy/safe/safe-utils.test.ts',
+        // Grandfathered when the fence was introduced (EXSC-957). Do NOT add a
+        // file here to make a new propose route lint-clean.
+        //
+        // Tron is a parallel non-EVM flow that hand-rolls its own signature and
+        // is excluded from reconcile too; the owner-change script sequences
+        // nonces across a loop of prebuilt transactions. Both are tracked for
+        // migration by EXSC-958.
+        'script/deploy/tron/propose-to-safe-tron.ts',
+        'script/deploy/safe/add-safe-owners-and-threshold.ts',
+      ],
+      rules: {
+        'no-restricted-syntax': 'off',
+      },
+    },
+  ],
+}

--- a/.eslintrc.funnel-fence.cjs
+++ b/.eslintrc.funnel-fence.cjs
@@ -28,8 +28,11 @@ const MESSAGE =
 
 const FENCE = [
   { selector: `Identifier[name='${FUNNEL}']`, message: MESSAGE },
-  // A computed lookup carries the name as a string, not as an identifier.
+  // A computed lookup carries the name as a string, not as an identifier —
+  // and a template literal is neither, which is how it slipped past a fence
+  // that had only the two selectors above.
   { selector: `Literal[value='${FUNNEL}']`, message: MESSAGE },
+  { selector: `TemplateElement[value.cooked='${FUNNEL}']`, message: MESSAGE },
 ]
 
 module.exports = {

--- a/.eslintrc.funnel-fence.cjs
+++ b/.eslintrc.funnel-fence.cjs
@@ -28,9 +28,8 @@ const MESSAGE =
 
 const FENCE = [
   { selector: `Identifier[name='${FUNNEL}']`, message: MESSAGE },
-  // A computed lookup carries the name as a string, not as an identifier —
-  // and a template literal is neither, which is how it slipped past a fence
-  // that had only the two selectors above.
+  // A computed lookup carries the name as a string rather than an identifier,
+  // and as a template literal it is neither.
   { selector: `Literal[value='${FUNNEL}']`, message: MESSAGE },
   { selector: `TemplateElement[value.cooked='${FUNNEL}']`, message: MESSAGE },
   // Not covered, deliberately: a name assembled by concatenation. No static
@@ -58,15 +57,12 @@ module.exports = {
         'script/deploy/safe/propose-safe-tx.ts',
         // its unit tests
         'script/deploy/safe/safe-utils.test.ts',
-        // Grandfathered when the fence was introduced (EXSC-957). Do NOT add a
-        // file here to make a new propose route lint-clean.
+        // Do NOT add a file here to make a new propose route lint-clean.
         //
-        // Tron is a parallel non-EVM flow that hand-rolls its own signature and
-        // is excluded from reconcile too; the owner-change script sequences
-        // nonces across a loop of prebuilt transactions. Both are tracked for
-        // migration by EXSC-958.
+        // Tron hand-rolls its own signature instead of going through a
+        // `SafeClient`, which is what the wrapper signs with, so it cannot pass
+        // through it as written. Tracked for migration by EXSC-984.
         'script/deploy/tron/propose-to-safe-tron.ts',
-        'script/deploy/safe/add-safe-owners-and-threshold.ts',
       ],
       rules: {
         'no-restricted-syntax': 'off',

--- a/.github/workflows/enforceProposalFunnel.yml
+++ b/.github/workflows/enforceProposalFunnel.yml
@@ -1,0 +1,56 @@
+# Enforce Safe Proposal Funnel
+# - enforces that every Safe proposal is created through proposeSafeTx()
+#   (`script/deploy/safe/propose-safe-tx.ts`), the seam the funnel's checks are sited in
+#   (mandatory Linear ticket link, provenance, duplicate-intent refusal)
+# - fails the build when any file outside the allowlist in `.eslintrc.funnel-fence.cjs`
+#   names `storeTransactionInMongoDB`, the storage function the funnel ends in
+# - the fence is an ESLint rule keyed on the AST identifier, so an alias, a namespace
+#   member access, a dynamic import or a computed lookup is flagged the same way a plain
+#   import is; it is not a text scan over the file
+# - runs on every pull request, drafts included, and on push to main; deliberately not
+#   path-filtered and with no aggregator job, so there is no state in which this reports
+#   green because a producing step did not run
+# - known limitations: the fence covers the funnel's storage function, not a hand-rolled
+#   insert into the proposal collection; `propose-to-safe-tron.ts` and
+#   `add-safe-owners-and-threshold.ts` are grandfathered in the allowlist (EXSC-958)
+
+name: Enforce Safe Proposal Funnel
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+
+# Default-deny at the workflow level; grant only what the job needs.
+permissions: {}
+
+concurrency:
+  group: enforce-proposal-funnel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  enforce-proposal-funnel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # required to fetch repository contents
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The fence runs on its own config rather than the repo-wide one, so a
+      # lint error elsewhere can neither hide a fence violation nor manufacture one.
+      - name: Check every Safe proposal goes through proposeSafeTx()
+        run: bun lint:funnel

--- a/.github/workflows/enforceProposalFunnel.yml
+++ b/.github/workflows/enforceProposalFunnel.yml
@@ -10,8 +10,11 @@
 # - runs on every pull request, drafts included, and on push to main; deliberately not
 #   path-filtered and with no aggregator job, so there is no state in which this reports
 #   green because a producing step did not run
+# - runs with `--no-inline-config` and over every module extension the repo can hold, so
+#   neither a file-level `eslint-disable` nor a `.mjs`/`.cts` route escapes the sweep
 # - known limitations: the fence covers the funnel's storage function, not a hand-rolled
-#   insert into the proposal collection; the Tron route is allowlisted (EXSC-984)
+#   insert into the proposal collection, and not an alias re-exported from an allowlisted
+#   file; the Tron route is allowlisted (EXSC-984)
 
 name: Enforce Safe Proposal Funnel
 on:

--- a/.github/workflows/enforceProposalFunnel.yml
+++ b/.github/workflows/enforceProposalFunnel.yml
@@ -11,8 +11,7 @@
 #   path-filtered and with no aggregator job, so there is no state in which this reports
 #   green because a producing step did not run
 # - known limitations: the fence covers the funnel's storage function, not a hand-rolled
-#   insert into the proposal collection; `propose-to-safe-tron.ts` and
-#   `add-safe-owners-and-threshold.ts` are grandfathered in the allowlist (EXSC-958)
+#   insert into the proposal collection; the Tron route is allowlisted (EXSC-984)
 
 name: Enforce Safe Proposal Funnel
 on:

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -94,7 +94,7 @@ the source prompt or inferred, **not** confirmed.
    silently in `notFoundOnChain`) so the drain surfaces it for investigation.
 3. `[code]` Both proposal-creation entry points funnel through
    `storeTransactionInMongoDB(pendingTransactions, safeAddress, network, chainId,
-   safeTx, safeTxHash, proposer)` — `script/deploy/safe/safe-utils.ts:1263`. It is
+   safeTx, safeTxHash, proposer)` — `script/deploy/safe/safe-utils.ts:1804`. It is
    the single point where a proposal is *persisted*; it receives a **pre-signed**
    `safeTx` and has **no Safe SDK client** in scope. Since EXSC-957 every EVM
    caller reaches it through `proposeSafeTx` (`propose-safe-tx.ts`), which a lint
@@ -102,8 +102,8 @@ the source prompt or inferred, **not** confirmed.
 4. `[code]` **`runPropose(options)` — `script/deploy/safe/propose-to-safe.ts:58` — is
    the true funnel for programmatic Safe proposals**, and it owns `{network,
    environment, safe client, Mongo collection}`. It does `normalizeProposeCalls →
-   initializeSafeClient → getSafeMongoCollection → getNextNonce → safe.createTransaction
-   → sign → storeTransactionInMongoDB` (`:59-249`). Everything else routes *into* it:
+   initializeSafeClient → getSafeMongoCollection → getNextNonce → proposeSafeTx`
+   (`:59-249`). Everything else routes *into* it:
    the manual CLI `main` (`:257`) only parses argv and calls `runPropose` (`:356`,
    `runMain(main)` `:375`); the **facet-cut path** `proposeDiamondCut`
    (`script/deploy/shared/propose-diamond-cut.ts:53`) calls `runPropose` for EVM
@@ -113,7 +113,7 @@ the source prompt or inferred, **not** confirmed.
    is `proposeDiamondCut → runPropose`, no CLI). A *separate* helper
    `sendOrPropose({calldata, network, environment, diamondAddress, signing})` —
    `script/safe/safeScriptHelpers.ts:29` — does its own `getSafeMongoCollection →
-   getNextNonce → createTransaction → sign → storeTransactionInMongoDB` and **does not
+   getNextNonce → proposeSafeTx` and **does not
    call `runPropose`**; it backs whitelist-sync and `cleanUpProdDiamond` removals
    (`script/tasks/cleanUpProdDiamond.ts:515` `proposeRemovals`). So a `runPropose` hook
    covers the facet-cut funnel but **not** the `sendOrPropose` funnel (§6 gap).
@@ -436,8 +436,7 @@ export async function _runPropose(
   parkedTaskRefs?: IParkedTaskRef[] // annotated onto the stored proposal
 ): Promise<{ safeTxHash: Hex; stored: boolean }> {
   /* normalizeProposeCalls → (append extraTimelockCalls) → initializeSafeClient →
-     getSafeMongoCollection → getNextNonce → createTransaction → sign →
-     storeTransactionInMongoDB(…, parkedTaskRefs) */
+     getSafeMongoCollection → getNextNonce → proposeSafeTx(…, parkedTaskRefs) */
 }
 
 export async function runPropose(options: IProposeToSafeOptions) {

--- a/docs/DeferredDiamondCleanupQueue.md
+++ b/docs/DeferredDiamondCleanupQueue.md
@@ -95,9 +95,10 @@ the source prompt or inferred, **not** confirmed.
 3. `[code]` Both proposal-creation entry points funnel through
    `storeTransactionInMongoDB(pendingTransactions, safeAddress, network, chainId,
    safeTx, safeTxHash, proposer)` — `script/deploy/safe/safe-utils.ts:1263`. It is
-   the single point where a proposal is *persisted*, but it is called from ~9 sites,
-   not via one wrapper; it receives a **pre-signed** `safeTx` and has **no Safe SDK
-   client** in scope.
+   the single point where a proposal is *persisted*; it receives a **pre-signed**
+   `safeTx` and has **no Safe SDK client** in scope. Since EXSC-957 every EVM
+   caller reaches it through `proposeSafeTx` (`propose-safe-tx.ts`), which a lint
+   fence enforces; the Tron route still calls it directly (EXSC-984).
 4. `[code]` **`runPropose(options)` — `script/deploy/safe/propose-to-safe.ts:58` — is
    the true funnel for programmatic Safe proposals**, and it owns `{network,
    environment, safe client, Mongo collection}`. It does `normalizeProposeCalls →
@@ -468,9 +469,11 @@ export async function runPropose(options: IProposeToSafeOptions) {
 **Known gap (stated, not hidden).** `sendOrPropose` (`safeScriptHelpers.ts:29`) is a
 *separate* funnel that does **not** call `runPropose` (Fact 4), so actions that go only
 through it — **whitelist syncs** and `cleanUpProdDiamond` removals — will **not** drain
-opportunistically, nor will the four bespoke scripts that call `storeTransactionInMongoDB`
-directly (`proposePolymerCCTPChainIdMappings`, `proposeMegaETHBridgeRegistrations`,
-`unpauseAllDiamonds`, `proposeDeBridgeDlnChainIdMappings`). This is an accepted
+opportunistically, nor will the bespoke scripts that propose through `proposeSafeTx`
+without `runPropose` (`proposePolymerCCTPChainIdMappings`,
+`proposeMegaETHBridgeRegistrations`, `unpauseAllDiamonds`,
+`proposeDeBridgeDlnChainIdMappings`, `proposeAllBridgeChainIdMappings`,
+`proposeFraxChainIdMappings`, `add-safe-owners-and-threshold`). This is an accepted
 consequence of hooking the facet-cut funnel only: deprecation removals naturally ride
 facet cuts (`proposeDiamondCut → runPropose`), and the **cold-network backstop (§8)**
 catches anything the opportunistic path misses. Extending the hook to `sendOrPropose` is

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -162,10 +162,21 @@ merge; the deploy scripts never commit.
 
 ### 4.2 Propose
 
-All EVM funnels end in `storeTransactionInMongoDB`
-(`script/deploy/safe/safe-utils.ts`), which is where the Linear ticket link is
+Every EVM entry point proposes through `proposeSafeTx`
+(`script/deploy/safe/propose-safe-tx.ts`), which checks Safe ownership, signs,
+hashes the signed transaction and calls `storeTransactionInMongoDB`
+(`script/deploy/safe/safe-utils.ts`). That is where the Linear ticket link is
 required and the missing-reason warning is emitted — placing them there rather
-than per entry point means no funnel can be added that skips them. The refusal
+than per entry point means no funnel can be added that skips them.
+
+The seam is enforced, not conventional: `.eslintrc.funnel-fence.cjs` refuses any
+file outside its allowlist that names `storeTransactionInMongoDB`, so a propose
+route added later either comes through `proposeSafeTx` or fails lint
+(`bun lint:funnel`, run in CI by `enforceProposalFunnel.yml`). It is an ESLint
+rule keyed on the AST identifier, so an alias, a namespace member access or a
+computed lookup is refused the same way a plain import is. What it does **not**
+cover: a hand-rolled insert into the `pendingTransactions` collection that never
+names the storage function. The refusal
 happens before the proposal document is inserted, so a refused proposal is never
 created and claims no nonce, and it names both `--ticket` and
 `SAFE_PROPOSAL_TICKET`.
@@ -206,18 +217,22 @@ run only on the branches that actually propose; a staging or testnet-only run, a
 - **Deferred-cleanup drain** (`script/deploy/safe/drain-parked-tasks.ts`) —
   gated on `DRAIN_PARKED_TASKS`, hooked at the tail of `runPropose`
   ([DeferredDiamondCleanupQueue.md](./DeferredDiamondCleanupQueue.md)).
-- **Bespoke task scripts** that store proposals directly:
-  `script/tasks/proposeMegaETHBridgeRegistrations.ts`,
+- **Bespoke task scripts** that propose without going through
+  `propose-to-safe.ts`: `script/tasks/proposeMegaETHBridgeRegistrations.ts`,
   `proposeDeBridgeDlnChainIdMappings.ts`,
   `proposePolymerCCTPChainIdMappings.ts`, `unpauseAllDiamonds.ts`,
-  `script/deploy/safe/add-safe-owners-and-threshold.ts`, and two more chain-id
-  mapping tasks (`proposeAllBridgeChainIdMappings.ts`,
-  `proposeFraxChainIdMappings.ts`) — there is **no single chokepoint**. All of
-  them reach `storeTransactionInMongoDB` directly rather than through
-  `propose-to-safe.ts`, so the deploy gate below does not see them. None encodes
-  a `diamondCut` today, so none installs facet code; the list is what
-  `grep -rn storeTransactionInMongoDB script/` returns, not a fixed set, so
-  check it rather than trusting this sentence.
+  `proposeAllBridgeChainIdMappings.ts` and `proposeFraxChainIdMappings.ts`.
+  They share the storage seam (`proposeSafeTx`) but **not**
+  `propose-to-safe.ts`, so the deploy gate below does not see them.
+  `script/deploy/safe/add-safe-owners-and-threshold.ts` is in the same position
+  and additionally still holds its own storage call, allowlisted in the fence.
+  None encodes a `diamondCut` today, so none installs facet code. Every propose
+  route is
+  `grep -rl 'import { proposeSafeTx }' script` plus the files still allowlisted
+  in `.eslintrc.funnel-fence.cjs` (`add-safe-owners-and-threshold.ts` and the
+  Tron route, both tracked for migration by EXSC-958). Run it rather than
+  trusting this sentence — the fence guarantees the two together are
+  exhaustive, not that this list is current.
 - **Tron** is a parallel flow (`script/deploy/tron/propose-to-safe-tron.ts`).
 
 The proposal funnel additionally runs the production deploy gate before it signs
@@ -494,7 +509,7 @@ parked tasks are reconciled weekly by `reconcileParkedTasks.yml`.
 | Stage | Check category | Behavior | Enforced by |
 |---|---|---|---|
 | Propose | CLI input validation: `--to`/`--calldata` pairing, address/hex validity, multi-call requires `--timelock` | Block | `script/deploy/safe/propose-calls.ts`, `timelock-abi.ts` |
-| Propose | Proposer must be a current Safe owner (on-chain `getOwners()`) | Block | `propose-to-safe.ts` (`runPropose`), `safeScriptHelpers.ts` (`sendOrPropose`) |
+| Propose | Proposer must be a current Safe owner (on-chain `getOwners()`), checked before the signature so a non-owner proposal never claims a nonce | Block | `proposeSafeTx` in `propose-safe-tx.ts`, on every path that proposes; `propose-to-safe.ts` (`runPropose`) also checks earlier, before it builds the call |
 | Propose | Ledger signing flags: unambiguous value, no repeat, no unusable combination, no multi-proposal run (see the `sendOrPropose` bullet in §3) | Block | `script/deploy/safe/cli-flags.ts`, `resolveSafeSigningOptions` in `safe-utils.ts`, `cleanUpProdDiamond.ts` |
 | Propose | Nonce safety: override collision checks, auto-nonce clamped to on-chain | Block / auto-correct | `propose-to-safe.ts`, `getNextNonce` in `safe-utils.ts` |
 | Propose | Duplicate-intent dedup (partial unique index on pending rows) | Block insert | `computeProposalIntentHash` + index in `safe-utils.ts` |
@@ -518,6 +533,7 @@ parked tasks are reconciled weekly by `reconcileParkedTasks.yml`.
 | CI (PR gate) | ≥ 1 approval from the SC core team | Block merge | Repository ruleset `main protection` — `required_reviewers` on the `smart-contract-core` team |
 | CI (PR gate) | Security-relevant paths need ISM/CTO approval | Block PR | `protectSecurityRelevantCode.yml` |
 | CI (PR gate) | Static analysis; LibAsset routing; config/deploy-log consistency and JSON validity; clear-signing sync; deploy smoke test; signed commits; solc floor; SPDX | Block PR | `olympixStaticAnalysis.yml` + `securityAlertsReview.yml`, `enforceLibAssetRouting.yml`, `deploymentAddressConsistency.yml`, `jsonChecker.yml`, `verifyClearSigning.yml`, `deploy-smoke-test.yml`, `verifyCommitsSigned.yml`, `solc-floor-build.yml`, `spdxLicenseChecker.yml` |
+| CI (PR gate) | Every Safe proposal is created through `proposeSafeTx`: any file outside the allowlist naming `storeTransactionInMongoDB` fails lint. AST-keyed, so an alias, namespace access or computed lookup is refused too; a hand-rolled insert into the collection is **not** covered | Block PR | `.eslintrc.funnel-fence.cjs` via `bun lint:funnel`, run by `.github/workflows/enforceProposalFunnel.yml` and by lint-staged through `.eslintrc.cjs` |
 | CI (ops) | Daily on-chain health check of every production diamond; weekly emergency-pause readiness | Alert | `healthCheckAllNetworks.yml`, `verifyEmergencyPauseReadiness.yml` |
 
 ## 6. What the signer must verify manually today
@@ -592,6 +608,7 @@ fleet-wide run ends with zero mainnets unpaused and no obvious cause.
 | Path | Role |
 |---|---|
 | `script/deploy/safe/propose-to-safe.ts` | Main proposal funnel (`runPropose`); `bun propose-safe-tx` |
+| `script/deploy/safe/propose-safe-tx.ts` | `proposeSafeTx` — the blessed seam every propose route goes through |
 | `script/deploy/safe/confirm-safe-tx.ts` | Signer review/sign/execute CLI; `bun confirm-safe-tx` |
 | `script/deploy/safe/safe-utils.ts` | `SafeClient`, Mongo store, signing, timelock wrap |
 | `script/deploy/safe/safe-decode-utils.ts` | Calldata decode for the signing view |
@@ -603,6 +620,7 @@ fleet-wide run ends with zero mainnets unpaused and no obvious cause.
 | `script/helperFunctions.sh` | bash `sendOrPropose` chokepoint + deploy logging |
 | `.github/workflows/runPendingTimelockTXs.yml` | "Timelock Auto Execution" 10-min cron |
 | `.github/workflows/reconcileParkedTasks.yml` | Weekly parked-task reconcile + TTL alert |
+| `.github/workflows/enforceProposalFunnel.yml` | Fence: no propose route outside `proposeSafeTx` |
 | `.agents/commands/multisig-rollout.md` | The end-to-end rollout runbook |
 
 ## 9. Planned improvements (proposal stage — NOT yet implemented)

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -162,26 +162,29 @@ merge; the deploy scripts never commit.
 
 ### 4.2 Propose
 
-Every EVM entry point proposes through `proposeSafeTx`
-(`script/deploy/safe/propose-safe-tx.ts`), which checks Safe ownership, signs,
-hashes the signed transaction and calls `storeTransactionInMongoDB`
-(`script/deploy/safe/safe-utils.ts`). That is where the Linear ticket link is
-required and the missing-reason warning is emitted — placing them there rather
-than per entry point means no funnel can be added that skips them.
+Every EVM entry point except
+`script/deploy/safe/add-safe-owners-and-threshold.ts` proposes through
+`proposeSafeTx` (`script/deploy/safe/propose-safe-tx.ts`), which checks Safe
+ownership, signs, hashes the signed transaction and calls
+`storeTransactionInMongoDB` (`script/deploy/safe/safe-utils.ts`). That last is
+where the Linear ticket link is required and the missing-reason warning is
+emitted — placing them there rather than per entry point means no funnel can be
+added that skips them. The refusal happens before the proposal document is
+inserted, so a refused proposal is never created and claims no nonce, and it
+names both `--ticket` and `SAFE_PROPOSAL_TICKET`.
 
 The seam is enforced, not conventional: `.eslintrc.funnel-fence.cjs` refuses any
 file outside its allowlist that names `storeTransactionInMongoDB`, so a propose
 route added later either comes through `proposeSafeTx` or fails lint
 (`bun lint:funnel`, run in CI by `enforceProposalFunnel.yml`). It is an ESLint
 rule keyed on the AST identifier, so an alias, a namespace member access or a
-computed lookup is refused the same way a plain import is. What it does **not**
-cover: a hand-rolled insert into the `pendingTransactions` collection that never
-names the storage function. The refusal
-happens before the proposal document is inserted, so a refused proposal is never
-created and claims no nonce, and it names both `--ticket` and
-`SAFE_PROPOSAL_TICKET`.
+computed lookup is refused the same way a plain import is. Two things it does
+**not** cover: a hand-rolled insert into the `pendingTransactions` collection
+that never names the storage function, and the two files still in the allowlist
+for their own storage call — `add-safe-owners-and-threshold.ts` and the Tron
+route, both tracked for migration by EXSC-958.
 
-That check is the backstop, not the first line: the entry points whose late
+The ticket check is the backstop, not the first line: the entry points whose late
 failure costs most — `unpauseAllDiamonds.ts`, `add-safe-owners-and-threshold.ts`,
 the Tron route, and the TS `sendOrPropose` — also call `assertTicketPresent`
 before they sign, and `propose-to-safe.ts` resolves the same intent up front in

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -176,12 +176,15 @@ The seam is enforced, not conventional: `.eslintrc.funnel-fence.cjs` refuses any
 file outside its allowlist that names `storeTransactionInMongoDB`, so a propose
 route added later either comes through `proposeSafeTx` or fails lint
 (`bun lint:funnel`, run in CI by `enforceProposalFunnel.yml`). It is an ESLint
-rule keyed on the AST identifier, so an alias, a namespace member access or a
-computed lookup is refused the same way a plain import is. Two things it does
-**not** cover: a hand-rolled insert into the `pendingTransactions` collection
-that never names the storage function, and the one file still allowlisted for
-its own storage call — the Tron route, which hand-rolls its own signature
-instead of signing through a `SafeClient` (EXSC-984).
+rule keyed on the AST identifier, so an alias, a namespace member access, a
+dynamic import or a computed lookup is refused the same way a plain import is,
+and the CI run passes `--no-inline-config` over every module extension the repo
+can hold, so neither a file-level `eslint-disable` nor a `.mjs` route escapes it.
+Three things it does **not** cover: a hand-rolled insert into the
+`pendingTransactions` collection that never names the storage function, an alias
+re-exported from an allowlisted file, and the one file still allowlisted for its
+own storage call — the Tron route, which hand-rolls its own signature instead of
+signing through a `SafeClient` (EXSC-984).
 
 The ticket check is the backstop, not the first line: the entry points whose late
 failure costs most — `unpauseAllDiamonds.ts`, `add-safe-owners-and-threshold.ts`,
@@ -227,11 +230,12 @@ run only on the branches that actually propose; a staging or testnet-only run, a
   `script/deploy/safe/add-safe-owners-and-threshold.ts`. They share the storage
   seam (`proposeSafeTx`) but **not** `propose-to-safe.ts`, so the deploy gate
   below does not see them. None encodes a `diamondCut` today, so none installs
-  facet code. Every propose route is
-  `grep -rl 'import { proposeSafeTx }' script` plus the files still allowlisted
-  in `.eslintrc.funnel-fence.cjs` (the Tron route, EXSC-984). Run it rather than
-  trusting this sentence — the fence guarantees the two together are
-  exhaustive, not that this list is current.
+  facet code. Every propose route is `git grep -l proposeSafeTx script` plus the
+  files still allowlisted in `.eslintrc.funnel-fence.cjs` (the Tron route,
+  EXSC-984) — matched on the name alone, because a route importing it alongside
+  a type is invisible to a grep for the import statement. Run it rather than
+  trusting this sentence: the fence guarantees the two together are exhaustive,
+  not that this list is current.
 - **Tron** is a parallel flow (`script/deploy/tron/propose-to-safe-tron.ts`).
 
 The proposal funnel additionally runs the production deploy gate before it signs
@@ -510,7 +514,7 @@ parked tasks are reconciled weekly by `reconcileParkedTasks.yml`.
 | Stage | Check category | Behavior | Enforced by |
 |---|---|---|---|
 | Propose | CLI input validation: `--to`/`--calldata` pairing, address/hex validity, multi-call requires `--timelock` | Block | `script/deploy/safe/propose-calls.ts`, `timelock-abi.ts` |
-| Propose | Proposer must be a current Safe owner (on-chain `getOwners()`), checked before the signature so a non-owner proposal never claims a nonce | Block | `proposeSafeTx` in `propose-safe-tx.ts`, on every path that proposes; `propose-to-safe.ts` (`runPropose`) also checks earlier, before it builds the call |
+| Propose | Proposer must be a current Safe owner (on-chain `getOwners()`), checked before the signature so a non-owner proposal never claims a nonce | Block | `proposeSafeTx` in `propose-safe-tx.ts`, on every path that proposes; `propose-to-safe.ts` (`runPropose`) and `add-safe-owners-and-threshold.ts` also check earlier, before they build a call |
 | Propose | Ledger signing flags: unambiguous value, no repeat, no unusable combination, no multi-proposal run (see the `sendOrPropose` bullet in §3) | Block | `script/deploy/safe/cli-flags.ts`, `resolveSafeSigningOptions` in `safe-utils.ts`, `cleanUpProdDiamond.ts` |
 | Propose | Nonce safety: override collision checks, auto-nonce clamped to on-chain | Block / auto-correct | `propose-to-safe.ts`, `getNextNonce` in `safe-utils.ts` |
 | Propose | Duplicate-intent dedup (partial unique index on pending rows) | Block insert | `computeProposalIntentHash` + index in `safe-utils.ts` |
@@ -534,7 +538,7 @@ parked tasks are reconciled weekly by `reconcileParkedTasks.yml`.
 | CI (PR gate) | ≥ 1 approval from the SC core team | Block merge | Repository ruleset `main protection` — `required_reviewers` on the `smart-contract-core` team |
 | CI (PR gate) | Security-relevant paths need ISM/CTO approval | Block PR | `protectSecurityRelevantCode.yml` |
 | CI (PR gate) | Static analysis; LibAsset routing; config/deploy-log consistency and JSON validity; clear-signing sync; deploy smoke test; signed commits; solc floor; SPDX | Block PR | `olympixStaticAnalysis.yml` + `securityAlertsReview.yml`, `enforceLibAssetRouting.yml`, `deploymentAddressConsistency.yml`, `jsonChecker.yml`, `verifyClearSigning.yml`, `deploy-smoke-test.yml`, `verifyCommitsSigned.yml`, `solc-floor-build.yml`, `spdxLicenseChecker.yml` |
-| CI (PR gate) | Every Safe proposal is created through `proposeSafeTx`: any file outside the allowlist naming `storeTransactionInMongoDB` fails lint. AST-keyed, so an alias, namespace access or computed lookup is refused too; a hand-rolled insert into the collection is **not** covered | Block PR | `.eslintrc.funnel-fence.cjs` via `bun lint:funnel`, run by `.github/workflows/enforceProposalFunnel.yml` and by lint-staged through `.eslintrc.cjs` |
+| CI (PR gate) | Every Safe proposal is created through `proposeSafeTx`: any file outside the allowlist naming `storeTransactionInMongoDB` fails lint. AST-keyed, so an alias, namespace access, dynamic import or computed lookup is refused too, and the CI run ignores inline `eslint-disable` comments; a hand-rolled insert into the collection and an alias re-exported from an allowlisted file are **not** covered | Report only until `enforce-proposal-funnel` is added to the `main protection` ruleset's required checks; blocks the job either way | `.eslintrc.funnel-fence.cjs` via `bun lint:funnel`, run by `.github/workflows/enforceProposalFunnel.yml` and by lint-staged through `.eslintrc.cjs` |
 | CI (ops) | Daily on-chain health check of every production diamond; weekly emergency-pause readiness | Alert | `healthCheckAllNetworks.yml`, `verifyEmergencyPauseReadiness.yml` |
 
 ## 6. What the signer must verify manually today

--- a/docs/MultisigSigningProcess.md
+++ b/docs/MultisigSigningProcess.md
@@ -162,9 +162,8 @@ merge; the deploy scripts never commit.
 
 ### 4.2 Propose
 
-Every EVM entry point except
-`script/deploy/safe/add-safe-owners-and-threshold.ts` proposes through
-`proposeSafeTx` (`script/deploy/safe/propose-safe-tx.ts`), which checks Safe
+Every EVM entry point proposes through `proposeSafeTx`
+(`script/deploy/safe/propose-safe-tx.ts`), which checks Safe
 ownership, signs, hashes the signed transaction and calls
 `storeTransactionInMongoDB` (`script/deploy/safe/safe-utils.ts`). That last is
 where the Linear ticket link is required and the missing-reason warning is
@@ -180,9 +179,9 @@ route added later either comes through `proposeSafeTx` or fails lint
 rule keyed on the AST identifier, so an alias, a namespace member access or a
 computed lookup is refused the same way a plain import is. Two things it does
 **not** cover: a hand-rolled insert into the `pendingTransactions` collection
-that never names the storage function, and the two files still in the allowlist
-for their own storage call — `add-safe-owners-and-threshold.ts` and the Tron
-route, both tracked for migration by EXSC-958.
+that never names the storage function, and the one file still allowlisted for
+its own storage call — the Tron route, which hand-rolls its own signature
+instead of signing through a `SafeClient` (EXSC-984).
 
 The ticket check is the backstop, not the first line: the entry points whose late
 failure costs most — `unpauseAllDiamonds.ts`, `add-safe-owners-and-threshold.ts`,
@@ -224,16 +223,13 @@ run only on the branches that actually propose; a staging or testnet-only run, a
   `propose-to-safe.ts`: `script/tasks/proposeMegaETHBridgeRegistrations.ts`,
   `proposeDeBridgeDlnChainIdMappings.ts`,
   `proposePolymerCCTPChainIdMappings.ts`, `unpauseAllDiamonds.ts`,
-  `proposeAllBridgeChainIdMappings.ts` and `proposeFraxChainIdMappings.ts`.
-  They share the storage seam (`proposeSafeTx`) but **not**
-  `propose-to-safe.ts`, so the deploy gate below does not see them.
-  `script/deploy/safe/add-safe-owners-and-threshold.ts` is in the same position
-  and additionally still holds its own storage call, allowlisted in the fence.
-  None encodes a `diamondCut` today, so none installs facet code. Every propose
-  route is
+  `proposeAllBridgeChainIdMappings.ts`, `proposeFraxChainIdMappings.ts` and
+  `script/deploy/safe/add-safe-owners-and-threshold.ts`. They share the storage
+  seam (`proposeSafeTx`) but **not** `propose-to-safe.ts`, so the deploy gate
+  below does not see them. None encodes a `diamondCut` today, so none installs
+  facet code. Every propose route is
   `grep -rl 'import { proposeSafeTx }' script` plus the files still allowlisted
-  in `.eslintrc.funnel-fence.cjs` (`add-safe-owners-and-threshold.ts` and the
-  Tron route, both tracked for migration by EXSC-958). Run it rather than
+  in `.eslintrc.funnel-fence.cjs` (the Tron route, EXSC-984). Run it rather than
   trusting this sentence — the fence guarantees the two together are
   exhaustive, not that this list is current.
 - **Tron** is a parallel flow (`script/deploy/tron/propose-to-safe-tron.ts`).
@@ -361,10 +357,12 @@ below.
 
 **One propose path does not go through either funnel**, and it is not the bash
 `sendOrPropose`: the identically-named **TypeScript** `sendOrPropose`
-(`script/safe/safeScriptHelpers.ts`) signs and stores a proposal itself. It is the
-third call site, carrying the same gate call inline so the two cannot diverge. A
-*fourth* proposer written against `storeTransactionInMongoDB` directly would not
-be covered — see the bespoke task scripts listed in §4.1, and the `sendOrPropose`
+(`script/safe/safeScriptHelpers.ts`) proposes through `proposeSafeTx` rather than
+through `runPropose`. It is the third call site, carrying the same gate call
+inline so the two cannot diverge. The funnel fence (§4.2) keeps the *storage*
+seam closed, but it says nothing about the gate: a *fourth* proposer that came
+through `proposeSafeTx` without calling `assertFunnelDeployGate` would still not
+be gated — see the bespoke task scripts listed in §4.1, and the `sendOrPropose`
 gap recorded in
 [DeferredDiamondCleanupQueue.md](./DeferredDiamondCleanupQueue.md) §6.
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lint:js:fix": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint:sol": "solhint \"src/**/*.sol\"",
     "lint:sol:fix": "solhint \"src/**/*.sol\" --fix",
-    "lint:funnel": "eslint --no-eslintrc -c ./.eslintrc.funnel-fence.cjs --ext .ts,.js,.tsx .",
+    "lint:funnel": "eslint --no-eslintrc -c ./.eslintrc.funnel-fence.cjs --no-inline-config --ext .ts,.tsx,.mts,.cts,.js,.mjs,.cjs .",
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "lint:fix": "bun lint:js:fix && bun lint:sol:fix",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "lint:js:fix": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint:sol": "solhint \"src/**/*.sol\"",
     "lint:sol:fix": "solhint \"src/**/*.sol\" --fix",
+    "lint:funnel": "eslint --no-eslintrc -c ./.eslintrc.funnel-fence.cjs --ext .ts,.js,.tsx .",
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "lint:fix": "bun lint:js:fix && bun lint:sol:fix",

--- a/script/deploy/safe/add-safe-owners-and-threshold.ts
+++ b/script/deploy/safe/add-safe-owners-and-threshold.ts
@@ -31,6 +31,7 @@ import { SAFE_THRESHOLD } from '../shared/constants'
 import { readBooleanFlag } from './cli-flags'
 import type { ILedgerAccountResult } from './ledger'
 import { assertTicketPresent } from './proposal-intent'
+import { proposeSafeTx } from './propose-safe-tx'
 import {
   getNextNonce,
   getPrivateKey,
@@ -38,7 +39,6 @@ import {
   getSafeMongoCollection,
   initializeSafeClient,
   isAddressASafeOwner,
-  storeTransactionInMongoDB,
   type ISafeTxDocument,
 } from './safe-utils'
 
@@ -391,29 +391,23 @@ async function processNetwork(
       )
 
       consola.info('Proposing to add owner', owner)
-      const signedTx = await safe.signTransaction(safeTransaction)
-      const safeTxHash = await safe.getTransactionHash(signedTx)
+      const { safeTxHash, stored } = await proposeSafeTx({
+        safe,
+        network,
+        chainId: chain.id,
+        safeAddress,
+        pendingTransactions,
+        payload: { kind: 'prebuilt', safeTx: safeTransaction },
+      })
       consola.info('Transaction signed:', safeTxHash)
 
-      const result = await storeTransactionInMongoDB(
-        pendingTransactions,
-        safe.getAddress(),
-        network,
-        chain.id,
-        signedTx,
-        safeTxHash,
-        senderAddress
-      )
-
-      if (result === null) {
-        consola.info('Proposal already exists - skipping')
-        addOwnerAlreadyProposed++
-      } else if (!result.acknowledged)
-        throw new Error('MongoDB insert was not acknowledged')
-      else {
+      if (stored) {
         consola.success('Transaction successfully stored in MongoDB')
         proposalsCreated++
         addOwnerNewlyProposed++
+      } else {
+        consola.info('Proposal already exists - skipping')
+        addOwnerAlreadyProposed++
       }
       nextNonce++
     }
@@ -442,29 +436,24 @@ async function processNetwork(
         SAFE_THRESHOLD,
         { nonce: nextNonce }
       )
-      const signedThresholdTx = await safe.signTransaction(changeThresholdTx)
-      const thresholdTxHash = await safe.getTransactionHash(signedThresholdTx)
+      const { safeTxHash: thresholdTxHash, stored: thresholdStored } =
+        await proposeSafeTx({
+          safe,
+          network,
+          chainId: chain.id,
+          safeAddress,
+          pendingTransactions,
+          payload: { kind: 'prebuilt', safeTx: changeThresholdTx },
+        })
       consola.info('Transaction signed:', thresholdTxHash)
 
-      const thresholdResult = await storeTransactionInMongoDB(
-        pendingTransactions,
-        safe.getAddress(),
-        network,
-        chain.id,
-        signedThresholdTx,
-        thresholdTxHash,
-        senderAddress
-      )
-
-      if (thresholdResult === null) {
-        consola.info('Proposal already exists - skipping')
-        thresholdAlreadyProposed = true
-      } else if (!thresholdResult.acknowledged)
-        throw new Error('MongoDB insert was not acknowledged')
-      else {
+      if (thresholdStored) {
         consola.success('Transaction successfully stored in MongoDB')
         proposalsCreated++
         thresholdNewlyProposed = true
+      } else {
+        consola.info('Proposal already exists - skipping')
+        thresholdAlreadyProposed = true
       }
     } else
       consola.success(

--- a/script/deploy/safe/propose-funnel-fence.test.ts
+++ b/script/deploy/safe/propose-funnel-fence.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Whether anything other than the blessed wrapper can reach the Safe-proposal
+ * storage function — and whether the rule that says so actually runs.
+ *
+ * Each case feeds a candidate call site to the real ESLint CLI on stdin under a
+ * virtual path, so nothing is written into the tree: a probe file left behind by
+ * a crashed run would itself fail the fence in CI.
+ *
+ * `propose-safe-tx.test.ts` covers what the wrapper does once a caller is
+ * through it.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..', '..')
+const FENCE_CONFIG = './.eslintrc.funnel-fence.cjs'
+const WORKFLOW = '.github/workflows/enforceProposalFunnel.yml'
+
+/** The identifying fragment of the fence's message, not the whole paragraph. */
+const REFUSAL = 'Safe proposals are created through proposeSafeTx()'
+
+/** 90 seconds: an ESLint run plus a cold bun start, well short of a hang. */
+const TIMEOUT_MS = 90_000
+
+/**
+ * Lints `source` as if it were the file at `virtualPath`.
+ *
+ * @param source - the candidate call site
+ * @param virtualPath - repo-relative path it is judged as, which is what the
+ *   allowlist matches on
+ * @param useRepoConfig - lint with the repo-wide config instead of the fence's
+ *   own, to show the fence is reachable from the config a commit is linted with
+ */
+const lint = async (
+  source: string,
+  virtualPath: string,
+  useRepoConfig = false
+): Promise<{ exitCode: number; output: string }> => {
+  const args = useRepoConfig
+    ? ['--stdin', '--stdin-filename', virtualPath]
+    : [
+        '--no-eslintrc',
+        '-c',
+        FENCE_CONFIG,
+        '--stdin',
+        '--stdin-filename',
+        virtualPath,
+      ]
+
+  // Async rather than `Bun.spawnSync`, whose options type pins stdin to
+  // 'ignore': feeding the candidate on stdin is the point of this helper.
+  const proc = Bun.spawn(['bunx', 'eslint', ...args], {
+    cwd: REPO_ROOT,
+    env: process.env as Record<string, string>,
+    stdin: Buffer.from(source),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: TIMEOUT_MS,
+  })
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  if (proc.signalCode !== null && proc.signalCode !== undefined)
+    throw new Error(
+      `eslint was killed by ${proc.signalCode}, so its verdict proves nothing`
+    )
+
+  return { exitCode: proc.exitCode ?? -1, output: `${stdout}${stderr}` }
+}
+
+const BYPASS_PATH = 'script/tasks/proposeSomethingNew.ts'
+
+describe('the funnel fence refuses a new propose route', () => {
+  it(
+    'refuses a plain import of the storage function',
+    async () => {
+      const result = await lint(
+        `import { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a namespace member access, which an import restriction would miss',
+    async () => {
+      const result = await lint(
+        `import * as safeUtils from '../deploy/safe/safe-utils'\n` +
+          `export const propose = safeUtils.storeTransactionInMongoDB\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a computed lookup, where the name is a string rather than an identifier',
+    async () => {
+      const result = await lint(
+        `import * as safeUtils from '../deploy/safe/safe-utils'\n` +
+          `export const propose = safeUtils['storeTransactionInMongoDB']\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a re-export, so the name cannot be laundered through a third file',
+    async () => {
+      const result = await lint(
+        `export { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+})
+
+describe('the funnel fence lets compliant code through', () => {
+  it(
+    'accepts a new call site that goes through the wrapper',
+    async () => {
+      // Without this, a fence that refused every file would pass every case above.
+      const result = await lint(
+        `import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'\n` +
+          `export const propose = proposeSafeTx\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).toBe(0)
+      expect(result.output).not.toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'accepts the wrapper itself, which is the one file allowed to name it',
+    async () => {
+      const result = await lint(
+        `import { storeTransactionInMongoDB } from './safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        'script/deploy/safe/propose-safe-tx.ts'
+      )
+
+      expect(result.exitCode).toBe(0)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'leaves a mention in a comment alone',
+    async () => {
+      // Comments carry no identifier node. A text scan would refuse this.
+      const result = await lint(
+        `/** See storeTransactionInMongoDB for what the funnel ends in. */\n` +
+          `export const propose = 1\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).toBe(0)
+    },
+    TIMEOUT_MS
+  )
+})
+
+describe('the fence runs where it has to run', () => {
+  it(
+    'fires through the repo-wide config, so a commit cannot land one',
+    async () => {
+      // A path that exists: the repo-wide config resolves types from
+      // `tsconfig.eslint.json`, whose include is a filesystem glob, so a virtual
+      // filename with no file behind it fails to parse before any rule runs. The
+      // source below is what this migrated call site must never go back to.
+      const result = await lint(
+        `import { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        'script/tasks/proposeFraxChainIdMappings.ts',
+        true
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'is the command CI runs, and that command passes on this tree',
+    async () => {
+      const result = Bun.spawnSync(['bun', 'lint:funnel'], {
+        cwd: REPO_ROOT,
+        env: process.env as Record<string, string>,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        timeout: TIMEOUT_MS,
+      })
+
+      const output = `${result.stdout.toString()}${result.stderr.toString()}`
+      expect(result.exitCode).toBe(0)
+
+      const workflow = readFileSync(join(REPO_ROOT, WORKFLOW), 'utf8')
+      expect(workflow).toContain('run: bun lint:funnel')
+      // A job the fence's verdict can be skipped or downgraded through would report
+      // green without having judged anything.
+      expect(workflow).not.toContain('continue-on-error')
+      expect(workflow).not.toContain('paths:')
+      expect(workflow).not.toContain('outputs')
+      // Paired with the exit code above: a script that does not exist also exits
+      // non-zero, and one wired to something else would pass while judging nothing.
+      expect(output).toContain('.eslintrc.funnel-fence.cjs')
+    },
+    TIMEOUT_MS
+  )
+})

--- a/script/deploy/safe/propose-funnel-fence.test.ts
+++ b/script/deploy/safe/propose-funnel-fence.test.ts
@@ -158,6 +158,38 @@ describe('the funnel fence refuses a new propose route', () => {
   )
 })
 
+describe('the allowlist is only what it claims to be', () => {
+  it(
+    'refuses the owner-change script, which used to own its storage call',
+    async () => {
+      const result = await lint(
+        `import { storeTransactionInMongoDB } from './safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        'script/deploy/safe/add-safe-owners-and-threshold.ts'
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it('grants no exemption beyond the files named in the config', async () => {
+    const config = (await import(
+      join(REPO_ROOT, '.eslintrc.funnel-fence.cjs')
+    )) as { default: { overrides: { files: string[] }[] } }
+
+    expect(
+      config.default.overrides.flatMap((override) => override.files)
+    ).toEqual([
+      'script/deploy/safe/safe-utils.ts',
+      'script/deploy/safe/propose-safe-tx.ts',
+      'script/deploy/safe/safe-utils.test.ts',
+      'script/deploy/tron/propose-to-safe-tron.ts',
+    ])
+  })
+})
+
 describe('the funnel fence lets compliant code through', () => {
   it(
     'accepts a new call site that goes through the wrapper',

--- a/script/deploy/safe/propose-funnel-fence.test.ts
+++ b/script/deploy/safe/propose-funnel-fence.test.ts
@@ -10,8 +10,8 @@
  * through it.
  */
 
-import { readFileSync } from 'fs'
-import { join } from 'path'
+import { readdirSync, readFileSync } from 'fs'
+import { extname, join } from 'path'
 
 import {
   describe,
@@ -23,6 +23,9 @@ import {
 const REPO_ROOT = join(import.meta.dir, '..', '..', '..')
 const FENCE_CONFIG = './.eslintrc.funnel-fence.cjs'
 const WORKFLOW = '.github/workflows/enforceProposalFunnel.yml'
+
+/** Extensions ESLint can parse as a module, so any of them could carry a route. */
+const MODULE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs', '.cjs']
 
 /** The identifying fragment of the fence's message, not the whole paragraph. */
 const REFUSAL = 'Safe proposals are created through proposeSafeTx()'
@@ -50,6 +53,9 @@ const lint = async (
         '--no-eslintrc',
         '-c',
         FENCE_CONFIG,
+        // The flag CI runs with. Without it the cases below that carry an
+        // `eslint-disable` would pass while the fence had judged nothing.
+        '--no-inline-config',
         '--stdin',
         '--stdin-filename',
         virtualPath,
@@ -144,6 +150,69 @@ describe('the funnel fence refuses a new propose route', () => {
   )
 
   it(
+    'refuses an aliased import, which renames the funnel but not the reference',
+    async () => {
+      const result = await lint(
+        `import { storeTransactionInMongoDB as persist } from '../deploy/safe/safe-utils'\n` +
+          `export const propose = persist\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a dynamic import, which no import declaration carries',
+    async () => {
+      const result = await lint(
+        `export const propose = async () =>\n` +
+          `  (await import('../deploy/safe/safe-utils')).storeTransactionInMongoDB\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a file that disables the rule on itself',
+    async () => {
+      // An `eslint-disable` is the one rewrite people reach for by habit; the
+      // suites in this directory already carry one for another rule.
+      const result = await lint(
+        `/* eslint-disable no-restricted-syntax */\n` +
+          `import { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
+    'refuses a route written at a module extension the repo-wide globs miss',
+    async () => {
+      const result = await lint(
+        `import { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n` +
+          `export const propose = storeTransactionInMongoDB\n`,
+        'script/tasks/proposeSomethingNew.mjs'
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
     'refuses a re-export, so the name cannot be laundered through a third file',
     async () => {
       const result = await lint(
@@ -160,7 +229,7 @@ describe('the funnel fence refuses a new propose route', () => {
 
 describe('the allowlist is only what it claims to be', () => {
   it(
-    'refuses the owner-change script, which used to own its storage call',
+    'refuses the owner-change script, which the allowlist does not name',
     async () => {
       const result = await lint(
         `import { storeTransactionInMongoDB } from './safe-utils'\n` +
@@ -179,14 +248,22 @@ describe('the allowlist is only what it claims to be', () => {
       join(REPO_ROOT, '.eslintrc.funnel-fence.cjs')
     )) as { default: { overrides: { files: string[] }[] } }
 
-    expect(
-      config.default.overrides.flatMap((override) => override.files)
-    ).toEqual([
-      'script/deploy/safe/safe-utils.ts',
-      'script/deploy/safe/propose-safe-tx.ts',
-      'script/deploy/safe/safe-utils.test.ts',
-      'script/deploy/tron/propose-to-safe-tron.ts',
-    ])
+    const allowed = config.default.overrides.flatMap(
+      (override) => override.files
+    )
+
+    // Length and membership rather than a fixed order, so widening the
+    // allowlist still fails here while reordering or retiring an entry does not.
+    expect(allowed).toHaveLength(5)
+    expect(allowed.sort()).toEqual(
+      [
+        '.eslintrc.funnel-fence.cjs',
+        'script/deploy/safe/safe-utils.ts',
+        'script/deploy/safe/propose-safe-tx.ts',
+        'script/deploy/safe/safe-utils.test.ts',
+        'script/deploy/tron/propose-to-safe-tron.ts',
+      ].sort()
+    )
   })
 })
 
@@ -243,8 +320,7 @@ describe('the fence runs where it has to run', () => {
     async () => {
       // A path that exists: the repo-wide config resolves types from
       // `tsconfig.eslint.json`, whose include is a filesystem glob, so a virtual
-      // filename with no file behind it fails to parse before any rule runs. The
-      // source below is what this migrated call site must never go back to.
+      // filename with no file behind it fails to parse before any rule runs.
       const result = await lint(
         `import { storeTransactionInMongoDB } from '../deploy/safe/safe-utils'\n` +
           `export const propose = storeTransactionInMongoDB\n`,
@@ -285,4 +361,32 @@ describe('the fence runs where it has to run', () => {
     },
     TIMEOUT_MS
   )
+
+  it('sweeps every module extension a propose route could be written at', () => {
+    const script = (
+      JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+        scripts: Record<string, string>
+      }
+    ).scripts['lint:funnel']
+    if (!script) throw new Error('package.json declares no lint:funnel script')
+
+    // A directory sweep judges only the extensions it is given, and the flag is
+    // what the stdin cases above cannot prove about the traversal. Measured
+    // against what the tree actually holds — `.mjs` is in use today — rather
+    // than against a list written here.
+    const present = new Set<string>()
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) walk(join(dir, entry.name))
+        else if (MODULE_EXTENSIONS.includes(extname(entry.name)))
+          present.add(extname(entry.name))
+      }
+    }
+    walk(join(REPO_ROOT, 'script'))
+    expect(present.size).toBeGreaterThan(0)
+
+    const swept = (/--ext\s+(\S+)/.exec(script)?.[1] ?? '').split(',')
+    for (const ext of present) expect(swept).toContain(ext)
+    expect(script).toContain('--no-inline-config')
+  })
 })

--- a/script/deploy/safe/propose-funnel-fence.test.ts
+++ b/script/deploy/safe/propose-funnel-fence.test.ts
@@ -129,6 +129,21 @@ describe('the funnel fence refuses a new propose route', () => {
   )
 
   it(
+    'refuses a template-literal lookup, which is neither an identifier nor a string',
+    async () => {
+      const result = await lint(
+        `import * as safeUtils from '../deploy/safe/safe-utils'\n` +
+          'export const propose = safeUtils[`storeTransactionInMongoDB`]\n',
+        BYPASS_PATH
+      )
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.output).toContain(REFUSAL)
+    },
+    TIMEOUT_MS
+  )
+
+  it(
     'refuses a re-export, so the name cannot be laundered through a third file',
     async () => {
       const result = await lint(

--- a/script/deploy/safe/propose-safe-tx.test.ts
+++ b/script/deploy/safe/propose-safe-tx.test.ts
@@ -266,6 +266,29 @@ describe('proposeSafeTx — what reaches the store', () => {
     expect(stored[0]?.safeTx.data.nonce).toBe(9n)
   })
 
+  it('passes the drain annotations through to the stored proposal', async () => {
+    const { safe } = buildSafeStub([OWNER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+    const parkedTaskRefs = [
+      { taskKey: 'mainnet:0xabc', prUrl: 'https://github.com/o/r/pull/1' },
+    ]
+
+    await proposeSafeTx({
+      safe,
+      network: 'mainnet',
+      chainId: 1,
+      safeAddress: SAFE,
+      pendingTransactions: collection,
+      payload: callPayload,
+      parkedTaskRefs: parkedTaskRefs as never,
+      provenance: { ticket: 'EXSC-957', reason: 'drained removals' },
+    })
+
+    // The removals a proposal drains are only traceable to their origin PR
+    // through these, and the wrapper is the only thing carrying them now.
+    expect(stored[0]?.parkedTaskRefs).toEqual(parkedTaskRefs)
+  })
+
   it('signs a prebuilt transaction without rebuilding it', async () => {
     const { safe, calls } = buildSafeStub([OWNER], OWNER)
     const { collection, calls: stored } = buildStore(acknowledged)

--- a/script/deploy/safe/propose-safe-tx.test.ts
+++ b/script/deploy/safe/propose-safe-tx.test.ts
@@ -1,0 +1,311 @@
+/**
+ * What the blessed proposal seam does, and in what order.
+ *
+ * `propose-funnel-fence.test.ts` covers whether anything else can reach the
+ * storage function; this covers what happens once a caller comes through here.
+ *
+ * Every refusal case pairs its claim with a positive marker — a run that never
+ * reached the signature must not be indistinguishable from a run that refused
+ * before it.
+ */
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+import type { Collection, InsertOneResult } from 'mongodb'
+import type { Address, Hex } from 'viem'
+
+import { proposeSafeTx, type ProposalPayload } from './propose-safe-tx'
+import {
+  OperationTypeEnum,
+  type ISafeTransaction,
+  type ISafeTxDocument,
+  type SafeClient,
+} from './safe-utils'
+
+const OWNER = '0x1111111111111111111111111111111111111111' as Address
+const STRANGER = '0x2222222222222222222222222222222222222222' as Address
+const SAFE = '0x3333333333333333333333333333333333333333' as Address
+const TARGET = '0x4444444444444444444444444444444444444444' as Address
+const CALLDATA = '0xdeadbeef' as Hex
+const HASH = `0x${'ab'.repeat(32)}` as Hex
+
+async function expectRejects(
+  promise: Promise<unknown>,
+  match: RegExp | string
+): Promise<void> {
+  let error: Error | undefined
+  try {
+    await promise
+  } catch (caught) {
+    error = caught as Error
+  }
+  expect(error).toBeInstanceOf(Error)
+  if (match instanceof RegExp) expect(error?.message).toMatch(match)
+  else expect(error?.message).toContain(match)
+}
+
+interface ISafeStubCalls {
+  created: unknown[]
+  signed: ISafeTransaction[]
+  hashed: ISafeTransaction[]
+}
+
+interface IStoreCall {
+  safeTx: ISafeTransaction
+  safeTxHash: Hex
+  proposer: Address
+  network: string
+  chainId: number
+  safeAddress: Address
+  parkedTaskRefs: unknown
+  provenance: unknown
+}
+
+const buildSafeStub = (
+  owners: Address[],
+  signer: Address = OWNER
+): { safe: SafeClient; calls: ISafeStubCalls } => {
+  const calls: ISafeStubCalls = { created: [], signed: [], hashed: [] }
+  const safe = {
+    account: { address: signer },
+    getOwners: async (): Promise<Address[]> => owners,
+    createTransaction: async (options: unknown): Promise<ISafeTransaction> => {
+      calls.created.push(options)
+      const tx = options as {
+        transactions: {
+          to: Address
+          value: bigint
+          data: Hex
+          operation: OperationTypeEnum
+          nonce: bigint
+        }[]
+      }
+      const [first] = tx.transactions
+      if (!first)
+        throw new Error('createTransaction was called with no transaction')
+      return {
+        data: {
+          to: first.to,
+          value: first.value,
+          data: first.data,
+          operation: first.operation,
+          nonce: first.nonce,
+        },
+        signatures: new Map(),
+      }
+    },
+    signTransaction: async (
+      tx: ISafeTransaction
+    ): Promise<ISafeTransaction> => {
+      calls.signed.push(tx)
+      const signatures = new Map(tx.signatures)
+      signatures.set(signer.toLowerCase(), { signer, data: '0xsig' as Hex })
+      return { data: tx.data, signatures }
+    },
+    getTransactionHash: async (tx: ISafeTransaction): Promise<Hex> => {
+      calls.hashed.push(tx)
+      return HASH
+    },
+  }
+
+  // The stub carries the members `proposeSafeTx` reaches for; the cast is what
+  // lets the call sites below be typed as the real client rather than `any`.
+  return { safe: safe as unknown as SafeClient, calls }
+}
+
+/**
+ * Stands in for the proposal store. `insertResult` is what
+ * `storeTransactionInMongoDB` is made to return, so the wrapper's own reading of
+ * that result is what each case observes.
+ */
+const buildStore = (
+  insertResult: InsertOneResult<ISafeTxDocument> | null
+): { collection: Collection<ISafeTxDocument>; calls: IStoreCall[] } => {
+  const calls: IStoreCall[] = []
+  const collection = {
+    insertOne: async (doc: ISafeTxDocument) => {
+      calls.push({
+        safeTx: doc.safeTx,
+        safeTxHash: doc.safeTxHash as Hex,
+        proposer: doc.proposer as Address,
+        network: doc.network,
+        chainId: doc.chainId,
+        safeAddress: doc.safeAddress as Address,
+        parkedTaskRefs: (doc as { parkedTaskRefs?: unknown }).parkedTaskRefs,
+        provenance: (doc as { provenance?: unknown }).provenance,
+      })
+      if (insertResult === null) {
+        const duplicate = Object.assign(
+          new Error('E11000 duplicate key error'),
+          { code: 11000, keyPattern: { intentHash: 1 } }
+        )
+        throw duplicate
+      }
+      return insertResult
+    },
+    createIndex: async (): Promise<string> => 'stub',
+    findOne: async (): Promise<null> => null,
+  } as unknown as Collection<ISafeTxDocument>
+
+  return { collection, calls }
+}
+
+const acknowledged = {
+  acknowledged: true,
+  insertedId: 'id',
+} as unknown as InsertOneResult<ISafeTxDocument>
+
+const unacknowledged = {
+  acknowledged: false,
+  insertedId: 'id',
+} as unknown as InsertOneResult<ISafeTxDocument>
+
+const callPayload: ProposalPayload = {
+  kind: 'call',
+  to: TARGET,
+  data: CALLDATA,
+  nonce: 7n,
+}
+
+const run = async (
+  safe: SafeClient,
+  collection: Collection<ISafeTxDocument>,
+  payload: ProposalPayload = callPayload
+) =>
+  proposeSafeTx({
+    safe,
+    network: 'mainnet',
+    chainId: 1,
+    safeAddress: SAFE,
+    pendingTransactions: collection,
+    payload,
+    // Passed rather than set in the environment: the store hard-blocks a
+    // proposal without one, and a suite that leans on `SAFE_PROPOSAL_TICKET`
+    // would both depend on and disturb whatever else reads it.
+    provenance: { ticket: 'EXSC-957' },
+  })
+
+describe('proposeSafeTx — the signer must be a Safe owner', () => {
+  it('refuses a non-owner before it signs or stores anything', async () => {
+    const { safe, calls } = buildSafeStub([STRANGER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+
+    await expectRejects(
+      run(safe, collection),
+      `Signer ${OWNER} is not an owner of Safe ${SAFE} on mainnet`
+    )
+
+    // The refusal message alone would also be satisfied by a run that failed
+    // somewhere else and never reached the check.
+    expect(calls.signed).toHaveLength(0)
+    expect(stored).toHaveLength(0)
+  })
+
+  it('proposes for an owner, so the refusal above is not refusing everything', async () => {
+    const { safe, calls } = buildSafeStub([STRANGER, OWNER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+
+    expect(await run(safe, collection)).toEqual({
+      safeTxHash: HASH,
+      stored: true,
+    })
+    expect(calls.signed).toHaveLength(1)
+    expect(stored).toHaveLength(1)
+  })
+})
+
+describe('proposeSafeTx — what reaches the store', () => {
+  it('stores the signed transaction, the hash taken from it, and the signer as proposer', async () => {
+    const { safe, calls } = buildSafeStub([OWNER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+
+    await run(safe, collection)
+
+    // Hashed off the signed transaction, not the unsigned one: the stored hash
+    // and the stored signature have to describe the same bytes.
+    expect(calls.hashed).toHaveLength(1)
+    expect(calls.hashed[0]?.signatures.size).toBe(1)
+
+    const [row] = stored
+    if (!row) throw new Error('nothing reached the store')
+    expect(row.safeTxHash).toBe(HASH)
+    expect(row.proposer).toBe(OWNER)
+    expect(row.safeAddress).toBe(SAFE)
+    expect(row.chainId).toBe(1)
+    expect(row.safeTx.data).toEqual({
+      to: TARGET,
+      value: 0n,
+      data: CALLDATA,
+      operation: OperationTypeEnum.Call,
+      nonce: 7n,
+    })
+    expect(row.safeTx.signatures.size).toBe(1)
+  })
+
+  it('honours an explicit value and operation instead of defaulting them', async () => {
+    const { safe } = buildSafeStub([OWNER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+
+    await run(safe, collection, {
+      kind: 'call',
+      to: TARGET,
+      value: 5n,
+      data: CALLDATA,
+      operation: OperationTypeEnum.DelegateCall,
+      nonce: 9n,
+    })
+
+    expect(stored[0]?.safeTx.data.value).toBe(5n)
+    expect(stored[0]?.safeTx.data.operation).toBe(
+      OperationTypeEnum.DelegateCall
+    )
+    expect(stored[0]?.safeTx.data.nonce).toBe(9n)
+  })
+
+  it('signs a prebuilt transaction without rebuilding it', async () => {
+    const { safe, calls } = buildSafeStub([OWNER], OWNER)
+    const { collection, calls: stored } = buildStore(acknowledged)
+    const prebuilt: ISafeTransaction = {
+      data: {
+        to: TARGET,
+        value: 0n,
+        data: '0xfeed' as Hex,
+        operation: OperationTypeEnum.Call,
+        nonce: 42n,
+      },
+      signatures: new Map(),
+    }
+
+    await run(safe, collection, { kind: 'prebuilt', safeTx: prebuilt })
+
+    expect(calls.created).toHaveLength(0)
+    expect(calls.signed[0]?.data).toEqual(prebuilt.data)
+    expect(stored[0]?.safeTx.data.nonce).toBe(42n)
+  })
+})
+
+describe('proposeSafeTx — how the store outcome is reported', () => {
+  it('reports stored=false when a pending proposal with the same intent exists', async () => {
+    const { safe } = buildSafeStub([OWNER], OWNER)
+    const { collection } = buildStore(null)
+
+    expect(await run(safe, collection)).toEqual({
+      safeTxHash: HASH,
+      stored: false,
+    })
+  })
+
+  it('refuses an unacknowledged insert rather than reporting a proposal', async () => {
+    const { safe } = buildSafeStub([OWNER], OWNER)
+    const { collection } = buildStore(unacknowledged)
+
+    await expectRejects(
+      run(safe, collection),
+      'MongoDB insert was not acknowledged'
+    )
+  })
+})

--- a/script/deploy/safe/propose-safe-tx.ts
+++ b/script/deploy/safe/propose-safe-tx.ts
@@ -1,0 +1,129 @@
+/**
+ * The one entry point that turns a call into a stored Safe proposal.
+ *
+ * The checks that ride on storage — the mandatory Linear ticket, the resolved
+ * reason, the duplicate-intent refusal, the nonce-collision retry — are only as
+ * wide as the set of paths that reach it, and that set used to be a convention.
+ * This is the named seam instead: `.eslintrc.funnel-fence.cjs` refuses any other
+ * file that names `storeTransactionInMongoDB`, so a propose route added later
+ * either comes through here or fails lint.
+ *
+ * Checks that need more than the proposal — the production deploy gate, the
+ * proposal card — stay at their call sites; this seam is what makes the set of
+ * those call sites enumerable.
+ *
+ * `docs/MultisigSigningProcess.md` §4.2 records which paths reach it.
+ */
+
+import type { Collection } from 'mongodb'
+import type { Address, Hex } from 'viem'
+
+import {
+  OperationTypeEnum,
+  isAddressASafeOwner,
+  storeTransactionInMongoDB,
+  type IParkedTaskRef,
+  type IProposalProvenanceOptions,
+  type ISafeTransaction,
+  type ISafeTxDocument,
+  type SafeClient,
+} from './safe-utils'
+
+/**
+ * What to propose: a single call this builds, or a transaction the caller has
+ * already built (`createAddOwnerTx`, `createChangeThresholdTx`).
+ *
+ * The nonce belongs to the caller in both forms. Resolving it here would need a
+ * "trust the caller's value" branch for the loops that propose several
+ * transactions off one on-chain read, and that branch is indistinguishable from
+ * an unvalidated override.
+ */
+export type ProposalPayload =
+  | {
+      kind: 'call'
+      to: Address
+      value?: bigint
+      data: Hex
+      operation?: OperationTypeEnum
+      nonce: bigint
+    }
+  | { kind: 'prebuilt'; safeTx: ISafeTransaction }
+
+export interface IProposeSafeTxInput {
+  safe: SafeClient
+  network: string
+  chainId: number
+  safeAddress: Address
+  pendingTransactions: Collection<ISafeTxDocument>
+  payload: ProposalPayload
+  /** Origin-PR links when this proposal carries drained facet removals. */
+  parkedTaskRefs?: IParkedTaskRef[]
+  provenance?: IProposalProvenanceOptions
+}
+
+export interface IProposeSafeTxResult {
+  safeTxHash: Hex
+  /** `false` when a pending proposal with the same intent already existed. */
+  stored: boolean
+}
+
+/**
+ * Signs and stores one Safe proposal.
+ *
+ * @param input - the Safe client, its network identity, the proposal store, and
+ *   the transaction to propose
+ * @returns the proposal's Safe tx hash, and whether this call created the record
+ * @throws If the signer is not a Safe owner, or the store rejects the write.
+ */
+export const proposeSafeTx = async (
+  input: IProposeSafeTxInput
+): Promise<IProposeSafeTxResult> => {
+  const proposer = input.safe.account.address
+
+  // Before the signature: a proposal signed by a non-owner is still stored and
+  // still occupies a Safe nonce, and fails only at execution time.
+  const owners = await input.safe.getOwners()
+  if (!isAddressASafeOwner(owners, proposer))
+    throw new Error(
+      `Signer ${proposer} is not an owner of Safe ${input.safeAddress} on ${input.network}`
+    )
+
+  const safeTx =
+    input.payload.kind === 'prebuilt'
+      ? input.payload.safeTx
+      : await input.safe.createTransaction({
+          transactions: [
+            {
+              to: input.payload.to,
+              value: input.payload.value ?? 0n,
+              data: input.payload.data,
+              operation: input.payload.operation ?? OperationTypeEnum.Call,
+              nonce: input.payload.nonce,
+            },
+          ],
+        })
+
+  const signedTx = await input.safe.signTransaction(safeTx)
+  // Hashed off the signed transaction, so the stored hash and the stored
+  // signature can only ever describe the same bytes.
+  const safeTxHash = await input.safe.getTransactionHash(signedTx)
+
+  const result = await storeTransactionInMongoDB(
+    input.pendingTransactions,
+    input.safeAddress,
+    input.network,
+    input.chainId,
+    signedTx,
+    safeTxHash,
+    proposer,
+    input.parkedTaskRefs,
+    input.provenance
+  )
+
+  if (result === null) return { safeTxHash, stored: false }
+
+  if (!result.acknowledged)
+    throw new Error('MongoDB insert was not acknowledged')
+
+  return { safeTxHash, stored: true }
+}

--- a/script/deploy/safe/propose-safe-tx.ts
+++ b/script/deploy/safe/propose-safe-tx.ts
@@ -3,10 +3,9 @@
  *
  * The checks that ride on storage — the mandatory Linear ticket, the resolved
  * reason, the duplicate-intent refusal, the nonce-collision retry — are only as
- * wide as the set of paths that reach it, and that set used to be a convention.
- * This is the named seam instead: `.eslintrc.funnel-fence.cjs` refuses any other
- * file that names `storeTransactionInMongoDB`, so a propose route added later
- * either comes through here or fails lint.
+ * wide as the set of paths that reach it. `.eslintrc.funnel-fence.cjs` refuses
+ * any other file that names `storeTransactionInMongoDB`, so a propose route
+ * added later either comes through here or fails lint.
  *
  * Checks that need more than the proposal — the production deploy gate, the
  * proposal card — stay at their call sites; this seam is what makes the set of

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -47,15 +47,14 @@ import { readBooleanFlag, readValueFlag } from './cli-flags'
 import { proposeWithDrain, type ITimelockCall } from './drain-parked-tasks'
 import { resolveProposalIntent } from './proposal-intent'
 import { normalizeProposeCalls } from './propose-calls'
+import { proposeSafeTx } from './propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
   isAddressASafeOwner,
   parseAccountIndex,
-  storeTransactionInMongoDB,
   wrapWithTimelockSchedule,
   type IParkedTaskRef,
 } from './safe-utils'
@@ -276,22 +275,6 @@ export async function _runPropose(
       await safe.getNonce()
     )
 
-  // Create and sign the Safe transaction
-  const safeTransaction = await safe.createTransaction({
-    transactions: [
-      {
-        to: finalTo,
-        value: 0n,
-        data: finalCalldata,
-        operation: OperationTypeEnum.Call,
-        nonce: nextNonce,
-      },
-    ],
-  })
-
-  const signedTx = await safe.signTransaction(safeTransaction)
-  const safeTxHash = await safe.getTransactionHash(signedTx)
-
   consola.info('Signer Address', senderAddress)
   consola.info('Safe Address', safeAddress)
   consola.info('Network', chain.name)
@@ -304,29 +287,23 @@ export async function _runPropose(
     )
   }
 
-  // Store transaction in MongoDB using the utility function
+  let outcome: { safeTxHash: Hex; stored: boolean }
   try {
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
+    outcome = await proposeSafeTx({
+      safe,
+      network: options.network,
+      chainId: chain.id,
       safeAddress,
-      options.network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      senderAddress,
+      pendingTransactions,
+      payload: {
+        kind: 'call',
+        to: finalTo,
+        data: finalCalldata,
+        nonce: nextNonce,
+      },
       parkedTaskRefs,
-      { ticket: options.ticket, reason: options.reason }
-    )
-
-    if (result === null) {
-      consola.info('Proposal already exists - no new proposal created')
-      return { safeTxHash, stored: false }
-    }
-
-    if (!result.acknowledged)
-      throw new Error('MongoDB insert was not acknowledged')
-
-    consola.success('Transaction successfully stored in MongoDB')
+      provenance: { ticket: options.ticket, reason: options.reason },
+    })
   } catch (error) {
     consola.error('Failed to store transaction in MongoDB:', error)
     throw error
@@ -334,8 +311,14 @@ export async function _runPropose(
     await mongoClient.close()
   }
 
+  if (!outcome.stored) {
+    consola.info('Proposal already exists - no new proposal created')
+    return outcome
+  }
+
+  consola.success('Transaction successfully stored in MongoDB')
   consola.info('Transaction proposed')
-  return { safeTxHash, stored: true }
+  return outcome
 }
 
 /**

--- a/script/deploy/safe/propose-to-safe.ts
+++ b/script/deploy/safe/propose-to-safe.ts
@@ -305,7 +305,7 @@ export async function _runPropose(
       provenance: { ticket: options.ticket, reason: options.reason },
     })
   } catch (error) {
-    consola.error('Failed to store transaction in MongoDB:', error)
+    consola.error('Failed to propose the transaction to the Safe:', error)
     throw error
   } finally {
     await mongoClient.close()

--- a/script/safe/safeScriptHelpers.ts
+++ b/script/safe/safeScriptHelpers.ts
@@ -10,14 +10,12 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 import { EnvironmentEnum } from '../common/types'
 import { assertTicketPresent } from '../deploy/safe/proposal-intent'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   resolveSafeSigningOptions,
-  storeTransactionInMongoDB,
   type ISafeSigningOptions,
 } from '../deploy/safe/safe-utils'
 import {
@@ -117,10 +115,10 @@ export async function sendOrPropose({
   assertTicketPresent()
 
   // This helper shares a name with the bash `sendOrPropose` but not its route:
-  // it signs and stores here rather than through propose-to-safe.ts, so the
-  // gate that funnel runs has to be called explicitly or a caller reaching for
-  // this one to install a facet would bypass it. Today's only caller proposes
-  // removals, which carry no installing entry and cost nothing here.
+  // it does not go through propose-to-safe.ts, so the gate that funnel runs has
+  // to be called explicitly or a caller reaching for this one to install a facet
+  // would bypass it. Today's only caller proposes removals, which carry no
+  // installing entry and cost nothing here.
   await assertFunnelDeployGate(
     { network, calldatas: [calldata] },
     createFunnelGateDeps()
@@ -142,15 +140,6 @@ export async function sendOrPropose({
     ledgerOptions
   )
 
-  // A proposal signed by a non-owner is still stored and still occupies a Safe
-  // nonce, failing only at execution time, so check ownership before storing.
-  const signerAddress = safe.account.address
-  const owners = await safe.getOwners()
-  if (!isAddressASafeOwner(owners, signerAddress))
-    throw new Error(
-      `Cannot propose transactions: signer ${signerAddress} is not an owner of Safe ${safeAddress}`
-    )
-
   consola.info(`🔐 Proposing transaction to Safe ${safeAddress}`)
 
   const { client: mongoClient, pendingTransactions } =
@@ -166,49 +155,37 @@ export async function sendOrPropose({
     currentSafeNonce
   )
 
-  const safeTransaction = await safe.createTransaction({
-    transactions: [
-      {
+  try {
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: {
+        kind: 'call',
         to: diamondAddress as Address,
-        value: 0n,
         data: calldata,
-        operation: OperationTypeEnum.Call,
         nonce: nextNonce,
       },
-    ],
-  })
+    })
 
-  const signedTx = await safe.signTransaction(safeTransaction)
-  const safeTxHash = await safe.getTransactionHash(signedTx)
+    consola.info('📝 Safe Address:', safeAddress)
+    consola.info('🧾 Safe Tx Hash:', safeTxHash)
 
-  consola.info('📝 Safe Address:', safeAddress)
-  consola.info('🧾 Safe Tx Hash:', safeTxHash)
-
-  try {
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info('ℹ️ Proposal already exists - no new proposal created')
       await mongoClient.close()
       return
     }
 
-    if (!result.acknowledged)
-      throw new Error('MongoDB insert was not acknowledged')
-
     consola.success('✅ Safe transaction proposed and stored in MongoDB')
   } catch (err: any) {
-    consola.error('❌ Failed to store transaction in MongoDB:', err)
+    consola.error('❌ Failed to propose the transaction to the Safe:', err)
     await mongoClient.close()
-    throw new Error(`Failed to store transaction in MongoDB: ${err.message}`)
+    throw new Error(
+      `Failed to propose the transaction to the Safe: ${err.message}`
+    )
   }
 
   await mongoClient.close()

--- a/script/tasks/proposeAllBridgeChainIdMappings.ts
+++ b/script/tasks/proposeAllBridgeChainIdMappings.ts
@@ -35,15 +35,13 @@ import {
 } from 'viem'
 
 import { EnvironmentEnum } from '../common/types'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   pickTimelockSalt,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import { encodeTimelockScheduleBatch } from '../deploy/safe/timelock-abi'
 import {
@@ -286,13 +284,6 @@ async function proposeToSafe(params: {
       rpcUrl
     )
 
-    const owners = await safe.getOwners()
-    if (!isAddressASafeOwner(owners, safe.account.address)) {
-      throw new Error(
-        `Signer ${safe.account.address} is not an owner of Safe ${safeAddress} on ${network}`
-      )
-    }
-
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,
@@ -301,38 +292,19 @@ async function proposeToSafe(params: {
       await safe.getNonce()
     )
 
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to,
-          value: 0n,
-          data: calldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: { kind: 'call', to, data: calldata, nonce: nextNonce },
     })
 
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info(`[${network}] ℹ️ Proposal already exists - skipping insert`)
       return
     }
-
-    if (!result.acknowledged)
-      throw new Error(`[${network}] MongoDB insert was not acknowledged`)
 
     consola.success(`[${network}] ✅ Proposed Safe tx ${safeTxHash}`)
   } finally {

--- a/script/tasks/proposeDeBridgeDlnChainIdMappings.ts
+++ b/script/tasks/proposeDeBridgeDlnChainIdMappings.ts
@@ -195,7 +195,6 @@ async function proposeToSafe(params: {
       rpcUrl
     )
 
-    // Ensure signer is an owner (avoid creating proposals with non-owner key)
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,

--- a/script/tasks/proposeDeBridgeDlnChainIdMappings.ts
+++ b/script/tasks/proposeDeBridgeDlnChainIdMappings.ts
@@ -32,15 +32,13 @@ import {
 } from 'viem'
 
 import { EnvironmentEnum } from '../common/types'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   pickTimelockSalt,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import { encodeTimelockScheduleBatch } from '../deploy/safe/timelock-abi'
 import {
@@ -198,13 +196,6 @@ async function proposeToSafe(params: {
     )
 
     // Ensure signer is an owner (avoid creating proposals with non-owner key)
-    const owners = await safe.getOwners()
-    if (!isAddressASafeOwner(owners, safe.account.address)) {
-      throw new Error(
-        `Signer ${safe.account.address} is not an owner of Safe ${safeAddress} on ${network}`
-      )
-    }
-
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,
@@ -213,38 +204,19 @@ async function proposeToSafe(params: {
       await safe.getNonce()
     )
 
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to,
-          value: 0n,
-          data: calldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: { kind: 'call', to, data: calldata, nonce: nextNonce },
     })
 
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info(`[${network}] ℹ️ Proposal already exists - skipping insert`)
       return
     }
-
-    if (!result.acknowledged)
-      throw new Error(`[${network}] MongoDB insert was not acknowledged`)
 
     consola.success(`[${network}] ✅ Proposed Safe tx ${safeTxHash}`)
   } finally {

--- a/script/tasks/proposeFraxChainIdMappings.ts
+++ b/script/tasks/proposeFraxChainIdMappings.ts
@@ -37,15 +37,13 @@ import {
 } from 'viem'
 
 import { EnvironmentEnum } from '../common/types'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   pickTimelockSalt,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import { encodeTimelockScheduleBatch } from '../deploy/safe/timelock-abi'
 import {
@@ -240,12 +238,6 @@ async function proposeToSafe(params: {
       rpcUrl
     )
 
-    const owners = await safe.getOwners()
-    if (!isAddressASafeOwner(owners, safe.account.address))
-      throw new Error(
-        `Signer ${safe.account.address} is not an owner of Safe ${safeAddress} on ${network}`
-      )
-
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,
@@ -254,38 +246,19 @@ async function proposeToSafe(params: {
       await safe.getNonce()
     )
 
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to,
-          value: 0n,
-          data: calldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: { kind: 'call', to, data: calldata, nonce: nextNonce },
     })
 
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info(`[${network}] ℹ️ Proposal already exists - skipping insert`)
       return
     }
-
-    if (!result.acknowledged)
-      throw new Error(`[${network}] MongoDB insert was not acknowledged`)
 
     consola.success(
       `[${network}] ✅ Proposed Safe tx ${safeTxHash} (nonce ${nextNonce})`

--- a/script/tasks/proposeMegaETHBridgeRegistrations.ts
+++ b/script/tasks/proposeMegaETHBridgeRegistrations.ts
@@ -32,15 +32,13 @@ import {
 } from 'viem'
 
 import { EnvironmentEnum } from '../common/types'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   pickTimelockSalt,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import { encodeTimelockScheduleBatch } from '../deploy/safe/timelock-abi'
 import {
@@ -207,13 +205,6 @@ async function proposeToSafe(params: {
       rpcUrl
     )
 
-    const owners = await safe.getOwners()
-    if (!isAddressASafeOwner(owners, safe.account.address)) {
-      throw new Error(
-        `Signer ${safe.account.address} is not an owner of Safe ${safeAddress} on ${network}`
-      )
-    }
-
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,
@@ -222,38 +213,19 @@ async function proposeToSafe(params: {
       await safe.getNonce()
     )
 
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to,
-          value: 0n,
-          data: calldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: { kind: 'call', to, data: calldata, nonce: nextNonce },
     })
 
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info(`[${network}] ℹ️ Proposal already exists - skipping insert`)
       return
     }
-
-    if (!result.acknowledged)
-      throw new Error(`[${network}] MongoDB insert was not acknowledged`)
 
     consola.success(`[${network}] ✅ Proposed Safe tx ${safeTxHash}`)
   } finally {

--- a/script/tasks/proposePolymerCCTPChainIdMappings.ts
+++ b/script/tasks/proposePolymerCCTPChainIdMappings.ts
@@ -35,15 +35,13 @@ import {
 } from 'viem'
 
 import { EnvironmentEnum } from '../common/types'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
-  OperationTypeEnum,
   getNextNonce,
   getPrivateKey,
   getSafeMongoCollection,
   initializeSafeClient,
-  isAddressASafeOwner,
   pickTimelockSalt,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import { encodeTimelockScheduleBatch } from '../deploy/safe/timelock-abi'
 import {
@@ -283,13 +281,6 @@ async function proposeToSafe(params: {
       rpcUrl
     )
 
-    const owners = await safe.getOwners()
-    if (!isAddressASafeOwner(owners, safe.account.address)) {
-      throw new Error(
-        `Signer ${safe.account.address} is not an owner of Safe ${safeAddress} on ${network}`
-      )
-    }
-
     const nextNonce = await getNextNonce(
       pendingTransactions,
       safeAddress,
@@ -298,38 +289,19 @@ async function proposeToSafe(params: {
       await safe.getNonce()
     )
 
-    const safeTransaction = await safe.createTransaction({
-      transactions: [
-        {
-          to,
-          value: 0n,
-          data: calldata,
-          operation: OperationTypeEnum.Call,
-          nonce: nextNonce,
-        },
-      ],
+    const { safeTxHash, stored } = await proposeSafeTx({
+      safe,
+      network,
+      chainId: chain.id,
+      safeAddress,
+      pendingTransactions,
+      payload: { kind: 'call', to, data: calldata, nonce: nextNonce },
     })
 
-    const signedTx = await safe.signTransaction(safeTransaction)
-    const safeTxHash = await safe.getTransactionHash(signedTx)
-
-    const result = await storeTransactionInMongoDB(
-      pendingTransactions,
-      safeAddress,
-      network,
-      chain.id,
-      signedTx,
-      safeTxHash,
-      safe.account.address
-    )
-
-    if (result === null) {
+    if (!stored) {
       consola.info(`[${network}] ℹ️ Proposal already exists - skipping insert`)
       return
     }
-
-    if (!result.acknowledged)
-      throw new Error(`[${network}] MongoDB insert was not acknowledged`)
 
     consola.success(`[${network}] ✅ Proposed Safe tx ${safeTxHash}`)
   } finally {

--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -257,7 +257,7 @@ const main = defineCommand({
             }
           } catch (error) {
             consola.error(
-              `[${network.name}] Failed to store transaction in MongoDB: ${error}`
+              `[${network.name}] Failed to propose the transaction to the Safe: ${error}`
             )
             throw error
           }

--- a/script/tasks/unpauseAllDiamonds.ts
+++ b/script/tasks/unpauseAllDiamonds.ts
@@ -14,14 +14,13 @@ import { privateKeyToAccount } from 'viem/accounts'
 
 import { EnvironmentEnum, type SupportedChain } from '../common/types'
 import { assertTicketPresent } from '../deploy/safe/proposal-intent'
+import { proposeSafeTx } from '../deploy/safe/propose-safe-tx'
 import {
   getNextNonce,
   getPrivateKey,
   getSafeInfo,
   getSafeMongoCollection,
   initializeSafeClient,
-  OperationTypeEnum,
-  storeTransactionInMongoDB,
 } from '../deploy/safe/safe-utils'
 import {
   castEnv,
@@ -183,7 +182,6 @@ const main = defineCommand({
 
     // Pass 2: production mainnets — propose to Safe. Initialize Safe / Mongo only now.
     const privateKey = getPrivateKey('PRIVATE_KEY_PRODUCTION')
-    const senderAddress = privateKeyToAccount(`0x${privateKey}`).address
     const { client: mongoClient, pendingTransactions } =
       await getSafeMongoCollection()
 
@@ -232,44 +230,26 @@ const main = defineCommand({
             safeInfo.nonce
           )
 
-          // prepare SAFE transaction
-          const safeTransaction = await safe.createTransaction({
-            transactions: [
-              {
+          try {
+            const { stored } = await proposeSafeTx({
+              safe,
+              network: network.name,
+              chainId: chain.id,
+              safeAddress,
+              pendingTransactions,
+              payload: {
+                kind: 'call',
                 to: timelockAddress as Address,
-                value: 0n,
                 data: calldata,
-                operation: OperationTypeEnum.Call,
                 nonce: nextNonce,
               },
-            ],
-          })
+            })
 
-          // sign transaction with SAFE_SIGNER_PRIVATE_KEY
-          const signedTx = await safe.signTransaction(safeTransaction)
-          const safeTxHash = await safe.getTransactionHash(safeTransaction)
-
-          // Store transaction proposal in MongoDB
-          try {
-            const result = await storeTransactionInMongoDB(
-              pendingTransactions,
-              safeAddress,
-              network.name,
-              chain.id,
-              signedTx,
-              safeTxHash,
-              senderAddress
-            )
-
-            if (result === null) {
+            if (!stored)
               consola.info(
                 `[${network.name}] Proposal already exists - skipping`
               )
-            } else if (!result.acknowledged) {
-              throw new Error(
-                `[${network.name}] MongoDB insert was not acknowledged`
-              )
-            } else {
+            else {
               consola.info(
                 `[${network.name}] Transaction successfully stored in MongoDB`
               )


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-957](https://linear.app/lifi-linear/issue/EXSC-957) — WP-7.5 of
[EXSC-686](https://linear.app/lifi-linear/issue/EXSC-686) (Multisig Signing Process 2.0),
acceptance row A7.8. The docs half of R6.5 landed in #2126; this is the funnel half.
Residue tracked by [EXSC-984](https://linear.app/lifi-linear/issue/EXSC-984).

# Why did I implement it this way?

**One seam instead of nine.** `proposeSafeTx()` (`script/deploy/safe/propose-safe-tx.ts`) is
now the only thing that turns a call into a stored Safe proposal: it checks Safe ownership,
signs, hashes **the signed transaction**, and stores. Nine call sites move onto it —
`propose-to-safe.ts`, the TypeScript `sendOrPropose`, the five chain-id-mapping /
registration tasks, `unpauseAllDiamonds.ts` and `add-safe-owners-and-threshold.ts` — each of
which previously repeated the build/sign/hash/store sequence and its own reading of the
store's return value.

The seam is only worth having if the set of paths through it is closed, which is what the
fence is for. Before this, that set was a convention plus a grep.

**The fence is structural, not textual.** `.eslintrc.funnel-fence.cjs` is
`no-restricted-syntax` keyed on the AST — `Identifier[name='storeTransactionInMongoDB']`,
plus `Literal[value=…]` and `TemplateElement[value.cooked=…]` for a computed lookup. Not
`no-restricted-imports`: an import restriction sees only `import` / `export … from`, so a
namespace member access (`safeUtils.storeTransactionInMongoDB`), a re-export, an alias, a
dynamic import or a bracket lookup would reach the funnel unflagged. Not a text scan
either: a mention in a comment is not a call site, and a file scan cannot tell the two
apart. Every one of those shapes has a test (`propose-funnel-fence.test.ts`), including
the negatives — a comment mention and a compliant call site both pass.

Two shapes the first cut of the fence missed, both now closed and both tested by planting
a real file and running the CI command: a file-level `/* eslint-disable
no-restricted-syntax */`, which the standalone run now refuses because it passes
`--no-inline-config`; and a route written at any extension outside `.ts`/`.js`/`.tsx`,
which the directory sweep did not visit at all — `.mjs` is live in this tree
(`script/claude/install.mjs`), and the repo-wide lint globs miss it too, so such a file
was linted by nothing. `lint:funnel` now sweeps `.ts,.tsx,.mts,.cts,.js,.mjs,.cjs`, which
also makes the fence see its own config, so `.eslintrc.funnel-fence.cjs` joins the
allowlist as the file that names the funnel to build the rule. A test asserts the swept
extensions cover every module extension actually present under `script/`, measured off the
tree rather than off a list in the test.

**It is named by what may proceed.** The rule denies the name everywhere; a five-entry file
allowlist in `overrides` is the closed positive set, and a test asserts its length and
membership so it cannot be widened unnoticed. A propose route added next month is
refused by default, and making it lint-clean means editing the allowlist — a reviewable act
with a reason and a ticket attached, not an omission. The entries are exact paths, not globs.

**Only one route is still exempt.** `propose-to-safe-tron.ts` hand-rolls its own signature
instead of signing through a `SafeClient`, which is what the wrapper signs with, so it cannot
pass through it as written — [EXSC-984](https://linear.app/lifi-linear/issue/EXSC-984).
`add-safe-owners-and-threshold.ts` needed no exemption: `proposeSafeTx` takes a prebuilt
`safeTx` with a caller-owned nonce, which is exactly what `createAddOwnerTx` and
`createChangeThresholdTx` produce, so it is migrated here rather than grandfathered.

**Where it still fails open, stated plainly.** Two shapes are out of reach and both are noted
in the config: a name assembled by concatenation, which no static selector can see; and — the
one that matters — the fence covers the funnel's storage *function*, not a hand-rolled
`insertOne` into the `pendingTransactions` collection that never names it. Closing that needs
a type-aware rule; the read-only reporting scripts legitimately open the same collection by
name, so widening the fence to the collection name would refuse them and train people to grow
the allowlist — the exact erosion this rule exists to prevent.

**Three behaviour changes worth a reviewer's eye:**

- `unpauseAllDiamonds.ts` hashed the **unsigned** transaction
  (`getTransactionHash(safeTransaction)` where the signed value was `signedTx`). Going through
  the wrapper fixes that; the stored hash and the stored signature can now only describe the
  same bytes.
- The owner check in the TypeScript `sendOrPropose` moved from before the Mongo connection to
  inside the wrapper, so its refusal message is now the wrapper's. The connection is closed on
  that path.
- `add-safe-owners-and-threshold.ts` now pays one extra `getOwners()` per proposed transaction
  (the wrapper's own check, on top of the script's up-front one). It runs once per Safe;
  `propose-to-safe.ts` keeps its earlier check too, deliberately, because it fires before the
  drain claims any parked task.
- The TypeScript `sendOrPropose` and `add-safe-owners-and-threshold.ts` used to print the
  Safe tx hash immediately after signing, so it appeared even when storage then failed.
  Both now print it after `proposeSafeTx` returns, so a nonce collision or a rejected
  insert reports the error without the hash. Kept: the hash of a proposal that was never
  stored identifies nothing the error message does not, and reconstructing it at the call
  site would mean rebuilding the transaction outside the seam.

**A missing check is not a green one:** `.github/workflows/enforceProposalFunnel.yml` is
guarded by the `protect-critical-code` required check, which only evaluates on
`pull_request_review: submitted`. It will show as pending until someone reviews — that is
expected here, not a failure.

**Two gaps in the enforcement around the fence, neither of which this PR closes.** Both are
repo settings rather than code, so they are called out rather than changed here:

- `enforce-proposal-funnel` is **not** in the `main protection` ruleset's required checks,
  so a red fence does not block a merge today. The job has no path filter and no skip
  condition, so it is safe to require directly.
- `protect-critical-code` matches `^\.github/|^\.husky/pre-commit|^script/emergency/|…`,
  which does **not** match `.eslintrc.cjs`, `.eslintrc.funnel-fence.cjs` or `package.json`.
  The fence's rule, the `extends` line that wires it in, and the `lint:funnel` script can
  therefore each be weakened with one ordinary approval — the same "a reviewer might
  notice" state this PR replaces everywhere else. Adding `^\.eslintrc` to that regex
  mirrors the immutable-registry precedent (#2308), but it changes what needs ISM/CTO
  sign-off repo-wide, so it is a call for the reviewer rather than a drive-by edit here.

**Draft CI is not evidence.** `run-ts-tests` and `deploy-smoke-test` skip on drafts while
their `*-required` aggregators report green, so `ts-tests-required` passing in 3 s on the
draft did not run either new suite. `enforce-proposal-funnel` (~29 s) is the only guard
that actually executed before this PR left draft.

`docs/MultisigSigningProcess.md` §4.1, §4.2, §5 and §8 are updated: §4.2 said "there is **no
single chokepoint**" and pointed at a `grep -rn storeTransactionInMongoDB` for the route list,
both of which this PR makes false. `docs/DeferredDiamondCleanupQueue.md` facts 3 and §6 said
the storage function is called from ~9 sites rather than one wrapper — also now false.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: n/a — no Solidity in this PR
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted

