### PR TITLE
fix(security): redact RPC endpoints in script logs (EXSC-965)

### DIFF
--- a/.agents/rules/200-typescript.md
+++ b/.agents/rules/200-typescript.md
@@ -119,7 +119,7 @@ Add comments only where the code doesn't speak for itself. Avoid restating what 
 
 `ETH_NODE_URI_*` embeds the provider key in the URL, so a log line naming the endpoint writes a live credential into every transcript of every run. Log the network name, or pass the URL through `redactUrls()` from `script/utils/redactUrls.ts`.
 
-`script/utils/rpc-url-log-scan.test.ts` enforces this over `script/` and `tasks/`. It matches a fixed vocabulary of identifiers (`rpcUrl`, `fullHost`, `ETH_NODE_URI*`, …), so it narrows the class rather than closing it — an endpoint held in a differently-named variable is still yours to redact.
+A test enforces this for the identifiers and log calls it knows about. It does not close the class: an endpoint held in a differently-named variable, or one embedded by viem in an `error.message`, is still yours to redact — pass the error through `redactErrorReason()`. In bash, use `redactRpcUrl` from `helperFunctions.sh`; nothing checks bash automatically.
 
 ## Testing
 

--- a/.agents/rules/200-typescript.md
+++ b/.agents/rules/200-typescript.md
@@ -119,7 +119,7 @@ Add comments only where the code doesn't speak for itself. Avoid restating what 
 
 `ETH_NODE_URI_*` embeds the provider key in the URL, so a log line naming the endpoint writes a live credential into every transcript of every run. Log the network name, or pass the URL through `redactUrls()` from `script/utils/redactUrls.ts`.
 
-A test enforces this for the identifiers and log calls it knows about. It does not close the class: an endpoint held in a differently-named variable, or one embedded by viem in an `error.message`, is still yours to redact — pass the error through `redactErrorReason()`. In bash, use `redactRpcUrl` from `helperFunctions.sh`; nothing checks bash automatically.
+`script/utils/rpc-url-log-scan.test.ts` enforces this for the identifiers and log calls it knows about. It does not close the class, so two cases stay yours: an endpoint held in a differently-named variable, and one viem embeds in an `error.message` — log `redactUrls(err.stack ?? String(err))` rather than the error itself (`redactErrorReason()` is for Slack: it collapses whitespace and truncates at 180 chars). In bash use `redactRpcUrl` from `helperFunctions.sh`; nothing checks bash automatically.
 
 ## Testing
 

--- a/.agents/rules/200-typescript.md
+++ b/.agents/rules/200-typescript.md
@@ -115,6 +115,12 @@ Add comments only where the code doesn't speak for itself. Avoid restating what 
 
 - CLI: use `citty`; logging via `consola`; validate env via `getEnvVar()`; exit 0/1 appropriately.
 
+### Never log a full RPC URL ([CONV:REDACT-RPC-URL])
+
+`ETH_NODE_URI_*` embeds the provider key in the URL, so a log line naming the endpoint writes a live credential into every transcript of every run. Log the network name, or pass the URL through `redactUrls()` from `script/utils/redactUrls.ts`.
+
+`script/utils/rpc-url-log-scan.test.ts` enforces this over `script/` and `tasks/`. It matches a fixed vocabulary of identifiers (`rpcUrl`, `fullHost`, `ETH_NODE_URI*`, …), so it narrows the class rather than closing it — an endpoint held in a differently-named variable is still yours to redact.
+
 ## Testing
 
 - New TypeScript helpers must be covered by a colocated `*.test.ts` file using Bun (`describe` / `it` / `expect`) with **100% coverage**. Cover edge cases and error paths.

--- a/.agents/rules/200-typescript.md
+++ b/.agents/rules/200-typescript.md
@@ -119,7 +119,7 @@ Add comments only where the code doesn't speak for itself. Avoid restating what 
 
 `ETH_NODE_URI_*` embeds the provider key in the URL, so a log line naming the endpoint writes a live credential into every transcript of every run. Log the network name, or pass the URL through `redactUrls()` from `script/utils/redactUrls.ts`.
 
-`script/utils/rpc-url-log-scan.test.ts` enforces this for the identifiers and log calls it knows about. It does not close the class, so two cases stay yours: an endpoint held in a differently-named variable, and one viem embeds in an `error.message` — log `redactUrls(err.stack ?? String(err))` rather than the error itself (`redactErrorReason()` is for Slack: it collapses whitespace and truncates at 180 chars). In bash use `redactRpcUrl` from `helperFunctions.sh`; nothing checks bash automatically.
+`script/utils/rpc-url-log-scan.test.ts` enforces this for the identifiers and log calls it knows about. It does not close the class, so two cases stay yours: an endpoint held in a differently-named variable, and one viem embeds in an `error.message` — log `redactUrls(err.stack ?? String(err))` rather than the error itself (`redactErrorReason()` is for Slack: it collapses whitespace and truncates at 180 chars). In bash use `redactRpcUrl` from `helperFunctions.sh`, or `bgRedactUrl` inside `script/emergency/`, which must not depend on `helperFunctions.sh` loading. `script/redactRpcUrl.test.ts` pins the shared bash print paths, but there is no bash-wide scan: `getRPCUrl` returns the endpoint on stdout by design, so a naive one false-reds on the function whose job is to return it.
 
 ## Testing
 

--- a/.agents/rules/300-bash.md
+++ b/.agents/rules/300-bash.md
@@ -41,6 +41,14 @@ Reuse these instead of inline regex for selector/address checks:
 | `isValidTronAddress VALUE` | Returns 0 if Tron Base58 (T + 33 alphanumeric) |
 | `isZeroAddress VALUE` | Returns 0 if zero address (0x0...0) |
 
+### Never echo a full RPC URL
+
+`ETH_NODE_URI_*` embeds the provider key, and `cast`/`forge` put `--rpc-url` in their error
+text, so echoing captured output publishes a live credential. Pass it through `redactRpcUrl`
+from `helperFunctions.sh`, or `bgRedactUrl` inside `script/emergency/`, which must not depend
+on `helperFunctions.sh` loading. `getRPCUrl`'s own stdout return stays verbatim — callers
+consume it. Full rule: `[CONV:REDACT-RPC-URL]` in `200-typescript.md`.
+
 ### Contract Interaction Helpers
 
 **Preferred**: use `universalCast ACTION NETWORK [rest...]` so all cast-like operations go through one entry point. New networks are handled inside the underlying helpers and `universalCast` supports them automatically.

--- a/.github/workflows/ts-unit-tests.yml
+++ b/.github/workflows/ts-unit-tests.yml
@@ -52,6 +52,9 @@ jobs:
           filters: |
             ts:
               - 'script/**'
+              # the suite walks tasks/ too, so a leak added there would otherwise ship with
+              # ts-tests-required green on a skipped job
+              - 'tasks/**'
               # several suites assert against the committed config files, so a
               # config-only change can break them without touching script/**
               - 'config/**'

--- a/.github/workflows/ts-unit-tests.yml
+++ b/.github/workflows/ts-unit-tests.yml
@@ -1,7 +1,8 @@
 # Run TypeScript Unit Tests
 # - Runs the TypeScript/Bun test suite (`bun test:ts` → every `script/**/*.test.ts`).
 # - Path-gated: the test job runs only when files that can affect the outcome change
-#   (`script/**`, `package.json`, `bun.lock`, `tsconfig*.json`, this workflow).
+#   (`script/**`, `tasks/**`, `config/**`, `package.json`, `bun.lock`, `tsconfig*.json`,
+#   this workflow).
 # - A `ts-tests-required` aggregator job always reports a final status so this workflow
 #   can remain a required check on `main` branch protection even when the test job is
 #   skipped (same pattern as `forge-unit-tests.yml`, see `.agents/rules/500-github-actions.md`).

