### PR TITLE
fix(test): withhold credentials from spawned children by setting, not deleting (EXSC-970)

### DIFF
--- a/script/deploy/safe/spawn-env.ts
+++ b/script/deploy/safe/spawn-env.ts
@@ -1,0 +1,32 @@
+/**
+ * The credential values handed to children spawned by the placement probes.
+ *
+ * Set rather than deleted: bun re-loads the repo `.env` inside the child for
+ * every name the passed environment leaves unset, so deleting a credential
+ * hands the real one back instead of withholding it.
+ *
+ * Malformed rather than merely wrong, so a child that reaches past the check
+ * under test dies before it can act: a key viem cannot parse throws where a
+ * valid-but-unfunded one would derive an address, and a URI the driver rejects
+ * on construction throws where an unreachable host would first spend its 30 s
+ * server-selection budget.
+ *
+ * The store URIs matter as much as the keys, because a key is not always the
+ * first credential a run reaches: `execute-pending-timelock-tx.ts` opens the
+ * timelock queue in its fleet prefetch before it reads any key.
+ */
+const MALFORMED_KEY = 'malformed-in-tests'
+const MALFORMED_STORE = 'malformed-in-tests://no-store'
+
+const SIGNING_KEYS = [
+  'PRIVATE_KEY',
+  'PRIVATE_KEY_PRODUCTION',
+  'SAFE_SIGNER_PRIVATE_KEY',
+] as const
+
+const PROPOSAL_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
+
+export const withholdCredentials = (env: Record<string, string>): void => {
+  for (const name of SIGNING_KEYS) env[name] = MALFORMED_KEY
+  for (const name of PROPOSAL_STORES) env[name] = MALFORMED_STORE
+}

--- a/script/deploy/safe/strict-flag-placement.test.ts
+++ b/script/deploy/safe/strict-flag-placement.test.ts
@@ -39,11 +39,24 @@ const REFUSAL = "accepts no value, 'true' or 'false'"
 const PROBE_NETWORK = 'zzplacementprobe'
 
 /**
- * Malformed on purpose, and set rather than deleted. Bun re-loads the repo
- * `.env` in the child for every name the passed environment leaves unset, so
- * deleting a credential hands the real one back instead of withholding it.
+ * Set rather than deleted: bun re-loads the repo `.env` in the child for every
+ * name the passed environment leaves unset, so deleting a credential hands the
+ * real one back instead of withholding it.
+ *
+ * Malformed rather than merely wrong, so a child that reached past the reader
+ * dies before it can act: a key viem cannot parse throws where a
+ * valid-but-unfunded one would derive an address, and a URI the driver rejects
+ * on construction throws where an unreachable host would first spend its 30 s
+ * server-selection budget.
  */
+const MALFORMED_KEYS = [
+  'PRIVATE_KEY',
+  'PRIVATE_KEY_PRODUCTION',
+  'SAFE_SIGNER_PRIVATE_KEY',
+] as const
 const MALFORMED_KEY = 'malformed-in-tests'
+const MALFORMED_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
+const MALFORMED_STORE = 'malformed-in-tests://no-store'
 
 /**
  * Some of these commands transitively import generated `typechain/` types, and
@@ -66,10 +79,11 @@ const run = (script: string, args: string[]): string => {
   }
   // `bun test` sets NODE_ENV=test; these children are exercised as CLIs.
   delete env.NODE_ENV
-  // These children include deploy-safe.ts and execute-pending-timelock-tx.ts, so
-  // a child that runs past the flag reader must not hold a usable key.
-  env.PRIVATE_KEY = MALFORMED_KEY
-  env.PRIVATE_KEY_PRODUCTION = MALFORMED_KEY
+  // The store URIs matter as much as the keys here: `execute-pending-timelock-tx.ts`
+  // opens the timelock queue in its fleet prefetch before it reads any key, so a
+  // malformed key alone would not keep a run past the reader off the real queue.
+  for (const name of MALFORMED_KEYS) env[name] = MALFORMED_KEY
+  for (const name of MALFORMED_STORES) env[name] = MALFORMED_STORE
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/safe/strict-flag-placement.test.ts
+++ b/script/deploy/safe/strict-flag-placement.test.ts
@@ -22,6 +22,8 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
+import { withholdCredentials } from './spawn-env'
+
 const REFUSAL = "accepts no value, 'true' or 'false'"
 
 /**
@@ -37,26 +39,6 @@ const REFUSAL = "accepts no value, 'true' or 'false'"
  * keys in this process does not take them away from it.
  */
 const PROBE_NETWORK = 'zzplacementprobe'