--- a/script/deploy/deployAndStoreCREATE3Factory.sh
+++ b/script/deploy/deployAndStoreCREATE3Factory.sh
@@ -114,7 +114,7 @@ deployAndStoreCREATE3Factory() {
 
   if [[ -z "$FACTORY_ADDRESS" || "$FACTORY_ADDRESS" == "null" ]]; then
     if [[ -n "${STDERR_CONTENT:-}" ]]; then
-      error "❌ Deployment failed on $NETWORK. Last stderr: ${STDERR_CONTENT:0:500}"
+      error "❌ Deployment failed on $NETWORK. Last stderr: $(redactRpcUrl "${STDERR_CONTENT:0:500}")"
     else
       error "Failed to obtain CREATE3Factory address on $NETWORK ($ENVIRONMENT)"
     fi

--- a/script/deploy/deployAndStoreCREATE3Factory.sh
+++ b/script/deploy/deployAndStoreCREATE3Factory.sh
@@ -89,7 +89,7 @@ deployAndStoreCREATE3Factory() {
       fi
       local TX_OUTPUT
       TX_OUTPUT=$(cast send --rpc-url "$RPC_URL" --private-key "$PRIVATE_KEY" --legacy --create "$BYTECODE" --json 2>&1) || {
-        error "cast send failed: $TX_OUTPUT"
+        error "cast send failed: $(redactRpcUrl "$TX_OUTPUT")"
         return 1
       }
       # cast may print log lines before the JSON; use last line or first {...} for jq

--- a/script/deploy/deployRegistrationPropagation.test.ts
+++ b/script/deploy/deployRegistrationPropagation.test.ts
@@ -183,7 +183,7 @@ describe('deployToNetworkWorker result file', () => {
   // repo-root check and would run the whole deploy), then drives it with a stubbed
   // deployAndAddContractToDiamond.
   const harness = `
-    eval "$(sed -n '/^function deployToNetworkWorker()/,/^}/p' "$REPO_ROOT/script/deploy/deployContractToNetworks.sh")"
+    source <(sed -n '/^function deployToNetworkWorker()/,/^}/p' "$REPO_ROOT/script/deploy/deployContractToNetworks.sh")
     ${STUB_PRELUDE}
     success() { echo "[success] $*"; }
     checkRequiredVariablesInDotEnv() { return 0; }

--- a/script/deploy/detect-evm-version.ts
+++ b/script/deploy/detect-evm-version.ts
@@ -110,8 +110,8 @@ const main = defineCommand({
         err.message?.includes('execution reverted')
       )
         consola.warn('PUSH0 caused invalid opcode — not supported')
-      // viem puts the full endpoint in `error.message`, so the raw error leaks the same URL
-      // the line above redacts.
+      // viem puts the full endpoint in `error.message`, so logging the raw error would publish
+      // the keyed URL this file redacts when it reports the connection.
       else
         consola.error(
           'Unexpected error testing PUSH0:',

--- a/script/deploy/detect-evm-version.ts
+++ b/script/deploy/detect-evm-version.ts
@@ -3,6 +3,7 @@ import { consola } from 'consola'
 import { createPublicClient, createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
+import { redactUrls } from '../utils/redactUrls'
 import { getViemChainForNetworkName } from '../utils/viemScriptHelpers'
 
 import { getPrivateKey } from './safe/safe-utils'
@@ -51,7 +52,11 @@ const main = defineCommand({
       transport: http(chain.rpcUrls.default.http[0]),
     })
 
-    consola.info(`Connected to ${network} via ${chain.rpcUrls.default.http[0]}`)
+    consola.info(
+      `Connected to ${network} via ${redactUrls(
+        chain.rpcUrls.default.http[0] ?? ''
+      )}`
+    )
     const block = await publicClient.getBlock()
 
     consola.info(`Latest block: ${block.number}`)

--- a/script/deploy/detect-evm-version.ts
+++ b/script/deploy/detect-evm-version.ts
@@ -110,7 +110,13 @@ const main = defineCommand({
         err.message?.includes('execution reverted')
       )
         consola.warn('PUSH0 caused invalid opcode — not supported')
-      else consola.error('Unexpected error testing PUSH0:', err)
+      // viem puts the full endpoint in `error.message`, so the raw error leaks the same URL
+      // the line above redacts.
+      else
+        consola.error(
+          'Unexpected error testing PUSH0:',
+          redactUrls(err?.stack ?? String(err))
+        )
     }
 
     // Adjust inferred version if PUSH0 failed

--- a/script/deploy/tron/deploy-core-facets.ts
+++ b/script/deploy/tron/deploy-core-facets.ts
@@ -15,6 +15,7 @@ import { consola } from 'consola'
 import type { IDeploymentResult, SupportedChain } from '../../common/types'
 import { EnvironmentEnum } from '../../common/types'
 import { getPrivateKeyForEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import { redactUrls } from '../../utils/redactUrls'
 import {
   getEnvVar,
   saveDiamondDeployment,
@@ -75,7 +76,7 @@ async function deployCoreFacetsImpl(options: {
   // Get RPC URL and API key configuration (automatically handles TronGrid API key)
   const { rpcUrl, headers } = getTronRPCConfig(networkName, options.verbose)
 
-  consola.info(`RPC URL: ${rpcUrl}`)
+  consola.info(`RPC URL: ${redactUrls(rpcUrl)}`)
 
   // Get the correct private key based on environment
   let privateKey: string

--- a/script/deploy/tron/register-facets-to-diamond.ts
+++ b/script/deploy/tron/register-facets-to-diamond.ts
@@ -15,6 +15,7 @@ import { consola } from 'consola'
 
 import { EnvironmentEnum, type SupportedChain } from '../../common/types'
 import { getPrivateKeyForEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import { redactUrls } from '../../utils/redactUrls'
 import { getEnvironment, updateDiamondJsonBatch } from '../../utils/utils'
 import { flagIsOn } from '../safe/cli-flags'
 
@@ -360,7 +361,7 @@ async function registerFacetsToDiamond(
       privateKey,
     })
 
-    consola.info(` Connected to: ${fullHost}`)
+    consola.info(` Connected to: ${redactUrls(fullHost)}`)
     consola.info(`👛 Deployer: ${tronWeb.defaultAddress.base58}`)
 
     // 3. Get LiFiDiamond contract

--- a/script/deploy/tron/transfer-ownership-to-timelock.ts
+++ b/script/deploy/tron/transfer-ownership-to-timelock.ts
@@ -13,6 +13,7 @@ import { consola } from 'consola'
 
 import { EnvironmentEnum } from '../../common/types'
 import { getPrivateKeyForEnvironment } from '../../demoScripts/utils/demoScriptHelpers'
+import { redactUrls } from '../../utils/redactUrls'
 import { getEnvVar, getEnvironment } from '../../utils/utils'
 import { flagIsOn, readOptOutFlag } from '../safe/cli-flags'
 
@@ -109,7 +110,7 @@ async function transferOwnershipToTimelock(options: {
       consola.info('   Using provided current owner private key')
 
     consola.info(`   Deployments file: deployments/${deploymentFileName}`)
-    consola.info(` Connected to: ${fullHost}`)
+    consola.info(` Connected to: ${redactUrls(fullHost)}`)
     consola.info(`👛 Current owner (signer): ${tronWeb.defaultAddress.base58}`)
     consola.info(`🔷 LiFiDiamond: ${diamondAddress}`)
     const timelockBase58 = formatAddressForNetworkCliDisplay(

--- a/script/emergency/emergencyPauseBreakGlass.sh
+++ b/script/emergency/emergencyPauseBreakGlass.sh
@@ -75,6 +75,13 @@ NETWORK="${NETWORK:-all}"
 # Vendored logging (no external dependency)
 # --------------------------------------------------------------------------------------------
 
+# `cast` puts the full --rpc-url in its error text, and ETH_NODE_URI_* carries the provider key,
+# so an RPC error echoed from here would publish a live credential. Defined locally rather than
+# pulled from helperFunctions.sh: this script is break-glass and must not depend on that loading.
+bgRedactUrl() {
+  printf '%s' "${1:-}" | sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]+#[redacted-url]#g'
+}
+
 function bgError() { printf '\033[31m[error] %s\033[0m\n' "$1"; }
 function bgWarning() { printf '\033[33m[warning] %s\033[0m\n' "$1"; }
 function bgSuccess() { printf '\033[0;32m[success] %s\033[0m\n' "$1"; }
@@ -190,7 +197,7 @@ function rpcCallWithRetry() {
       return 0
     fi
     if [ "$ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
-      echo "[retry] $LABEL attempt $ATTEMPT failed ($(< "$ERR_FILE")), sleeping ${RPC_RETRY_SLEEP_SECONDS}s..." >&2
+      echo "[retry] $LABEL attempt $ATTEMPT failed ($(bgRedactUrl "$(< "$ERR_FILE")")), sleeping ${RPC_RETRY_SLEEP_SECONDS}s..." >&2
       sleep "$RPC_RETRY_SLEEP_SECONDS"
     fi
     ATTEMPT=$((ATTEMPT + 1))
@@ -349,7 +356,7 @@ function handleNetwork() {
     echo "[network: $NETWORK] The diamond is not yet paused. Proceeding..."
   else
     # Fail closed: pause state undetermined after retries — do NOT pause blindly.
-    bgError "[network: $NETWORK] RPC/network error while checking pause state after $RPC_MAX_ATTEMPTS attempts: $PRE_PAUSE_RESPONSE"
+    bgError "[network: $NETWORK] RPC/network error while checking pause state after $RPC_MAX_ATTEMPTS attempts: $(bgRedactUrl "$PRE_PAUSE_RESPONSE")"
     echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
     return 1
   fi

--- a/script/emergency/emergencyPauseBreakGlass.sh
+++ b/script/emergency/emergencyPauseBreakGlass.sh
@@ -450,7 +450,7 @@ function handleNetwork() {
     FINAL_ATTEMPT=$((FINAL_ATTEMPT + 1))
   done
 
-  bgError "[network: $NETWORK] final pause check failed after $RPC_MAX_ATTEMPTS attempts - please check diamond ($DIAMOND_ADDRESS) manually (last response: $FINAL_RESPONSE)"
+  bgError "[network: $NETWORK] final pause check failed after $RPC_MAX_ATTEMPTS attempts - please check diamond ($DIAMOND_ADDRESS) manually (last response: $(bgRedactUrl "$FINAL_RESPONSE"))"
   echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< end network $NETWORK <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
   return 1
 }
@@ -491,7 +491,7 @@ function printStatus() {
   elif [[ "$RESPONSE" =~ ^0x[0-9a-fA-F]{40}$ ]] || [[ "$RESPONSE" == T* ]]; then
     bgError "[network: $NETWORK] diamond NOT paused."
   else
-    bgError "[network: $NETWORK] RPC/network error while checking pause state: $RESPONSE"
+    bgError "[network: $NETWORK] RPC/network error while checking pause state: $(bgRedactUrl "$RESPONSE")"
   fi
 }
 

--- a/script/emergency/emergencyPauseBreakGlass.sh
+++ b/script/emergency/emergencyPauseBreakGlass.sh
@@ -205,7 +205,9 @@ function rpcCallWithRetry() {
   local LAST_ERR
   LAST_ERR=$(< "$ERR_FILE")
   rm -f "$ERR_FILE"
-  printf "%s" "${LAST_ERR:-$OUT}"
+  # Redacted at the single return rather than at each caller: every one of them echoes this
+  # string, and `cast` puts the full --rpc-url in its error text.
+  printf "%s" "$(bgRedactUrl "${LAST_ERR:-$OUT}")"
   return 1
 }
 

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -1203,7 +1203,7 @@ function saveDiamondPeriphery() {
   echoDebug "ENVIRONMENT=$ENVIRONMENT"
   echoDebug "USE_MUTABLE_DIAMOND=$USE_MUTABLE_DIAMOND"
   echoDebug "FILE_SUFFIX=$FILE_SUFFIX"
-  echoDebug "RPC_URL=$RPC_URL"
+  echoDebug "RPC_URL=$(redactRpcUrl "$RPC_URL")"
   echoDebug "DIAMOND_ADDRESS=$DIAMOND_ADDRESS"
   echoDebug "DIAMOND_FILE=$DIAMOND_FILE"
 
@@ -2177,6 +2177,13 @@ function extractFromVerificationOutput() {
 # argument (never over a joined string) so a key containing whitespace or a
 # newline cannot spill its tail past the substitution, and remaining arguments
 # are quoted with %q so their boundaries stay visible in the log.
+function redactRpcUrl() {
+  # Endpoint URLs carry the provider key in the path or query, so the value must never reach a
+  # log line verbatim. Callers that need the URL itself (getRPCUrl returns it on stdout) must
+  # not use this.
+  printf '%s' "$1" | sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]+#[redacted-url]#g'
+}
+
 function redactVerifyCmd() {
   local PLACEHOLDER='***REDACTED***'
   local OUTPUT=''

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -2177,13 +2177,6 @@ function extractFromVerificationOutput() {
 # argument (never over a joined string) so a key containing whitespace or a
 # newline cannot spill its tail past the substitution, and remaining arguments
 # are quoted with %q so their boundaries stay visible in the log.
-function redactRpcUrl() {
-  # Endpoint URLs carry the provider key in the path or query, so the value must never reach a
-  # log line verbatim. Callers that need the URL itself (getRPCUrl returns it on stdout) must
-  # not use this.
-  printf '%s' "$1" | sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]+#[redacted-url]#g'
-}
-
 function redactVerifyCmd() {
   local PLACEHOLDER='***REDACTED***'
   local OUTPUT=''
@@ -2209,6 +2202,13 @@ function redactVerifyCmd() {
   done
 
   printf '%s\n' "$OUTPUT"
+}
+
+# Endpoint URLs carry the provider key in the path or query, so the value must never reach a log
+# line verbatim. Only a scheme-bearing URL is matched, mirroring the TypeScript redactUrls().
+# Callers that need the URL itself — getRPCUrl returns it on stdout — must not use this.
+function redactRpcUrl() {
+  printf '%s' "${1:-}" | sed -E 's#[a-zA-Z][a-zA-Z0-9+.-]*://[^[:space:]]+#[redacted-url]#g'
 }
 
 function verifyContract() {

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -5300,7 +5300,7 @@ function handleForgeScriptError() {
       warning "forge script returned exit code 0 but with unexpected/empty return data${NETWORK_MSG}${ATTEMPT_MSG}"
     fi
     if [[ -n "${STDERR_CONTENT:-}" ]]; then
-      error "stderr: ${STDERR_CONTENT}"
+      error "stderr: $(redactRpcUrl "${STDERR_CONTENT}")"
     fi
     if [[ -z "${RAW_RETURN_DATA:-}" || "${RAW_RETURN_DATA:-}" == "" ]]; then
       warning "No JSON output received. This usually indicates a connection/RPC error."
@@ -6072,7 +6072,7 @@ function estimatePauseCost() {
       return 2
     fi
     if [[ $ATTEMPT -ge $ESTIMATE_MAX_ATTEMPTS ]]; then
-      error "estimatePauseCost: cast estimate failed for $NETWORK after $ESTIMATE_MAX_ATTEMPTS attempts: ${CAST_ERR:-non-numeric gas estimate ($GAS_ESTIMATE)}" >&2
+      error "estimatePauseCost: cast estimate failed for $NETWORK after $ESTIMATE_MAX_ATTEMPTS attempts: $(redactRpcUrl "${CAST_ERR:-non-numeric gas estimate ($GAS_ESTIMATE)}")" >&2
       return 1
     fi
     sleep "$ESTIMATE_RETRY_SLEEP_SECONDS"

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -5079,7 +5079,7 @@ function executeAndCapture() {
 
   # Debug: Show what we captured
   echoDebug "=== RAW_RETURN_DATA (stdout) ==="
-  echoDebug "$RAW_RETURN_DATA"
+  echoDebug "$(redactRpcUrl "$RAW_RETURN_DATA")"
   echoDebug "=== STDERR_CONTENT (stderr) ==="
   echoDebug "$(redactRpcUrl "$STDERR_CONTENT")"
 
@@ -5154,7 +5154,7 @@ function parseExecuteCommandResult() {
         error "stderr: $(redactRpcUrl "$STDERR_CONTENT")"
       fi
       if [[ -n "$RAW_RETURN_DATA" ]]; then
-        echoDebug "stdout: $RAW_RETURN_DATA"
+        echoDebug "stdout: $(redactRpcUrl "$RAW_RETURN_DATA")"
       fi
 
       case "$ON_ERROR_ACTION" in

--- a/script/helperFunctions.sh
+++ b/script/helperFunctions.sh
@@ -5081,7 +5081,7 @@ function executeAndCapture() {
   echoDebug "=== RAW_RETURN_DATA (stdout) ==="
   echoDebug "$RAW_RETURN_DATA"
   echoDebug "=== STDERR_CONTENT (stderr) ==="
-  echoDebug "$STDERR_CONTENT"
+  echoDebug "$(redactRpcUrl "$STDERR_CONTENT")"
 
   # Extract JSON if requested
   if [[ "$EXTRACT_JSON" == "true" ]]; then
@@ -5151,7 +5151,7 @@ function parseExecuteCommandResult() {
     if [[ "$RETURN_CODE" -ne 0 ]]; then
       error "$ERROR_MESSAGE (exit code: $RETURN_CODE)"
       if [[ -n "$STDERR_CONTENT" ]]; then
-        error "stderr: $STDERR_CONTENT"
+        error "stderr: $(redactRpcUrl "$STDERR_CONTENT")"
       fi
       if [[ -n "$RAW_RETURN_DATA" ]]; then
         echoDebug "stdout: $RAW_RETURN_DATA"

--- a/script/playgroundHelpers.sh
+++ b/script/playgroundHelpers.sh
@@ -782,7 +782,7 @@ function analyzeFailingTx() {
     return 1
   fi
 
-  echo "Analyzing transaction: $TX_HASH on network: $NETWORK with RPC URL: $RPC_URL"
+  echo "Analyzing transaction: $TX_HASH on network: $NETWORK with RPC URL: $(redactRpcUrl "$RPC_URL")"
   echo ""
 
   # Step 1: Run cast run

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -164,3 +164,35 @@ describe.each(RETRY_SCRIPTS)('%s > rpcCallWithRetry', (_label, defs) => {
     ).toBe('see https://docs.example/x')
   })
 })
+
+/**
+ * The widest of the bash paths: every `forge`/`cast` execution routed through `executeAndParse`
+ * lands here, and `error` is not debug-gated, so a failed deploy prints the captured stderr —
+ * which carries `--rpc-url` — on any run, not only a `DEBUG=true` one.
+ */
+describe('script/helperFunctions.sh > parseExecuteCommandResult', () => {
+  const run = (stderr: string): string =>
+    withBashFns(
+      [
+        ['script/helperFunctions.sh', 'redactRpcUrl'],
+        ['script/helperFunctions.sh', 'error'],
+        ['script/helperFunctions.sh', 'echoDebug'],
+        ['script/helperFunctions.sh', 'parseExecuteCommandResult'],
+      ],
+      `parseExecuteCommandResult "$1" "deploy failed" "continue" 2>&1 || true`,
+      [JSON.stringify({ stdout: '', stderr, returnCode: 1 })]
+    )
+
+  it('redacts the endpoint in the stderr it prints on failure', () => {
+    const out = run(
+      'Error: error sending request for url (https://lb.drpc.org/ogrpc?network=base&dkey=FAKEKEY999)'
+    )
+    expect(out).not.toContain('FAKEKEY999')
+    expect(out).toContain('[redacted-url]')
+    expect(out).toContain('deploy failed')
+  })
+
+  it('leaves failure stderr that names no endpoint intact', () => {
+    expect(run('EvmError: Revert')).toContain('EvmError: Revert')
+  })
+})

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -1,9 +1,13 @@
 /**
- * Regression tests for redactRpcUrl (script/helperFunctions.sh).
+ * Regression tests for the two bash endpoint redactors and the retry helper that returns their
+ * output: `redactRpcUrl` (`script/helperFunctions.sh`) and `bgRedactUrl`
+ * (`script/emergency/emergencyPauseBreakGlass.sh`).
  *
- * `getRPCUrl` returns the keyed `ETH_NODE_URI_<NETWORK>` on stdout, and several scripts echo that
- * value into a log line — one of them ungated. The provider key sits in the path or the query, so
- * the whole URL has to go.
+ * `getRPCUrl` returns the keyed `ETH_NODE_URI_<NETWORK>` on stdout and `cast` embeds `--rpc-url`
+ * in its error text, so both the value and any RPC failure carry the provider key.
+ *
+ * `bgRedactUrl` is a deliberate second copy: the break-glass script must not depend on
+ * `helperFunctions.sh` loading. Both are exercised here so the copy cannot rot.
  */
 import { execFileSync } from 'child_process'
 import { join } from 'path'
@@ -18,48 +22,66 @@ import {
 const REPO_ROOT = join(import.meta.dir, '..')
 
 /**
- * Call redactRpcUrl with the given value and return its output.
+ * Run `script` with the named bash functions pulled out of their files.
  *
- * @param value - the text to redact
+ * The functions are extracted rather than sourced: `emergencyPauseBreakGlass.sh` runs `main` at
+ * the bottom, so sourcing it would execute the break-glass path.
+ *
+ * @param defs - [file, function name] pairs to make available
+ * @param script - bash to run once the definitions are loaded
+ * @param args - positional arguments for the script
  */
-function redact(value: string): string {
+function withBashFns(
+  defs: [string, string][],
+  script: string,
+  args: string[] = []
+): string {
+  const extracts = defs
+    .map(
+      ([file, fn]) =>
+        // -E, not BRE: BSD sed has no `\\?`, so a basic-regex extraction silently matches nothing
+        // and every test then fails with "command not found".
+        `eval "$(sed -nE '/^(function )?${fn}\\(\\) \\{/,/^\\}/p' ${file})"`
+    )
+    .join('\n')
   return execFileSync(
     'bash',
-    [
-      '-c',
-      'source script/helperFunctions.sh >/dev/null 2>&1; redactRpcUrl "$1"',
-      'harness',
-      value,
-    ],
-    { cwd: REPO_ROOT, encoding: 'utf8' }
+    ['-c', `${extracts}\n${script}`, 'harness', ...args],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }
   )
 }
 
-describe('redactRpcUrl', () => {
+const REDACTORS: [string, string][] = [
+  ['script/helperFunctions.sh', 'redactRpcUrl'],
+  ['script/emergency/emergencyPauseBreakGlass.sh', 'bgRedactUrl'],
+]
+
+describe.each(REDACTORS)('%s > %s', (file, fn) => {
+  const redact = (value: string): string =>
+    withBashFns([[file, fn]], `${fn} "$1"`, [value])
+
   it.each([
     ['a key in the path', 'https://lb.drpc.org/ogrpc/KEY123'],
     ['a key in the query', 'https://eth.example/v1?dkey=KEY123'],
-    [
-      'a key as the whole path segment',
-      'https://eth-mainnet.nodereal.io/v1/KEY123',
-    ],
+    ['a nodereal-style path key', 'https://eth-mainnet.nodereal.io/v1/KEY123'],
     ['a websocket endpoint', 'wss://eth.example/ws/KEY123'],
   ])('removes %s', (_name, url) => {
-    const out = redact(url)
-    expect(out).not.toContain('KEY123')
-    expect(out).toBe('[redacted-url]')
+    expect(redact(url)).toBe('[redacted-url]')
   })
 
-  it('redacts a URL embedded in a longer line, keeping the rest', () => {
+  it('redacts a URL inside a realistic cast error, keeping the rest', () => {
     const out = redact(
-      'Analyzing tx 0xabc on network: mainnet with RPC URL: https://x.io/v1/KEY123'
+      'Error: error sending request for url (https://x.io/v1/KEY123): operation timed out'
     )
     expect(out).not.toContain('KEY123')
-    expect(out).toContain('Analyzing tx 0xabc on network: mainnet')
+    expect(out).toContain('operation timed out')
   })
 
   it('leaves text with no endpoint untouched', () => {
-    // Paired negative: a redactor that returned a constant would satisfy every case above.
+    // Paired negative: a redactor returning a constant would satisfy every case above.
     expect(redact('no endpoint here')).toBe('no endpoint here')
   })
 
@@ -67,5 +89,41 @@ describe('redactRpcUrl', () => {
     const out = redact('primary https://a.io/K1 fallback https://b.io/K2')
     expect(out).not.toContain('K1')
     expect(out).not.toContain('K2')
+  })
+
+  it('survives an empty argument under set -u', () => {
+    expect(withBashFns([[file, fn]], `set -u; ${fn} ""`)).toBe('')
+  })
+})
+
+describe('rpcCallWithRetry returns a redacted error but an untouched result', () => {
+  const BG = 'script/emergency/emergencyPauseBreakGlass.sh'
+  const run = (script: string): string =>
+    withBashFns(
+      [
+        [BG, 'bgRedactUrl'],
+        [BG, 'rpcCallWithRetry'],
+      ],
+      `RPC_MAX_ATTEMPTS=2\nRPC_RETRY_SLEEP_SECONDS=0\n${script}`
+    )
+
+  it('redacts the endpoint on the exhaustion path', () => {
+    // The failing path is the one that runs during an incident, and every caller echoes what it
+    // returns. Redacting only the per-attempt retry line left this one leaking.
+    const out = run(
+      `failing() { echo "Error: error sending request for url (https://lb.drpc.org/ogrpc?network=base&dkey=FAKEKEY777)" >&2; return 1; }\n` +
+        `rpcCallWithRetry "label" failing 2>/dev/null || true`
+    )
+    expect(out).not.toContain('FAKEKEY777')
+    expect(out).toContain('[redacted-url]')
+  })
+
+  it('leaves a successful result verbatim', () => {
+    // The success path returns data callers parse — a balance, an address. Redacting it would
+    // break every one of them, so this is the assertion that keeps the fix honest.
+    const out = run(
+      `ok() { echo "1000000000000000000"; }\nrpcCallWithRetry "label" ok`
+    )
+    expect(out).toBe('1000000000000000000')
   })
 })

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -1,7 +1,8 @@
 /**
- * Regression tests for the two bash endpoint redactors and the retry helper that returns their
- * output: `redactRpcUrl` (`script/helperFunctions.sh`) and `bgRedactUrl`
- * (`script/emergency/emergencyPauseBreakGlass.sh`).
+ * Regression tests for the two bash endpoint redactors — `redactRpcUrl`
+ * (`script/helperFunctions.sh`) and `bgRedactUrl`
+ * (`script/emergency/emergencyPauseBreakGlass.sh`) — and for the shared bash paths that print
+ * their output: the retry helper that returns it, and `parseExecuteCommandResult`.
  *
  * `getRPCUrl` returns the keyed `ETH_NODE_URI_<NETWORK>` on stdout and `cast` embeds `--rpc-url`
  * in its error text, so both the value and any RPC failure carry the provider key.
@@ -166,7 +167,7 @@ describe.each(RETRY_SCRIPTS)('%s > rpcCallWithRetry', (_label, defs) => {
 })
 
 /**
- * The widest of the bash paths: every `forge`/`cast` execution routed through `executeAndParse`
+ * The widest of the bash paths: every `forge script` execution routed through `executeAndParse`
  * lands here, and `error` is not debug-gated, so a failed deploy prints the captured stderr —
  * which carries `--rpc-url` — on any run, not only a `DEBUG=true` one.
  */

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -41,7 +41,7 @@ function withBashFns(
       ([file, fn]) =>
         // -E, not BRE: BSD sed has no `\\?`, so a basic-regex extraction silently matches nothing
         // and every test then fails with "command not found".
-        `eval "$(sed -nE '/^(function )?${fn}\\(\\) \\{/,/^\\}/p' ${file})"`
+        `source <(sed -nE '/^(function )?${fn}\\(\\) \\{/,/^\\}/p' ${file})`
     )
     .join('\n')
   return execFileSync(

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -96,14 +96,34 @@ describe.each(REDACTORS)('%s > %s', (file, fn) => {
   })
 })
 
-describe('rpcCallWithRetry returns a redacted error but an untouched result', () => {
-  const BG = 'script/emergency/emergencyPauseBreakGlass.sh'
+/**
+ * Both scripts define their own `rpcCallWithRetry`. The readiness one runs on a schedule in
+ * GitHub Actions, where its output lands in a CI log, and was the untested of the two.
+ */
+const RETRY_SCRIPTS: [string, [string, string][]][] = [
+  [
+    'script/emergency/emergencyPauseBreakGlass.sh',
+    [
+      ['script/emergency/emergencyPauseBreakGlass.sh', 'bgRedactUrl'],
+      ['script/emergency/emergencyPauseBreakGlass.sh', 'rpcCallWithRetry'],
+    ],
+  ],
+  [
+    'script/utils/verifyEmergencyPauseReadinessGitHub.sh',
+    [
+      ['script/helperFunctions.sh', 'redactRpcUrl'],
+      [
+        'script/utils/verifyEmergencyPauseReadinessGitHub.sh',
+        'rpcCallWithRetry',
+      ],
+    ],
+  ],
+]
+
+describe.each(RETRY_SCRIPTS)('%s > rpcCallWithRetry', (_label, defs) => {
   const run = (script: string): string =>
     withBashFns(
-      [
-        [BG, 'bgRedactUrl'],
-        [BG, 'rpcCallWithRetry'],
-      ],
+      defs,
       `RPC_MAX_ATTEMPTS=2\nRPC_RETRY_SLEEP_SECONDS=0\n${script}`
     )
 
@@ -118,12 +138,29 @@ describe('rpcCallWithRetry returns a redacted error but an untouched result', ()
     expect(out).toContain('[redacted-url]')
   })
 
+  it('redacts an endpoint that arrived on stdout instead of stderr', () => {
+    // The `${LAST_ERR:-$OUT}` fallback: helpers that merge stderr with 2>&1 land here.
+    const out = run(
+      `failing() { echo "failed for url (https://x.io/v1/FAKEKEY888)"; return 1; }\n` +
+        `rpcCallWithRetry "label" failing 2>/dev/null || true`
+    )
+    expect(out).not.toContain('FAKEKEY888')
+    expect(out).toContain('[redacted-url]')
+  })
+
   it('leaves a successful result verbatim', () => {
     // The success path returns data callers parse — a balance, an address. Redacting it would
     // break every one of them, so this is the assertion that keeps the fix honest.
-    const out = run(
-      `ok() { echo "1000000000000000000"; }\nrpcCallWithRetry "label" ok`
-    )
-    expect(out).toBe('1000000000000000000')
+    expect(
+      run(`ok() { echo "1000000000000000000"; }\nrpcCallWithRetry "label" ok`)
+    ).toBe('1000000000000000000')
+  })
+
+  it('does not redact a URL that appears in successful output', () => {
+    expect(
+      run(
+        `ok() { echo "see https://docs.example/x"; }\nrpcCallWithRetry "label" ok`
+      )
+    ).toBe('see https://docs.example/x')
   })
 })

--- a/script/redactRpcUrl.test.ts
+++ b/script/redactRpcUrl.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for redactRpcUrl (script/helperFunctions.sh).
+ *
+ * `getRPCUrl` returns the keyed `ETH_NODE_URI_<NETWORK>` on stdout, and several scripts echo that
+ * value into a log line — one of them ungated. The provider key sits in the path or the query, so
+ * the whole URL has to go.
+ */
+import { execFileSync } from 'child_process'
+import { join } from 'path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const REPO_ROOT = join(import.meta.dir, '..')
+
+/**
+ * Call redactRpcUrl with the given value and return its output.
+ *
+ * @param value - the text to redact
+ */
+function redact(value: string): string {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      'source script/helperFunctions.sh >/dev/null 2>&1; redactRpcUrl "$1"',
+      'harness',
+      value,
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  )
+}
+
+describe('redactRpcUrl', () => {
+  it.each([
+    ['a key in the path', 'https://lb.drpc.org/ogrpc/KEY123'],
+    ['a key in the query', 'https://eth.example/v1?dkey=KEY123'],
+    [
+      'a key as the whole path segment',
+      'https://eth-mainnet.nodereal.io/v1/KEY123',
+    ],
+    ['a websocket endpoint', 'wss://eth.example/ws/KEY123'],
+  ])('removes %s', (_name, url) => {
+    const out = redact(url)
+    expect(out).not.toContain('KEY123')
+    expect(out).toBe('[redacted-url]')
+  })
+
+  it('redacts a URL embedded in a longer line, keeping the rest', () => {
+    const out = redact(
+      'Analyzing tx 0xabc on network: mainnet with RPC URL: https://x.io/v1/KEY123'
+    )
+    expect(out).not.toContain('KEY123')
+    expect(out).toContain('Analyzing tx 0xabc on network: mainnet')
+  })
+
+  it('leaves text with no endpoint untouched', () => {
+    // Paired negative: a redactor that returned a constant would satisfy every case above.
+    expect(redact('no endpoint here')).toBe('no endpoint here')
+  })
+
+  it('redacts every endpoint on the line, not just the first', () => {
+    const out = redact('primary https://a.io/K1 fallback https://b.io/K2')
+    expect(out).not.toContain('K1')
+    expect(out).not.toContain('K2')
+  })
+})

--- a/script/tasks/diamondEMERGENCYPause.sh
+++ b/script/tasks/diamondEMERGENCYPause.sh
@@ -171,7 +171,7 @@ function handleNetwork() {
         return 0
     else
         # Handle other RPC or network errors
-        error "[network: $NETWORK] RPC or network error while checking if diamond is paused: $RESPONSE"
+        error "[network: $NETWORK] RPC or network error while checking if diamond is paused: $(redactRpcUrl "$RESPONSE")"
     fi
   fi
 

--- a/script/tasks/diamondEMERGENCYPause.sh
+++ b/script/tasks/diamondEMERGENCYPause.sh
@@ -146,7 +146,7 @@ function handleNetwork() {
   echoDebug "in function handleNetwork"
   echoDebug "NETWORK=$NETWORK"
   echoDebug "ACTION=$ACTION"
-  echoDebug "RPC_URL=$RPC_URL"
+  echoDebug "RPC_URL=$(redactRpcUrl "$RPC_URL")"
   echoDebug "DIAMOND_ADDRESS=$DIAMOND_ADDRESS"
   echoDebug "FACET_CONTRACT_NAME=$FACET_CONTRACT_NAME"
   echoDebug "BLACKLIST=$BLACKLIST"

--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -1177,7 +1177,7 @@ function diamondSyncWhitelist {
           OUTPUT=$(universalCast "send" "$NETWORK" "$ENVIRONMENT" "$DIAMOND_ADDRESS" "batchSetContractSelectorWhitelist(address[],bytes4[],bool)" "$SEND_ARGS" "$TIMELOCK_FLAG" 2>&1)
           local EXIT_CODE=$?
 
-          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then echo "$OUTPUT"; fi
+          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then printf '%s\n' "$(redactRpcUrl "$OUTPUT")"; fi
 
           if [[ $EXIT_CODE -eq 0 ]]; then
             if [[ "$TIMELOCK_FLAG" == "true" ]]; then

--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -312,7 +312,7 @@ function diamondSyncWhitelist {
 
     RPC_URL=$(getRPCUrl "$NETWORK") || checkFailure $? "get rpc url"
 
-    echoSyncDebug "Using RPC URL: $RPC_URL"
+    echoSyncDebug "Using RPC URL: $(redactRpcUrl "$RPC_URL")"
     echoSyncDebug "Diamond address: $DIAMOND_ADDRESS"
 
     # Function to get contract-selector pairs from whitelist files (whitelist.json or whitelist.staging.json)

--- a/script/tasks/diamondSyncWhitelist.sh
+++ b/script/tasks/diamondSyncWhitelist.sh
@@ -980,7 +980,7 @@ function diamondSyncWhitelist {
           local REMOVE_EXIT_CODE=$?
 
           # Print output in verbose mode
-          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then echo "$REMOVE_OUTPUT"; fi
+          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then printf '%s\n' "$(redactRpcUrl "$REMOVE_OUTPUT")"; fi
 
           if [[ $REMOVE_EXIT_CODE -eq 0 ]]; then
             if [[ "$TIMELOCK_FLAG" == "true" ]]; then
@@ -1240,7 +1240,7 @@ function diamondSyncWhitelist {
           local COMBINED_EXIT_CODE=$?
 
           # Print output in verbose mode
-          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then echo "$COMBINED_OUTPUT"; fi
+          if [[ "$MULTI_NETWORK_RUN" != "true" ]]; then printf '%s\n' "$(redactRpcUrl "$COMBINED_OUTPUT")"; fi
 
           if [[ $COMBINED_EXIT_CODE -eq 0 ]]; then
             printf '\033[0;32m%s\033[0m\n' "✅ [$NETWORK] Combined removal+addition proposal submitted successfully!"

--- a/script/tasks/diamondUpdatePeriphery.sh
+++ b/script/tasks/diamondUpdatePeriphery.sh
@@ -197,7 +197,7 @@ register() {
   echoDebug "DIAMOND=$DIAMOND"
   echoDebug "CONTRACT_NAME=$CONTRACT_NAME"
   echoDebug "ADDR=$ADDR"
-  echoDebug "RPC_URL=$RPC_URL"
+  echoDebug "RPC_URL=$(redactRpcUrl "$RPC_URL")"
   echoDebug "ENVIRONMENT=$ENVIRONMENT"
   echoDebug "GAS_ESTIMATE_MULTIPLIER=$GAS_ESTIMATE_MULTIPLIER (default value: 130, set in .env for example to 200 for doubling Foundry's estimate)"
   echo ""

--- a/script/troncast/utils/tronweb.ts
+++ b/script/troncast/utils/tronweb.ts
@@ -22,6 +22,7 @@ import { consola } from 'consola'
 import { TronWeb } from 'tronweb'
 
 import { sleep } from '../../utils/delay'
+import { redactUrls } from '../../utils/redactUrls'
 import { getEnvVar, getRPCEnvVarName } from '../../utils/utils'
 import type { Environment } from '../types'
 /* eslint-enable import/first */
@@ -48,7 +49,9 @@ export function initTronWeb(
     rpcUrl = getEnvVar(envVarName)
   }
 
-  consola.debug(`Initializing TronWeb with ${env} network: ${rpcUrl}`)
+  consola.debug(
+    `Initializing TronWeb with ${env} network: ${redactUrls(rpcUrl)}`
+  )
 
   // TronGrid rate-limits anonymous traffic hard enough that read-heavy scripts (the health
   // check's refund-wallet-access in particular) fail with 429 before finishing. Send

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -82,6 +82,15 @@ describe('no shipped script logs a raw RPC endpoint', () => {
     for (const path of EXEMPT.keys()) expect(scanned).toContain(path)
   })
 
+  // Pinned by VALUE for the same reason as the vocabulary below: a widened exemption would
+  // otherwise carry its own test with it and silence a real leak in that file.
+  it('pins the exempted identifiers', () => {
+    expect(
+      [...EXEMPT].map(([path, { identifiers }]) => [path, identifiers])
+    ).toEqual([['script/demoScripts/demoPaxosTransit.ts', ['RPC_URL']]])
+    for (const { why } of EXEMPT.values()) expect(why.length).toBeGreaterThan(0)
+  })
+
   it('an exempted file is still scanned for everything it did not exempt', () => {
     // The one exempted file also reads ETH_NODE_URI_MAINNET for its anvil fork. A whole-file
     // skip would hide a credential-bearing log added there later.

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -25,7 +25,12 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { EXEMPT, scanForRawRpcUrlLogs } from './rpc-url-log-scan'
+import {
+  EXEMPT,
+  LOG_METHODS,
+  RPC_IDENTIFIERS,
+  scanForRawRpcUrlLogs,
+} from './rpc-url-log-scan'
 
 const REPO_ROOT = join(import.meta.dir, '..', '..')
 
@@ -61,6 +66,13 @@ describe('no shipped script logs a raw RPC endpoint', () => {
     expect(scanned.length).toBeGreaterThan(100)
     expect(scanned).toContain('script/troncast/utils/tronweb.ts')
     expect(scanned).toContain('script/deploy/tron/deploy-core-facets.ts')
+  })
+
+  it('walks every root it claims, not just script/', () => {
+    // Dropping `tasks` from the default roots leaves >100 files scanned and both asserted paths
+    // present, so nothing else here would notice.
+    const { scanned } = scanForRawRpcUrlLogs(REPO_ROOT)
+    expect(scanned.some((p) => p.startsWith('tasks/'))).toBe(true)
   })
 
   it('every exemption still names a file that exists', () => {
@@ -134,6 +146,57 @@ describe('the scan fires on a new leak', () => {
     expect(identifiers('consola.info({ [rpcUrl]: n })\n')).toEqual(['rpcUrl'])
   })
 
+  // The two sets are pinned by VALUE. Iterating the constant alone is self-referential: deleting
+  // an entry also deletes its case, so the assertion moves with the mutation.
+  it('pins the vocabulary and the log surface', () => {
+    expect([...RPC_IDENTIFIERS]).toEqual([
+      'rpcUrl',
+      'rpcUrls',
+      'fullHost',
+      'nodeUrl',
+      'providerUrl',
+      'endpointUrl',
+    ])
+    expect([...LOG_METHODS]).toEqual([
+      'debug',
+      'info',
+      'log',
+      'warn',
+      'error',
+      'success',
+      'start',
+      'ready',
+      'fail',
+      'box',
+      'fatal',
+      'trace',
+      'verbose',
+      'silent',
+      'dir',
+      'table',
+      'group',
+      'groupCollapsed',
+    ])
+  })
+
+  it.each([...RPC_IDENTIFIERS])('catches the identifier %s', (name) => {
+    expect(identifiers(`consola.info(\`\${${name}}\`)\n`)).toEqual([name])
+  })
+
+  it.each([...LOG_METHODS])('catches consola.%s', (method) => {
+    expect(identifiers(`consola.${method}(\`\${rpcUrl}\`)\n`)).toEqual([
+      'rpcUrl',
+    ])
+  })
+
+  it('reports the line and the text a developer reads when CI goes red', () => {
+    const [finding] = scanFixture(
+      '// a leading comment\nconst x = 1\nconsola.info(`connecting via ${rpcUrl}`)\n'
+    ).findings
+    expect(finding?.line).toBe(3)
+    expect(finding?.text).toContain('rpcUrl')
+  })
+
   it('stays silent once the same site is redacted', () => {
     expect(
       scanFixture(
@@ -143,9 +206,21 @@ describe('the scan fires on a new leak', () => {
     ).toEqual([])
   })
 
-  it('accepts hostOf as a redaction too', () => {
-    expect(scanFixture('consola.info(hostOf(rpcUrl))\n').findings).toEqual([])
+  it('accepts a redactor reached through a namespace', () => {
+    // `utils.redactUrls(...)` — without the member branch of calleeName this reads as an
+    // unredacted call and reports honest code.
+    expect(
+      scanFixture('consola.info(utils.redactUrls(rpcUrl))\n').findings
+    ).toEqual([])
   })
+
+  it.each(['hostOf', 'redactErrorReason'])(
+    'accepts %s as a redaction too',
+    (fn) => {
+      // redactErrorReason has 27 call sites in the repo and was unpinned.
+      expect(scanFixture(`consola.info(${fn}(rpcUrl))\n`).findings).toEqual([])
+    }
+  )
 })
 
 describe('the innocent mentions stay silent, beside a leak that does not', () => {
@@ -214,6 +289,30 @@ describe('the innocent mentions stay silent, beside a leak that does not', () =>
   it('a consola or console method that prints nothing is not a log surface', () => {
     expect(identifiers(`console.time(rpcUrl)\n${LEAK}`)).toEqual(['fullHost'])
     expect(identifiers(`consola.withTag(rpcUrl)\n${LEAK}`)).toEqual([
+      'fullHost',
+    ])
+  })
+
+  it.each([
+    ['a method shorthand', 'consola.info({ rpcUrl() { return 1 } })'],
+    ['a getter', 'consola.info({ get rpcUrl() { return 1 } })'],
+    ['a setter', 'consola.info({ set rpcUrl(v) {} })'],
+    ['a class property', 'consola.info(class { rpcUrl = 1 })'],
+    [
+      'a named function expression',
+      'consola.info((function rpcUrl(){ return 1 })())',
+    ],
+    ['a renamed binding', 'consola.info((({ rpcUrl: u }) => hostOf(u))(o))'],
+  ])('%s names something rather than reading it', (_n, src) => {
+    // Asked structurally, so this list is illustration rather than the rule — an enumeration of
+    // declaration kinds is what left accessors and methods reporting.
+    expect(identifiers(`${src}\n${LEAK}`)).toEqual(['fullHost'])
+  })
+
+  it('a logger that is not consola or console is not a log surface', () => {
+    // Without the receiver check this becomes "any x.info()", and every wrapper in the repo
+    // starts failing CI.
+    expect(identifiers(`logger.info(\`\${rpcUrl}\`)\n${LEAK}`)).toEqual([
       'fullHost',
     ])
   })

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The credential rule this repo now enforces: no shipped script puts a raw RPC endpoint into a
+ * log line.
+ *
+ * `ETH_NODE_URI_*` embeds the provider key in the URL, so `consola.info(`… ${rpcUrl}`)` writes a
+ * live credential into every transcript of every run. One such site (troncast) leaked the Tron
+ * key into a session on 2026-09-09.
+ *
+ * The scan is textual, so most of what follows is aimed at the scan itself rather than at the
+ * tree: each innocent way this repo mentions an endpoint is pinned as a NEGATIVE beside a real
+ * leak in the same fixture, so a check that started refusing everything — or nothing — fails here
+ * before it reaches a reviewer.
+ */
+/* eslint-disable no-template-curly-in-string --
+   The fixtures below are TypeScript SOURCE TEXT handed to the scanner. `${rpcUrl}` is the leak
+   being detected, not an interpolation this file means to perform. */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { blankNonCode, EXEMPT, scanForRawRpcUrlLogs } from './rpc-url-log-scan'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+
+/** Run the scan over a throwaway tree holding exactly `source`. */
+function scanFixture(source: string): ReturnType<typeof scanForRawRpcUrlLogs> {
+  const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+  try {
+    const dir = join(root, 'script')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'fixture.ts'), source)
+    return scanForRawRpcUrlLogs(root, ['script'])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+describe('no shipped script logs a raw RPC endpoint', () => {
+  it('finds nothing in script/ and tasks/', () => {
+    const { findings } = scanForRawRpcUrlLogs(REPO_ROOT)
+    expect(
+      findings.map((f) => `${f.file}:${f.line} [${f.identifier}] ${f.text}`)
+    ).toEqual([])
+  })
+
+  // A scan that walked nothing would satisfy the assertion above without reading a line.
+  it('actually examined the tree it cleared', () => {
+    const { scanned } = scanForRawRpcUrlLogs(REPO_ROOT)
+    expect(scanned.length).toBeGreaterThan(100)
+    expect(scanned).toContain('script/troncast/utils/tronweb.ts')
+    expect(scanned).toContain('script/deploy/tron/deploy-core-facets.ts')
+  })
+
+  it('every exemption still names a file that exists', () => {
+    const { scanned } = scanForRawRpcUrlLogs(REPO_ROOT)
+    // A stale exemption silently widens the rule to a path nobody is watching.
+    for (const path of EXEMPT.keys()) expect(scanned).toContain(path)
+  })
+})
+
+describe('the scan fires on a new leak', () => {
+  // The ticket's own criterion: add a log of a raw RPC URL and watch it go red. It also proves
+  // the walk reads the filesystem — a `git ls-files` enumeration cannot see an uncommitted file,
+  // which is precisely the file a new leak arrives in.
+  it('catches a freshly written file that logs the endpoint', () => {
+    const { findings, scanned } = scanFixture(
+      'const rpcUrl = process.env.ETH_NODE_URI_TRON\nconsola.info(`connecting via ${rpcUrl}`)\n'
+    )
+    expect(scanned).toContain('script/fixture.ts')
+    expect(findings.map((f) => f.identifier)).toEqual(['rpcUrl'])
+  })
+
+  it('catches the endpoint read straight off the environment', () => {
+    const { findings } = scanFixture(
+      'consola.warn(`using ${process.env.ETH_NODE_URI_TRON}`)\n'
+    )
+    expect(findings.map((f) => f.identifier)).toEqual(['ETH_NODE_URI_TRON'])
+  })
+
+  it('stays silent once the same site is redacted', () => {
+    const { findings } = scanFixture(
+      'const rpcUrl = process.env.ETH_NODE_URI_TRON\n' +
+        'consola.info(`connecting via ${redactUrls(rpcUrl)}`)\n'
+    )
+    expect(findings).toEqual([])
+  })
+})
+
+describe('the three innocent mentions stay silent, beside a leak that does not', () => {
+  // Each case carries a real leak alongside the innocent form. Without it the case would pass
+  // against a scan that had stopped looking at that file at all.
+  const leak = 'consola.error(`down: ${fullHost}`)\n'
+
+  it('a doc comment naming rpcUrl is not a log', () => {
+    const { findings } = scanFixture(
+      `/** Takes an rpcUrl and logs it. */\n${leak}`
+    )
+    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+  })
+
+  it('a help string mentioning --rpcUrl is not a log', () => {
+    const { findings } = scanFixture(
+      `consola.info('run with --rpcUrl <url>')\n${leak}`
+    )
+    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+  })
+
+  it('an object key named rpcUrl labels a field rather than reading one', () => {
+    const { findings } = scanFixture(
+      `consola.info('Network', { rpcUrl: networkName })\n${leak}`
+    )
+    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+  })
+
+  it('a string literal inside a template interpolation is still a string', () => {
+    // The bug this pins: keeping `${...}` as code, but forgetting that code can hold strings.
+    const { findings } = scanFixture(
+      `consola.warn(\`\${name.replace('ETH_NODE_URI_', '')}\`)\n${leak}`
+    )
+    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+  })
+})
+
+describe('blankNonCode', () => {
+  it('keeps length and line numbering so offsets still line up', () => {
+    const src = "const a = 'xx' // yy\nconst b = 1\n"
+    const out = blankNonCode(src)
+    expect(out.length).toBe(src.length)
+    expect(out.split('\n').length).toBe(src.split('\n').length)
+  })
+
+  it('blanks a string body but keeps a template interpolation', () => {
+    const out = blankNonCode("const s = 'secret'\nconst t = `x ${rpcUrl} y`\n")
+    expect(out).not.toContain('secret')
+    expect(out).toContain('rpcUrl')
+  })
+
+  it('blanks a string nested inside a template interpolation', () => {
+    const out = blankNonCode("const t = `${n.replace('ETH_NODE_URI_', '')}`\n")
+    expect(out).not.toContain('ETH_NODE_URI_')
+    expect(out).toContain('replace')
+  })
+})

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -1,20 +1,20 @@
-/**
- * The credential rule this repo now enforces: no shipped script puts a raw RPC endpoint into a
- * log line.
- *
- * `ETH_NODE_URI_*` embeds the provider key in the URL, so `consola.info(`… ${rpcUrl}`)` writes a
- * live credential into every transcript of every run. One such site (troncast) leaked the Tron
- * key into a session on 2026-09-09.
- *
- * The scan is textual, so most of what follows is aimed at the scan itself rather than at the
- * tree: each innocent way this repo mentions an endpoint is pinned as a NEGATIVE beside a real
- * leak in the same fixture, so a check that started refusing everything — or nothing — fails here
- * before it reaches a reviewer.
- */
 /* eslint-disable no-template-curly-in-string --
-   The fixtures below are TypeScript SOURCE TEXT handed to the scanner. `${rpcUrl}` is the leak
-   being detected, not an interpolation this file means to perform. */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+   The fixtures are TypeScript SOURCE TEXT handed to the scanner. `${rpcUrl}` is the leak being
+   detected, not an interpolation this file performs. */
+/**
+ * Guards the rule that no shipped script puts a raw RPC endpoint into a log line.
+ *
+ * The scan is textual, so most of what follows aims at the scan rather than at the tree: every
+ * innocent way this repo names an endpoint is pinned as a negative BESIDE a real leak in the same
+ * fixture, so a check that has started refusing everything — or seeing nothing — fails here.
+ */
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -29,18 +29,23 @@ import { blankNonCode, EXEMPT, scanForRawRpcUrlLogs } from './rpc-url-log-scan'
 
 const REPO_ROOT = join(import.meta.dir, '..', '..')
 
+/** A real leak, appended to a fixture so no case can pass by the scan skipping the file. */
+const LEAK = 'consola.error(`down: ${fullHost}`)\n'
+
 /** Run the scan over a throwaway tree holding exactly `source`. */
 function scanFixture(source: string): ReturnType<typeof scanForRawRpcUrlLogs> {
   const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
   try {
-    const dir = join(root, 'script')
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(join(dir, 'fixture.ts'), source)
+    mkdirSync(join(root, 'script'), { recursive: true })
+    writeFileSync(join(root, 'script', 'fixture.ts'), source)
     return scanForRawRpcUrlLogs(root, ['script'])
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
 }
+
+const identifiers = (source: string): string[] =>
+  scanFixture(source).findings.map((f) => f.identifier)
 
 describe('no shipped script logs a raw RPC endpoint', () => {
   it('finds nothing in script/ and tasks/', () => {
@@ -60,15 +65,29 @@ describe('no shipped script logs a raw RPC endpoint', () => {
 
   it('every exemption still names a file that exists', () => {
     const { scanned } = scanForRawRpcUrlLogs(REPO_ROOT)
-    // A stale exemption silently widens the rule to a path nobody is watching.
+    // Asserted non-empty first: a for-of over an emptied map is vacuously green.
+    expect(EXEMPT.size).toBeGreaterThan(0)
     for (const path of EXEMPT.keys()) expect(scanned).toContain(path)
+  })
+
+  it('reads test files but never reports them', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+    try {
+      mkdirSync(join(root, 'script'), { recursive: true })
+      writeFileSync(join(root, 'script', 'a.test.ts'), LEAK)
+      writeFileSync(join(root, 'script', 'b.ts'), LEAK)
+      const { findings, scanned } = scanForRawRpcUrlLogs(root, ['script'])
+      expect(scanned).toEqual(['script/b.ts'])
+      expect(findings).toHaveLength(1)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })
 
 describe('the scan fires on a new leak', () => {
-  // The ticket's own criterion: add a log of a raw RPC URL and watch it go red. It also proves
-  // the walk reads the filesystem — a `git ls-files` enumeration cannot see an uncommitted file,
-  // which is precisely the file a new leak arrives in.
+  // The ticket's own criterion. It also proves the walk reads the filesystem — a `git ls-files`
+  // enumeration cannot see an uncommitted file, which is where a new leak arrives.
   it('catches a freshly written file that logs the endpoint', () => {
     const { findings, scanned } = scanFixture(
       'const rpcUrl = process.env.ETH_NODE_URI_TRON\nconsola.info(`connecting via ${rpcUrl}`)\n'
@@ -78,53 +97,199 @@ describe('the scan fires on a new leak', () => {
   })
 
   it('catches the endpoint read straight off the environment', () => {
-    const { findings } = scanFixture(
-      'consola.warn(`using ${process.env.ETH_NODE_URI_TRON}`)\n'
-    )
-    expect(findings.map((f) => f.identifier)).toEqual(['ETH_NODE_URI_TRON'])
+    expect(
+      identifiers('consola.warn(`using ${process.env.ETH_NODE_URI_TRON}`)\n')
+    ).toEqual(['ETH_NODE_URI_TRON'])
+  })
+
+  // The Tron path reads the suffixed form: `@lifi/tron-devkit`'s getTronRpcUrl resolves
+  // RPC_URL_TRON, so a word-boundary match on `RPC_URL` would never see it.
+  it('catches the suffixed Tron endpoint variable', () => {
+    expect(
+      identifiers('consola.info(`${process.env.RPC_URL_TRON}`)\n')
+    ).toEqual(['RPC_URL_TRON'])
+  })
+
+  it.each(['fatal', 'trace', 'verbose'])('catches consola.%s', (method) => {
+    expect(identifiers(`consola.${method}(\`\${rpcUrl}\`)\n`)).toEqual([
+      'rpcUrl',
+    ])
+  })
+
+  it('catches console.dir, which dumps a whole object', () => {
+    expect(identifiers('console.dir({ url: rpcUrl })\n')).toEqual(['rpcUrl'])
   })
 
   it('stays silent once the same site is redacted', () => {
-    const { findings } = scanFixture(
-      'const rpcUrl = process.env.ETH_NODE_URI_TRON\n' +
-        'consola.info(`connecting via ${redactUrls(rpcUrl)}`)\n'
-    )
-    expect(findings).toEqual([])
+    expect(
+      scanFixture(
+        'const rpcUrl = process.env.ETH_NODE_URI_TRON\n' +
+          'consola.info(`connecting via ${redactUrls(rpcUrl)}`)\n'
+      ).findings
+    ).toEqual([])
+  })
+
+  it('accepts hostOf as a redaction too', () => {
+    expect(scanFixture('consola.info(hostOf(rpcUrl))\n').findings).toEqual([])
   })
 })
 
-describe('the three innocent mentions stay silent, beside a leak that does not', () => {
-  // Each case carries a real leak alongside the innocent form. Without it the case would pass
-  // against a scan that had stopped looking at that file at all.
-  const leak = 'consola.error(`down: ${fullHost}`)\n'
-
+describe('the innocent mentions stay silent, beside a leak that does not', () => {
+  // Each fixture carries a real leak. Without it a case would pass against a scan that had
+  // stopped reading the file entirely.
   it('a doc comment naming rpcUrl is not a log', () => {
-    const { findings } = scanFixture(
-      `/** Takes an rpcUrl and logs it. */\n${leak}`
-    )
-    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+    // The comment sits INSIDE the argument list: text outside a log call is never inspected, so a
+    // comment placed above one asserts nothing about comment handling.
+    expect(
+      identifiers(
+        `consola.info(\n  // the rpcUrl is deliberately not printed\n  'network', name\n)\n${LEAK}`
+      )
+    ).toEqual(['fullHost'])
   })
 
   it('a help string mentioning --rpcUrl is not a log', () => {
-    const { findings } = scanFixture(
-      `consola.info('run with --rpcUrl <url>')\n${leak}`
-    )
-    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+    expect(
+      identifiers(`consola.info('run with --rpcUrl <url>')\n${LEAK}`)
+    ).toEqual(['fullHost'])
   })
 
   it('an object key named rpcUrl labels a field rather than reading one', () => {
-    const { findings } = scanFixture(
-      `consola.info('Network', { rpcUrl: networkName })\n${leak}`
-    )
-    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+    expect(
+      identifiers(`consola.info('Network', { rpcUrl: networkName })\n${LEAK}`)
+    ).toEqual(['fullHost'])
   })
 
   it('a string literal inside a template interpolation is still a string', () => {
-    // The bug this pins: keeping `${...}` as code, but forgetting that code can hold strings.
-    const { findings } = scanFixture(
-      `consola.warn(\`\${name.replace('ETH_NODE_URI_', '')}\`)\n${leak}`
-    )
-    expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+    expect(
+      identifiers(
+        `consola.warn(\`\${name.replace('ETH_NODE_URI_', '')}\`)\n${LEAK}`
+      )
+    ).toEqual(['fullHost'])
+  })
+})
+
+describe('a value read through an operator is still a value', () => {
+  // Requiring only a following `:` would suppress this: it is how an override-or-default is
+  // written at exactly these call sites.
+  it('catches the consequent of a ternary', () => {
+    expect(identifiers("consola.info(`${flag ? rpcUrl : ''}`)\n")).toEqual([
+      'rpcUrl',
+    ])
+  })
+
+  it('catches the alternative of a ternary', () => {
+    expect(identifiers("consola.info(`${flag ? '' : rpcUrl}`)\n")).toEqual([
+      'rpcUrl',
+    ])
+  })
+})
+
+describe('regex literals do not derail the lexer', () => {
+  // A regex is blanked like a string. Without that, a quote or backtick inside one opens a
+  // phantom literal that swallows the rest of the file — four shipped files went blind this way.
+  it.each([
+    ['a character class holding quotes', 'const RE = /[\'"]/g\n'],
+    ['a character class holding a backtick', 'const RE = /[`]/g\n'],
+    [
+      'a scheme strip, which contains //',
+      "const s = x.replace(/^https:\\/\\//, '')\n",
+    ],
+    ['an apostrophe inside a regex', "const RE = /don't/\n"],
+  ])('still sees a leak after %s', (_name, prefix) => {
+    expect(
+      identifiers(`${prefix}consola.info(\`connecting via \${rpcUrl}\`)\n`)
+    ).toEqual(['rpcUrl'])
+  })
+
+  it('sees a leak in a log call that itself contains a regex', () => {
+    expect(
+      identifiers(
+        "consola.info(`${scheme.replace(/^https:\\/\\//, '')} -> ${rpcUrl}`)\n"
+      )
+    ).toEqual(['rpcUrl'])
+  })
+
+  // Division must not be mistaken for a regex, or real code gets blanked instead.
+  it('does not read division as a regex', () => {
+    expect(
+      identifiers(
+        `const q = a/b/c\nconsola.info('n', { rpcUrl: net })\n${LEAK}`
+      )
+    ).toEqual(['fullHost'])
+  })
+
+  it('does not let a parenthesis inside a regex spill the call boundary', () => {
+    // An unmatched `(` in a regex used to run the "arguments" to end-of-file, reporting later,
+    // unrelated lines as leaks.
+    expect(
+      scanFixture(
+        "consola.info(msg.replace(/\\(/g, ''))\n" +
+          'const rpcUrl = process.env.ETH_NODE_URI_TRON\n' +
+          'const client = http(rpcUrl)\n'
+      ).findings
+    ).toEqual([])
+  })
+})
+
+describe('malformed sources do not crash or hang the walk', () => {
+  it('an unterminated call still terminates', () => {
+    expect(identifiers('consola.info(`${rpcUrl}`\n')).toEqual(['rpcUrl'])
+  })
+
+  it('an unterminated string does not throw', () => {
+    expect(() => scanFixture("const s = 'oops\n")).not.toThrow()
+  })
+})
+
+describe('the walk survives what a real tree contains', () => {
+  it('skips a directory that does not exist', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+    try {
+      const { findings, scanned } = scanForRawRpcUrlLogs(root, ['nope'])
+      expect(scanned).toEqual([])
+      expect(findings).toEqual([])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('steps over a dangling symlink and still reads its neighbour', () => {
+    // An unguarded stat throws ENOENT out of the whole scan, failing the suite with an error
+    // that names neither this rule nor the file.
+    const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+    try {
+      mkdirSync(join(root, 'script'), { recursive: true })
+      symlinkSync(
+        join(root, 'script', 'gone.ts'),
+        join(root, 'script', 'dangling.ts')
+      )
+      writeFileSync(join(root, 'script', 'real.ts'), LEAK)
+      const { findings, scanned } = scanForRawRpcUrlLogs(root, ['script'])
+      expect(scanned).toEqual(['script/real.ts'])
+      expect(findings.map((f) => f.identifier)).toEqual(['fullHost'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not follow a symlinked directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+    try {
+      mkdirSync(join(root, 'script', 'real'), { recursive: true })
+      writeFileSync(join(root, 'script', 'real', 'a.ts'), LEAK)
+      symlinkSync(join(root, 'script', 'real'), join(root, 'script', 'link'))
+      const { scanned } = scanForRawRpcUrlLogs(root, ['script'])
+      expect(scanned).toEqual(['script/real/a.ts'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('an unterminated regex running to end of file does not hang', () => {
+    // endOfRegex gives up rather than blanking on, so the leak before it is still reported.
+    expect(identifiers('consola.info(`${rpcUrl}`)\nconst RE = /abc[')).toEqual([
+      'rpcUrl',
+    ])
   })
 })
 
@@ -146,5 +311,10 @@ describe('blankNonCode', () => {
     const out = blankNonCode("const t = `${n.replace('ETH_NODE_URI_', '')}`\n")
     expect(out).not.toContain('ETH_NODE_URI_')
     expect(out).toContain('replace')
+  })
+
+  it('blanks a regex body but leaves division alone', () => {
+    expect(blankNonCode('const RE = /secret/g\n')).not.toContain('secret')
+    expect(blankNonCode('const q = total/count\n')).toContain('total/count')
   })
 })

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -82,6 +82,34 @@ describe('no shipped script logs a raw RPC endpoint', () => {
     for (const path of EXEMPT.keys()) expect(scanned).toContain(path)
   })
 
+  it('an exempted file is still scanned for everything it did not exempt', () => {
+    // The one exempted file also reads ETH_NODE_URI_MAINNET for its anvil fork. A whole-file
+    // skip would hide a credential-bearing log added there later.
+    const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
+    try {
+      const roots = new Set<string>()
+      for (const [path, entry] of EXEMPT) {
+        mkdirSync(join(root, path.slice(0, path.lastIndexOf('/'))), {
+          recursive: true,
+        })
+        const exemptedLogs = entry.identifiers
+          .map((id) => `consola.info(\`\${${id}}\`)`)
+          .join('\n')
+        writeFileSync(
+          join(root, path),
+          `${exemptedLogs}\nconsola.warn(\`\${process.env.ETH_NODE_URI_MAINNET}\`)\n`
+        )
+        roots.add(path.slice(0, path.indexOf('/')))
+      }
+      const { findings } = scanForRawRpcUrlLogs(root, [...roots])
+      expect(findings.map((f) => f.identifier)).toEqual(
+        [...EXEMPT.keys()].map(() => 'ETH_NODE_URI_MAINNET')
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('reads test files but never reports them', () => {
     const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
     try {

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -4,9 +4,9 @@
 /**
  * Guards the rule that no shipped script puts a raw RPC endpoint into a log line.
  *
- * The scan is textual, so most of what follows aims at the scan rather than at the tree: every
- * innocent way this repo names an endpoint is pinned as a negative BESIDE a real leak in the same
- * fixture, so a check that has started refusing everything — or seeing nothing — fails here.
+ * Every innocent way this repo names an endpoint is pinned as a negative BESIDE a real leak in
+ * the same fixture, so a scan that has started refusing everything — or seeing nothing — fails
+ * here rather than in review.
  */
 import {
   mkdirSync,
@@ -25,7 +25,7 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { blankNonCode, EXEMPT, scanForRawRpcUrlLogs } from './rpc-url-log-scan'
+import { EXEMPT, scanForRawRpcUrlLogs } from './rpc-url-log-scan'
 
 const REPO_ROOT = join(import.meta.dir, '..', '..')
 
@@ -110,6 +110,12 @@ describe('the scan fires on a new leak', () => {
     ).toEqual(['RPC_URL_TRON'])
   })
 
+  it('catches an endpoint reached through a property chain', () => {
+    expect(
+      identifiers('consola.info(`${chain.rpcUrls.default.http[0]}`)\n')
+    ).toEqual(['rpcUrls'])
+  })
+
   it.each(['fatal', 'trace', 'verbose'])('catches consola.%s', (method) => {
     expect(identifiers(`consola.${method}(\`\${rpcUrl}\`)\n`)).toEqual([
       'rpcUrl',
@@ -118,6 +124,14 @@ describe('the scan fires on a new leak', () => {
 
   it('catches console.dir, which dumps a whole object', () => {
     expect(identifiers('console.dir({ url: rpcUrl })\n')).toEqual(['rpcUrl'])
+  })
+
+  it('catches a shorthand property, which reads the variable', () => {
+    expect(identifiers('consola.info({ rpcUrl })\n')).toEqual(['rpcUrl'])
+  })
+
+  it('catches a computed key, where the endpoint becomes the printed key', () => {
+    expect(identifiers('consola.info({ [rpcUrl]: n })\n')).toEqual(['rpcUrl'])
   })
 
   it('stays silent once the same site is redacted', () => {
@@ -138,8 +152,8 @@ describe('the innocent mentions stay silent, beside a leak that does not', () =>
   // Each fixture carries a real leak. Without it a case would pass against a scan that had
   // stopped reading the file entirely.
   it('a doc comment naming rpcUrl is not a log', () => {
-    // The comment sits INSIDE the argument list: text outside a log call is never inspected, so a
-    // comment placed above one asserts nothing about comment handling.
+    // Inside the argument list: text outside a log call is never inspected, so a comment placed
+    // above one would assert nothing about comment handling.
     expect(
       identifiers(
         `consola.info(\n  // the rpcUrl is deliberately not printed\n  'network', name\n)\n${LEAK}`
@@ -166,11 +180,52 @@ describe('the innocent mentions stay silent, beside a leak that does not', () =>
       )
     ).toEqual(['fullHost'])
   })
+
+  it('a type annotation names a field that never renders', () => {
+    expect(
+      identifiers(`consola.info('cfg', cfg as { rpcUrl?: string })\n${LEAK}`)
+    ).toEqual(['fullHost'])
+  })
+
+  it('a parameter binding is a name, not a read', () => {
+    expect(
+      identifiers(
+        `consola.info(list.map((rpcUrl) => hostOf(rpcUrl)).join())\n${LEAK}`
+      )
+    ).toEqual(['fullHost'])
+  })
+
+  it('a type query names a type, not a value', () => {
+    // `cfg as { rpcUrl?: string }` is caught by the property-signature rule alone; this shape
+    // reaches the identifier only if type nodes are skipped outright.
+    expect(identifiers(`consola.info(cfg as typeof rpcUrl)\n${LEAK}`)).toEqual([
+      'fullHost',
+    ])
+  })
+
+  it('a variable declared inside the call is a name, not a read', () => {
+    expect(
+      identifiers(
+        `consola.info((() => { const rpcUrl = pick(); return hostOf(rpcUrl) })())\n${LEAK}`
+      )
+    ).toEqual(['fullHost'])
+  })
+
+  it('a consola or console method that prints nothing is not a log surface', () => {
+    expect(identifiers(`console.time(rpcUrl)\n${LEAK}`)).toEqual(['fullHost'])
+    expect(identifiers(`consola.withTag(rpcUrl)\n${LEAK}`)).toEqual([
+      'fullHost',
+    ])
+  })
+
+  it('a vocabulary word inside a regex is not a value', () => {
+    expect(identifiers(`consola.info(typeof /rpcUrl/)\n${LEAK}`)).toEqual([
+      'fullHost',
+    ])
+  })
 })
 
 describe('a value read through an operator is still a value', () => {
-  // Requiring only a following `:` would suppress this: it is how an override-or-default is
-  // written at exactly these call sites.
   it('catches the consequent of a ternary', () => {
     expect(identifiers("consola.info(`${flag ? rpcUrl : ''}`)\n")).toEqual([
       'rpcUrl',
@@ -184,9 +239,9 @@ describe('a value read through an operator is still a value', () => {
   })
 })
 
-describe('regex literals do not derail the lexer', () => {
-  // A regex is blanked like a string. Without that, a quote or backtick inside one opens a
-  // phantom literal that swallows the rest of the file — four shipped files went blind this way.
+describe('grammar the previous text-scanning versions got wrong', () => {
+  // Each of these blinded or false-alarmed a hand-written lexer across three rounds. They are
+  // kept as behaviour, not as lexer internals: the parser is what makes them uninteresting.
   it.each([
     ['a character class holding quotes', 'const RE = /[\'"]/g\n'],
     ['a character class holding a backtick', 'const RE = /[`]/g\n'],
@@ -195,93 +250,29 @@ describe('regex literals do not derail the lexer', () => {
       "const s = x.replace(/^https:\\/\\//, '')\n",
     ],
     ['an apostrophe inside a regex', "const RE = /don't/\n"],
+    [
+      'a regex in value position after a call',
+      'if (isTron(net)) /[\'"]/.test(s)\n',
+    ],
+    [
+      'a regex in value position after an index',
+      'const R = LIST[0] /[\'"]/.test(s)\n',
+    ],
   ])('still sees a leak after %s', (_name, prefix) => {
     expect(
       identifiers(`${prefix}consola.info(\`connecting via \${rpcUrl}\`)\n`)
     ).toEqual(['rpcUrl'])
   })
 
-  it('sees a leak in a log call that itself contains a regex', () => {
+  it('does not report a vocabulary word in a regex reached without a semicolon', () => {
     expect(
-      identifiers(
-        "consola.info(`${scheme.replace(/^https:\\/\\//, '')} -> ${rpcUrl}`)\n"
-      )
-    ).toEqual(['rpcUrl'])
-  })
-
-  // Every case below puts the leak where a WRONG decision would blank it, so the assertion
-  // observes the decision rather than the lines around it. The previous version sat on a line
-  // the assertions never inspected, and nine mutations of this logic survived it.
-  it('does not read division as a regex, on the same line as the leak', () => {
-    expect(identifiers('consola.info(`${a/b} ${rpcUrl} ${c/d}`)\n')).toEqual([
-      'rpcUrl',
-    ])
-  })
-
-  it('treats a postfix increment as the end of a value, not a regex opener', () => {
-    expect(
-      identifiers('consola.info(`${a++ / b} ${rpcUrl} ${c / d}`)\n')
-    ).toEqual(['rpcUrl'])
-  })
-
-  it.each([
-    ['a call', 'if (isTron(net)) /[\'"]/.test(s)\n'],
-    ['an optional call', 'const r = f?.() /[\'"]/.test(s)\n'],
-    ['an index', 'const RE = LIST[0] /[\'"]/.test(s)\n'],
-  ])(
-    'survives a quote-bearing regex in value position after %s',
-    (_n, prefix) => {
-      expect(
-        identifiers(`${prefix}consola.info(\`connecting via \${rpcUrl}\`)\n`)
-      ).toEqual(['rpcUrl'])
-    }
-  )
-
-  it.each(['return', 'typeof', 'case'])(
-    'reads a regex after the keyword %s',
-    (kw) => {
-      expect(
-        identifiers(
-          `const f = () => { ${kw} /['"]/.test(s) }\nconsola.info(\`\${rpcUrl}\`)\n`
-        )
-      ).toEqual(['rpcUrl'])
-    }
-  )
-
-  it('starts each interpolation with a clean token history', () => {
-    // Carrying the previous interpolation's last token in makes this `/` look like division, and
-    // its quote then hides the leak beside it.
-    expect(
-      identifiers('consola.info(`a${b}c${/[\'"]/.test(s)} ${rpcUrl}`)\n')
-    ).toEqual(['rpcUrl'])
-  })
-
-  // The keyword list and the per-interpolation reset are observable as FALSE POSITIVES: a `/`
-  // wrongly read as division leaves the regex body as code, so a vocabulary word inside it is
-  // reported as a leak. (They are not observable as missed leaks any more — a stray quote can no
-  // longer swallow a following line.)
-  it('does not report a vocabulary word inside a regex after a keyword', () => {
-    expect(scanFixture('consola.info(typeof /rpcUrl/)\n').findings).toEqual([])
-  })
-
-  it('does not report a vocabulary word inside a regex in a tagged template', () => {
-    // The token before the backtick is a value, so without a per-interpolation reset the `/`
-    // reads as division and the regex body is scanned as code.
-    expect(
-      scanFixture('consola.info(String.raw`${/rpcUrl/.test(s)}`)\n').findings
+      scanFixture(
+        'consola.info(\n  items.map((x) => {\n    n++\n    return /rpcUrl/.test(x)\n  }).length\n)\n'
+      ).findings
     ).toEqual([])
   })
 
-  it('gives up on an unterminated regex instead of running to the next slash', () => {
-    // Without the newline stop this swallows lines 1-3, taking the leak with it.
-    expect(
-      identifiers('const RE = /abc\nconsola.info(`${rpcUrl}`)\nconst y = p/q\n')
-    ).toEqual(['rpcUrl'])
-  })
-
   it('does not let a parenthesis inside a regex spill the call boundary', () => {
-    // An unmatched `(` in a regex used to run the "arguments" to end-of-file, reporting later,
-    // unrelated lines as leaks.
     expect(
       scanFixture(
         "consola.info(msg.replace(/\\(/g, ''))\n" +
@@ -292,8 +283,9 @@ describe('regex literals do not derail the lexer', () => {
   })
 })
 
-describe('malformed sources do not crash or hang the walk', () => {
-  it('an unterminated call still terminates', () => {
+describe('malformed sources do not crash the walk', () => {
+  it('an unterminated call still reports what it can', () => {
+    // The parser error-recovers rather than throwing.
     expect(identifiers('consola.info(`${rpcUrl}`\n')).toEqual(['rpcUrl'])
   })
 
@@ -315,8 +307,6 @@ describe('the walk survives what a real tree contains', () => {
   })
 
   it('steps over a dangling symlink and still reads its neighbour', () => {
-    // An unguarded stat throws ENOENT out of the whole scan, failing the suite with an error
-    // that names neither this rule nor the file.
     const root = mkdtempSync(join(tmpdir(), 'rpc-log-scan-'))
     try {
       mkdirSync(join(root, 'script'), { recursive: true })
@@ -344,59 +334,5 @@ describe('the walk survives what a real tree contains', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
-  })
-
-  it('an unterminated regex running to end of file does not hang', () => {
-    // endOfRegex gives up rather than blanking on, so the leak before it is still reported.
-    expect(identifiers('consola.info(`${rpcUrl}`)\nconst RE = /abc[')).toEqual([
-      'rpcUrl',
-    ])
-  })
-})
-
-describe('blankNonCode', () => {
-  it('keeps length and line numbering so offsets still line up', () => {
-    const src = "const a = 'xx' // yy\nconst b = 1\n"
-    const out = blankNonCode(src)
-    expect(out.length).toBe(src.length)
-    expect(out.split('\n').length).toBe(src.split('\n').length)
-  })
-
-  it('blanks a string body but keeps a template interpolation', () => {
-    const out = blankNonCode("const s = 'secret'\nconst t = `x ${rpcUrl} y`\n")
-    expect(out).not.toContain('secret')
-    expect(out).toContain('rpcUrl')
-  })
-
-  it('blanks a string nested inside a template interpolation', () => {
-    const out = blankNonCode("const t = `${n.replace('ETH_NODE_URI_', '')}`\n")
-    expect(out).not.toContain('ETH_NODE_URI_')
-    expect(out).toContain('replace')
-  })
-
-  it('blanks a regex body, its character class and its flags', () => {
-    // `total/count` holds one slash, so endOfRegex declines it whatever the decision says; the
-    // three-slash form is what actually distinguishes the two readings.
-    expect(blankNonCode('const RE = /secret/g\n')).not.toContain('secret')
-    expect(blankNonCode('const q = total/count/other\n')).toContain(
-      'total/count/other'
-    )
-  })
-
-  it('consumes a regex\u2019s trailing flags', () => {
-    // Leaving them behind makes the flag letters read as an identifier, which then decides the
-    // next `/` the wrong way.
-    expect(blankNonCode('const RE = /a/gi\n').trimEnd()).toBe('const RE =')
-  })
-
-  it('does not end a regex at a slash inside its character class', () => {
-    expect(blankNonCode('const RE = /[/]x/g\n')).not.toContain('x')
-  })
-
-  it('leaves a quote with no partner on its line as a lone character', () => {
-    // Otherwise the apostrophe opens a string that swallows every following line.
-    expect(blankNonCode("const s = don't\nconst keep = rpcUrl\n")).toContain(
-      'rpcUrl'
-    )
   })
 })

--- a/script/utils/rpc-url-log-scan.test.ts
+++ b/script/utils/rpc-url-log-scan.test.ts
@@ -209,13 +209,74 @@ describe('regex literals do not derail the lexer', () => {
     ).toEqual(['rpcUrl'])
   })
 
-  // Division must not be mistaken for a regex, or real code gets blanked instead.
-  it('does not read division as a regex', () => {
+  // Every case below puts the leak where a WRONG decision would blank it, so the assertion
+  // observes the decision rather than the lines around it. The previous version sat on a line
+  // the assertions never inspected, and nine mutations of this logic survived it.
+  it('does not read division as a regex, on the same line as the leak', () => {
+    expect(identifiers('consola.info(`${a/b} ${rpcUrl} ${c/d}`)\n')).toEqual([
+      'rpcUrl',
+    ])
+  })
+
+  it('treats a postfix increment as the end of a value, not a regex opener', () => {
     expect(
-      identifiers(
-        `const q = a/b/c\nconsola.info('n', { rpcUrl: net })\n${LEAK}`
-      )
-    ).toEqual(['fullHost'])
+      identifiers('consola.info(`${a++ / b} ${rpcUrl} ${c / d}`)\n')
+    ).toEqual(['rpcUrl'])
+  })
+
+  it.each([
+    ['a call', 'if (isTron(net)) /[\'"]/.test(s)\n'],
+    ['an optional call', 'const r = f?.() /[\'"]/.test(s)\n'],
+    ['an index', 'const RE = LIST[0] /[\'"]/.test(s)\n'],
+  ])(
+    'survives a quote-bearing regex in value position after %s',
+    (_n, prefix) => {
+      expect(
+        identifiers(`${prefix}consola.info(\`connecting via \${rpcUrl}\`)\n`)
+      ).toEqual(['rpcUrl'])
+    }
+  )
+
+  it.each(['return', 'typeof', 'case'])(
+    'reads a regex after the keyword %s',
+    (kw) => {
+      expect(
+        identifiers(
+          `const f = () => { ${kw} /['"]/.test(s) }\nconsola.info(\`\${rpcUrl}\`)\n`
+        )
+      ).toEqual(['rpcUrl'])
+    }
+  )
+
+  it('starts each interpolation with a clean token history', () => {
+    // Carrying the previous interpolation's last token in makes this `/` look like division, and
+    // its quote then hides the leak beside it.
+    expect(
+      identifiers('consola.info(`a${b}c${/[\'"]/.test(s)} ${rpcUrl}`)\n')
+    ).toEqual(['rpcUrl'])
+  })
+
+  // The keyword list and the per-interpolation reset are observable as FALSE POSITIVES: a `/`
+  // wrongly read as division leaves the regex body as code, so a vocabulary word inside it is
+  // reported as a leak. (They are not observable as missed leaks any more — a stray quote can no
+  // longer swallow a following line.)
+  it('does not report a vocabulary word inside a regex after a keyword', () => {
+    expect(scanFixture('consola.info(typeof /rpcUrl/)\n').findings).toEqual([])
+  })
+
+  it('does not report a vocabulary word inside a regex in a tagged template', () => {
+    // The token before the backtick is a value, so without a per-interpolation reset the `/`
+    // reads as division and the regex body is scanned as code.
+    expect(
+      scanFixture('consola.info(String.raw`${/rpcUrl/.test(s)}`)\n').findings
+    ).toEqual([])
+  })
+
+  it('gives up on an unterminated regex instead of running to the next slash', () => {
+    // Without the newline stop this swallows lines 1-3, taking the leak with it.
+    expect(
+      identifiers('const RE = /abc\nconsola.info(`${rpcUrl}`)\nconst y = p/q\n')
+    ).toEqual(['rpcUrl'])
   })
 
   it('does not let a parenthesis inside a regex spill the call boundary', () => {
@@ -313,8 +374,29 @@ describe('blankNonCode', () => {
     expect(out).toContain('replace')
   })
 
-  it('blanks a regex body but leaves division alone', () => {
+  it('blanks a regex body, its character class and its flags', () => {
+    // `total/count` holds one slash, so endOfRegex declines it whatever the decision says; the
+    // three-slash form is what actually distinguishes the two readings.
     expect(blankNonCode('const RE = /secret/g\n')).not.toContain('secret')
-    expect(blankNonCode('const q = total/count\n')).toContain('total/count')
+    expect(blankNonCode('const q = total/count/other\n')).toContain(
+      'total/count/other'
+    )
+  })
+
+  it('consumes a regex\u2019s trailing flags', () => {
+    // Leaving them behind makes the flag letters read as an identifier, which then decides the
+    // next `/` the wrong way.
+    expect(blankNonCode('const RE = /a/gi\n').trimEnd()).toBe('const RE =')
+  })
+
+  it('does not end a regex at a slash inside its character class', () => {
+    expect(blankNonCode('const RE = /[/]x/g\n')).not.toContain('x')
+  })
+
+  it('leaves a quote with no partner on its line as a lone character', () => {
+    // Otherwise the apostrophe opens a string that swallows every following line.
+    expect(blankNonCode("const s = don't\nconst keep = rpcUrl\n")).toContain(
+      'rpcUrl'
+    )
   })
 })

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -17,8 +17,8 @@
  * - A computed environment read, `process.env[name]` — the form three scripts here use.
  * - Anything needing dataflow: a value renamed, destructured to another name, or handed to a
  *   helper that logs it.
- * - A path in {@link EXEMPT}, which is whole-file rather than per-line, and anything outside the
- *   roots the caller passes.
+ * - The specific identifiers a path lists in {@link EXEMPT}; everything else in such a file is
+ *   still scanned. And anything outside the roots the caller passes.
  */
 import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
@@ -71,10 +71,16 @@ const REDACTORS = new Set(['redactUrls', 'redactErrorReason', 'hostOf'])
  * Sites that name an endpoint in a log deliberately. An entry is a standing exception to a
  * credential rule, so each carries its reason.
  */
-export const EXEMPT = new Map<string, string>([
+export const EXEMPT = new Map<
+  string,
+  { identifiers: readonly string[]; why: string }
+>([
   [
     'script/demoScripts/demoPaxosTransit.ts',
-    'prints the local anvil endpoint it starts itself (127.0.0.1), which carries no credential',
+    {
+      identifiers: ['RPC_URL'],
+      why: 'RPC_URL is the local anvil endpoint the demo starts itself (127.0.0.1), no credential',
+    },
   ],
 ])
 
@@ -183,7 +189,10 @@ export function scanForRawRpcUrlLogs(
     for (const abs of tsFilesUnder(join(repoRoot, r))) {
       const rel = relative(repoRoot, abs).replace(/\\/g, '/')
       scanned.push(rel)
-      if (EXEMPT.has(rel)) continue
+      // Per identifier, never per file: the one exempted file also holds a real
+      // `ETH_NODE_URI_MAINNET` for its anvil fork, so skipping the whole file would hide a
+      // credential-bearing log added to it later.
+      const exemptHere = EXEMPT.get(rel)?.identifiers ?? []
 
       let src: string
       try {
@@ -212,6 +221,7 @@ export function scanForRawRpcUrlLogs(
           !nowRedacted &&
           ts.isIdentifier(node) &&
           namesAnEndpoint(node.text) &&
+          !exemptHere.includes(node.text) &&
           !declaresRatherThanReads(node)
         )
           findings.push({

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -1,22 +1,16 @@
 /**
- * Find log calls that put a raw RPC endpoint on screen.
+ * Finds log calls that put a raw RPC endpoint on screen.
  *
- * `ETH_NODE_URI_*` carries the provider key inside the URL, so one `consola.info(...)` naming the
- * endpoint publishes a live credential into every transcript that runs the script. An endpoint
- * reaches a log through `redactUrls()` or it does not reach one.
+ * `ETH_NODE_URI_*` embeds the provider key in the URL, so a log line naming the endpoint writes a
+ * live credential into every transcript of the run. Imported by `rpc-url-log-scan.test.ts`, which
+ * fails when a new such site appears under `script/` or `tasks/`.
  *
- * Two limits, stated because a reader will otherwise assume they are not there:
- *
- * 1. The reach is {@link RPC_IDENTIFIERS}. An endpoint laundered through a variable named
- *    something else is invisible, so this narrows the class rather than closing it.
- * 2. It reads text, not an AST — a TypeScript-aware parser is not usable here (the repo's
- *    `typescript` is the Go port, whose JS compiler API is absent, and `oxc-parser` segfaults the
- *    runtime on these files). What makes the text scan trustworthy is {@link blankNonCode}: the
- *    only three ways this repo mentions an endpoint innocently — a doc comment, a help string and
- *    an object key — are removed structurally before anything is matched, and each is covered by
- *    a case in the test.
+ * What it does NOT reach, so nobody mistakes a green run for a closed class:
+ * bash (`.sh` is not walked), endpoints embedded in an error object's `message` by viem or
+ * tronweb, identifiers outside {@link RPC_IDENTIFIERS}, and log surfaces outside
+ * {@link LOG_METHODS}.
  */
-import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
 /** Identifiers whose value is, or holds, a full endpoint URL. */
@@ -27,22 +21,48 @@ export const RPC_IDENTIFIERS: readonly string[] = [
   'nodeUrl',
   'providerUrl',
   'endpointUrl',
-  'RPC_URL',
 ]
 
 /**
- * Matched as a prefix, so `process.env.ETH_NODE_URI_TRON` is caught. A plain word-boundary entry
- * in {@link RPC_IDENTIFIERS} cannot be: the network suffix leaves no boundary after `URI`.
+ * Matched as prefixes, so `ETH_NODE_URI_TRON` and `RPC_URL_TRON` are caught. A word-boundary entry
+ * cannot be: the network suffix leaves no boundary after the base name. `@lifi/tron-devkit`'s
+ * `getTronRpcUrl` reads `RPC_URL_TRON`, so the suffixed form is the one the Tron path uses.
  */
-const RPC_ENV_PREFIX = 'ETH_NODE_URI'
+const RPC_ENV_PREFIXES: readonly string[] = ['ETH_NODE_URI', 'RPC_URL']
 
-const LOG_CALL =
-  /\b(?:consola|console)\s*\.\s*(?:debug|info|log|warn|error|success|start|ready|fail|box)\s*\(/g
+/** consola's `LogType` union plus the `console` methods that dump a whole object. */
+const LOG_METHODS = [
+  'debug',
+  'info',
+  'log',
+  'warn',
+  'error',
+  'success',
+  'start',
+  'ready',
+  'fail',
+  'box',
+  'fatal',
+  'trace',
+  'verbose',
+  'silent',
+  'dir',
+  'table',
+  'group',
+  'groupCollapsed',
+] as const
+const LOG_CALL = new RegExp(
+  String.raw`\b(?:consola|console)\s*\.\s*(?:${LOG_METHODS.join('|')})\s*\(`,
+  'g'
+)
 
 /**
  * Sites that name an endpoint in a log deliberately. An entry is a standing exception to a
  * credential rule, so each carries its reason.
  */
+/** Calls whose argument is safe to log; `hostOf` strips a URL to its host. */
+const REDACTORS = new Set(['redactUrls', 'redactErrorReason', 'hostOf'])
+
 export const EXEMPT = new Map<string, string>([
   [
     'script/demoScripts/demoPaxosTransit.ts',
@@ -57,13 +77,68 @@ export interface IFinding {
   text: string
 }
 
+/** After these, a `/` starts a regex; after any other word it is division. */
+const REGEX_OK_AFTER_WORD = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'case',
+  'do',
+  'else',
+  'yield',
+  'await',
+])
+
+const isWordChar = (c: string | undefined): boolean =>
+  c !== undefined && /[A-Za-z0-9_$]/.test(c)
+
 /**
- * Replace every comment and string body with spaces, keeping length and newlines so offsets and
- * line numbers still line up with the original source.
+ * End offset (exclusive) of the regex literal opening at `i`, or -1 if there is none on that line.
  *
- * A template literal's `${...}` expressions are deliberately KEPT — `${rpcUrl}` is the single most
- * common way this leak is written, and blanking the whole template would hide exactly the case
- * this module exists to catch. Only the literal text around them is blanked.
+ * Looked ahead without mutating, so a `/` that turns out to be division — or an unterminated
+ * literal — leaves the source untouched rather than blanking a line of real code.
+ *
+ * @param src - source text.
+ * @param i - offset of the opening `/`.
+ * @returns offset just past the closing `/` and its flags, or -1.
+ */
+function endOfRegex(src: string, i: number): number {
+  let j = i + 1
+  let inClass = false
+  while (j < src.length) {
+    const c = src[j]
+    if (c === '\n') return -1
+    if (c === '\\') {
+      j += 2
+      continue
+    }
+    if (c === '[') inClass = true
+    else if (c === ']') inClass = false
+    else if (c === '/' && !inClass) {
+      j++
+      while (j < src.length && /[a-z]/i.test(src[j] ?? '')) j++
+      return j
+    }
+    j++
+  }
+  return -1
+}
+
+/**
+ * Replace every comment, string body and regex body with spaces, keeping length and newlines so
+ * offsets and line numbers still line up with the original source.
+ *
+ * A template literal's `${...}` expressions are deliberately KEPT — `${rpcUrl}` is the most common
+ * way this leak is written, and blanking the whole template would hide the case this module
+ * exists to catch. Only the literal text around them is blanked.
+ *
+ * Regex literals are blanked for the same reason strings are: `/['"`]/` would otherwise open a
+ * phantom string that swallows the rest of the file, and `/^https:\/\//` reads as a line comment.
  *
  * @param src - original source text.
  * @returns the same text with non-code spans replaced by spaces.
@@ -74,15 +149,16 @@ export function blankNonCode(src: string): string {
     if (out[i] !== '\n') out[i] = ' '
   }
 
-  // A stack, because the two contexts nest without limit: a template holds `${...}` code, which
-  // holds another template, which holds another string. A single pass with one flag blanks the
-  // wrong half — the first version of this kept an interpolation as code but never blanked the
-  // string literals inside it, so `` `${n.replace('ETH_NODE_URI_', '')}` `` read as a live
-  // endpoint. `braceDepth` is what stops an object literal's `}` from ending the interpolation.
+  // A stack, because the contexts nest without limit: a template holds `${...}` code, which holds
+  // another template, which holds another string. `braceDepth` is what stops an object literal's
+  // `}` from ending the interpolation.
   const stack: { kind: 'code' | 'tmpl'; braceDepth: number }[] = [
     { kind: 'code', braceDepth: 0 },
   ]
   let i = 0
+  // Decides the `/` ambiguity. A regex may follow an operator or a keyword, never a value.
+  let prevChar = ''
+  let prevWord = ''
 
   while (i < src.length) {
     const top = stack[stack.length - 1]
@@ -97,16 +173,22 @@ export function blankNonCode(src: string): string {
       } else if (c === '$' && n === '{') {
         i += 2
         stack.push({ kind: 'code', braceDepth: 0 })
+        prevChar = ''
+        prevWord = ''
       } else if (c === '`') {
         blank(i++)
         stack.pop()
+        prevChar = '`'
+        prevWord = ''
       } else blank(i++)
       continue
     }
 
     if (c === '/' && n === '/') {
       while (i < src.length && src[i] !== '\n') blank(i++)
-    } else if (c === '/' && n === '*') {
+      continue
+    }
+    if (c === '/' && n === '*') {
       blank(i++)
       blank(i++)
       while (i < src.length && !(src[i] === '*' && src[i + 1] === '/'))
@@ -115,28 +197,56 @@ export function blankNonCode(src: string): string {
         blank(i++)
         blank(i++)
       }
-    } else if (c === "'" || c === '"') {
+      continue
+    }
+    if (
+      c === '/' &&
+      (!isWordChar(prevChar) || REGEX_OK_AFTER_WORD.has(prevWord)) &&
+      prevChar !== ')' &&
+      prevChar !== ']'
+    ) {
+      const end = endOfRegex(src, i)
+      if (end !== -1) {
+        while (i < end) blank(i++)
+        prevChar = '/'
+        prevWord = ''
+        continue
+      }
+    }
+    if (c === "'" || c === '"') {
       blank(i++)
       while (i < src.length && src[i] !== c) {
         if (src[i] === '\\') blank(i++)
         if (i < src.length) blank(i++)
       }
       if (i < src.length) blank(i++)
-    } else if (c === '`') {
+      prevChar = c
+      prevWord = ''
+      continue
+    }
+    if (c === '`') {
       blank(i++)
       stack.push({ kind: 'tmpl', braceDepth: 0 })
-    } else if (c === '{') {
-      top.braceDepth++
-      i++
-    } else if (c === '}') {
-      if (top.braceDepth > 0) {
-        top.braceDepth--
-        i++
-      } else if (stack.length > 1) {
-        stack.pop()
-        i++
-      } else i++
-    } else i++
+      continue
+    }
+    if (c !== undefined && /[A-Za-z_$]/.test(c)) {
+      let j = i
+      while (j < src.length && isWordChar(src[j])) j++
+      prevWord = src.slice(i, j)
+      prevChar = src[j - 1] ?? ''
+      i = j
+      continue
+    }
+    if (c === '{') top.braceDepth++
+    else if (c === '}') {
+      if (top.braceDepth > 0) top.braceDepth--
+      else if (stack.length > 1) stack.pop()
+    }
+    if (c !== undefined && !/\s/.test(c)) {
+      prevChar = c
+      prevWord = ''
+    }
+    i++
   }
   return out.join('')
 }
@@ -154,10 +264,10 @@ function endOfCall(src: string, openParen: number): number {
   return src.length
 }
 
-/** Argument spans of every `redactUrls(...)` / `redactErrorReason(...)` call. */
+/** Argument spans of every redaction call. */
 function redactedSpans(code: string): [number, number][] {
   const spans: [number, number][] = []
-  const re = /\bredact(?:Urls|ErrorReason)\s*\(/g
+  const re = new RegExp(String.raw`\b(?:${[...REDACTORS].join('|')})\s*\(`, 'g')
   let m: RegExpExecArray | null
   while ((m = re.exec(code)) !== null) {
     const open = m.index + m[0].length - 1
@@ -166,21 +276,46 @@ function redactedSpans(code: string): [number, number][] {
   return spans
 }
 
+/**
+ * True when the identifier at `at` is an object-literal key rather than a value being read.
+ *
+ * Both halves are required. Testing only for a following `:` also suppresses the consequent of a
+ * ternary — `${flag ? rpcUrl : ''}` — which is a normal way to write an endpoint override, so the
+ * preceding `{` or `,` is what separates a label from a value.
+ *
+ * @param code - blanked source.
+ * @param at - offset of the identifier.
+ * @param length - identifier length.
+ * @returns whether this occurrence names a field.
+ */
+function isObjectKey(code: string, at: number, length: number): boolean {
+  if (!/^\s*:/.test(code.slice(at + length))) return false
+  let b = at - 1
+  while (b >= 0 && /\s/.test(code[b] ?? '')) b--
+  const prev = code[b]
+  return prev === '{' || prev === ','
+}
+
 function tsFilesUnder(root: string, out: string[] = []): string[] {
-  let entries: string[]
+  let entries: Dirent[]
   try {
-    entries = readdirSync(root)
+    // withFileTypes, so the kind comes back with the listing: a second stat call would both
+    // follow symlinked directories (a self-referential one loops) and race a file being removed
+    // between the two calls.
+    entries = readdirSync(root, { withFileTypes: true })
   } catch {
     return out
   }
   for (const e of entries) {
-    if (e === 'node_modules' || e.startsWith('.')) continue
-    const p = join(root, e)
-    if (statSync(p).isDirectory()) tsFilesUnder(p, out)
+    const name = e.name
+    if (name === 'node_modules' || name.startsWith('.') || e.isSymbolicLink())
+      continue
+    const p = join(root, name)
+    if (e.isDirectory()) tsFilesUnder(p, out)
     else if (
-      e.endsWith('.ts') &&
-      !e.endsWith('.test.ts') &&
-      !e.endsWith('.d.ts')
+      name.endsWith('.ts') &&
+      !name.endsWith('.test.ts') &&
+      !name.endsWith('.d.ts')
     )
       out.push(p)
   }
@@ -196,6 +331,7 @@ function tsFilesUnder(root: string, out: string[] = []): string[] {
  * @param repoRoot - repository root.
  * @param roots - directories to walk, relative to the root.
  * @returns one finding per offending log argument, and the files actually examined.
+ * @throws never for an unreadable path — a directory or file it cannot read is skipped.
  */
 export function scanForRawRpcUrlLogs(
   repoRoot: string,
@@ -210,7 +346,12 @@ export function scanForRawRpcUrlLogs(
       scanned.push(rel)
       if (EXEMPT.has(rel)) continue
 
-      const src = readFileSync(abs, 'utf8')
+      let src: string
+      try {
+        src = readFileSync(abs, 'utf8')
+      } catch {
+        continue
+      }
       const code = blankNonCode(src)
       const safe = redactedSpans(code)
 
@@ -221,17 +362,15 @@ export function scanForRawRpcUrlLogs(
         const close = endOfCall(code, open)
         const args = code.slice(open, close)
 
-        for (const id of [...RPC_IDENTIFIERS, RPC_ENV_PREFIX]) {
-          const idRe =
-            id === RPC_ENV_PREFIX
-              ? new RegExp(`\\b${id}\\w*\\b`, 'g')
-              : new RegExp(`\\b${id}\\b`, 'g')
+        for (const id of [...RPC_IDENTIFIERS, ...RPC_ENV_PREFIXES]) {
+          const idRe = RPC_ENV_PREFIXES.includes(id)
+            ? new RegExp(String.raw`\b${id}\w*\b`, 'g')
+            : new RegExp(String.raw`\b${id}\b`, 'g')
           let m: RegExpExecArray | null
           while ((m = idRe.exec(args)) !== null) {
             const at = open + m.index
-            // `{ rpcUrl: network }` labels a field rather than reading an endpoint.
-            if (/^\s*:/.test(code.slice(at + m[0].length))) continue
-            if (safe.some(([s, e]) => at > s && at < e)) continue
+            if (isObjectKey(code, at, m[0].length)) continue
+            if (safe.some(([st, e]) => at > st && at < e)) continue
             findings.push({
               file: rel,
               line: src.slice(0, at).split('\n').length,

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -5,10 +5,11 @@
  * live credential into every transcript of the run. Imported by `rpc-url-log-scan.test.ts`, which
  * fails when a new such site appears under `script/` or `tasks/`.
  *
- * What it does NOT reach, so nobody mistakes a green run for a closed class:
- * bash (`.sh` is not walked), endpoints embedded in an error object's `message` by viem or
- * tronweb, identifiers outside {@link RPC_IDENTIFIERS}, and log surfaces outside
- * {@link LOG_METHODS}.
+ * What it does NOT reach, so nobody mistakes a green run for a closed class: bash (`.sh` is not
+ * walked); endpoints embedded in an error object's `message` by viem or tronweb; identifiers
+ * outside {@link RPC_IDENTIFIERS}; log surfaces outside {@link LOG_METHODS}; anything under a
+ * path in {@link EXEMPT}, which is whole-file rather than per-line; and anything outside the
+ * roots the caller passes.
  */
 import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
@@ -158,7 +159,12 @@ export function blankNonCode(src: string): string {
   let i = 0
   // Decides the `/` ambiguity. A regex may follow an operator or a keyword, never a value.
   let prevChar = ''
+  let prevTwo = ''
   let prevWord = ''
+  const endsAValue = (): boolean =>
+    [')', ']', "'", '"', '`'].includes(prevChar) ||
+    prevTwo === '++' ||
+    prevTwo === '--'
 
   while (i < src.length) {
     const top = stack[stack.length - 1]
@@ -202,8 +208,7 @@ export function blankNonCode(src: string): string {
     if (
       c === '/' &&
       (!isWordChar(prevChar) || REGEX_OK_AFTER_WORD.has(prevWord)) &&
-      prevChar !== ')' &&
-      prevChar !== ']'
+      !endsAValue()
     ) {
       const end = endOfRegex(src, i)
       if (end !== -1) {
@@ -214,13 +219,18 @@ export function blankNonCode(src: string): string {
       }
     }
     if (c === "'" || c === '"') {
-      blank(i++)
-      while (i < src.length && src[i] !== c) {
-        if (src[i] === '\\') blank(i++)
-        if (i < src.length) blank(i++)
-      }
-      if (i < src.length) blank(i++)
+      // Looked ahead before blanking, and bounded to the line: a quoted string cannot hold a raw
+      // newline, so a quote with no partner on its own line is not a string opener — usually a
+      // quote inside a regex this pass declined to read as one. Blanking such a quote all the way
+      // to end-of-file is what made four shipped files invisible, so any future mis-decision is
+      // now confined to the line it happens on.
+      let j = i + 1
+      while (j < src.length && src[j] !== c && src[j] !== '\n')
+        j += src[j] === '\\' ? 2 : 1
+      if (j < src.length && src[j] === c) while (i <= j) blank(i++)
+      else i++
       prevChar = c
+      prevTwo = ''
       prevWord = ''
       continue
     }
@@ -243,6 +253,7 @@ export function blankNonCode(src: string): string {
       else if (stack.length > 1) stack.pop()
     }
     if (c !== undefined && !/\s/.test(c)) {
+      prevTwo = prevChar + c
       prevChar = c
       prevWord = ''
     }

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -25,7 +25,18 @@
 import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
-import ts from 'typescript'
+import {
+  createSourceFile,
+  forEachChild,
+  isCallExpression,
+  isIdentifier,
+  isPropertyAccessExpression,
+  isQualifiedName,
+  isShorthandPropertyAssignment,
+  isTypeNode,
+  ScriptTarget,
+} from 'typescript'
+import type { CallExpression, Identifier, Node } from 'typescript'
 
 /** Identifiers whose value is, or holds, a full endpoint URL. */
 export const RPC_IDENTIFIERS: readonly string[] = [
@@ -97,17 +108,17 @@ const namesAnEndpoint = (text: string): boolean =>
   RPC_IDENTIFIERS.includes(text) ||
   RPC_ENV_PREFIXES.some((p) => text.startsWith(p))
 
-const calleeName = (node: ts.CallExpression): string | undefined => {
-  if (ts.isIdentifier(node.expression)) return node.expression.text
-  if (ts.isPropertyAccessExpression(node.expression))
+const calleeName = (node: CallExpression): string | undefined => {
+  if (isIdentifier(node.expression)) return node.expression.text
+  if (isPropertyAccessExpression(node.expression))
     return node.expression.name.text
   return undefined
 }
 
-const isLogCall = (node: ts.Node): boolean =>
-  ts.isCallExpression(node) &&
-  ts.isPropertyAccessExpression(node.expression) &&
-  ts.isIdentifier(node.expression.expression) &&
+const isLogCall = (node: Node): boolean =>
+  isCallExpression(node) &&
+  isPropertyAccessExpression(node.expression) &&
+  isIdentifier(node.expression.expression) &&
   LOGGERS.has(node.expression.expression.text) &&
   LOG_METHODS.includes(node.expression.name.text)
 
@@ -123,15 +134,15 @@ const isLogCall = (node: ts.Node): boolean =>
  * reports. A property access reads a member, so `chain.rpcUrls` reports even though `rpcUrls` is
  * its parent's `name`.
  */
-function declaresRatherThanReads(node: ts.Identifier): boolean {
+function declaresRatherThanReads(node: Identifier): boolean {
   const p = node.parent
   if (!p) return false
-  if (ts.isPropertyAccessExpression(p) || ts.isQualifiedName(p)) return false
-  if (ts.isShorthandPropertyAssignment(p)) return false
-  const named = p as ts.Node & {
-    name?: ts.Node
-    propertyName?: ts.Node
-    label?: ts.Node
+  if (isPropertyAccessExpression(p) || isQualifiedName(p)) return false
+  if (isShorthandPropertyAssignment(p)) return false
+  const named = p as Node & {
+    name?: Node
+    propertyName?: Node
+    label?: Node
   }
   return (
     named.name === node || named.propertyName === node || named.label === node
@@ -203,25 +214,21 @@ export function scanForRawRpcUrlLogs(
         continue
       }
       // The parser error-recovers rather than throwing, so a malformed file still yields a tree.
-      const sf = ts.createSourceFile(abs, src, ts.ScriptTarget.Latest, true)
+      const sf = createSourceFile(abs, src, ScriptTarget.Latest, true)
 
-      const visit = (
-        node: ts.Node,
-        inLog: boolean,
-        redacted: boolean
-      ): void => {
+      const visit = (node: Node, inLog: boolean, redacted: boolean): void => {
         // A type never renders at runtime, so `cfg as { rpcUrl?: string }` names nothing.
-        if (ts.isTypeNode(node)) return
+        if (isTypeNode(node)) return
 
         const nowLog = inLog || isLogCall(node)
         const nowRedacted =
           redacted ||
-          (ts.isCallExpression(node) && REDACTORS.has(calleeName(node) ?? ''))
+          (isCallExpression(node) && REDACTORS.has(calleeName(node) ?? ''))
 
         if (
           nowLog &&
           !nowRedacted &&
-          ts.isIdentifier(node) &&
+          isIdentifier(node) &&
           namesAnEndpoint(node.text) &&
           !exemptHere.includes(node.text) &&
           !declaresRatherThanReads(node)
@@ -238,11 +245,11 @@ export function scanForRawRpcUrlLogs(
               .replace(/\s+/g, ' '),
           })
 
-        ts.forEachChild(node, (c) => {
+        forEachChild(node, (c) => {
           // `consola.info` — the method name is not an argument.
           if (
             nowLog &&
-            ts.isCallExpression(node) &&
+            isCallExpression(node) &&
             c === node.expression &&
             isLogCall(node)
           )

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -1,0 +1,248 @@
+/**
+ * Find log calls that put a raw RPC endpoint on screen.
+ *
+ * `ETH_NODE_URI_*` carries the provider key inside the URL, so one `consola.info(...)` naming the
+ * endpoint publishes a live credential into every transcript that runs the script. An endpoint
+ * reaches a log through `redactUrls()` or it does not reach one.
+ *
+ * Two limits, stated because a reader will otherwise assume they are not there:
+ *
+ * 1. The reach is {@link RPC_IDENTIFIERS}. An endpoint laundered through a variable named
+ *    something else is invisible, so this narrows the class rather than closing it.
+ * 2. It reads text, not an AST — a TypeScript-aware parser is not usable here (the repo's
+ *    `typescript` is the Go port, whose JS compiler API is absent, and `oxc-parser` segfaults the
+ *    runtime on these files). What makes the text scan trustworthy is {@link blankNonCode}: the
+ *    only three ways this repo mentions an endpoint innocently — a doc comment, a help string and
+ *    an object key — are removed structurally before anything is matched, and each is covered by
+ *    a case in the test.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+/** Identifiers whose value is, or holds, a full endpoint URL. */
+export const RPC_IDENTIFIERS: readonly string[] = [
+  'rpcUrl',
+  'rpcUrls',
+  'fullHost',
+  'nodeUrl',
+  'providerUrl',
+  'endpointUrl',
+  'RPC_URL',
+]
+
+/**
+ * Matched as a prefix, so `process.env.ETH_NODE_URI_TRON` is caught. A plain word-boundary entry
+ * in {@link RPC_IDENTIFIERS} cannot be: the network suffix leaves no boundary after `URI`.
+ */
+const RPC_ENV_PREFIX = 'ETH_NODE_URI'
+
+const LOG_CALL =
+  /\b(?:consola|console)\s*\.\s*(?:debug|info|log|warn|error|success|start|ready|fail|box)\s*\(/g
+
+/**
+ * Sites that name an endpoint in a log deliberately. An entry is a standing exception to a
+ * credential rule, so each carries its reason.
+ */
+export const EXEMPT = new Map<string, string>([
+  [
+    'script/demoScripts/demoPaxosTransit.ts',
+    'prints the local anvil endpoint it starts itself (127.0.0.1), which carries no credential',
+  ],
+])
+
+export interface IFinding {
+  file: string
+  line: number
+  identifier: string
+  text: string
+}
+
+/**
+ * Replace every comment and string body with spaces, keeping length and newlines so offsets and
+ * line numbers still line up with the original source.
+ *
+ * A template literal's `${...}` expressions are deliberately KEPT — `${rpcUrl}` is the single most
+ * common way this leak is written, and blanking the whole template would hide exactly the case
+ * this module exists to catch. Only the literal text around them is blanked.
+ *
+ * @param src - original source text.
+ * @returns the same text with non-code spans replaced by spaces.
+ */
+export function blankNonCode(src: string): string {
+  const out = src.split('')
+  const blank = (i: number): void => {
+    if (out[i] !== '\n') out[i] = ' '
+  }
+
+  // A stack, because the two contexts nest without limit: a template holds `${...}` code, which
+  // holds another template, which holds another string. A single pass with one flag blanks the
+  // wrong half — the first version of this kept an interpolation as code but never blanked the
+  // string literals inside it, so `` `${n.replace('ETH_NODE_URI_', '')}` `` read as a live
+  // endpoint. `braceDepth` is what stops an object literal's `}` from ending the interpolation.
+  const stack: { kind: 'code' | 'tmpl'; braceDepth: number }[] = [
+    { kind: 'code', braceDepth: 0 },
+  ]
+  let i = 0
+
+  while (i < src.length) {
+    const top = stack[stack.length - 1]
+    if (!top) break
+    const c = src[i]
+    const n = src[i + 1]
+
+    if (top.kind === 'tmpl') {
+      if (c === '\\') {
+        blank(i++)
+        if (i < src.length) blank(i++)
+      } else if (c === '$' && n === '{') {
+        i += 2
+        stack.push({ kind: 'code', braceDepth: 0 })
+      } else if (c === '`') {
+        blank(i++)
+        stack.pop()
+      } else blank(i++)
+      continue
+    }
+
+    if (c === '/' && n === '/') {
+      while (i < src.length && src[i] !== '\n') blank(i++)
+    } else if (c === '/' && n === '*') {
+      blank(i++)
+      blank(i++)
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/'))
+        blank(i++)
+      if (i < src.length) {
+        blank(i++)
+        blank(i++)
+      }
+    } else if (c === "'" || c === '"') {
+      blank(i++)
+      while (i < src.length && src[i] !== c) {
+        if (src[i] === '\\') blank(i++)
+        if (i < src.length) blank(i++)
+      }
+      if (i < src.length) blank(i++)
+    } else if (c === '`') {
+      blank(i++)
+      stack.push({ kind: 'tmpl', braceDepth: 0 })
+    } else if (c === '{') {
+      top.braceDepth++
+      i++
+    } else if (c === '}') {
+      if (top.braceDepth > 0) {
+        top.braceDepth--
+        i++
+      } else if (stack.length > 1) {
+        stack.pop()
+        i++
+      } else i++
+    } else i++
+  }
+  return out.join('')
+}
+
+/** Offset of the `)` matching the `(` at `openParen`. */
+function endOfCall(src: string, openParen: number): number {
+  let depth = 0
+  for (let i = openParen; i < src.length; i++) {
+    if (src[i] === '(') depth++
+    else if (src[i] === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return src.length
+}
+
+/** Argument spans of every `redactUrls(...)` / `redactErrorReason(...)` call. */
+function redactedSpans(code: string): [number, number][] {
+  const spans: [number, number][] = []
+  const re = /\bredact(?:Urls|ErrorReason)\s*\(/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(code)) !== null) {
+    const open = m.index + m[0].length - 1
+    spans.push([open, endOfCall(code, open)])
+  }
+  return spans
+}
+
+function tsFilesUnder(root: string, out: string[] = []): string[] {
+  let entries: string[]
+  try {
+    entries = readdirSync(root)
+  } catch {
+    return out
+  }
+  for (const e of entries) {
+    if (e === 'node_modules' || e.startsWith('.')) continue
+    const p = join(root, e)
+    if (statSync(p).isDirectory()) tsFilesUnder(p, out)
+    else if (
+      e.endsWith('.ts') &&
+      !e.endsWith('.test.ts') &&
+      !e.endsWith('.d.ts')
+    )
+      out.push(p)
+  }
+  return out
+}
+
+/**
+ * Scan shipped modules for log calls naming an endpoint outside a redaction.
+ *
+ * Enumerates the filesystem rather than `git ls-files` deliberately: an uncommitted file is
+ * exactly where a new leak arrives, and a git-backed listing cannot see one.
+ *
+ * @param repoRoot - repository root.
+ * @param roots - directories to walk, relative to the root.
+ * @returns one finding per offending log argument, and the files actually examined.
+ */
+export function scanForRawRpcUrlLogs(
+  repoRoot: string,
+  roots: string[] = ['script', 'tasks']
+): { findings: IFinding[]; scanned: string[] } {
+  const findings: IFinding[] = []
+  const scanned: string[] = []
+
+  for (const r of roots)
+    for (const abs of tsFilesUnder(join(repoRoot, r))) {
+      const rel = relative(repoRoot, abs).replace(/\\/g, '/')
+      scanned.push(rel)
+      if (EXEMPT.has(rel)) continue
+
+      const src = readFileSync(abs, 'utf8')
+      const code = blankNonCode(src)
+      const safe = redactedSpans(code)
+
+      LOG_CALL.lastIndex = 0
+      let call: RegExpExecArray | null
+      while ((call = LOG_CALL.exec(code)) !== null) {
+        const open = call.index + call[0].length - 1
+        const close = endOfCall(code, open)
+        const args = code.slice(open, close)
+
+        for (const id of [...RPC_IDENTIFIERS, RPC_ENV_PREFIX]) {
+          const idRe =
+            id === RPC_ENV_PREFIX
+              ? new RegExp(`\\b${id}\\w*\\b`, 'g')
+              : new RegExp(`\\b${id}\\b`, 'g')
+          let m: RegExpExecArray | null
+          while ((m = idRe.exec(args)) !== null) {
+            const at = open + m.index
+            // `{ rpcUrl: network }` labels a field rather than reading an endpoint.
+            if (/^\s*:/.test(code.slice(at + m[0].length))) continue
+            if (safe.some(([s, e]) => at > s && at < e)) continue
+            findings.push({
+              file: rel,
+              line: src.slice(0, at).split('\n').length,
+              identifier: m[0],
+              text: src
+                .slice(at, Math.min(at + 70, src.length))
+                .replace(/\s+/g, ' '),
+            })
+          }
+        }
+      }
+    }
+  return { findings, scanned }
+}

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -14,6 +14,8 @@
  * - Any receiver that is not a bare `consola`/`console` with a dotted method: an alias
  *   (`const c = consola`), `console['log'](…)`, `consola.info.call(…)` and a tagged template are
  *   each invisible however the method is named.
+ * - A redactor trusted by name: a local function called `redactUrls` that returns its argument
+ *   unchanged is believed. Resolving the binding needs a type-checked program, not one file.
  * - A computed environment read, `process.env[name]` — the form three scripts here use.
  * - Anything needing dataflow: a value renamed, destructured to another name, or handed to a
  *   helper that logs it.

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -5,11 +5,20 @@
  * live credential into every transcript of the run. Imported by `rpc-url-log-scan.test.ts`, which
  * fails when a new such site appears under `script/` or `tasks/`.
  *
- * What it does NOT reach, so nobody mistakes a green run for a closed class: bash (`.sh` is not
- * walked); endpoints embedded in an error object's `message` by viem or tronweb; identifiers
- * outside {@link RPC_IDENTIFIERS}; log surfaces outside {@link LOG_METHODS}; anything under a
- * path in {@link EXEMPT}, which is whole-file rather than per-line; and anything outside the
- * roots the caller passes.
+ * What it does NOT reach, so nobody mistakes a green run for a closed class:
+ *
+ * - bash — `.sh` is not walked at all.
+ * - An endpoint viem or tronweb embeds in an error object's `message`.
+ * - A name outside {@link RPC_IDENTIFIERS} / `RPC_ENV_PREFIXES`, or a method outside
+ *   {@link LOG_METHODS}.
+ * - Any receiver that is not a bare `consola`/`console` with a dotted method: an alias
+ *   (`const c = consola`), `console['log'](…)`, `consola.info.call(…)` and a tagged template are
+ *   each invisible however the method is named.
+ * - A computed environment read, `process.env[name]` — the form three scripts here use.
+ * - Anything needing dataflow: a value renamed, destructured to another name, or handed to a
+ *   helper that logs it.
+ * - A path in {@link EXEMPT}, which is whole-file rather than per-line, and anything outside the
+ *   roots the caller passes.
  */
 import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
@@ -97,19 +106,28 @@ const isLogCall = (node: ts.Node): boolean =>
 /**
  * True when this identifier declares a name rather than reading a value.
  *
- * An object key, a parameter and a binding all *mention* the word without putting an endpoint on
- * screen. A shorthand `{ rpcUrl }` is deliberately NOT one of these: it reads the variable.
+ * An object key, a parameter, a binding, a method name and a label all *mention* the word without
+ * putting an endpoint on screen. Asked structurally — is this identifier the thing its parent is
+ * naming — rather than by listing declaration kinds: a fixed list of node kinds silently omits
+ * accessors, methods, enum members and labels, and that omission is a false red on honest code.
+ *
+ * Two deliberate exceptions. A shorthand `{ rpcUrl }` is both the name and the read, so it
+ * reports. A property access reads a member, so `chain.rpcUrls` reports even though `rpcUrls` is
+ * its parent's `name`.
  */
 function declaresRatherThanReads(node: ts.Identifier): boolean {
   const p = node.parent
   if (!p) return false
-  if (ts.isPropertyAssignment(p) && p.name === node) return true
-  if (ts.isParameter(p) && p.name === node) return true
-  if (ts.isBindingElement(p) && (p.name === node || p.propertyName === node))
-    return true
-  if (ts.isVariableDeclaration(p) && p.name === node) return true
-  if (ts.isPropertySignature(p) && p.name === node) return true
-  return false
+  if (ts.isPropertyAccessExpression(p) || ts.isQualifiedName(p)) return false
+  if (ts.isShorthandPropertyAssignment(p)) return false
+  const named = p as ts.Node & {
+    name?: ts.Node
+    propertyName?: ts.Node
+    label?: ts.Node
+  }
+  return (
+    named.name === node || named.propertyName === node || named.label === node
+  )
 }
 
 function tsFilesUnder(root: string, out: string[] = []): string[] {

--- a/script/utils/rpc-url-log-scan.ts
+++ b/script/utils/rpc-url-log-scan.ts
@@ -14,6 +14,8 @@
 import { type Dirent, readFileSync, readdirSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
+import ts from 'typescript'
+
 /** Identifiers whose value is, or holds, a full endpoint URL. */
 export const RPC_IDENTIFIERS: readonly string[] = [
   'rpcUrl',
@@ -25,14 +27,13 @@ export const RPC_IDENTIFIERS: readonly string[] = [
 ]
 
 /**
- * Matched as prefixes, so `ETH_NODE_URI_TRON` and `RPC_URL_TRON` are caught. A word-boundary entry
- * cannot be: the network suffix leaves no boundary after the base name. `@lifi/tron-devkit`'s
+ * Matched as prefixes, so `ETH_NODE_URI_TRON` and `RPC_URL_TRON` are caught. `@lifi/tron-devkit`'s
  * `getTronRpcUrl` reads `RPC_URL_TRON`, so the suffixed form is the one the Tron path uses.
  */
 const RPC_ENV_PREFIXES: readonly string[] = ['ETH_NODE_URI', 'RPC_URL']
 
 /** consola's `LogType` union plus the `console` methods that dump a whole object. */
-const LOG_METHODS = [
+export const LOG_METHODS: readonly string[] = [
   'debug',
   'info',
   'log',
@@ -51,19 +52,16 @@ const LOG_METHODS = [
   'table',
   'group',
   'groupCollapsed',
-] as const
-const LOG_CALL = new RegExp(
-  String.raw`\b(?:consola|console)\s*\.\s*(?:${LOG_METHODS.join('|')})\s*\(`,
-  'g'
-)
+]
+const LOGGERS = new Set(['consola', 'console'])
+
+/** Calls whose argument is safe to log; `hostOf` strips a URL to its host. */
+const REDACTORS = new Set(['redactUrls', 'redactErrorReason', 'hostOf'])
 
 /**
  * Sites that name an endpoint in a log deliberately. An entry is a standing exception to a
  * credential rule, so each carries its reason.
  */
-/** Calls whose argument is safe to log; `hostOf` strips a URL to its host. */
-const REDACTORS = new Set(['redactUrls', 'redactErrorReason', 'hostOf'])
-
 export const EXEMPT = new Map<string, string>([
   [
     'script/demoScripts/demoPaxosTransit.ts',
@@ -78,233 +76,40 @@ export interface IFinding {
   text: string
 }
 
-/** After these, a `/` starts a regex; after any other word it is division. */
-const REGEX_OK_AFTER_WORD = new Set([
-  'return',
-  'typeof',
-  'instanceof',
-  'in',
-  'of',
-  'new',
-  'delete',
-  'void',
-  'case',
-  'do',
-  'else',
-  'yield',
-  'await',
-])
+const namesAnEndpoint = (text: string): boolean =>
+  RPC_IDENTIFIERS.includes(text) ||
+  RPC_ENV_PREFIXES.some((p) => text.startsWith(p))
 
-const isWordChar = (c: string | undefined): boolean =>
-  c !== undefined && /[A-Za-z0-9_$]/.test(c)
+const calleeName = (node: ts.CallExpression): string | undefined => {
+  if (ts.isIdentifier(node.expression)) return node.expression.text
+  if (ts.isPropertyAccessExpression(node.expression))
+    return node.expression.name.text
+  return undefined
+}
+
+const isLogCall = (node: ts.Node): boolean =>
+  ts.isCallExpression(node) &&
+  ts.isPropertyAccessExpression(node.expression) &&
+  ts.isIdentifier(node.expression.expression) &&
+  LOGGERS.has(node.expression.expression.text) &&
+  LOG_METHODS.includes(node.expression.name.text)
 
 /**
- * End offset (exclusive) of the regex literal opening at `i`, or -1 if there is none on that line.
+ * True when this identifier declares a name rather than reading a value.
  *
- * Looked ahead without mutating, so a `/` that turns out to be division — or an unterminated
- * literal — leaves the source untouched rather than blanking a line of real code.
- *
- * @param src - source text.
- * @param i - offset of the opening `/`.
- * @returns offset just past the closing `/` and its flags, or -1.
+ * An object key, a parameter and a binding all *mention* the word without putting an endpoint on
+ * screen. A shorthand `{ rpcUrl }` is deliberately NOT one of these: it reads the variable.
  */
-function endOfRegex(src: string, i: number): number {
-  let j = i + 1
-  let inClass = false
-  while (j < src.length) {
-    const c = src[j]
-    if (c === '\n') return -1
-    if (c === '\\') {
-      j += 2
-      continue
-    }
-    if (c === '[') inClass = true
-    else if (c === ']') inClass = false
-    else if (c === '/' && !inClass) {
-      j++
-      while (j < src.length && /[a-z]/i.test(src[j] ?? '')) j++
-      return j
-    }
-    j++
-  }
-  return -1
-}
-
-/**
- * Replace every comment, string body and regex body with spaces, keeping length and newlines so
- * offsets and line numbers still line up with the original source.
- *
- * A template literal's `${...}` expressions are deliberately KEPT — `${rpcUrl}` is the most common
- * way this leak is written, and blanking the whole template would hide the case this module
- * exists to catch. Only the literal text around them is blanked.
- *
- * Regex literals are blanked for the same reason strings are: `/['"`]/` would otherwise open a
- * phantom string that swallows the rest of the file, and `/^https:\/\//` reads as a line comment.
- *
- * @param src - original source text.
- * @returns the same text with non-code spans replaced by spaces.
- */
-export function blankNonCode(src: string): string {
-  const out = src.split('')
-  const blank = (i: number): void => {
-    if (out[i] !== '\n') out[i] = ' '
-  }
-
-  // A stack, because the contexts nest without limit: a template holds `${...}` code, which holds
-  // another template, which holds another string. `braceDepth` is what stops an object literal's
-  // `}` from ending the interpolation.
-  const stack: { kind: 'code' | 'tmpl'; braceDepth: number }[] = [
-    { kind: 'code', braceDepth: 0 },
-  ]
-  let i = 0
-  // Decides the `/` ambiguity. A regex may follow an operator or a keyword, never a value.
-  let prevChar = ''
-  let prevTwo = ''
-  let prevWord = ''
-  const endsAValue = (): boolean =>
-    [')', ']', "'", '"', '`'].includes(prevChar) ||
-    prevTwo === '++' ||
-    prevTwo === '--'
-
-  while (i < src.length) {
-    const top = stack[stack.length - 1]
-    if (!top) break
-    const c = src[i]
-    const n = src[i + 1]
-
-    if (top.kind === 'tmpl') {
-      if (c === '\\') {
-        blank(i++)
-        if (i < src.length) blank(i++)
-      } else if (c === '$' && n === '{') {
-        i += 2
-        stack.push({ kind: 'code', braceDepth: 0 })
-        prevChar = ''
-        prevWord = ''
-      } else if (c === '`') {
-        blank(i++)
-        stack.pop()
-        prevChar = '`'
-        prevWord = ''
-      } else blank(i++)
-      continue
-    }
-
-    if (c === '/' && n === '/') {
-      while (i < src.length && src[i] !== '\n') blank(i++)
-      continue
-    }
-    if (c === '/' && n === '*') {
-      blank(i++)
-      blank(i++)
-      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/'))
-        blank(i++)
-      if (i < src.length) {
-        blank(i++)
-        blank(i++)
-      }
-      continue
-    }
-    if (
-      c === '/' &&
-      (!isWordChar(prevChar) || REGEX_OK_AFTER_WORD.has(prevWord)) &&
-      !endsAValue()
-    ) {
-      const end = endOfRegex(src, i)
-      if (end !== -1) {
-        while (i < end) blank(i++)
-        prevChar = '/'
-        prevWord = ''
-        continue
-      }
-    }
-    if (c === "'" || c === '"') {
-      // Looked ahead before blanking, and bounded to the line: a quoted string cannot hold a raw
-      // newline, so a quote with no partner on its own line is not a string opener — usually a
-      // quote inside a regex this pass declined to read as one. Blanking such a quote all the way
-      // to end-of-file is what made four shipped files invisible, so any future mis-decision is
-      // now confined to the line it happens on.
-      let j = i + 1
-      while (j < src.length && src[j] !== c && src[j] !== '\n')
-        j += src[j] === '\\' ? 2 : 1
-      if (j < src.length && src[j] === c) while (i <= j) blank(i++)
-      else i++
-      prevChar = c
-      prevTwo = ''
-      prevWord = ''
-      continue
-    }
-    if (c === '`') {
-      blank(i++)
-      stack.push({ kind: 'tmpl', braceDepth: 0 })
-      continue
-    }
-    if (c !== undefined && /[A-Za-z_$]/.test(c)) {
-      let j = i
-      while (j < src.length && isWordChar(src[j])) j++
-      prevWord = src.slice(i, j)
-      prevChar = src[j - 1] ?? ''
-      i = j
-      continue
-    }
-    if (c === '{') top.braceDepth++
-    else if (c === '}') {
-      if (top.braceDepth > 0) top.braceDepth--
-      else if (stack.length > 1) stack.pop()
-    }
-    if (c !== undefined && !/\s/.test(c)) {
-      prevTwo = prevChar + c
-      prevChar = c
-      prevWord = ''
-    }
-    i++
-  }
-  return out.join('')
-}
-
-/** Offset of the `)` matching the `(` at `openParen`. */
-function endOfCall(src: string, openParen: number): number {
-  let depth = 0
-  for (let i = openParen; i < src.length; i++) {
-    if (src[i] === '(') depth++
-    else if (src[i] === ')') {
-      depth--
-      if (depth === 0) return i
-    }
-  }
-  return src.length
-}
-
-/** Argument spans of every redaction call. */
-function redactedSpans(code: string): [number, number][] {
-  const spans: [number, number][] = []
-  const re = new RegExp(String.raw`\b(?:${[...REDACTORS].join('|')})\s*\(`, 'g')
-  let m: RegExpExecArray | null
-  while ((m = re.exec(code)) !== null) {
-    const open = m.index + m[0].length - 1
-    spans.push([open, endOfCall(code, open)])
-  }
-  return spans
-}
-
-/**
- * True when the identifier at `at` is an object-literal key rather than a value being read.
- *
- * Both halves are required. Testing only for a following `:` also suppresses the consequent of a
- * ternary — `${flag ? rpcUrl : ''}` — which is a normal way to write an endpoint override, so the
- * preceding `{` or `,` is what separates a label from a value.
- *
- * @param code - blanked source.
- * @param at - offset of the identifier.
- * @param length - identifier length.
- * @returns whether this occurrence names a field.
- */
-function isObjectKey(code: string, at: number, length: number): boolean {
-  if (!/^\s*:/.test(code.slice(at + length))) return false
-  let b = at - 1
-  while (b >= 0 && /\s/.test(code[b] ?? '')) b--
-  const prev = code[b]
-  return prev === '{' || prev === ','
+function declaresRatherThanReads(node: ts.Identifier): boolean {
+  const p = node.parent
+  if (!p) return false
+  if (ts.isPropertyAssignment(p) && p.name === node) return true
+  if (ts.isParameter(p) && p.name === node) return true
+  if (ts.isBindingElement(p) && (p.name === node || p.propertyName === node))
+    return true
+  if (ts.isVariableDeclaration(p) && p.name === node) return true
+  if (ts.isPropertySignature(p) && p.name === node) return true
+  return false
 }
 
 function tsFilesUnder(root: string, out: string[] = []): string[] {
@@ -336,12 +141,17 @@ function tsFilesUnder(root: string, out: string[] = []): string[] {
 /**
  * Scan shipped modules for log calls naming an endpoint outside a redaction.
  *
+ * Uses the TypeScript parser rather than a text scan. Every distinction that decides a case here
+ * is a question about the grammar — a type annotation versus a value, a binding versus a read, a
+ * comment or string versus code, a regex literal versus division — and none of them survives an
+ * approximation of the grammar.
+ *
  * Enumerates the filesystem rather than `git ls-files` deliberately: an uncommitted file is
  * exactly where a new leak arrives, and a git-backed listing cannot see one.
  *
  * @param repoRoot - repository root.
  * @param roots - directories to walk, relative to the root.
- * @returns one finding per offending log argument, and the files actually examined.
+ * @returns one finding per offending identifier, and the files actually examined.
  * @throws never for an unreadable path — a directory or file it cannot read is skipped.
  */
 export function scanForRawRpcUrlLogs(
@@ -363,36 +173,54 @@ export function scanForRawRpcUrlLogs(
       } catch {
         continue
       }
-      const code = blankNonCode(src)
-      const safe = redactedSpans(code)
+      // The parser error-recovers rather than throwing, so a malformed file still yields a tree.
+      const sf = ts.createSourceFile(abs, src, ts.ScriptTarget.Latest, true)
 
-      LOG_CALL.lastIndex = 0
-      let call: RegExpExecArray | null
-      while ((call = LOG_CALL.exec(code)) !== null) {
-        const open = call.index + call[0].length - 1
-        const close = endOfCall(code, open)
-        const args = code.slice(open, close)
+      const visit = (
+        node: ts.Node,
+        inLog: boolean,
+        redacted: boolean
+      ): void => {
+        // A type never renders at runtime, so `cfg as { rpcUrl?: string }` names nothing.
+        if (ts.isTypeNode(node)) return
 
-        for (const id of [...RPC_IDENTIFIERS, ...RPC_ENV_PREFIXES]) {
-          const idRe = RPC_ENV_PREFIXES.includes(id)
-            ? new RegExp(String.raw`\b${id}\w*\b`, 'g')
-            : new RegExp(String.raw`\b${id}\b`, 'g')
-          let m: RegExpExecArray | null
-          while ((m = idRe.exec(args)) !== null) {
-            const at = open + m.index
-            if (isObjectKey(code, at, m[0].length)) continue
-            if (safe.some(([st, e]) => at > st && at < e)) continue
-            findings.push({
-              file: rel,
-              line: src.slice(0, at).split('\n').length,
-              identifier: m[0],
-              text: src
-                .slice(at, Math.min(at + 70, src.length))
-                .replace(/\s+/g, ' '),
-            })
-          }
-        }
+        const nowLog = inLog || isLogCall(node)
+        const nowRedacted =
+          redacted ||
+          (ts.isCallExpression(node) && REDACTORS.has(calleeName(node) ?? ''))
+
+        if (
+          nowLog &&
+          !nowRedacted &&
+          ts.isIdentifier(node) &&
+          namesAnEndpoint(node.text) &&
+          !declaresRatherThanReads(node)
+        )
+          findings.push({
+            file: rel,
+            line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+            identifier: node.text,
+            text: src
+              .slice(
+                node.getStart(sf),
+                Math.min(node.getStart(sf) + 70, src.length)
+              )
+              .replace(/\s+/g, ' '),
+          })
+
+        ts.forEachChild(node, (c) => {
+          // `consola.info` — the method name is not an argument.
+          if (
+            nowLog &&
+            ts.isCallExpression(node) &&
+            c === node.expression &&
+            isLogCall(node)
+          )
+            return
+          visit(c, nowLog, nowRedacted)
+        })
       }
+      visit(sf, false, false)
     }
   return { findings, scanned }
 }

--- a/script/utils/utils.test.ts
+++ b/script/utils/utils.test.ts
@@ -16,6 +16,10 @@ import {
   mock,
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
+import { consola } from 'consola'
+
+import type { INetworkInfo } from '../common/types'
+import { EnvironmentEnum } from '../common/types'
 
 // Capture the real fs exports BEFORE mock.module replaces the registry entry,
 // otherwise the passthrough below would recurse into the mock itself.
@@ -41,9 +45,11 @@ mock.module('fs', () => ({
 }))
 
 const {
+  displayNetworkInfo,
   getContractAddress,
   getFacetSelectors,
   getFoundryDefaultOptimizerRuns,
+  node_url,
 } = await import('./utils')
 
 type NetworkArg = Parameters<typeof getContractAddress>[0]
@@ -157,5 +163,59 @@ describe('getFacetSelectors path guard', () => {
     await expect(getFacetSelectors('/etc/passwd')).rejects.toThrow(
       /Invalid facet name/
     )
+  })
+})
+
+describe('endpoint redaction', () => {
+  // A dRPC-shaped endpoint: the provider key rides in the query string, so any print of
+  // this string is a live credential.
+  const KEYED_URL =
+    'https://lb.drpc.org/ogrpc?network=tron&dkey=SYNTHETIC-NOT-REAL-abc123'
+
+  it('keeps the endpoint out of the network info box', () => {
+    const realBox = consola.box
+    let captured = ''
+    consola.box = ((arg: { message: string }) => {
+      captured = arg.message
+    }) as typeof consola.box
+
+    try {
+      displayNetworkInfo(
+        { address: '0x0', balance: '0', block: 0 } as unknown as INetworkInfo,
+        EnvironmentEnum.production,
+        KEYED_URL
+      )
+    } finally {
+      consola.box = realBox
+    }
+
+    expect(captured).not.toContain('dkey')
+    expect(captured).toContain('[redacted-url]')
+    // the mainnet/shasta split reads the raw argument, so redacting the print must not move it
+    expect(captured).toContain('Network: Mainnet')
+  })
+
+  it('keeps the endpoint out of the unsubstituted-template error', () => {
+    const previousUri = process.env.ETH_NODE_URI
+    const previousNetworkUri = process.env.ETH_NODE_URI_TESTNET
+    delete process.env.ETH_NODE_URI_TESTNET
+    process.env.ETH_NODE_URI =
+      'https://lb.drpc.org/ogrpc?chain={{chain}}&dkey=SYNTHETIC-NOT-REAL-abc123'
+
+    try {
+      let message = ''
+      try {
+        node_url('testnet')
+      } catch (error) {
+        message = (error as Error).message
+      }
+      expect(message).toContain('[redacted-url]')
+      expect(message).not.toContain('dkey')
+    } finally {
+      if (previousUri === undefined) delete process.env.ETH_NODE_URI
+      else process.env.ETH_NODE_URI = previousUri
+      if (previousNetworkUri !== undefined)
+        process.env.ETH_NODE_URI_TESTNET = previousNetworkUri
+    }
   })
 })

--- a/script/utils/utils.ts
+++ b/script/utils/utils.ts
@@ -28,6 +28,7 @@ import { EnvironmentEnum } from '../common/types'
 import { EVM_VERSIONS } from '../deploy/shared/constants'
 import { getContractVersion } from '../deploy/shared/getContractVersion'
 
+import { redactUrls } from './redactUrls'
 import { spawnAndCapture } from './spawnAndCapture'
 
 const networks: INetworksObject = networksConfig
@@ -72,7 +73,9 @@ export function node_url(networkName: string): string {
 
   if (uri.indexOf('{{') >= 0)
     throw new Error(
-      `invalid uri or network not supported by node provider : ${uri}`
+      `invalid uri or network not supported by node provider : ${redactUrls(
+        uri
+      )}`
     )
 
   return uri
@@ -963,7 +966,7 @@ export function displayNetworkInfo(
 
   const infoContent = `
 Network: ${networkName}
-RPC URL: ${rpcUrl}
+RPC URL: ${redactUrls(rpcUrl)}
 Environment: ${environmentString}
 Address: ${networkInfo.address}
 Balance: ${networkInfo.balance}

--- a/script/utils/verifyEmergencyPauseReadinessGitHub.sh
+++ b/script/utils/verifyEmergencyPauseReadinessGitHub.sh
@@ -79,7 +79,9 @@ function rpcCallWithRetry() {
   local LAST_ERR
   LAST_ERR=$(< "$ERR_FILE")
   rm -f "$ERR_FILE"
-  printf "%s" "${LAST_ERR:-$OUT}"
+  # Redacted at the single return rather than at each caller: every one of them echoes this
+  # string, and `cast` puts the full --rpc-url in its error text.
+  printf "%s" "$(redactRpcUrl "${LAST_ERR:-$OUT}")"
   return 1
 }
 

--- a/script/utils/verifyEmergencyPauseReadinessGitHub.sh
+++ b/script/utils/verifyEmergencyPauseReadinessGitHub.sh
@@ -67,7 +67,7 @@ function rpcCallWithRetry() {
       return 0
     fi
     if [ "$ATTEMPT" -lt "$RPC_MAX_ATTEMPTS" ]; then
-      echo "[retry] $LABEL attempt $ATTEMPT failed ($(< "$ERR_FILE")), sleeping ${RPC_RETRY_SLEEP_SECONDS}s..." >&2
+      echo "[retry] $LABEL attempt $ATTEMPT failed ($(redactRpcUrl "$(< "$ERR_FILE")")), sleeping ${RPC_RETRY_SLEEP_SECONDS}s..." >&2
       sleep "$RPC_RETRY_SLEEP_SECONDS"
     fi
     ATTEMPT=$((ATTEMPT + 1))


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-965](https://linear.app/lifi-linear/issue/EXSC-965/troncast-prints-the-full-rpc-url-so-a-keyed-endpoint-leaks-into-every)

# Why did I implement it this way?

`ETH_NODE_URI_*` is a dRPC URL with the API key in the path, so a log line naming the endpoint writes a **live credential** into every transcript of every run. troncast did exactly that and leaked the Tron key on 2026-09-09.

## The leaks

**TypeScript — five sites**, now through `redactUrls()`:

| file | was |
|---|---|
| `script/troncast/utils/tronweb.ts` | `Initializing TronWeb with … ${rpcUrl}` |
| `script/deploy/tron/deploy-core-facets.ts` | `RPC URL: ${rpcUrl}` |
| `script/deploy/tron/transfer-ownership-to-timelock.ts` | `Connected to: ${fullHost}` |
| `script/deploy/tron/register-facets-to-diamond.ts` | `Connected to: ${fullHost}` |
| `script/deploy/detect-evm-version.ts` | `via ${chain.rpcUrls.default.http[0]}`, plus its `consola.error(…, err)` — viem puts the endpoint in `error.message` |

**Bash — the scan reads no `.sh`, and it was leaking the same class.** Eighteen `echo`/`echoDebug`/`error` sites, thirteen of them **not debug-gated**, now through a new `redactRpcUrl` and its break-glass twin — including `parseExecuteCommandResult`, the shared executor that prints the captured stderr of every bash `forge` run, all three verbose-output prints in `diamondSyncWhitelist.sh`, and the pause-state error paths in both emergency scripts. A test pins the executor: removing the redaction fails it. `getRPCUrl`'s own stdout returns are deliberately untouched: redacting those breaks every caller.

**The bash class is not closed**, and nothing enforces it — these are the sites that were found, not all that exist. At least five more echo a variable that can hold `cast` error text (`playgroundHelpers.sh:1967/1973/2020/2027`, `helperFunctions.sh:3598/3696/3851`). They belong to [EXSC-974](https://linear.app/lifi-linear/issue/EXSC-974) with the enforcement, because the awkward part is that `getRPCUrl` legitimately returns the endpoint on stdout, so a naive bash scan false-reds on the function whose job is to return it.

Also the **exhaustion path** of `rpcCallWithRetry` in both break-glass scripts. Only the per-attempt retry line was redacted at first; the terminal return handed the raw `cast` error — which embeds `--rpc-url` — to callers that all echo it. That is the path that runs during a real incident. Redacted at the single return rather than at the eight call sites; the success path stays verbatim, because callers parse it.

**Shown by running it, not by reading it.** The real `initTronWeb` at `CONSOLA_LEVEL=5` with a *synthetic* key:

```text
before:  Initializing TronWeb with mainnet network: https://lb.drpc.org/ogrpc?network=tron&dkey=SYNTHETICKEY-NOT-REAL-abc123
after:   Initializing TronWeb with mainnet network: [redacted-url]
```

## The check parses the source

`script/utils/rpc-url-log-scan.ts` walks every shipped module under `script/` and `tasks/` and fails on a log call naming an endpoint outside a redaction.

It uses `ts.createSourceFile`. Every distinction that decides a case is a question about the grammar — a type annotation versus a value, a binding versus a read, a comment or string versus code, a regex literal versus division — and I first tried to approximate all four with a text scan. That cost three rounds: each version shipped a hole (one blinded the scan on 4 of 240 real files, including a troncast command), and each fix made the previous round's tests vacuous rather than failing. The parser answers all four for free and deletes ~200 lines of tokenizer plus the tests defending it.

Worth stating plainly since an earlier version of this description said otherwise: **the note that this repo's `typescript` had no usable compiler API was wrong.** The repo pins `^5.4.5` and resolves 5.9.2. I had read that in a worktree with no `node_modules`, where bun silently auto-installed a different major version.

Two limits are written into the docblock rather than implied: the reach is a fixed identifier vocabulary and log-method list, and it does not read bash or error-object embedding. Those two channels are [EXSC-974](https://linear.app/lifi-linear/issue/EXSC-974); the devkit's own `--verbose` leak is [EXSC-975](https://linear.app/lifi-linear/issue/EXSC-975).

## Evidence

- **Blind sweep**: the canonical leak line injected into a scratch copy of each of the 240 walked files, appended and prepended — **0 blind** either way (the one hit is the declared `EXEMPT` entry).
- **Mutation testing**: every decision the module makes was mutated one at a time and each killed by a named test — the type-node skip, the declaration rule and each of its exceptions, redactor detection (bare and namespaced), the receiver check, each vocabulary and log-method entry individually, the env prefixes, the walked roots, the exemption, the symlink skip, the test-file exclusion, the reported line, and both bash retry paths. Restore verified byte-identical with `cmp`, never `git checkout`.
  A first pass at this was itself vacuous: `it.each(RPC_IDENTIFIERS)` iterates the list being mutated, so deleting an entry deletes its own case. All three sets — the vocabulary, the log methods, and the exemption's identifiers — are now pinned by **value** as well; the exemption is per-identifier rather than whole-file, so the one exempted file is still scanned for everything it did not exempt.
- **False positives**: the shapes that must stay silent are asserted, including the three the lexer got wrong (an optional type property, an arrow parameter, a regex reached without a semicolon) and the six the first parser version got wrong (method shorthand, getter, setter, class property, named function expression, label).
- Every negative is pinned **beside a real leak in the same fixture**, so no case can pass because the scan stopped reading the file.
- `bun test script/` → **3489 pass / 0 fail** at `cba9381f3`. `tsc-files` and `eslint` clean; scanner coverage 100% funcs. (`tsc` caught two errors `bun test` did not, both times.)

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>