-
-/**
- * Set rather than deleted: bun re-loads the repo `.env` in the child for every
- * name the passed environment leaves unset, so deleting a credential hands the
- * real one back instead of withholding it.
- *
- * Malformed rather than merely wrong, so a child that reached past the reader
- * dies before it can act: a key viem cannot parse throws where a
- * valid-but-unfunded one would derive an address, and a URI the driver rejects
- * on construction throws where an unreachable host would first spend its 30 s
- * server-selection budget.
- */
-const MALFORMED_KEYS = [
-  'PRIVATE_KEY',
-  'PRIVATE_KEY_PRODUCTION',
-  'SAFE_SIGNER_PRIVATE_KEY',
-] as const
-const MALFORMED_KEY = 'malformed-in-tests'
-const MALFORMED_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
-const MALFORMED_STORE = 'malformed-in-tests://no-store'
 
 /**
  * Some of these commands transitively import generated `typechain/` types, and
@@ -79,11 +61,7 @@ const run = (script: string, args: string[]): string => {
   }
   // `bun test` sets NODE_ENV=test; these children are exercised as CLIs.
   delete env.NODE_ENV
-  // The store URIs matter as much as the keys here: `execute-pending-timelock-tx.ts`
-  // opens the timelock queue in its fleet prefetch before it reads any key, so a
-  // malformed key alone would not keep a run past the reader off the real queue.
-  for (const name of MALFORMED_KEYS) env[name] = MALFORMED_KEY
-  for (const name of MALFORMED_STORES) env[name] = MALFORMED_STORE
+  withholdCredentials(env)
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/safe/strict-flag-placement.test.ts
+++ b/script/deploy/safe/strict-flag-placement.test.ts
@@ -39,6 +39,13 @@ const REFUSAL = "accepts no value, 'true' or 'false'"
 const PROBE_NETWORK = 'zzplacementprobe'
 
 /**
+ * Malformed on purpose, and set rather than deleted. Bun re-loads the repo
+ * `.env` in the child for every name the passed environment leaves unset, so
+ * deleting a credential hands the real one back instead of withholding it.
+ */
+const MALFORMED_KEY = 'malformed-in-tests'
+
+/**
  * Some of these commands transitively import generated `typechain/` types, and
  * the CI job that runs this suite does not generate them, so the child dies at
  * module load before reaching the reader. Such a run cannot judge the placement
@@ -59,9 +66,10 @@ const run = (script: string, args: string[]): string => {
   }
   // `bun test` sets NODE_ENV=test; these children are exercised as CLIs.
   delete env.NODE_ENV
-  // Withheld so a child that runs past the reader cannot reach a signature.
-  delete env.PRIVATE_KEY
-  delete env.PRIVATE_KEY_PRODUCTION
+  // These children include deploy-safe.ts and execute-pending-timelock-tx.ts, so
+  // a child that runs past the flag reader must not hold a usable key.
+  env.PRIVATE_KEY = MALFORMED_KEY
+  env.PRIVATE_KEY_PRODUCTION = MALFORMED_KEY
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/safe/ticket-gate-placement.test.ts
+++ b/script/deploy/safe/ticket-gate-placement.test.ts
@@ -25,11 +25,24 @@ const REFUSAL = 'No Linear ticket supplied'
 const TIMEOUT_MS = 20_000
 
 /**
- * Malformed on purpose, and set rather than deleted. Bun re-loads the repo
- * `.env` in the child for every name the passed environment leaves unset, so
- * deleting a credential hands the real one back instead of withholding it.
+ * Set rather than deleted: bun re-loads the repo `.env` in the child for every
+ * name the passed environment leaves unset, so deleting a credential hands the
+ * real one back instead of withholding it.
+ *
+ * Malformed rather than merely wrong, so a child that reached past the gate
+ * dies before it can act: a key viem cannot parse throws where a
+ * valid-but-unfunded one would derive an address, and a URI the driver rejects
+ * on construction throws where an unreachable host would first spend its 30 s
+ * server-selection budget.
  */
+const MALFORMED_KEYS = [
+  'PRIVATE_KEY',
+  'PRIVATE_KEY_PRODUCTION',
+  'SAFE_SIGNER_PRIVATE_KEY',
+] as const
 const MALFORMED_KEY = 'malformed-in-tests'
+const MALFORMED_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
+const MALFORMED_STORE = 'malformed-in-tests://no-store'
 
 const run = (
   script: string,
@@ -46,10 +59,11 @@ const run = (
   // local value through process.env. Cleared, or a developer's own decides these.
   delete env.SAFE_PROPOSAL_TICKET
   if (ticket !== undefined) env.SAFE_PROPOSAL_TICKET = ticket
-  // One case below asserts a run is NOT refused, which means letting it go on
-  // to a branch that sends directly — with a real key that branch signs.
-  env.PRIVATE_KEY = MALFORMED_KEY
-  env.PRIVATE_KEY_PRODUCTION = MALFORMED_KEY
+  // One case below asserts a run is NOT refused, which means letting it go on to
+  // a branch that sends directly — with a real key that branch signs, and with a
+  // real store URI the pass after it proposes.
+  for (const name of MALFORMED_KEYS) env[name] = MALFORMED_KEY
+  for (const name of MALFORMED_STORES) env[name] = MALFORMED_STORE
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/safe/ticket-gate-placement.test.ts
+++ b/script/deploy/safe/ticket-gate-placement.test.ts
@@ -24,6 +24,13 @@ const REFUSAL = 'No Linear ticket supplied'
 /** 20 seconds: long enough to reach the gate, short enough that a run past it is cheap. */
 const TIMEOUT_MS = 20_000
 
+/**
+ * Malformed on purpose, and set rather than deleted. Bun re-loads the repo
+ * `.env` in the child for every name the passed environment leaves unset, so
+ * deleting a credential hands the real one back instead of withholding it.
+ */
+const MALFORMED_KEY = 'malformed-in-tests'
+
 const run = (
   script: string,
   args: string[],
@@ -39,11 +46,10 @@ const run = (
   // local value through process.env. Cleared, or a developer's own decides these.
   delete env.SAFE_PROPOSAL_TICKET
   if (ticket !== undefined) env.SAFE_PROPOSAL_TICKET = ticket
-  // Withheld so a child that runs past the gate cannot reach a signature. One
-  // case below asserts a run is NOT refused, which means letting it go on to a
-  // branch that sends directly.
-  delete env.PRIVATE_KEY
-  delete env.PRIVATE_KEY_PRODUCTION
+  // One case below asserts a run is NOT refused, which means letting it go on
+  // to a branch that sends directly — with a real key that branch signs.
+  env.PRIVATE_KEY = MALFORMED_KEY
+  env.PRIVATE_KEY_PRODUCTION = MALFORMED_KEY
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/safe/ticket-gate-placement.test.ts
+++ b/script/deploy/safe/ticket-gate-placement.test.ts
@@ -19,30 +19,12 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
+import { withholdCredentials } from './spawn-env'
+
 const REFUSAL = 'No Linear ticket supplied'
 
 /** 20 seconds: long enough to reach the gate, short enough that a run past it is cheap. */
 const TIMEOUT_MS = 20_000
-
-/**
- * Set rather than deleted: bun re-loads the repo `.env` in the child for every
- * name the passed environment leaves unset, so deleting a credential hands the
- * real one back instead of withholding it.
- *
- * Malformed rather than merely wrong, so a child that reached past the gate
- * dies before it can act: a key viem cannot parse throws where a
- * valid-but-unfunded one would derive an address, and a URI the driver rejects
- * on construction throws where an unreachable host would first spend its 30 s
- * server-selection budget.
- */
-const MALFORMED_KEYS = [
-  'PRIVATE_KEY',
-  'PRIVATE_KEY_PRODUCTION',
-  'SAFE_SIGNER_PRIVATE_KEY',
-] as const
-const MALFORMED_KEY = 'malformed-in-tests'
-const MALFORMED_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
-const MALFORMED_STORE = 'malformed-in-tests://no-store'
 
 const run = (
   script: string,
@@ -62,8 +44,7 @@ const run = (
   // One case below asserts a run is NOT refused, which means letting it go on to
   // a branch that sends directly — with a real key that branch signs, and with a
   // real store URI the pass after it proposes.
-  for (const name of MALFORMED_KEYS) env[name] = MALFORMED_KEY
-  for (const name of MALFORMED_STORES) env[name] = MALFORMED_STORE
+  withholdCredentials(env)
 
   const result = Bun.spawnSync(
     [process.execPath, join(import.meta.dir, '..', '..', script), ...args],

--- a/script/deploy/shared/funnel-deploy-gate.cli.test.ts
+++ b/script/deploy/shared/funnel-deploy-gate.cli.test.ts
@@ -182,6 +182,7 @@ const spawnCli = (options: {
   // key-absent message that a malformed value would replace.
   delete env.PRIVATE_KEY // spawn-env: child cwd has no .env
   delete env.PRIVATE_KEY_PRODUCTION // spawn-env: child cwd has no .env
+  delete env.SAFE_SIGNER_PRIVATE_KEY // spawn-env: child cwd has no .env
   // Deliberately malformed rather than merely unroutable: the driver spends its
   // 30 s server-selection budget on an unreachable host, where a URI it cannot
   // parse throws on construction, so a probe that gets past the gate dies at

--- a/script/deploy/shared/funnel-deploy-gate.cli.test.ts
+++ b/script/deploy/shared/funnel-deploy-gate.cli.test.ts
@@ -177,12 +177,9 @@ const spawnCli = (options: {
   // unroutable host rather than removed. An earlier version of this probe
   // inherited the real store and queued a proposal on a production Safe, which
   // takes a real nonce and blocks the queue behind it.
-  // Deleted rather than set to a malformed value, which is the opposite of what
-  // the sibling placement probes must do: those spawn with no `cwd`, so the
-  // child resolves the repo's own env file and a deleted name comes back at its
-  // real length. Here `cwd` is the mkdtempSync fixture repo, which has no env
-  // file to resolve, and four cases below assert the key-absent message that a
-  // malformed value would replace.
+  // Deleted, not set to a malformed value: `cwd` is the mkdtempSync fixture repo,
+  // which has no env file for bun to re-load, and four cases below assert the
+  // key-absent message that a malformed value would replace.
   delete env.PRIVATE_KEY // spawn-env: child cwd has no .env
   delete env.PRIVATE_KEY_PRODUCTION // spawn-env: child cwd has no .env
   // Deliberately malformed rather than merely unroutable: the driver spends its

--- a/script/deploy/shared/funnel-deploy-gate.cli.test.ts
+++ b/script/deploy/shared/funnel-deploy-gate.cli.test.ts
@@ -177,8 +177,14 @@ const spawnCli = (options: {
   // unroutable host rather than removed. An earlier version of this probe
   // inherited the real store and queued a proposal on a production Safe, which
   // takes a real nonce and blocks the queue behind it.
-  delete env.PRIVATE_KEY
-  delete env.PRIVATE_KEY_PRODUCTION
+  // Deleted rather than set to a malformed value, which is the opposite of what
+  // the sibling placement probes must do: those spawn with no `cwd`, so the
+  // child resolves the repo's own env file and a deleted name comes back at its
+  // real length. Here `cwd` is the mkdtempSync fixture repo, which has no env
+  // file to resolve, and four cases below assert the key-absent message that a
+  // malformed value would replace.
+  delete env.PRIVATE_KEY // spawn-env: child cwd has no .env
+  delete env.PRIVATE_KEY_PRODUCTION // spawn-env: child cwd has no .env
   // Deliberately malformed rather than merely unroutable: the driver spends its
   // 30 s server-selection budget on an unreachable host, where a URI it cannot
   // parse throws on construction, so a probe that gets past the gate dies at

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -97,24 +97,43 @@ const allShippedTests = (): string[] =>
 const shippedTests = (): string[] =>
   allShippedTests().filter((path) => path !== SELF)
 
+/** Blanks block comments, keeping line and column positions intact. */
+const blankBlockComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//gu, (block) => block.replace(/[^\n]/gu, ' '))
+
 /**
  * A line terminator between `delete` and its operand is legal grammar — the
  * spec puts no `[no LineTerminator here]` restriction there — so a per-line
  * scan would walk straight past `delete\n  env.PRIVATE_KEY`. Joining the
  * operand onto the keyword's line first also carries any trailing marker
- * comment with it, which keeps the exemption line-scoped.
+ * comment with it, which keeps the exemption attached to its own delete.
  */
 const joinDeleteOperands = (source: string): string =>
   source.replace(/\bdelete\s+/gu, 'delete ')
 
-/** Lines that delete a credential and do not carry the marker. */
-const unexemptedDeletions = (source: string): string[] =>
-  joinDeleteOperands(source)
+/**
+ * One entry per statement, not per line: a marker earns an exemption for the
+ * delete it sits beside, and `a; b` on one line is two deletes of which only
+ * the annotated one may pass.
+ */
+const statements = (source: string): string[] =>
+  joinDeleteOperands(blankBlockComments(source))
     .split('\n')
-    .filter(
-      (line) =>
-        DELETES_A_CREDENTIAL.test(line) && !line.includes(EXEMPTION_MARKER)
-    )
+    .flatMap((line) => line.split(';'))
+
+/**
+ * Statements that delete a credential and carry no marker.
+ *
+ * The marker is read before line comments are dropped, because the marker IS a
+ * line comment; the drop then keeps prose that merely mentions a deletion —
+ * a "never do this" example, say — from being reported as one.
+ */
+const unexemptedDeletions = (source: string): string[] =>
+  statements(source).filter(
+    (statement) =>
+      !statement.includes(EXEMPTION_MARKER) &&
+      DELETES_A_CREDENTIAL.test(statement.replace(/\/\/.*$/u, ''))
+  )
 
 describe('no shipped test deletes a credential from a child environment', () => {
   it('enumerates the tree, so a clean result is not vacuous', () => {
@@ -169,6 +188,27 @@ describe('no shipped test deletes a credential from a child environment', () => 
         ].join('\n')
       )
     ).toEqual(['  delete env.PRIVATE_KEY_PRODUCTION'])
+  })
+
+  it('judges two deletes sharing one line separately', () => {
+    // A marker sits at the end of the line, so a line-wide reading of it lets
+    // one justified delete carry an unjustified neighbour past the guard.
+    expect(
+      unexemptedDeletions(
+        `delete env.PRIVATE_KEY; delete env.MNEMONIC // ${EXEMPTION_MARKER} fixture cwd`
+      )
+    ).toEqual(['delete env.PRIVATE_KEY'])
+  })
+
+  it('does not report prose that merely mentions a deletion', () => {
+    // Both comment shapes, because this file's own guidance is written in them:
+    // describing the hazard must not be indistinguishable from committing it.
+    expect(
+      unexemptedDeletions('  // never write delete env.PRIVATE_KEY here\n')
+    ).toEqual([])
+    expect(
+      unexemptedDeletions('/**\n * Not this: delete env.MNEMONIC\n */\n')
+    ).toEqual([])
   })
 
   it('recognises each form the deletion is written in', () => {

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -68,8 +68,20 @@ const DELETES_A_CREDENTIAL = new RegExp(
  */
 const EXEMPTION_MARKER = 'spawn-env: child cwd has no .env'
 
-/** Tracked test files under the script tree — the ones that spawn CLIs. */
-const shippedTests = (): string[] =>
+/**
+ * This file, which holds the violation as test data below and would otherwise
+ * report itself. Excluded by exact path rather than by a pattern, so the
+ * exclusion cannot widen to cover a real offender — a test below pins it at
+ * exactly one file.
+ *
+ * Note it did not report itself until it was committed: `git ls-files` lists
+ * tracked files only, so the suite was green while the file was untracked and
+ * red immediately after the commit.
+ */
+const SELF = 'script/spawn-env-credentials.test.ts'
+
+/** Every tracked test file under the script tree — the ones that spawn CLIs. */
+const allShippedTests = (): string[] =>
   execFileSync('git', ['ls-files', 'script', 'tasks'], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
@@ -77,9 +89,22 @@ const shippedTests = (): string[] =>
     .split('\n')
     .filter((path) => path.endsWith('.test.ts'))
 
+const shippedTests = (): string[] =>
+  allShippedTests().filter((path) => path !== SELF)
+
+/**
+ * A line terminator between `delete` and its operand is legal grammar — the
+ * spec puts no `[no LineTerminator here]` restriction there — so a per-line
+ * scan would walk straight past `delete\n  env.PRIVATE_KEY`. Joining the
+ * operand onto the keyword's line first also carries any trailing marker
+ * comment with it, which keeps the exemption line-scoped.
+ */
+const joinDeleteOperands = (source: string): string =>
+  source.replace(/\bdelete\s+/gu, 'delete ')
+
 /** Lines that delete a credential and do not carry the marker. */
 const unexemptedDeletions = (source: string): string[] =>
-  source
+  joinDeleteOperands(source)
     .split('\n')
     .filter(
       (line) =>
@@ -99,6 +124,33 @@ describe('no shipped test deletes a credential from a child environment', () => 
     )
 
     expect(offenders).toEqual([])
+  })
+
+  it('excludes exactly one file, this one', () => {
+    // The self-exclusion is the guard's only blind spot, so it is pinned by
+    // count: a second entry could hide a real offender behind the same reason.
+    const all = allShippedTests()
+
+    expect(all).toContain(SELF)
+    expect(all.length - shippedTests().length).toBe(1)
+  })
+
+  it('sees a delete whose operand is on the next line', () => {
+    // Legal grammar: nothing in the spec forbids a line terminator between
+    // `delete` and its operand, so a per-line scan walks past this.
+    expect(unexemptedDeletions('  delete\n    env.PRIVATE_KEY\n')).toEqual([
+      '  delete env.PRIVATE_KEY',
+    ])
+  })
+
+  it('keeps the marker attached across that join', () => {
+    // The exemption must survive the newline it was written across, or the fix
+    // above turns every annotated delete back into an offender.
+    expect(
+      unexemptedDeletions(
+        `  delete\n    env.PRIVATE_KEY // ${EXEMPTION_MARKER}\n`
+      )
+    ).toEqual([])
   })
 
   it('counts the exemption as an exemption only on its own line', () => {

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Guards every shipped test against `delete`-ing a credential out of a child's
+ * environment, which does not withhold it.
+ *
+ * Bun re-loads the repo `.env` inside a spawned child for every name the passed
+ * environment leaves unset, so deleting a credential name hands the real value
+ * back. Measured rather than assumed: a child spawned with
+ * `PRIVATE_KEY_PRODUCTION` deleted reports it at its real 64-character length,
+ * and at 18 characters when the name is set to `malformed-in-tests` instead.
+ *
+ * This matters most in exactly the tests that look safest. The blast radius of
+ * a spawn test is the *failing* path, and mutation testing manufactures that
+ * path deliberately — so a probe whose only barrier is the refusal it is
+ * testing will, the moment that refusal is mutated away, run a real CLI with a
+ * real production key. Three files on `main` did this; `strict-flag-placement`
+ * spawns `deploy-safe.ts` and `execute-pending-timelock-tx.ts`.
+ *
+ * A source assertion rather than a behavioural one, because the behaviour it
+ * would have to observe is a child holding a live credential — which is the
+ * thing being prevented.
+ */
+import { execFileSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+// eslint-disable-next-line import/no-unresolved
+import { describe, expect, it } from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..')
+
+/**
+ * Names whose real value must never reach a spawned child. Every one of these
+ * is declared in the repo `.env`, which is what makes deleting them worse than
+ * useless.
+ */
+const CREDENTIAL_NAMES = [
+  'PRIVATE_KEY',
+  'PRIVATE_KEY_PRODUCTION',
+  'SAFE_SIGNER_PRIVATE_KEY',
+  'TIMELOCK_EXECUTOR_PRIVATE_KEY',
+  'MONGODB_URI',
+  'SC_MONGODB_URI',
+] as const
+
+/**
+ * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']` and
+ * `delete process.env.PRIVATE_KEY` for any of the names above, whatever the
+ * holder is called.
+ */
+const DELETES_A_CREDENTIAL = new RegExp(
+  `delete\\s+[A-Za-z_$][\\w$.]*(?:\\.(?:${CREDENTIAL_NAMES.join(
+    '|'
+  )})\\b|\\[['"\`](?:${CREDENTIAL_NAMES.join('|')})['"\`]\\])`,
+  'u'
+)
+
+/**
+ * The one legitimate reason to delete instead of set: the child's `cwd` is a
+ * fixture directory with no `.env`, so there is nothing for bun to re-load and
+ * the delete really does unset. `funnel-deploy-gate.cli.test.ts` is that case —
+ * it spawns into a `mkdtempSync` repo — and its assertions depend on the
+ * key-absent message, which a malformed value would replace.
+ *
+ * Annotated rather than inferred, because whether a spawn's `cwd` can reach a
+ * `.env` is not decidable from the call site: it depends on a value computed
+ * elsewhere. Writing the reason down puts the burden on whoever adds the next
+ * one.
+ */
+const EXEMPTION_MARKER = 'spawn-env: child cwd has no .env'
+
+/** Tracked test files under the script tree — the ones that spawn CLIs. */
+const shippedTests = (): string[] =>
+  execFileSync('git', ['ls-files', 'script', 'tasks'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter((path) => path.endsWith('.test.ts'))
+
+/** Lines that delete a credential and do not carry the marker. */
+const unexemptedDeletions = (source: string): string[] =>
+  source
+    .split('\n')
+    .filter(
+      (line) =>
+        DELETES_A_CREDENTIAL.test(line) && !line.includes(EXEMPTION_MARKER)
+    )
+
+describe('no shipped test deletes a credential from a child environment', () => {
+  it('enumerates the tree, so a clean result is not vacuous', () => {
+    expect(shippedTests().length).toBeGreaterThan(100)
+  })
+
+  it('finds no unexempted test deleting a credential name', () => {
+    const offenders = shippedTests().filter(
+      (path) =>
+        unexemptedDeletions(readFileSync(join(REPO_ROOT, path), 'utf8'))
+          .length > 0
+    )
+
+    expect(offenders).toEqual([])
+  })
+
+  it('counts the exemption as an exemption only on its own line', () => {
+    // Otherwise one annotated delete would license every other delete in the
+    // file, which is how an exemption list stops meaning anything.
+    expect(
+      unexemptedDeletions(
+        [
+          `  delete env.PRIVATE_KEY // ${EXEMPTION_MARKER}`,
+          '  delete env.PRIVATE_KEY_PRODUCTION',
+        ].join('\n')
+      )
+    ).toEqual(['  delete env.PRIVATE_KEY_PRODUCTION'])
+  })
+
+  it('recognises each form the deletion is written in', () => {
+    // The paired present: without this, a pattern that matched nothing at all
+    // would report the same clean result as a tree that is genuinely clean.
+    for (const source of [
+      'delete env.PRIVATE_KEY',
+      "delete env['PRIVATE_KEY_PRODUCTION']",
+      'delete process.env.SC_MONGODB_URI',
+      'delete childEnv.MONGODB_URI',
+    ])
+      expect(DELETES_A_CREDENTIAL.test(source), source).toBe(true)
+  })
+
+  it('does not object to setting one, or to deleting a non-credential', () => {
+    // Setting a malformed value is the fix, so it must not trip the guard, and
+    // an unset of NODE_ENV is legitimate — `.env` does not declare it, so
+    // deleting it really does unset it.
+    for (const source of [
+      "env.PRIVATE_KEY = 'malformed-in-tests'",
+      'delete env.NODE_ENV',
+      'delete env.SAFE_PROPOSAL_TICKET',
+      'delete env.ENVIRONMENT',
+    ])
+      expect(DELETES_A_CREDENTIAL.test(source), source).toBe(false)
+  })
+})

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -15,33 +15,47 @@
  * replacement depends on, without any real credential taking part.
  */
 import { execFileSync } from 'child_process'
-import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
 // eslint-disable-next-line import/no-unresolved
-import { describe, expect, it } from 'bun:test'
+import { afterAll, describe, expect, it } from 'bun:test'
 
 const REPO_ROOT = join(import.meta.dir, '..')
 
 /**
- * Any name holding a signing key or a store URI. Matched by substring rather
- * than enumerated because `.env` declares seventeen of them, well past the
- * handful any one probe neutralizes — the pauser, refund and withdraw wallets
- * and several retired deployer generations all sit in the same file, and an
- * enumeration would silently stop covering the next one added.
+ * Names holding a signing secret or a proposal-store URI. Matched by substring
+ * rather than enumerated because the wallet keys come in generations — pauser,
+ * refund and withdraw wallets sit alongside several retired deployer ones — so
+ * an enumeration would silently stop covering the next name added.
  *
- * `ENABLE_MONGODB_LOGGING` is the near miss this must not match, so the URI
- * half anchors on `MONGODB_URI` rather than on `MONGODB`.
+ * The keyed RPC endpoints, explorer and provider API keys and Slack webhooks
+ * are deliberately outside this: deleting one of those is often how a fallback
+ * gets tested, and matching them would put a marker on every such test to
+ * withhold something no signature depends on.
+ *
+ * The store half anchors on the full URI suffix rather than on the driver name
+ * alone, so the logging toggle that shares that prefix is not mistaken for a
+ * credential.
  */
-const CREDENTIAL_NAME = '[A-Z0-9_]*(?:PRIVATE_KEY|MONGODB_URI)[A-Z0-9_]*'
+const CREDENTIAL_NAME =
+  '[A-Z0-9_]*(?:PRIVATE_KEY|MNEMONIC|MONGODB_URI)[A-Z0-9_]*'
 
 /**
- * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']` and
- * `delete process.env.PRIVATE_KEY`, whatever the holder is called.
+ * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']`,
+ * `delete process.env.PRIVATE_KEY` and the optional-chained forms, whatever the
+ * holder is called.
+ *
+ * Only literal member access is visible here. A computed key
+ * (`delete env[name]`), a concatenated one, `Reflect.deleteProperty`, and
+ * dropping a name by rest-destructuring all withhold nothing in the same way
+ * and are all invisible to a source scan — deciding them needs a parser and a
+ * constant-folding pass. The hermetic spawn below is what covers the mechanism
+ * itself; this pattern only catches the spelling people actually reach for.
  */
 const DELETES_A_CREDENTIAL = new RegExp(
-  `delete\\s+[A-Za-z_$][\\w$.]*(?:\\.${CREDENTIAL_NAME}\\b|\\[['"\`]${CREDENTIAL_NAME}['"\`]\\])`,
+  `delete\\s+[A-Za-z_$][\\w$.?]*(?:\\.${CREDENTIAL_NAME}\\b|\\[['"\`]${CREDENTIAL_NAME}['"\`]\\])`,
   'u'
 )
 
@@ -170,6 +184,9 @@ describe('no shipped test deletes a credential from a child environment', () => 
       'delete env.PRIVATE_KEY_REFUND_WALLET',
       'delete env.PRIVATE_KEY_WITHDRAW_WALLET',
       'delete env.PRIVATE_KEY_PRODUCTION_OLD_V3',
+      'delete env.MNEMONIC',
+      'delete env?.PRIVATE_KEY',
+      "delete process.env?.['PRIVATE_KEY_PRODUCTION']",
     ])
       expect(DELETES_A_CREDENTIAL.test(source), source).toBe(true)
   })
@@ -208,6 +225,8 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
     `const v = process.env[${JSON.stringify(NAME)}]\n` +
       `console.log(v === undefined ? 'undefined' : String(v.length))\n`
   )
+
+  afterAll(() => rmSync(fixture, { force: true, recursive: true }))
 
   /** What the child reports the name's length to be, or `'undefined'`. */
   const lengthInChild = (

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -193,9 +193,9 @@ describe('no shipped test deletes a credential from a child environment', () => 
 
   it('does not object to setting one, or to deleting a non-credential', () => {
     // Setting a malformed value is the fix, so it must not trip the guard, and
-    // these unsets are legitimate — `.env` declares none of these names, so
-    // deleting them really does unset them. `ENABLE_MONGODB_LOGGING` is the
-    // near miss: it is declared, but holds a flag rather than a credential.
+    // these unsets are legitimate: none of these names holds a credential, so
+    // whatever a child re-loads for them cannot be one. `ENABLE_MONGODB_LOGGING`
+    // is the near miss the store half must not swallow.
     for (const source of [
       "env.PRIVATE_KEY = 'malformed-in-tests'",
       'delete env.NODE_ENV',
@@ -263,9 +263,9 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
   })
 
   it('lets a passed value win over that re-load', () => {
-    // What every `env.PRIVATE_KEY = MALFORMED_KEY` in the placement probes
-    // rests on. If bun ever gave the env file precedence, those probes would
-    // start handing children real keys again with every suite still green.
+    // What `withholdCredentials` rests on. If bun ever gave the env file
+    // precedence, the placement probes would start handing children real keys
+    // again with every suite still green.
     expect(lengthInChild((env) => (env[NAME] = PASSED_VALUE))).toBe(
       String(PASSED_VALUE.length)
     )

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -26,9 +26,9 @@ const REPO_ROOT = join(import.meta.dir, '..')
 
 /**
  * Any name holding a signing key or a store URI. Matched by substring rather
- * than enumerated because `.env` declares far more of them than the two the
- * placement probes reach for — the pauser, refund and withdraw wallets and
- * several retired deployer generations all sit in the same file, and an
+ * than enumerated because `.env` declares seventeen of them, well past the
+ * handful any one probe neutralizes — the pauser, refund and withdraw wallets
+ * and several retired deployer generations all sit in the same file, and an
  * enumeration would silently stop covering the next one added.
  *
  * `ENABLE_MONGODB_LOGGING` is the near miss this must not match, so the URI

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -4,23 +4,19 @@
  *
  * Bun re-loads the repo `.env` inside a spawned child for every name the passed
  * environment leaves unset, so deleting a credential name hands the real value
- * back. Measured rather than assumed: a child spawned with
- * `PRIVATE_KEY_PRODUCTION` deleted reports it at its real 64-character length,
- * and at 18 characters when the name is set to `malformed-in-tests` instead.
- *
- * This matters most in exactly the tests that look safest. The blast radius of
- * a spawn test is the *failing* path, and mutation testing manufactures that
- * path deliberately — so a probe whose only barrier is the refusal it is
+ * back. The blast radius is the *failing* path, which mutation testing
+ * manufactures deliberately: a probe whose only barrier is the refusal it is
  * testing will, the moment that refusal is mutated away, run a real CLI with a
- * real production key. Three files on `main` did this; `strict-flag-placement`
- * spawns `deploy-safe.ts` and `execute-pending-timelock-tx.ts`.
+ * real production key.
  *
- * A source assertion rather than a behavioural one, because the behaviour it
- * would have to observe is a child holding a live credential — which is the
- * thing being prevented.
+ * Two checks, because either alone is weak. A source assertion catches the
+ * spelling across the whole tree but cannot tell whether the replacement
+ * actually works; a spawn against a fixture `.env` pins the bun behaviour the
+ * replacement depends on, without any real credential taking part.
  */
 import { execFileSync } from 'child_process'
-import { readFileSync } from 'fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
 import { join } from 'path'
 
 // eslint-disable-next-line import/no-unresolved
@@ -29,58 +25,53 @@ import { describe, expect, it } from 'bun:test'
 const REPO_ROOT = join(import.meta.dir, '..')
 
 /**
- * Names whose real value must never reach a spawned child. Every one of these
- * is declared in the repo `.env`, which is what makes deleting them worse than
- * useless.
+ * Any name holding a signing key or a store URI. Matched by substring rather
+ * than enumerated because `.env` declares far more of them than the two the
+ * placement probes reach for — the pauser, refund and withdraw wallets and
+ * several retired deployer generations all sit in the same file, and an
+ * enumeration would silently stop covering the next one added.
+ *
+ * `ENABLE_MONGODB_LOGGING` is the near miss this must not match, so the URI
+ * half anchors on `MONGODB_URI` rather than on `MONGODB`.
  */
-const CREDENTIAL_NAMES = [
-  'PRIVATE_KEY',
-  'PRIVATE_KEY_PRODUCTION',
-  'SAFE_SIGNER_PRIVATE_KEY',
-  'TIMELOCK_EXECUTOR_PRIVATE_KEY',
-  'MONGODB_URI',
-  'SC_MONGODB_URI',
-] as const
+const CREDENTIAL_NAME = '[A-Z0-9_]*(?:PRIVATE_KEY|MONGODB_URI)[A-Z0-9_]*'
 
 /**
  * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']` and
- * `delete process.env.PRIVATE_KEY` for any of the names above, whatever the
- * holder is called.
+ * `delete process.env.PRIVATE_KEY`, whatever the holder is called.
  */
 const DELETES_A_CREDENTIAL = new RegExp(
-  `delete\\s+[A-Za-z_$][\\w$.]*(?:\\.(?:${CREDENTIAL_NAMES.join(
-    '|'
-  )})\\b|\\[['"\`](?:${CREDENTIAL_NAMES.join('|')})['"\`]\\])`,
+  `delete\\s+[A-Za-z_$][\\w$.]*(?:\\.${CREDENTIAL_NAME}\\b|\\[['"\`]${CREDENTIAL_NAME}['"\`]\\])`,
   'u'
 )
 
 /**
- * The one legitimate reason to delete instead of set: the child's `cwd` is a
- * fixture directory with no `.env`, so there is nothing for bun to re-load and
- * the delete really does unset. `funnel-deploy-gate.cli.test.ts` is that case —
- * it spawns into a `mkdtempSync` repo — and its assertions depend on the
- * key-absent message, which a malformed value would replace.
+ * Marks a delete whose reason is written down next to it. The reason is free
+ * text after the prefix, because there is more than one legitimate shape: a
+ * child spawned into a fixture directory with no `.env` has nothing to
+ * re-load, and an in-process test that needs the name genuinely unset is not
+ * spawning at all.
  *
  * Annotated rather than inferred, because whether a spawn's `cwd` can reach a
  * `.env` is not decidable from the call site: it depends on a value computed
  * elsewhere. Writing the reason down puts the burden on whoever adds the next
  * one.
  */
-const EXEMPTION_MARKER = 'spawn-env: child cwd has no .env'
+const EXEMPTION_MARKER = 'spawn-env:'
 
 /**
  * This file, which holds the violation as test data below and would otherwise
  * report itself. Excluded by exact path rather than by a pattern, so the
  * exclusion cannot widen to cover a real offender — a test below pins it at
  * exactly one file.
- *
- * Note it did not report itself until it was committed: `git ls-files` lists
- * tracked files only, so the suite was green while the file was untracked and
- * red immediately after the commit.
  */
 const SELF = 'script/spawn-env-credentials.test.ts'
 
-/** Every tracked test file under the script tree — the ones that spawn CLIs. */
+/**
+ * Every *tracked* test file under the script tree. Tracked, because
+ * `git ls-files` is what makes the guard land with the code it guards: a new
+ * offender is invisible here until it is staged, and red from then on.
+ */
 const allShippedTests = (): string[] =>
   execFileSync('git', ['ls-files', 'script', 'tasks'], {
     cwd: REPO_ROOT,
@@ -148,7 +139,7 @@ describe('no shipped test deletes a credential from a child environment', () => 
     // above turns every annotated delete back into an offender.
     expect(
       unexemptedDeletions(
-        `  delete\n    env.PRIVATE_KEY // ${EXEMPTION_MARKER}\n`
+        `  delete\n    env.PRIVATE_KEY // ${EXEMPTION_MARKER} fixture cwd\n`
       )
     ).toEqual([])
   })
@@ -159,7 +150,7 @@ describe('no shipped test deletes a credential from a child environment', () => 
     expect(
       unexemptedDeletions(
         [
-          `  delete env.PRIVATE_KEY // ${EXEMPTION_MARKER}`,
+          `  delete env.PRIVATE_KEY // ${EXEMPTION_MARKER} fixture cwd`,
           '  delete env.PRIVATE_KEY_PRODUCTION',
         ].join('\n')
       )
@@ -174,20 +165,90 @@ describe('no shipped test deletes a credential from a child environment', () => 
       "delete env['PRIVATE_KEY_PRODUCTION']",
       'delete process.env.SC_MONGODB_URI',
       'delete childEnv.MONGODB_URI',
+      'delete env.SAFE_SIGNER_PRIVATE_KEY',
+      'delete env.PRIVATE_KEY_PAUSER_WALLET',
+      'delete env.PRIVATE_KEY_REFUND_WALLET',
+      'delete env.PRIVATE_KEY_WITHDRAW_WALLET',
+      'delete env.PRIVATE_KEY_PRODUCTION_OLD_V3',
     ])
       expect(DELETES_A_CREDENTIAL.test(source), source).toBe(true)
   })
 
   it('does not object to setting one, or to deleting a non-credential', () => {
     // Setting a malformed value is the fix, so it must not trip the guard, and
-    // an unset of NODE_ENV is legitimate — `.env` does not declare it, so
-    // deleting it really does unset it.
+    // these unsets are legitimate — `.env` declares none of these names, so
+    // deleting them really does unset them. `ENABLE_MONGODB_LOGGING` is the
+    // near miss: it is declared, but holds a flag rather than a credential.
     for (const source of [
       "env.PRIVATE_KEY = 'malformed-in-tests'",
       'delete env.NODE_ENV',
       'delete env.SAFE_PROPOSAL_TICKET',
       'delete env.ENVIRONMENT',
+      'delete env.ENABLE_MONGODB_LOGGING',
     ])
       expect(DELETES_A_CREDENTIAL.test(source), source).toBe(false)
+  })
+})
+
+describe('setting a credential, unlike deleting it, withholds it from a child', () => {
+  /**
+   * Hermetic: a fixture directory holding its own env file and the child that
+   * reports back, so the behaviour is pinned without a real credential taking
+   * part. Lengths only, never values.
+   */
+  const NAME = 'PRIVATE_KEY_PRODUCTION'
+  const FIXTURE_VALUE = 'value-from-fixture-env'
+  const PASSED_VALUE = 'malformed-in-tests'
+
+  const fixture = mkdtempSync(join(tmpdir(), 'spawn-env-'))
+  writeFileSync(join(fixture, '.env'), `${NAME}=${FIXTURE_VALUE}\n`)
+  const child = join(fixture, 'report-length.ts')
+  writeFileSync(
+    child,
+    `const v = process.env[${JSON.stringify(NAME)}]\n` +
+      `console.log(v === undefined ? 'undefined' : String(v.length))\n`
+  )
+
+  /** What the child reports the name's length to be, or `'undefined'`. */
+  const lengthInChild = (
+    mutate: (env: Record<string, string>) => void
+  ): string => {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+    }
+    delete env.NODE_ENV
+    delete env[NAME] // spawn-env: what a delete leaves behind is the case under test
+    mutate(env)
+
+    const result = Bun.spawnSync([process.execPath, child], {
+      cwd: fixture,
+      env,
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 20_000,
+    })
+    if (result.signalCode)
+      throw new Error(
+        `child killed by ${result.signalCode}, so its output proves nothing`
+      )
+
+    return result.stdout.toString().trim()
+  }
+
+  it('re-loads a deleted name from the env file in cwd', () => {
+    // The defect itself. Without this half the assertion below would pass just
+    // as well on a bun that never re-loaded anything, and the whole fix would
+    // be guarding against nothing.
+    expect(lengthInChild(() => undefined)).toBe(String(FIXTURE_VALUE.length))
+  })
+
+  it('lets a passed value win over that re-load', () => {
+    // What every `env.PRIVATE_KEY = MALFORMED_KEY` in the placement probes
+    // rests on. If bun ever gave the env file precedence, those probes would
+    // start handing children real keys again with every suite still green.
+    expect(lengthInChild((env) => (env[NAME] = PASSED_VALUE))).toBe(
+      String(PASSED_VALUE.length)
+    )
   })
 })


### PR DESCRIPTION
# Which Linear task belongs to this PR?

- Fixes [EXSC-970](https://linear.app/lifi-linear/issue/EXSC-970) · Urgent

Follow-ups split out of review: [EXSC-987](https://linear.app/lifi-linear/issue/EXSC-987) (breach checks), [EXSC-988](https://linear.app/lifi-linear/issue/EXSC-988) (the credentials still inherited).

# Why did I implement it this way?

## The defect

Two spawn probes deleted `PRIVATE_KEY` and `PRIVATE_KEY_PRODUCTION` from the child environment. That does not withhold them. Both spawn with no `cwd`, so the child resolves this repo's own env file and re-loads every name the passed environment leaves unset.

Measured by length, never by value: a deleted `PRIVATE_KEY_PRODUCTION` arrives in the child at **64 characters**; set to `malformed-in-tests` it arrives at **18**. The comments above those lines claimed the keys were withheld — the opposite of what the code did.

This matters on the *failing* path, which is the one mutation testing manufactures deliberately. A probe whose only barrier is the refusal under test runs a real CLI with a real production key the moment that refusal is mutated away.

## Set, not deleted — and the stores too, not just the keys

`withholdCredentials` (`script/deploy/safe/spawn-env.ts`) sets the three signing keys and both proposal-store URIs to malformed values, shared by both probes so they cannot drift apart.

The store URIs are not decoration. `execute-pending-timelock-tx.ts` — spawned by `strict-flag-placement.test.ts` — opens the timelock queue in its fleet prefetch (`:255`) **before** it reads any key (`:859`), so on that path a malformed key never gets a say. Malformed rather than merely unroutable, so a run that got past the check dies at once: the driver rejects the URI on construction (verified: `MongoParseError`), where an unreachable host would first spend its 30 s server-selection budget.

## The file that keeps its deletes

`funnel-deploy-gate.cli.test.ts` spawns with `cwd` set to its `mkdtempSync` fixture repo, which has no env file to re-load, so there the delete genuinely unsets — and four of its cases assert the key-absent message a malformed value would replace. It keeps its deletes, annotated with a `spawn-env:` marker.

So the ticket's premise — three files, same defect — was wrong for one of them. Confirmed the hard way, by changing it and watching those four go red:

```text
Expected to contain: "in environment. Set it, or pass --ledger"
Received: "Failed to initialize Safe for mainnet: invalid private key, expected hex or 32 bytes, got string"
```

## The guard, and what it deliberately does not cover

`script/spawn-env-credentials.test.ts` enumerates every tracked `*.test.ts` under `script/` and `tasks/` and fails on an unmarked delete of a credential name. Names are matched by substring, because the env store declares seventeen wallet-key names — pauser, refund and withdraw wallets plus several retired deployer generations — and an enumeration had already missed eleven of them.

Explicitly **not** covered, and stated as such in the file: the keyed RPC endpoints, provider API keys and Slack webhook URLs. Deleting one of those is often the legitimate way to test a fallback, so widening the guard is a policy call about which unsets are real — [EXSC-988](https://linear.app/lifi-linear/issue/EXSC-988).

A source assertion alone would be weak, since it cannot tell whether the replacement works. So a second, hermetic check spawns a child against a fixture env file and asserts by length that a deleted name comes back and a passed one wins. No real credential takes part. Without it, nothing failed if bun ever stopped giving the passed value precedence — the single behaviour the whole fix rests on.

## Everything new was watched failing

| Reverted | Result |
| --- | --- |
| reintroduce the delete in `strict-flag-placement` | guard fails, naming that file |
| plant `delete env.PRIVATE_KEY_PAUSER_WALLET` | guard fails (the enumeration missed this name) |
| strip the marker from `funnel-deploy-gate.cli` | guard fails, naming that file |
| remove the fixture env file | "re-loads a deleted name" fails |
| stop the passed value winning | "lets a passed value win" fails |
| read lines instead of statements | two-deletes-on-one-line fails |
| drop comment handling | prose-is-not-a-deletion fails |
| narrow the holder pattern | optional-chained form fails |
| drop `MNEMONIC` | credential-forms fails |

Run against `origin/main`'s 134 test files, the guard flags exactly the three files the ticket named and nothing else.

## Not run, and why

**`ticket-gate-placement.test.ts` and `strict-flag-placement.test.ts` were not executed.** They spawn `deploy-safe.ts`, `deploy-safe-tron.ts` and `add-safe-owners-and-threshold.ts`, which must not be run, including from a test. For those two the evidence is `tsc-files` and `eslint` clean, the guard green, and a static argument that the change cannot move their assertions:

- every asserted string is printed upstream of both the key read and the store open — `add-safe-owners-and-threshold.ts:167` prints "Checking N network(s)" before `getPrivateKey` at `:207` and the store at `:222`; `unpauseAllDiamonds.ts:143` prints the staging line before the read at `:185` and the store at `:188`; `:110` prints "No matching active networks" earlier still
- a malformed URI cannot pre-empt those prints, because no module constructs a client at import time — every `new MongoClient` sits inside a function body (verified: importing `safe-utils.ts` with a malformed URI does not throw; construction throws only at the call site)

Their first real run is this PR going out of draft: `run-ts-tests` skips on drafts while `ts-tests-required` still reports green, so draft CI is not evidence for them.

## Deliberately deferred

No breach check on the child's output, unlike the shape in `a739bed3d` — which is worth noting is on the still-unmerged draft #2359, not on `main`. The check is three lines; proving it *fires* needs the suite to run, which is exactly what these two files cannot do. Landing an unproven check would break the rule that a new guard must be shown able to fire, so it is [EXSC-987](https://linear.app/lifi-linear/issue/EXSC-987) instead.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

