### PR TITLE
docs(safe): fallback runbook for the pinned escape commit (EXSC-976)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@
 ## Processes
 
 - [Multisig Signing Process — deploy → propose → sign → execute](./MultisigSigningProcess.md)
+- [Signing Fallback Runbook — the pinned escape commit](./SigningFallbackRunbook.md)
 - [Facet Removal Reconciliation](./FacetRemovalReconciliation.md)
 - [Deferred Diamond-Cleanup Queue](./DeferredDiamondCleanupQueue.md)
 - [Wallet-rotation skill suite — design & architecture](./wallet-rotation-skill-suite.md)

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -41,20 +41,25 @@ to reconcile.
 **What the fallback does not weaken.** It drops the 2.0 gate layer; it does
 not drop the multisig or the timelock. The baseline reads the threshold from
 the Safe contract itself (`safe.getThreshold()` in `confirm-safe-tx.ts`, not
-from the frozen `config/`), and offers an execute option only once
-`hasEnoughSignatures` finds the collected signatures at or above it — so
-quorum is enforced by the same on-chain value either way, and there is no
-single-signer path. `--timelock` still wraps the call in a
+from the frozen `config/`), and every execute option is gated against it —
+`Execute` on `hasEnoughSignatures` (signatures already collected),
+`Sign & Execute` on `wouldMeetThreshold` (collected + you), the deployer
+variants on collected + signer + deployer. Quorum is enforced against the same
+on-chain value either way. Note what that does *not* say: on a threshold-2
+Safe, one person holding both `SAFE_SIGNER_PRIVATE_KEY` and
+`PRIVATE_KEY_PRODUCTION` still satisfies it alone in a single run — two keys,
+one human. That is equally true on `main`; the fallback neither creates nor
+closes it. `--timelock` still wraps the call in a
 `scheduleBatch` via `wrapWithTimelockSchedule`, still resolving
 `LiFiTimelockController` from `deployments/` (§4 covers what being frozen
 costs there). What is lost is provenance and the ticket binding, which is §6.
 
 ### Which side of the ceremony has to fall back
 
-**Answer this before checking anything out.** At `49f05efa9` every 2.0 gate
-module is absent outright — `delegatecall-gate.ts`, `codehash-sign-gate.ts`,
-`confirm-integrity-asserts.ts`, `ledger-guards.ts`, `proposal-intent.ts` and
-`calldata-address-check.ts` are all missing from `script/deploy/safe/`, and
+**Answer this before checking anything out.** At `49f05efa9` the 2.0 gate
+modules are absent outright — `delegatecall-gate.ts`, `codehash-sign-gate.ts`,
+`confirm-integrity-asserts.ts`, `proposal-intent.ts`, `calldata-address-check.ts`
+and `pinned-target-state.ts` are all missing from `script/deploy/safe/`, and
 all six exist on `main`. So this commit clears any gate. That is a property of
 this commit, established by checking those paths — not something the §8
 directory diff would have told you, which is why §8 asks a different question
@@ -73,8 +78,9 @@ That is a first cut, not the whole answer: **a gate can be wired on both
 paths.** `evaluateDelegateCallGate` is — `confirm-safe-tx.ts` calls it
 directly, and so do three methods in `safe-utils.ts`
 (`signTransactionWithHash`, `signTransaction`, `executeTransaction`). The
-propose path reaches it through the third of those: `propose-safe-tx.ts` calls
-`safe.signTransaction()`, which asserts the gate before it signs. So grep the
+propose path reaches it through `signTransaction`: `propose-safe-tx.ts` calls
+`safe.signTransaction()`, which asserts the gate before it signs.
+`executeTransaction` is never reached while proposing. So grep the
 refusing gate's call sites *and follow them back to an entry point* — a gate
 that looks sign-only can sit behind a helper the proposer also calls, and then
 both sides fall back.
@@ -193,10 +199,11 @@ done
 
 **An exported `SC_MONGODB_URI` does more than win — it splits the two halves
 apart.** `with-safe-tunnel.sh` reads the URI by grepping `.env` and never
-consults the environment, so it opens the port named in the *file*, while the
-script connects to the URI in the *environment*. The failure that produces is
-a tunnel that comes up healthy (`✓ Safe Mongo tunnel already up`) in front of
-a proposal written somewhere else. If any of the three warns above, `unset` it
+consults the environment: it takes the *file's* port as its readiness probe
+and reports the tunnel healthy on that basis, while the script connects to the
+URI in the *environment*. The failure that produces is `✓ Safe Mongo tunnel
+already up` in front of a proposal written somewhere else. If any of the three
+warns above, `unset` it
 and start the ceremony in a fresh shell rather than reasoning about which
 value applies where.
 
@@ -268,19 +275,33 @@ proposing, diff the values this run will actually resolve — for the one
 network you are targeting, not the whole file:
 
 ```bash
-NET=<network>
+NET=arbitrum   # substitute your target network before pasting
 
-# The target network's entry, not the whole file — §4's other drift is noise here.
-diff <(git show "origin/main:config/networks.json" | jq ".$NET") \
-     <(jq ".$NET" config/networks.json) && echo "same: networks.json[$NET]"
+M=$(mktemp); B=$(mktemp)
 
-# The deployment file --timelock reads.
-diff <(git show "origin/main:deployments/$NET.json") "deployments/$NET.json" \
-  && echo "same: deployments/$NET.json"
+# 1. The network's own entry, not the whole file — §4's other drift is noise here.
+git show "origin/main:config/networks.json" | jq ".$NET" > "$M" 2>/dev/null
+jq ".$NET" config/networks.json > "$B" 2>/dev/null
+if ! [ -s "$M" ] || ! [ -s "$B" ]; then
+  echo "✗ one side produced nothing (jq missing? read failed?) — THIS CHECK PROVED NOTHING"
+elif diff "$M" "$B" >/dev/null; then
+  echo "✓ networks.json[$NET] identical"
+else
+  echo "✗ networks.json[$NET] differs — read it:"; diff "$M" "$B"
+fi
 
-# global.json is not per-network, so read this one rather than expecting silence.
+# 2. Only the field --timelock actually sends to. The rest of the deployment
+#    file is facet-address churn and will always differ.
+echo "timelock on main:     $(git show "origin/main:deployments/$NET.json" 2>/dev/null | jq -r '.LiFiTimelockController // "ABSENT"')"
+echo "timelock at baseline: $(jq -r '.LiFiTimelockController // "ABSENT"' "deployments/$NET.json" 2>/dev/null || echo 'FILE ABSENT')"
+
+# 3. global.json is not per-network — expect output, and read it.
 diff <(git show "origin/main:config/global.json") config/global.json
 ```
+
+An empty result is not a pass. Step 1 says so out loud because the natural
+shape of that check — two substitutions into `diff` — exits 0 when *both*
+sides fail, which prints a green line for a comparison that never happened.
 
 Three things make the difference between a stale value and a wrong proposal:
 the network's `status` on `main` (a name the baseline accepts may be retired),
@@ -314,11 +335,15 @@ Say, in the channel where the ceremony is coordinated:
 - the ticket link, which nothing on the row carries, so it has to travel with
   the message.
 
-That last point is the substantive loss. The binding check on `main` is
-`resolveProposalIntent` inside `storeTransactionInMongoDB` — the unbypassable
-one, which runs after signing — while `assertTicketPresent` is the early exit
-that saves a Ledger tap. Neither exists at the baseline, so nothing ties the
-proposal to a ticket except what a human writes down.
+That last point is the substantive loss. On `main` this path binds the ticket
+twice, both through `resolveProposalIntent`: once early in
+`propose-to-safe.ts` (before the Ledger tap) and again inside
+`storeTransactionInMongoDB`, which is the unbypassable one because it runs on
+the write. (`assertTicketPresent` is the same module's guard for the *other*
+proposal entry points — the Tron proposer, `add-safe-owners-and-threshold`,
+`unpauseAllDiamonds` — not for this one.) The whole module is absent at the
+baseline, so nothing ties a fallback proposal to a ticket except what a human
+writes down.
 
 ## 7. Reconcile afterwards
 
@@ -407,7 +432,8 @@ to re-establish at the candidate commit, in the order that fails fastest:
    cannot be missed:
    `git ls-tree -r <sha> -- script/deploy/safe/ script/deploy/shared/` against
    the same paths on `main`. **That diff is a candidate list, not an answer** —
-   it is non-empty from 2026-07-28 onward and most of what it names is
+   it is never empty, not even at the escape commit itself (49 non-test paths
+   on `main` are missing at `49f05efa9`), and most of what it names is
    unrelated tooling (a prefetch cache, a selector registry, a read-only
    client). For each candidate, ask the only question that matters: does an
    entry point reach it on a path that can *refuse*? Follow its call sites
@@ -426,12 +452,17 @@ to re-establish at the candidate commit, in the order that fails fastest:
    the borrowed `node_modules` is `main`'s, and a `bun install` in the clone
    can invalidate it without touching this repo.
 
-**One case this list cannot satisfy.** The earliest signing gates —
-`ledger-guards.ts` and `proposal-intent.ts` — landed **2026-09-02**. For a
-network added after that date, no commit both knows the network and predates
-the gates, so there is no fallback for it at all: the answer is to fix the
-gate, not to move the tag. Say so on the ticket rather than retagging to
-something that still carries the gate.
+**One case this list cannot satisfy.** The earliest thing on a ceremony path
+that can refuse is `canExecuteWithNonceStatus`, which `confirm-safe-tx.ts`
+reaches and which withdraws execute options on a future nonce; it landed with
+`80c3c1bf6` on **2026-09-01**, the same commit as the provenance cutover §7
+uses. `proposal-intent.ts` follows on 2026-09-02. (`ledger-guards.ts` landed
+alongside them but is *not* a gate by requirement 1's own test — its only
+caller is `script/tasks/cleanUpProdDiamond.ts`, which is neither entry point.)
+For a network added after 2026-09-01, no commit both knows the network and
+predates every refusal, so there is no fallback for it at all: the answer is
+to fix the gate, not to move the tag. Say so on the ticket rather than
+retagging to something that still carries the gate.
 
 Both networks §4 names predate that, so a candidate exists for each
 (`injective` 2026-07-31, `sepolia` 2026-08-25) — but requirement 1's diff is

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -134,8 +134,16 @@ if [ "$RESOLVED" = "$EXPECTED" ]; then
   [ -d "$ESC" ]                 || git -C "$CLONE" worktree add --detach "$ESC" "$RESOLVED"
   [ -e "$ESC/.env" ]            || ln -s "$CLONE/.env" "$ESC/.env"
   [ -e "$ESC/node_modules" ]    || ln -s "$CLONE/node_modules" "$ESC/node_modules"
+  # What reuse can inherit wrongly: `-e` proves a link resolves, not where it
+  # points, and `HEAD` says nothing about the working files §5 reads or the
+  # propose script itself. `diff`, not `status --porcelain` — `.gitignore` has
+  # `node_modules/`, which being directory-only misses the symlink, so porcelain
+  # is dirty on every honest run.
   [ "$(git -C "$ESC" rev-parse HEAD 2>/dev/null)" = "$RESOLVED" ] \
+    && [ "$(readlink "$ESC/.env")" = "$CLONE/.env" ] \
+    && [ "$(readlink "$ESC/node_modules")" = "$CLONE/node_modules" ] \
     && [ -e "$ESC/.env" ] && [ -e "$ESC/node_modules" ] \
+    && git -C "$ESC" diff --quiet HEAD \
     && ESCAPEOK=1
   if [ "$ESCAPEOK" -eq 1 ] && cd "$ESC"; then
     echo "✓ escape worktree ready at $RESOLVED"
@@ -152,9 +160,18 @@ The checkout is inside the `if` on purpose: a mismatch has to leave you with no
 escape worktree at all, not with one you were told not to use.
 
 Re-pasting the block is safe, and an escape worktree left by an earlier ceremony
-is reused rather than refused — but only after its `HEAD` is checked against
-`$EXPECTED`, so reuse is never a way to inherit a stale tree. To clear it
-deliberately: `git -C "$CLONE" worktree remove --force ~/contracts-escape`.
+is reused rather than refused — but only once its commit, its two link targets
+and its tracked contents all check out, because reuse is the one path that can
+inherit someone else's tree.
+
+To clear it deliberately:
+`git -C "$CLONE" worktree remove --force ~/contracts-escape` — which needs
+`$CLONE` set, so re-paste the first line of this section if you are in a fresh
+shell. That command **fails** if the tree's `.git` file is damaged
+(`validation failed, cannot remove working tree`), and `prune` does not clear
+that state either; the recovery is `rm -rf ~/contracts-escape` and a re-paste,
+which the `prune` above is there to absorb. A plain file sitting at the escape
+path is the same story — `rm` it.
 
 A worktree rather than a checkout in place: the fallback runs alongside a
 normal clone, and nothing about the working repo has to be disturbed.
@@ -187,11 +204,13 @@ plus the Ledger packages and node builtins; none was dropped, and the installed
 `viem` and `tronweb` both still satisfy the baseline's ranges.
 
 The Ledger side deserves its own note. `@ledgerhq/hw-transport-node-hid` and
-`@ledgerhq/hw-app-eth` are loaded by **dynamic import**, so a resolution
-failure there surfaces at Ledger-tap time rather than at startup —
-mid-ceremony, in other words. `@ledgerhq/hw-transport` itself is imported only
-as a type and is declared in neither `package.json`; it resolves today as a
-hoisted transitive of `hw-transport-node-hid`.
+`@ledgerhq/hw-app-eth` are loaded by dynamic import, but not lazily enough to
+matter: both entry points reach them through `initializeSafeClient` before any
+signing prompt, so a resolution failure is a startup crash rather than a
+mid-ceremony one — see the note above the check below.
+`@ledgerhq/hw-transport` itself is imported only as a type and is declared in
+neither `package.json`; it resolves today as a hoisted transitive of
+`hw-transport-node-hid`.
 
 Nothing enforces any of this, and one `bun install` in the clone can end it. The
 slower, correct alternative is a real `bun install` in the escape worktree
@@ -355,13 +374,16 @@ network you are targeting, not the whole file:
 
 ```bash
 NET=arbitrum   # substitute your target network before pasting
+SIGNER=key     # or `ledger` — §5 refuses until this says which key signs
 
 DRIFT=0   # any check that does not positively pass sets this to 1
 # The baseline side of every comparison below is read cwd-relative, so pasted
 # anywhere else — the clone on `main` being the easy mistake — these compare
 # main with main and pass having proved nothing.
-[ "$(git rev-parse HEAD 2>/dev/null)" = "${EXPECTED:-}" ] \
-  || { echo "✗ not in the escape worktree at ${EXPECTED:-<unset>} — cd there first"; DRIFT=1; }
+[ -n "${EXPECTED:-}" ] \
+  || { echo "✗ EXPECTED is unset — re-paste §2 in this shell, then re-run §5"; DRIFT=1; }
+[ -n "${EXPECTED:-}" ] && [ "$(git rev-parse HEAD 2>/dev/null)" != "$EXPECTED" ] \
+  && { echo "✗ this tree is not the escape worktree — cd ~/contracts-escape first"; DRIFT=1; }
 MAIN_NET=$(git show "origin/main:config/networks.json" 2>/dev/null)
 
 # 1. The two fields in the network entry that decide correctness — NOT the whole
@@ -442,22 +464,32 @@ is actually standing on, rather than on having read the output. Every one of
 them defaults to the refusing value, so pasting this without having run §2, §3
 and §5 refuses instead of proposing.
 
-`SIGNER` is there because `LEDGEROK` cannot simply be required. A Ledger and a
-raw key are a free choice on **both** commands — `propose-to-safe.ts` reads
-`options.ledger` and otherwise falls back to `PRIVATE_KEY_PRODUCTION` — so the
-choice is orthogonal to whether you are proposing or confirming, and §2's resolve
-step is honestly skipped on one branch and mandatory on the other. Defaulting it
-to *pass* would make the two indistinguishable: an unset `LEDGEROK` would mean
-both "raw key, never needed it" and "Ledger, skipped the check", and the second
-is the one that fails at Ledger-tap time mid-ceremony. Stating the signer costs a
-word and is a thing you know before you start.
+`SIGNER` is there because `LEDGEROK` can be neither required nor ignored. Both
+commands take a Ledger or a raw key, so the choice is orthogonal to whether you
+are proposing or confirming — but **their defaults are opposite**, and that is
+the part worth knowing before you paste: at the baseline `propose-to-safe.ts:85`
+reads `options.ledger || false`, so a propose run with no flag uses
+`PRIVATE_KEY_PRODUCTION`, while `confirm-safe-tx` keeps Ledger as its default
+signer, so a confirm run with no flag taps a device. Defaulting `LEDGEROK` to
+*pass* would make an unset value mean both "raw key, never needed the check" and
+"Ledger, skipped the check". Naming the signer separates them, and it is a thing
+you know before you start.
+
+Two limits of this, stated rather than glossed. `SIGNER` is what you *assert*,
+not what the command carries, so it is interpolated into the command below —
+declaring `key` and then hand-editing `--ledger` in would defeat the check it
+exists for. And there is no gate on the **confirm** side at all: signers get
+Ledger by default there, so treat §2's Ledger check as mandatory before
+confirming, whatever `SIGNER` says here.
 
 ```bash
 READY=1
 [ "${ESCAPEOK:-0}"    -eq 1 ] || { echo "✗ §2 not clean: no verified escape worktree"; READY=0; }
 # ESCAPEOK says a verified tree was built, not that you are standing in it.
-[ "$(git rev-parse HEAD 2>/dev/null)" = "${EXPECTED:-}" ] \
-  || { echo "✗ cwd is not the escape worktree — cd there and re-run §5"; READY=0; }
+[ -n "${EXPECTED:-}" ] \
+  || { echo "✗ EXPECTED is unset — re-paste §2 in this shell"; READY=0; }
+[ -n "${EXPECTED:-}" ] && [ "$(git rev-parse HEAD 2>/dev/null)" != "$EXPECTED" ] \
+  && { echo "✗ cwd is not the escape worktree — cd there and re-run §5"; READY=0; }
 [ "${ENVCONFLICT:-1}" -eq 0 ] || { echo "✗ §3 not clean: an export beats .env"; READY=0; }
 [ "${DRIFT:-1}"       -eq 0 ] || { echo "✗ §5 not clean: config drift or a check proved nothing"; READY=0; }
 # SIGNER names the key you will actually pass. §2's Ledger check bears on one of
@@ -470,8 +502,10 @@ case "${SIGNER:-}" in
 esac
 
 [ "$READY" -eq 1 ] || echo "✗ refusing to propose — fix the above and re-run the checks"
+# --signer flags derived from $SIGNER, so the declared signer is the one passed.
+[ "${SIGNER:-}" = "ledger" ] && SIGNFLAGS="--ledger" || SIGNFLAGS=""
 [ "$READY" -eq 1 ] && bun propose-safe-tx --network "$NET" --to <target> \
-  --calldataFile <path> --timelock
+  --calldataFile <path> --timelock $SIGNFLAGS
 ```
 
 **`--network "$NET"`, not a placeholder you retype.** The checks above validated

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -138,12 +138,14 @@ if [ "$RESOLVED" = "$EXPECTED" ]; then
   # points, and `HEAD` says nothing about the working files §5 reads or the
   # propose script itself. `diff`, not `status --porcelain` — `.gitignore` has
   # `node_modules/`, which being directory-only misses the symlink, so porcelain
-  # is dirty on every honest run.
+  # is dirty on every honest run. `bun.lock` is excluded because the real
+  # `bun install` below rewrites it, and refusing after the step this section
+  # recommends is a refusal nobody can act on.
   [ "$(git -C "$ESC" rev-parse HEAD 2>/dev/null)" = "$RESOLVED" ] \
     && [ "$(readlink "$ESC/.env")" = "$CLONE/.env" ] \
     && [ "$(readlink "$ESC/node_modules")" = "$CLONE/node_modules" ] \
     && [ -e "$ESC/.env" ] && [ -e "$ESC/node_modules" ] \
-    && git -C "$ESC" diff --quiet HEAD \
+    && git -C "$ESC" diff --quiet HEAD -- ':!bun.lock' \
     && ESCAPEOK=1
   if [ "$ESCAPEOK" -eq 1 ] && cd "$ESC"; then
     echo "✓ escape worktree ready at $RESOLVED"
@@ -374,7 +376,7 @@ network you are targeting, not the whole file:
 
 ```bash
 NET=arbitrum   # substitute your target network before pasting
-SIGNER=key     # or `ledger` — §5 refuses until this says which key signs
+SIGNER=        # set to `key` or `ledger`; §5 refuses while it is empty
 
 DRIFT=0   # any check that does not positively pass sets this to 1
 # The baseline side of every comparison below is read cwd-relative, so pasted
@@ -502,7 +504,8 @@ case "${SIGNER:-}" in
 esac
 
 [ "$READY" -eq 1 ] || echo "✗ refusing to propose — fix the above and re-run the checks"
-# --signer flags derived from $SIGNER, so the declared signer is the one passed.
+# The signer flag is derived from $SIGNER, so the signer you declared is the
+# one the command carries.
 [ "${SIGNER:-}" = "ledger" ] && SIGNFLAGS="--ledger" || SIGNFLAGS=""
 [ "$READY" -eq 1 ] && bun propose-safe-tx --network "$NET" --to <target> \
   --calldataFile <path> --timelock $SIGNFLAGS

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -43,17 +43,26 @@ is what §8 tells the next person to re-run rather than trusting a list of
 names — so the escape commit clears any gate. But it only clears the ones
 that run on the side that checks it out:
 
-| refusing gate | runs at | who falls back |
-|---|---|---|
-| `assertTicketPresent`, the `proposeSafeTx` funnel and its deploy gate | propose time | the proposer only |
-| `runIntegrityAsserts`, `evaluateCodehashSignGate` | sign time, inside `confirm-safe-tx.ts` | **the signers too** |
+**The command that printed the refusal is the answer**, and it is a better
+guide than any list of gate names, which will go out of date:
+
+| the refusal appeared while running | who falls back |
+|---|---|
+| `bun propose-safe-tx` (or a deploy script that proposes) | the proposer only |
+| `bun confirm-safe-tx` | **the signers too** |
+
+Sign-time gates are the larger group and they refuse in different ways, so do
+not expect a single recognisable message: `evaluateCodehashSignGate` and
+`runIntegrityAsserts` both block by leaving their verdict unevaluated
+(`blockingUnevaluatedGate()`, and an undefined integrity run *is* the blocking
+state), `evaluateDelegateCallGate` silently removes every signing option from
+the menu, and `evaluateTargetStateIntent` prints `✗  EXPECTED-STATE CHECK
+FAILED — NOT SIGNING OR EXECUTING` and moves to the next network.
 
 Getting this wrong wastes the ceremony: proposing from the escape commit does
 nothing for a sign-time refusal, because the signer on `main` reaches the
 identical check — and the proposal is then stuck *and* carries neither
-provenance nor a ticket binding. Both sign-time gates block rather than skip:
-an unevaluated codehash gate becomes `blockingUnevaluatedGate()`, and a failed
-integrity run leaves the run undefined, which is itself the blocking state.
+provenance nor a ticket binding.
 
 ## 2. Check out the escape commit
 
@@ -88,8 +97,12 @@ mechanism has not been pinned down, so treat the flag as the remedy and
 
 **The `node_modules` symlink borrows `main`'s resolved versions, not the
 baseline's.** That works today — the baseline's propose/confirm import closure
-is `citty consola viem mongodb dotenv @lifi/tron-devkit fs path`, none of which
-was dropped, and the installed `viem` still satisfies the baseline's range —
+is `citty consola viem viem/accounts mongodb dotenv @lifi/tron-devkit tronweb
+@ledgerhq/hw-transport` plus node builtins, none of which was dropped, and the
+installed `viem` and `tronweb` both still satisfy the baseline's ranges. Note
+that `@ledgerhq/hw-transport-node-hid` and `@ledgerhq/hw-app-eth` are loaded by
+**dynamic import**, so a resolution failure there surfaces at Ledger-tap time
+rather than at startup —
 but nothing enforces it, and one `bun install` in the clone can end it. The
 slower, correct alternative is a real `bun install` in the escape worktree
 against the baseline's own lockfile.
@@ -98,14 +111,20 @@ against the baseline's own lockfile.
 
 Both entry points load `.env` themselves — `import 'dotenv/config'` in
 `propose-to-safe.ts`, `dotenv.config()` in `confirm-safe-tx.ts` — and
-`with-safe-tunnel.sh` greps the repo-root `.env` directly. **None of them
-reads your shell**, so checking exported variables would report everything
-unset on a correctly configured worktree. Check the file, and never print a
-value:
+`with-safe-tunnel.sh` greps the repo-root `.env` directly, so nothing has to
+be exported into your shell for the scripts to work.
+
+**But an export still wins.** Neither call passes `override: true`, and dotenv
+only fills in names that are not already in `process.env`; `getPrivateKey`
+then reads `process.env[keyType]` directly. So a stale value exported earlier
+in the session silently beats the file. Check both, and never print a value:
 
 ```bash
 for v in SC_MONGODB_URI PRIVATE_KEY_PRODUCTION SAFE_SIGNER_PRIVATE_KEY; do
-  grep -qE "^${v}=." .env && echo "$v: declared" || echo "$v: MISSING from .env"
+  grep -qE "^[[:space:]]*${v}=." .env \
+    && echo "$v: declared in .env" || echo "$v: MISSING from .env"
+  eval "exported=\${$v:-}"
+  [ -n "$exported" ] && echo "  ⚠ $v is ALSO exported in this shell — the export wins"
 done
 ```
 
@@ -129,11 +148,22 @@ likely to bite:
 - **`injective` and `sepolia` do not exist in the baseline's
   `config/networks.json`.** A fallback proposal on either is impossible from
   the escape commit; the tag has to move first (§8).
-- **Seven networks the org has since dropped are still `active` there** —
-  `botanix`, `moonbeam`, `sophon`, `superposition`, `swellchain`, `taiko`,
-  `tronshasta`. `getNetworksToProcess()` with no `--network` returns every
-  active network, so **always pass `--network`**: an unqualified run fans out
-  over the baseline's 76 rather than today's 71.
+- **Seven networks are still `active` there that are not active on `main`** —
+  `botanix`, `moonbeam`, `sophon`, `superposition`, `swellchain`, `taiko` and
+  `tronshasta` (the first six were removed from `networks.json` outright; the
+  seventh is still listed but `inactive`). The baseline will therefore accept
+  a `--network` the org has since retired, and answer with its stale
+  addresses. `--network` is required by the baseline's `propose-to-safe.ts`,
+  so there is no fan-out risk — the risk is that a name it accepts no longer
+  means what you think.
+- **`deployments/` is frozen too, and `--timelock` reads it.** The baseline's
+  `propose-to-safe.ts` loads `deployments/<network>.json` and requires
+  `LiFiTimelockController` in it whenever `--timelock` is passed, throwing
+  `Deployment file not found` otherwise. `injective.json` and `sepolia.json`
+  do not exist at the baseline at all — the same two networks, failing a
+  second way. For the 69 files both trees share, no `LiFiTimelockController`
+  address drifted, so this is a missing-network problem rather than a
+  wrong-address one.
 - `safeAddress` is unchanged on every network both files share, which is the
   one thing that would have made this unusable.
 - `config/global.json` has drifted too — diff it rather than trust this list.
@@ -182,13 +212,16 @@ proposal to a ticket except what a human writes down.
 
 ## 7. Reconcile afterwards
 
-**Name the rows.** Every row `main` has written since 2026-09-01 carries a
-provenance block: `buildProposalProvenance` returns one unconditionally, never
-throws, and yields sentinel values with the cause in `captureErrors` when
-capture fails. So fallback rows are identified exactly, not approximately:
+**Name the rows.** Every row `main` has written since provenance landed
+carries a provenance block: `buildProposalProvenance` returns one
+unconditionally, never throws, and yields sentinel values with the cause in
+`captureErrors` when capture fails. The cutover is the merge of `80c3c1bf6`,
+and it is a **time of day, not a date** — rows written earlier that same
+morning have no provenance and would otherwise be swept in:
 
 ```text
-{ provenance: { $exists: false }, timestamp: { $gte: ISODate("2026-09-01") } }
+{ provenance: { $exists: false },
+  timestamp: { $gte: ISODate("2026-09-01T09:13:19Z") } }
 ```
 
 Record the ceremony window on the ticket anyway — it is what lets a reader
@@ -200,6 +233,13 @@ safeTx.data.nonce}`, partial on `status ∈ {pending, submitted}` — refuses a
 colliding nonce from the escape commit exactly as it would from `main`,
 because the baseline's writer sets every one of those fields. That refusal is
 correct. The reporting is not.
+
+On a Safe whose rows hold both address spellings — `propose-to-safe-tron.ts`
+stores lowercase hex, `initializeSafeClient` stores checksummed — this is not
+a rare collision but a reliable one: the index compares under collation, and
+the baseline's `getNextNonce` reads **uncollated**, so it is blind to the very
+row that will reject it and keeps handing back the same nonce. `main`'s read
+is collated for exactly this reason.
 
 `main` classifies which index rejected the write (`classifyDuplicateKeyError`)
 and turns a nonce collision into an explicit *"Nonce … is already taken by
@@ -216,6 +256,12 @@ and **exits 0**. That second line is the one an operator acts on, and in the
 nonce case it is simply wrong: nothing was stored, and the intent may never
 have been proposed at all. Check the Safe's in-flight nonces before believing
 it.
+
+The escape commit does not create that index — `getSafeMongoCollection` at the
+baseline creates only `unique_pending_intent_hash`. It refuses the insert
+because `main` has already created it on the live collection, which is also
+why a rehearsal store has to be seeded with today's indexes to reproduce any
+of this.
 
 Two smaller traps in the same area. The intent index is partial on
 `{ status: 'pending', intentHash: { $exists: true } }` — the `status` half is
@@ -240,5 +286,15 @@ to re-establish at the candidate commit, in the order that fails fastest:
    `package.json`, and `with-safe-tunnel.sh`.
 3. The `ISafeTxDocument` field diff against `main`, stated — today it is
    `+provenance`, optional.
-4. The `config/networks.json` and `config/global.json` diff against `main`,
-   stated as in §4.
+4. The `config/networks.json`, `config/global.json` and `deployments/` diffs
+   against `main`, stated as in §4 — a network present on `main` and missing
+   from either the config or the deployment file cannot be proposed for.
+5. That the escape worktree still resolves its dependencies, per §2's caveat:
+   the borrowed `node_modules` is `main`'s, and a `bun install` in the clone
+   can invalidate it without touching this repo.
+
+**One case this list cannot satisfy.** Requirement 1 wants a commit with no
+2.0 gate module, and the earliest of those landed 2026-09-02. For a network
+added after that date there is no such commit, so there is no fallback for it
+at all — the answer then is to fix the gate, not to move the tag. Say so on
+the ticket rather than retagging to something that still carries the gate.

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -120,12 +120,21 @@ git -C "$CLONE" fetch origin --tags --force
 EXPECTED=49f05efa948d3bd208bbdfcf34ff70ce5eb183bf
 RESOLVED=$(git -C "$CLONE" rev-parse "pre-signing-2.0-baseline^{commit}")
 
+ESCAPEOK=0
 if [ "$RESOLVED" = "$EXPECTED" ]; then
   echo "✓ tag resolves to the documented commit: $RESOLVED"
-  git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED"
-  cd ~/contracts-escape
-  ln -s "$CLONE/.env" .env
-  ln -s "$CLONE/node_modules" node_modules
+  # &&-chained: a ~/contracts-escape left by an earlier ceremony fails `worktree
+  # add`, and an unchained `cd` then lands in that stale tree at an unknown
+  # commit with both symlinks refused as "File exists".
+  git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED" \
+    && cd ~/contracts-escape \
+    && ln -s "$CLONE/.env" .env \
+    && ln -s "$CLONE/node_modules" node_modules \
+    && [ "$(git rev-parse HEAD)" = "$RESOLVED" ] \
+    && ESCAPEOK=1
+  [ "$ESCAPEOK" -eq 1 ] \
+    && echo "✓ escape worktree ready at $RESOLVED" \
+    || echo "✗ STOP — setup did not complete; do not use ~/contracts-escape"
 else
   echo "✗ STOP — tag resolves to $RESOLVED, not $EXPECTED (see §8)"
 fi
@@ -398,15 +407,19 @@ moved on from. `status` and `safeAddress` both live inside the entry step 1
 compares, so all three are covered — by `$DRIFT`, not by your reading.
 
 Which is why the proposal is gated on those variables rather than on having read
-the output. Both default to the refusing value, so pasting this without having
-run §3 and §5 refuses instead of proposing:
+the output. `ESCAPEOK`, `ENVCONFLICT` and `DRIFT` default to the refusing value,
+so pasting this without having run §2, §3 and §5 refuses instead of proposing.
+`LEDGEROK` defaults the other way on purpose: the deployer path never runs §2's
+Ledger step, and a gate that refuses every honest run is one you learn to paste
+past.
 
 ```bash
 READY=1
+[ "${ESCAPEOK:-0}"    -eq 1 ] || { echo "✗ §2 not clean: no verified escape worktree"; READY=0; }
 [ "${ENVCONFLICT:-1}" -eq 0 ] || { echo "✗ §3 not clean: an export beats .env"; READY=0; }
 [ "${DRIFT:-1}"       -eq 0 ] || { echo "✗ §5 not clean: config drift or a check proved nothing"; READY=0; }
-# --ledger only: §2's resolve step must have passed.
-# [ "${LEDGEROK:-0}" -eq 1 ] || { echo "✗ §2 not clean: a Ledger package does not resolve"; READY=0; }
+# Unset passes here: the deployer path never runs §2's Ledger step. Ran-and-failed refuses.
+[ "${LEDGEROK:-1}"    -eq 1 ] || { echo "✗ §2 not clean: a Ledger package does not resolve"; READY=0; }
 
 [ "$READY" -eq 1 ] || echo "✗ refusing to propose — fix the above and re-run the checks"
 [ "$READY" -eq 1 ] && bun propose-safe-tx --network "$NET" --to <target> \

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -4,11 +4,12 @@ How to propose and sign a production Safe transaction from the pinned pre-2.0
 baseline when a check added by the Signing 2.0 work is refusing an honest
 proposal and cannot be fixed forward in time.
 
+Ticket: **EXSC-976** · D26.
+
 Status: **written, not yet rehearsed.** The rehearsal against a testnet Safe
 and a rehearsal store is EXSC-976 item 3, and until it runs, everything below
 about how the live store behaves is read off the code rather than observed.
-Treat the reconciliation step in §5 as the part most likely to need
-correction.
+Treat §7 as the part most likely to need correction.
 
 ---
 
@@ -20,7 +21,6 @@ The fallback is a **commit you check out**, never a flag you set:
 |---|---|
 | tag | `pre-signing-2.0-baseline` |
 | commit | `49f05efa948d3bd208bbdfcf34ff70ce5eb183bf` (2026-07-24) |
-| why this one | none of the 2.0 gates exist there — `assertTicketPresent`, `proposeSafeTx`, `runIntegrityAsserts` and `evaluateCodehashSignGate` are all absent from `script/` at that commit |
 
 A `--legacy` / `SKIP_GATES` switch was refused (D26). A bypass one environment
 variable away gets reached for under exactly the pressure where the gates
@@ -30,113 +30,215 @@ Checking out a tag is deliberately slower and deliberately visible.
 **Reach for this only when a gate is refusing a proposal that is genuinely
 correct and the fix cannot ship in the time available.** A gate refusing a
 proposal that is *wrong* is the system working. If the refusal is a false red
-with a known cause, prefer fixing the gate — the fallback costs a ceremony and
-leaves rows in the store that §5 has to clean up afterwards.
+with a known cause, prefer fixing the gate — the fallback costs a ceremony,
+freezes config as well as code (§4), and leaves rows in the store that §7 has
+to clean up.
+
+### Which side of the ceremony has to fall back
+
+**Answer this before checking anything out.** The entire 2.0 gate layer is
+absent at the baseline — `git ls-tree -r 49f05efa9 -- script/deploy/safe/
+script/deploy/shared/` against the same paths on `main` is the check, and it
+is what §8 tells the next person to re-run rather than trusting a list of
+names — so the escape commit clears any gate. But it only clears the ones
+that run on the side that checks it out:
+
+| refusing gate | runs at | who falls back |
+|---|---|---|
+| `assertTicketPresent`, the `proposeSafeTx` funnel and its deploy gate | propose time | the proposer only |
+| `runIntegrityAsserts`, `evaluateCodehashSignGate` | sign time, inside `confirm-safe-tx.ts` | **the signers too** |
+
+Getting this wrong wastes the ceremony: proposing from the escape commit does
+nothing for a sign-time refusal, because the signer on `main` reaches the
+identical check — and the proposal is then stuck *and* carries neither
+provenance nor a ticket binding. Both sign-time gates block rather than skip:
+an unevaluated codehash gate becomes `blockingUnevaluatedGate()`, and a failed
+integrity run leaves the run undefined, which is itself the blocking state.
 
 ## 2. Check out the escape commit
 
+From inside your existing clone:
+
 ```bash
-git fetch origin --tags
-git worktree add --detach ~/contracts-escape pre-signing-2.0-baseline
+CLONE=~/Documents/GitHub/contracts   # wherever yours lives
+git -C "$CLONE" fetch origin --tags
+git -C "$CLONE" worktree add --detach ~/contracts-escape pre-signing-2.0-baseline
 cd ~/contracts-escape
-ln -s ~/Documents/GitHub/contracts/.env .env
-ln -s ~/Documents/GitHub/contracts/node_modules node_modules
-git submodule update --init --force --recursive
+ln -s "$CLONE/.env" .env
+ln -s "$CLONE/node_modules" node_modules
 ```
 
 A worktree rather than a checkout in place: the fallback runs alongside a
-normal clone, and nothing about the working repo has to be disturbed to reach
-it. `--force` on the submodules is not optional — without it the command exits
-0, leaves `lib/` empty, and the failure surfaces later as `ds-test not found`.
+normal clone, and nothing about the working repo has to be disturbed.
+
+**Only the confirm path needs a build.** `bun confirm-safe-tx` runs
+`build:typechain-and-abi` (so `forge build src`, so the `lib/` submodules);
+`bun propose-safe-tx` imports nothing from `typechain/` or `out/`. If you are
+proposing only, skip the next step.
+
+```bash
+git submodule update --init --force --recursive
+```
+
+`--force` is what this repo's worktrees have needed in practice — without it
+the command has been observed exiting 0 and leaving `lib/` empty, and the
+failure then surfaces as `ds-test not found` inside `forge build`. The
+mechanism has not been pinned down, so treat the flag as the remedy and
+`ls lib/forge-std` as the check.
+
+**The `node_modules` symlink borrows `main`'s resolved versions, not the
+baseline's.** That works today — the baseline's propose/confirm import closure
+is `citty consola viem mongodb dotenv @lifi/tron-devkit fs path`, none of which
+was dropped, and the installed `viem` still satisfies the baseline's range —
+but nothing enforces it, and one `bun install` in the clone can end it. The
+slower, correct alternative is a real `bun install` in the escape worktree
+against the baseline's own lockfile.
 
 ## 3. What the environment needs
 
-Same as the normal path, and no more. The entry points are unchanged across
-the gap — at both the escape commit and `main`, `bun propose-safe-tx` and
-`bun confirm-safe-tx` open the tunnel via `script/deploy/safe/with-safe-tunnel.sh`
-before running the TypeScript.
-
-The variable names did not change across the gap either. Two Mongo URIs exist
-and they are different stores — `SC_MONGODB_URI` holds
-`sc_private.pendingTransactions`, the proposal store, at both commits, while
-`MONGODB_URI` is the deployment-log and timelock-queue store. A fallback
-proposal therefore lands where today's signers already look.
-
-Confirm each required variable is **present**, by length, never by printing
-it:
+Both entry points load `.env` themselves — `import 'dotenv/config'` in
+`propose-to-safe.ts`, `dotenv.config()` in `confirm-safe-tx.ts` — and
+`with-safe-tunnel.sh` greps the repo-root `.env` directly. **None of them
+reads your shell**, so checking exported variables would report everything
+unset on a correctly configured worktree. Check the file, and never print a
+value:
 
 ```bash
 for v in SC_MONGODB_URI PRIVATE_KEY_PRODUCTION SAFE_SIGNER_PRIVATE_KEY; do
-  eval "val=\${$v:-}"
-  [ -n "$val" ] && echo "$v: set (${#val} chars)" || echo "$v: UNSET"
+  grep -qE "^${v}=." .env && echo "$v: declared" || echo "$v: MISSING from .env"
 done
 ```
 
-The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer confirming from the
-escape commit needs `SAFE_SIGNER_PRIVATE_KEY` (or `SAFE_SIGNER`), the same
-pair the current path uses.
+The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer needs
+`SAFE_SIGNER_PRIVATE_KEY` or `PRIVATE_KEY_PRODUCTION`, which are the two
+`confirm-safe-tx.ts` offers. There is no `SAFE_SIGNER` variable —
+`PrivateKeyTypeEnum.SAFE_SIGNER` is an internal enum member, and the only key
+names `getPrivateKey` accepts are `PRIVATE_KEY`, `PRIVATE_KEY_PRODUCTION` and
+`SAFE_SIGNER_PRIVATE_KEY`.
 
-## 4. What the signers are told
+The store is the same one either way: `SC_MONGODB_URI` holds
+`sc_private.pendingTransactions` at both commits, and `MONGODB_URI` is the
+deployment-log and timelock-queue store, unrelated to proposals. So a fallback
+proposal lands where today's signers already look.
 
-Signers do **not** need to check out the tag. A proposal written by the escape
-commit is a valid row for today's `confirm-safe-tx.ts`: the only schema
-difference across the gap is the optional `provenance` block (§5), and its
-declaration on `main` states that consumers must treat `undefined` as a legacy
-row rather than as a clean, authorless proposal.
+## 4. What the escape commit freezes besides `script/`
 
-So tell the signers, in the channel where the ceremony is coordinated:
+Checking out the tag rolls back **`config/` too**, and that is the part most
+likely to bite:
 
-- this proposal was created from the escape commit, and why;
-- **its provenance block will be empty in the signing prompt** — that absence
-  is expected here and is not the usual "this row predates capture";
-- the ticket link, which the escape commit does not record on the row, so it
-  has to travel with the message instead.
+- **`injective` and `sepolia` do not exist in the baseline's
+  `config/networks.json`.** A fallback proposal on either is impossible from
+  the escape commit; the tag has to move first (§8).
+- **Seven networks the org has since dropped are still `active` there** —
+  `botanix`, `moonbeam`, `sophon`, `superposition`, `swellchain`, `taiko`,
+  `tronshasta`. `getNetworksToProcess()` with no `--network` returns every
+  active network, so **always pass `--network`**: an unqualified run fans out
+  over the baseline's 76 rather than today's 71.
+- `safeAddress` is unchanged on every network both files share, which is the
+  one thing that would have made this unusable.
+- `config/global.json` has drifted too — diff it rather than trust this list.
+  As of `b7fc074df` the baseline still names `LiFiIntentEscrowFacet` where
+  `main` has `LiFiIntentEscrowFacetV2` in `coreFacets`, still carries
+  `FeeCollector` in `corePeriphery`, and still approves
+  `CBridgeFacet.triggerRefund` (`0x0d19e519`) in
+  `approvedSelectorsForRefundWallet`. Anything reading those — a diamond cut
+  in particular — is reading stale values.
 
-That third point is the substantive loss. `assertTicketPresent` reads
-`SAFE_PROPOSAL_TICKET` at propose time on `main`; at the escape commit nothing
-does, so nothing binds the proposal to a ticket except what a human writes.
+## 5. Make the proposal
 
-## 5. Reconcile afterwards
+From the escape worktree. The baseline's `propose-to-safe.ts` requires
+`--network` and `--to`, takes the payload as `--calldata` or `--calldataFile`,
+signs with `--privateKey` or `--ledger`, and routes through the timelock with
+`--timelock`:
 
-Two things are left behind by a fallback proposal.
-
-**The row has no `provenance`.** Every other field of `ISafeTxDocument` is
-identical across the gap — `provenance` is the single field `main` adds. Rows
-written during the fallback are therefore indistinguishable from genuinely old
-rows by shape alone, which is why the window has to be recorded: note the
-first and last proposal timestamp of the ceremony on the ticket, so the rows
-can be named later without guessing.
-
-**A nonce collision is reported as something else.** `unique_inflight_safe_nonce_ci`
-constrains every pending/submitted row regardless of which code wrote it, so
-the database refuses a colliding nonce from the escape commit exactly as it
-would from `main`. That refusal is correct. What is not correct is the
-message: `main` classifies which index rejected the write
-(`classifyDuplicateKeyError`), while the escape commit treats **every** E11000
-as the intent-hash duplicate and prints
-
-```text
-Duplicate pending proposal detected - skipping storage.
-  Intent hash: 0x…
+```bash
+bun propose-safe-tx --network <network> --to <target> \
+  --calldataFile <path> --timelock
 ```
 
-before returning `null`. So during a fallback, that message means *either* a
-duplicate intent *or* an in-flight nonce collision, and in both cases **no
-proposal was created**. Check the Safe's in-flight nonces before concluding
-the intent was already proposed.
+There is no `--ticket` flag: that gate does not exist at the baseline, which
+is what §6's third bullet is about.
 
-The intent index itself is partial on `intentHash: {$exists: true}`, and the
-escape commit does write `intentHash`, so rows it creates are subject to that
-index normally.
+Record the printed `safeTxHash` and the time, first and last if there are
+several. §7 needs the ceremony's window.
 
-## 6. When the tag has to move
+## 6. What the signers are told
 
-Any change to the stored proposal-record schema is a **re-rehearsal trigger**.
-The pinned baseline is the field set above: if a future change makes a row
-written by the escape commit invalid — a required field, a changed type, an
-index the old writer cannot satisfy — then the escape commit no longer works
-and the tag has to move forward.
+Say, in the channel where the ceremony is coordinated:
 
-Moving it is a recorded decision on EXSC-976, never a silent retag. The new
-commit must be re-checked the same way: the 2.0 gates absent from `script/`,
-the entry points still reachable, and the schema diff against `main` stated.
+- that this proposal was created from the escape commit, and why;
+- **what the provenance line will say.** It is not blank — the signer sees
+  `— not recorded (proposal predates provenance capture) —`, which in this
+  case is false. The row has no provenance because the escape commit does not
+  write one, not because it is old;
+- the ticket link, which nothing on the row carries, so it has to travel with
+  the message.
+
+That last point is the substantive loss. The binding check on `main` is
+`resolveProposalIntent` inside `storeTransactionInMongoDB` — the unbypassable
+one, which runs after signing — while `assertTicketPresent` is the early exit
+that saves a Ledger tap. Neither exists at the baseline, so nothing ties the
+proposal to a ticket except what a human writes down.
+
+## 7. Reconcile afterwards
+
+**Name the rows.** Every row `main` has written since 2026-09-01 carries a
+provenance block: `buildProposalProvenance` returns one unconditionally, never
+throws, and yields sentinel values with the cause in `captureErrors` when
+capture fails. So fallback rows are identified exactly, not approximately:
+
+```text
+{ provenance: { $exists: false }, timestamp: { $gte: ISODate("2026-09-01") } }
+```
+
+Record the ceremony window on the ticket anyway — it is what lets a reader
+tell one fallback from another.
+
+**A nonce collision is reported as something else.**
+`unique_inflight_safe_nonce_ci` — keyed on `{safeAddress, network, chainId,
+safeTx.data.nonce}`, partial on `status ∈ {pending, submitted}` — refuses a
+colliding nonce from the escape commit exactly as it would from `main`,
+because the baseline's writer sets every one of those fields. That refusal is
+correct. The reporting is not.
+
+`main` classifies which index rejected the write (`classifyDuplicateKeyError`)
+and turns a nonce collision into an explicit *"Nonce … is already taken by
+another in-flight proposal"*. The escape commit treats **every** E11000 as the
+intent-hash duplicate:
+
+```text
+WARN  Duplicate pending proposal detected - skipping storage.
+        Intent hash: 0x…
+ℹ Proposal already exists - no new proposal created
+```
+
+and **exits 0**. That second line is the one an operator acts on, and in the
+nonce case it is simply wrong: nothing was stored, and the intent may never
+have been proposed at all. Check the Safe's in-flight nonces before believing
+it.
+
+Two smaller traps in the same area. The intent index is partial on
+`{ status: 'pending', intentHash: { $exists: true } }` — the `status` half is
+load-bearing, since a `submitted` row's `intentHash` is unconstrained. And
+`main` recognises a legacy index name, `unique_inflight_safe_nonce`, alongside
+the `_ci` one; which the live collection carries is worth confirming during the
+rehearsal.
+
+## 8. When the tag has to move
+
+Any change to the stored proposal-record schema is a **re-rehearsal trigger**,
+and so is a new network, since §4 shows config is pinned along with the code.
+
+Moving the tag is a recorded decision on EXSC-976, never a silent retag. What
+to re-establish at the candidate commit, in the order that fails fastest:
+
+1. No 2.0 gate module is present. Check the layer, not a list of names —
+   `git ls-tree -r <sha> -- script/deploy/safe/ script/deploy/shared/` against
+   the same paths on `main`, so a gate added after this runbook was written
+   cannot be missed by a stale list.
+2. The entry points still resolve: `propose-safe-tx` and `confirm-safe-tx` in
+   `package.json`, and `with-safe-tunnel.sh`.
+3. The `ISafeTxDocument` field diff against `main`, stated — today it is
+   `+provenance`, optional.
+4. The `config/networks.json` and `config/global.json` diff against `main`,
+   stated as in §4.

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -56,11 +56,14 @@ costs there). What is lost is provenance and the ticket binding, which is §6.
 
 ### Which side of the ceremony has to fall back
 
-**Answer this before checking anything out.** At `49f05efa9` the 2.0 gate
-modules are absent outright — `delegatecall-gate.ts`, `codehash-sign-gate.ts`,
-`confirm-integrity-asserts.ts`, `proposal-intent.ts`, `calldata-address-check.ts`
-and `pinned-target-state.ts` are all missing from `script/deploy/safe/`, and
-all six exist on `main`. So this commit clears any gate. That is a property of
+**Answer this before checking anything out.** At `49f05efa9` the modules that
+actually refuse are absent outright: `delegatecall-gate.ts`,
+`codehash-sign-gate.ts`, `confirm-integrity-asserts.ts`, `proposal-intent.ts`
+and `pinned-target-state.ts` in `script/deploy/safe/`, plus
+`funnel-deploy-gate.ts` in `script/deploy/shared/` — which `propose-to-safe.ts`
+calls directly, and which is the reason §8's diff spans both directories
+rather than `safe/` alone. All six exist on `main`. So this commit clears any
+gate. That is a property of
 this commit, established by checking those paths — not something the §8
 directory diff would have told you, which is why §8 asks a different question
 of a *candidate* commit. But it only clears the gates that run on the side
@@ -282,8 +285,9 @@ M=$(mktemp); B=$(mktemp)
 # 1. The network's own entry, not the whole file — §4's other drift is noise here.
 git show "origin/main:config/networks.json" | jq ".$NET" > "$M" 2>/dev/null
 jq ".$NET" config/networks.json > "$B" 2>/dev/null
-if ! [ -s "$M" ] || ! [ -s "$B" ]; then
-  echo "✗ one side produced nothing (jq missing? read failed?) — THIS CHECK PROVED NOTHING"
+if ! [ -s "$M" ] || ! [ -s "$B" ] || grep -qx null "$M" || grep -qx null "$B"; then
+  echo "✗ no entry on one side — typo'd network, jq missing, or absent at the"
+  echo "  baseline (§4). Either way THIS CHECK PROVED NOTHING; resolve it first."
 elif diff "$M" "$B" >/dev/null; then
   echo "✓ networks.json[$NET] identical"
 else
@@ -292,8 +296,10 @@ fi
 
 # 2. Only the field --timelock actually sends to. The rest of the deployment
 #    file is facet-address churn and will always differ.
-echo "timelock on main:     $(git show "origin/main:deployments/$NET.json" 2>/dev/null | jq -r '.LiFiTimelockController // "ABSENT"')"
-echo "timelock at baseline: $(jq -r '.LiFiTimelockController // "ABSENT"' "deployments/$NET.json" 2>/dev/null || echo 'FILE ABSENT')"
+tl_main=$(git show "origin/main:deployments/$NET.json" 2>/dev/null | jq -r '.LiFiTimelockController // "KEY ABSENT"' 2>/dev/null)
+tl_base=$(jq -r '.LiFiTimelockController // "KEY ABSENT"' "deployments/$NET.json" 2>/dev/null)
+echo "timelock on main:     ${tl_main:-FILE ABSENT}"
+echo "timelock at baseline: ${tl_base:-FILE ABSENT}"
 
 # 3. global.json is not per-network — expect output, and read it.
 diff <(git show "origin/main:config/global.json") config/global.json
@@ -341,7 +347,9 @@ twice, both through `resolveProposalIntent`: once early in
 `storeTransactionInMongoDB`, which is the unbypassable one because it runs on
 the write. (`assertTicketPresent` is the same module's guard for the *other*
 proposal entry points — the Tron proposer, `add-safe-owners-and-threshold`,
-`unpauseAllDiamonds` — not for this one.) The whole module is absent at the
+`unpauseAllDiamonds`, and the `sendOrPropose` flow in
+`script/safe/safeScriptHelpers.ts` — not for this one.) The whole module is
+absent at the
 baseline, so nothing ties a fallback proposal to a ticket except what a human
 writes down.
 

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -1,0 +1,142 @@
+# Signing Fallback Runbook — the escape commit
+
+How to propose and sign a production Safe transaction from the pinned pre-2.0
+baseline when a check added by the Signing 2.0 work is refusing an honest
+proposal and cannot be fixed forward in time.
+
+Status: **written, not yet rehearsed.** The rehearsal against a testnet Safe
+and a rehearsal store is EXSC-976 item 3, and until it runs, everything below
+about how the live store behaves is read off the code rather than observed.
+Treat the reconciliation step in §5 as the part most likely to need
+correction.
+
+---
+
+## 1. What this is, and what it deliberately is not
+
+The fallback is a **commit you check out**, never a flag you set:
+
+| | |
+|---|---|
+| tag | `pre-signing-2.0-baseline` |
+| commit | `49f05efa948d3bd208bbdfcf34ff70ce5eb183bf` (2026-07-24) |
+| why this one | none of the 2.0 gates exist there — `assertTicketPresent`, `proposeSafeTx`, `runIntegrityAsserts` and `evaluateCodehashSignGate` are all absent from `script/` at that commit |
+
+A `--legacy` / `SKIP_GATES` switch was refused (D26). A bypass one environment
+variable away gets reached for under exactly the pressure where the gates
+matter most, and every gate's threat model would then have to account for it.
+Checking out a tag is deliberately slower and deliberately visible.
+
+**Reach for this only when a gate is refusing a proposal that is genuinely
+correct and the fix cannot ship in the time available.** A gate refusing a
+proposal that is *wrong* is the system working. If the refusal is a false red
+with a known cause, prefer fixing the gate — the fallback costs a ceremony and
+leaves rows in the store that §5 has to clean up afterwards.
+
+## 2. Check out the escape commit
+
+```bash
+git fetch origin --tags
+git worktree add --detach ~/contracts-escape pre-signing-2.0-baseline
+cd ~/contracts-escape
+ln -s ~/Documents/GitHub/contracts/.env .env
+ln -s ~/Documents/GitHub/contracts/node_modules node_modules
+git submodule update --init --force --recursive
+```
+
+A worktree rather than a checkout in place: the fallback runs alongside a
+normal clone, and nothing about the working repo has to be disturbed to reach
+it. `--force` on the submodules is not optional — without it the command exits
+0, leaves `lib/` empty, and the failure surfaces later as `ds-test not found`.
+
+## 3. What the environment needs
+
+Same as the normal path, and no more. The entry points are unchanged across
+the gap — at both the escape commit and `main`, `bun propose-safe-tx` and
+`bun confirm-safe-tx` open the tunnel via `script/deploy/safe/with-safe-tunnel.sh`
+before running the TypeScript.
+
+The variable names did not change across the gap either. Two Mongo URIs exist
+and they are different stores — `SC_MONGODB_URI` holds
+`sc_private.pendingTransactions`, the proposal store, at both commits, while
+`MONGODB_URI` is the deployment-log and timelock-queue store. A fallback
+proposal therefore lands where today's signers already look.
+
+Confirm each required variable is **present**, by length, never by printing
+it:
+
+```bash
+for v in SC_MONGODB_URI PRIVATE_KEY_PRODUCTION SAFE_SIGNER_PRIVATE_KEY; do
+  eval "val=\${$v:-}"
+  [ -n "$val" ] && echo "$v: set (${#val} chars)" || echo "$v: UNSET"
+done
+```
+
+The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer confirming from the
+escape commit needs `SAFE_SIGNER_PRIVATE_KEY` (or `SAFE_SIGNER`), the same
+pair the current path uses.
+
+## 4. What the signers are told
+
+Signers do **not** need to check out the tag. A proposal written by the escape
+commit is a valid row for today's `confirm-safe-tx.ts`: the only schema
+difference across the gap is the optional `provenance` block (§5), and its
+declaration on `main` states that consumers must treat `undefined` as a legacy
+row rather than as a clean, authorless proposal.
+
+So tell the signers, in the channel where the ceremony is coordinated:
+
+- this proposal was created from the escape commit, and why;
+- **its provenance block will be empty in the signing prompt** — that absence
+  is expected here and is not the usual "this row predates capture";
+- the ticket link, which the escape commit does not record on the row, so it
+  has to travel with the message instead.
+
+That third point is the substantive loss. `assertTicketPresent` reads
+`SAFE_PROPOSAL_TICKET` at propose time on `main`; at the escape commit nothing
+does, so nothing binds the proposal to a ticket except what a human writes.
+
+## 5. Reconcile afterwards
+
+Two things are left behind by a fallback proposal.
+
+**The row has no `provenance`.** Every other field of `ISafeTxDocument` is
+identical across the gap — `provenance` is the single field `main` adds. Rows
+written during the fallback are therefore indistinguishable from genuinely old
+rows by shape alone, which is why the window has to be recorded: note the
+first and last proposal timestamp of the ceremony on the ticket, so the rows
+can be named later without guessing.
+
+**A nonce collision is reported as something else.** `unique_inflight_safe_nonce_ci`
+constrains every pending/submitted row regardless of which code wrote it, so
+the database refuses a colliding nonce from the escape commit exactly as it
+would from `main`. That refusal is correct. What is not correct is the
+message: `main` classifies which index rejected the write
+(`classifyDuplicateKeyError`), while the escape commit treats **every** E11000
+as the intent-hash duplicate and prints
+
+```text
+Duplicate pending proposal detected - skipping storage.
+  Intent hash: 0x…
+```
+
+before returning `null`. So during a fallback, that message means *either* a
+duplicate intent *or* an in-flight nonce collision, and in both cases **no
+proposal was created**. Check the Safe's in-flight nonces before concluding
+the intent was already proposed.
+
+The intent index itself is partial on `intentHash: {$exists: true}`, and the
+escape commit does write `intentHash`, so rows it creates are subject to that
+index normally.
+
+## 6. When the tag has to move
+
+Any change to the stored proposal-record schema is a **re-rehearsal trigger**.
+The pinned baseline is the field set above: if a future change makes a row
+written by the escape commit invalid — a required field, a changed type, an
+index the old writer cannot satisfy — then the escape commit no longer works
+and the tag has to move forward.
+
+Moving it is a recorded decision on EXSC-976, never a silent retag. The new
+commit must be re-checked the same way: the 2.0 gates absent from `script/`,
+the entry points still reachable, and the schema diff against `main` stated.

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -327,9 +327,11 @@ MAIN_NET=$(git show "origin/main:config/networks.json" 2>/dev/null)
 # 1. The two fields in the network entry that decide correctness — NOT the whole
 #    entry. `targetEvmVersion` replaced `deployedWith{Evm,Solc}Version` on every
 #    network, so diffing the entry wholesale refuses every honest run.
-st_main=$(printf '%s' "$MAIN_NET" | jq -r ".$NET.status // \"ABSENT\"" 2>/dev/null)
-sa_main=$(printf '%s' "$MAIN_NET" | jq -r ".$NET.safeAddress // \"ABSENT\"" 2>/dev/null)
-sa_base=$(jq -r ".$NET.safeAddress // \"ABSENT\"" config/networks.json 2>/dev/null)
+# Bracket form, not `.$NET`: `0g` is a real network name and `jq '.0g'` is a
+# syntax error, which would refuse a legitimate network rather than check it.
+st_main=$(printf '%s' "$MAIN_NET" | jq -r --arg net "$NET" '.[$net].status // "ABSENT"' 2>/dev/null)
+sa_main=$(printf '%s' "$MAIN_NET" | jq -r --arg net "$NET" '.[$net].safeAddress // "ABSENT"' 2>/dev/null)
+sa_base=$(jq -r --arg net "$NET" '.[$net].safeAddress // "ABSENT"' config/networks.json 2>/dev/null)
 
 echo "status on main:       ${st_main:-ABSENT}"
 [ "${st_main:-ABSENT}" = "active" ] \
@@ -345,7 +347,8 @@ case "${sa_main:-ABSENT}" in
 esac
 
 # The rest of the entry, for you to read — never a gate.
-diff <(printf '%s' "$MAIN_NET" | jq ".$NET") <(jq ".$NET" config/networks.json)
+diff <(printf '%s' "$MAIN_NET" | jq --arg net "$NET" '.[$net]') \
+     <(jq --arg net "$NET" '.[$net]' config/networks.json)
 
 # 2. Only the field --timelock actually sends to. The rest of the deployment
 #    file is facet-address churn and will always differ.
@@ -394,19 +397,28 @@ not a note: it means the baseline would address a Safe or timelock the org has
 moved on from. `status` and `safeAddress` both live inside the entry step 1
 compares, so all three are covered — by `$DRIFT`, not by your reading.
 
-Which is why the proposal is gated on that variable rather than on having read
-the output. `${DRIFT:-1}` defaults to **1**, so pasting this without having run
-the block above refuses instead of proposing:
+Which is why the proposal is gated on those variables rather than on having read
+the output. Both default to the refusing value, so pasting this without having
+run §3 and §5 refuses instead of proposing:
 
 ```bash
-[ "${DRIFT:-1}" -eq 0 ] || echo "✗ refusing: §5's config check did not pass"
-[ "${DRIFT:-1}" -eq 0 ] && bun propose-safe-tx --network <network> --to <target> \
+READY=1
+[ "${ENVCONFLICT:-1}" -eq 0 ] || { echo "✗ §3 not clean: an export beats .env"; READY=0; }
+[ "${DRIFT:-1}"       -eq 0 ] || { echo "✗ §5 not clean: config drift or a check proved nothing"; READY=0; }
+# --ledger only: §2's resolve step must have passed.
+# [ "${LEDGEROK:-0}" -eq 1 ] || { echo "✗ §2 not clean: a Ledger package does not resolve"; READY=0; }
+
+[ "$READY" -eq 1 ] || echo "✗ refusing to propose — fix the above and re-run the checks"
+[ "$READY" -eq 1 ] && bun propose-safe-tx --network "$NET" --to <target> \
   --calldataFile <path> --timelock
 ```
 
-(Two statements rather than `exit 1`, because this is pasted into an
-interactive shell and `exit` would close it — losing the tunnel §3 set up
-along with it.)
+**`--network "$NET"`, not a placeholder you retype.** The checks above validated
+exactly that value; a hand-typed name here would propose against a network
+nothing verified, which is the one way to hold a green gate and still be wrong.
+
+(Statements rather than `exit 1`, because this is pasted into an interactive
+shell and `exit` would close it — losing the tunnel §3 set up along with it.)
 
 There is no `--ticket` flag: that gate does not exist at the baseline, which
 is what §6's third bullet is about.

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -121,20 +121,28 @@ EXPECTED=49f05efa948d3bd208bbdfcf34ff70ce5eb183bf
 RESOLVED=$(git -C "$CLONE" rev-parse "pre-signing-2.0-baseline^{commit}")
 
 ESCAPEOK=0
+ESC=~/contracts-escape
 if [ "$RESOLVED" = "$EXPECTED" ]; then
   echo "✓ tag resolves to the documented commit: $RESOLVED"
-  # &&-chained: a ~/contracts-escape left by an earlier ceremony fails `worktree
-  # add`, and an unchained `cd` then lands in that stale tree at an unknown
-  # commit with both symlinks refused as "File exists".
-  git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED" \
-    && cd ~/contracts-escape \
-    && ln -s "$CLONE/.env" .env \
-    && ln -s "$CLONE/node_modules" node_modules \
-    && [ "$(git rev-parse HEAD)" = "$RESOLVED" ] \
+  # The verdict is the tree's final state, not the exit codes of the steps that
+  # built it — an escape tree left by an earlier ceremony fails `worktree add`
+  # while being perfectly usable, and one deleted with `rm -rf` stays registered
+  # until pruned. Nothing cd's until that state is proven: a `cd` cannot be
+  # undone by a later failure, and §3's checks are cwd-relative, so a shell
+  # parked in a half-built tree would check it instead of the clone.
+  git -C "$CLONE" worktree prune
+  [ -d "$ESC" ]                 || git -C "$CLONE" worktree add --detach "$ESC" "$RESOLVED"
+  [ -e "$ESC/.env" ]            || ln -s "$CLONE/.env" "$ESC/.env"
+  [ -e "$ESC/node_modules" ]    || ln -s "$CLONE/node_modules" "$ESC/node_modules"
+  [ "$(git -C "$ESC" rev-parse HEAD 2>/dev/null)" = "$RESOLVED" ] \
+    && [ -e "$ESC/.env" ] && [ -e "$ESC/node_modules" ] \
     && ESCAPEOK=1
-  [ "$ESCAPEOK" -eq 1 ] \
-    && echo "✓ escape worktree ready at $RESOLVED" \
-    || echo "✗ STOP — setup did not complete; do not use ~/contracts-escape"
+  if [ "$ESCAPEOK" -eq 1 ] && cd "$ESC"; then
+    echo "✓ escape worktree ready at $RESOLVED"
+  else
+    ESCAPEOK=0
+    echo "✗ STOP — $ESC is not a verified checkout of $RESOLVED; you are still in $PWD"
+  fi
 else
   echo "✗ STOP — tag resolves to $RESOLVED, not $EXPECTED (see §8)"
 fi
@@ -142,6 +150,11 @@ fi
 
 The checkout is inside the `if` on purpose: a mismatch has to leave you with no
 escape worktree at all, not with one you were told not to use.
+
+Re-pasting the block is safe, and an escape worktree left by an earlier ceremony
+is reused rather than refused — but only after its `HEAD` is checked against
+`$EXPECTED`, so reuse is never a way to inherit a stale tree. To clear it
+deliberately: `git -C "$CLONE" worktree remove --force ~/contracts-escape`.
 
 A worktree rather than a checkout in place: the fallback runs alongside a
 normal clone, and nothing about the working repo has to be disturbed.
@@ -184,12 +197,17 @@ Nothing enforces any of this, and one `bun install` in the clone can end it. The
 slower, correct alternative is a real `bun install` in the escape worktree
 against the baseline's own lockfile.
 
-Resolve them up front, so a broken link fails here rather than at Ledger-tap
-time:
+Resolve them up front, so you learn before the ceremony rather than inside it.
+Note what the failure is **not**: on the propose path a missing package is a
+startup crash, not a mid-ceremony one — `initializeSafeClient`
+(`propose-to-safe.ts:120`) reaches `SafeClient.init`, which awaits
+`import('./ledger')` and `getLedgerAccount` (`safe-utils.ts:340-341` at the
+baseline) before the owner check and before any store write, so it dies in the
+first seconds with nothing half-written:
 
 ```bash
 LEDGEROK=1
-for m in @ledgerhq/hw-transport-node-hid @ledgerhq/hw-app-eth @ledgerhq/hw-transport; do
+for m in @ledgerhq/hw-transport-node-hid @ledgerhq/hw-app-eth; do
   # `node`, NOT `bun`: bun auto-installs a missing package, so `bun -e
   # "require.resolve(...)"` reports success for a name that does not exist and
   # for an absent node_modules alike — it cannot fail, so it proves nothing.
@@ -198,14 +216,22 @@ for m in @ledgerhq/hw-transport-node-hid @ledgerhq/hw-app-eth @ledgerhq/hw-trans
   else echo "✗ $m DOES NOT RESOLVE"; LEDGEROK=0
   fi
 done
+# Reported, never gated: `ledger.ts` takes @ledgerhq/hw-transport as `import
+# type` only, so it is erased at runtime and its absence cannot fail a run.
+node -e "require.resolve('@ledgerhq/hw-transport')" >/dev/null 2>&1 \
+  && echo "· @ledgerhq/hw-transport resolves (types only — not required at runtime)" \
+  || echo "· @ledgerhq/hw-transport absent (types only — harmless)"
 [ "$LEDGEROK" -eq 1 ] \
   && echo "✓ Ledger path ready" \
   || echo "✗ STOP — fix this before the ceremony, not during it"
 ```
 
-Only the first two are loaded; `@ledgerhq/hw-transport` is checked because it
-is declared in neither `package.json` and survives purely as a hoisted
-transitive, which is the one most likely to vanish under a reinstall.
+`@ledgerhq/hw-transport` is printed rather than gated on, and the reason is the
+same fact that makes it tempting to gate: it is declared in neither
+`package.json` and survives purely as a hoisted transitive, so it is the one
+most likely to vanish under a reinstall. But `ledger.ts` imports it as a type
+only, so a run without it is unaffected — refusing on its absence would block
+ceremonies that would have worked, and block them most often.
 
 ## 3. What the environment needs
 
@@ -331,6 +357,11 @@ network you are targeting, not the whole file:
 NET=arbitrum   # substitute your target network before pasting
 
 DRIFT=0   # any check that does not positively pass sets this to 1
+# The baseline side of every comparison below is read cwd-relative, so pasted
+# anywhere else — the clone on `main` being the easy mistake — these compare
+# main with main and pass having proved nothing.
+[ "$(git rev-parse HEAD 2>/dev/null)" = "${EXPECTED:-}" ] \
+  || { echo "✗ not in the escape worktree at ${EXPECTED:-<unset>} — cd there first"; DRIFT=1; }
 MAIN_NET=$(git show "origin/main:config/networks.json" 2>/dev/null)
 
 # 1. The two fields in the network entry that decide correctness — NOT the whole
@@ -406,20 +437,37 @@ not a note: it means the baseline would address a Safe or timelock the org has
 moved on from. `status` and `safeAddress` both live inside the entry step 1
 compares, so all three are covered — by `$DRIFT`, not by your reading.
 
-Which is why the proposal is gated on those variables rather than on having read
-the output. `ESCAPEOK`, `ENVCONFLICT` and `DRIFT` default to the refusing value,
-so pasting this without having run §2, §3 and §5 refuses instead of proposing.
-`LEDGEROK` defaults the other way on purpose: the deployer path never runs §2's
-Ledger step, and a gate that refuses every honest run is one you learn to paste
-past.
+Which is why the proposal is gated on those variables, plus the commit the shell
+is actually standing on, rather than on having read the output. Every one of
+them defaults to the refusing value, so pasting this without having run §2, §3
+and §5 refuses instead of proposing.
+
+`SIGNER` is there because `LEDGEROK` cannot simply be required. A Ledger and a
+raw key are a free choice on **both** commands — `propose-to-safe.ts` reads
+`options.ledger` and otherwise falls back to `PRIVATE_KEY_PRODUCTION` — so the
+choice is orthogonal to whether you are proposing or confirming, and §2's resolve
+step is honestly skipped on one branch and mandatory on the other. Defaulting it
+to *pass* would make the two indistinguishable: an unset `LEDGEROK` would mean
+both "raw key, never needed it" and "Ledger, skipped the check", and the second
+is the one that fails at Ledger-tap time mid-ceremony. Stating the signer costs a
+word and is a thing you know before you start.
 
 ```bash
 READY=1
 [ "${ESCAPEOK:-0}"    -eq 1 ] || { echo "✗ §2 not clean: no verified escape worktree"; READY=0; }
+# ESCAPEOK says a verified tree was built, not that you are standing in it.
+[ "$(git rev-parse HEAD 2>/dev/null)" = "${EXPECTED:-}" ] \
+  || { echo "✗ cwd is not the escape worktree — cd there and re-run §5"; READY=0; }
 [ "${ENVCONFLICT:-1}" -eq 0 ] || { echo "✗ §3 not clean: an export beats .env"; READY=0; }
 [ "${DRIFT:-1}"       -eq 0 ] || { echo "✗ §5 not clean: config drift or a check proved nothing"; READY=0; }
-# Unset passes here: the deployer path never runs §2's Ledger step. Ran-and-failed refuses.
-[ "${LEDGEROK:-1}"    -eq 1 ] || { echo "✗ §2 not clean: a Ledger package does not resolve"; READY=0; }
+# SIGNER names the key you will actually pass. §2's Ledger check bears on one of
+# the two answers only, so the gate has to be told which — and an unset SIGNER
+# is the case where skipping §2 would otherwise go unnoticed.
+case "${SIGNER:-}" in
+  ledger) [ "${LEDGEROK:-0}" -eq 1 ] || { echo "✗ §2 not clean: a Ledger package does not resolve"; READY=0; } ;;
+  key)    ;;
+  *)      echo "✗ set SIGNER=ledger or SIGNER=key — §2's Ledger check depends on it"; READY=0 ;;
+esac
 
 [ "$READY" -eq 1 ] || echo "✗ refusing to propose — fix the above and re-run the checks"
 [ "$READY" -eq 1 ] && bun propose-safe-tx --network "$NET" --to <target> \

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -34,14 +34,28 @@ with a known cause, prefer fixing the gate — the fallback costs a ceremony,
 freezes config as well as code (§4), and leaves rows in the store that §7 has
 to clean up.
 
+**What the fallback does not weaken.** It drops the 2.0 gate layer; it does
+not drop the multisig or the timelock. The baseline reads the threshold from
+the Safe contract itself (`safe.getThreshold()` in `confirm-safe-tx.ts`, not
+from the frozen `config/`), and offers an execute option only once
+`hasEnoughSignatures` finds the collected signatures at or above it — so
+quorum is enforced by the same on-chain value either way, and there is no
+single-signer path. `--timelock` still wraps the call in a
+`scheduleBatch` via `wrapWithTimelockSchedule`, still resolving
+`LiFiTimelockController` from `deployments/` (§4 covers what being frozen
+costs there). What is lost is provenance and the ticket binding, which is §6.
+
 ### Which side of the ceremony has to fall back
 
-**Answer this before checking anything out.** The entire 2.0 gate layer is
-absent at the baseline — `git ls-tree -r 49f05efa9 -- script/deploy/safe/
-script/deploy/shared/` against the same paths on `main` is the check, and it
-is what §8 tells the next person to re-run rather than trusting a list of
-names — so the escape commit clears any gate. But it only clears the ones
-that run on the side that checks it out:
+**Answer this before checking anything out.** At `49f05efa9` every 2.0 gate
+module is absent outright — `delegatecall-gate.ts`, `codehash-sign-gate.ts`,
+`confirm-integrity-asserts.ts`, `ledger-guards.ts`, `proposal-intent.ts` and
+`calldata-address-check.ts` are all missing from `script/deploy/safe/`, and
+all six exist on `main`. So this commit clears any gate. That is a property of
+this commit, established by checking those paths — not something the §8
+directory diff would have told you, which is why §8 asks a different question
+of a *candidate* commit. But it only clears the gates that run on the side
+that checks it out:
 
 **The command that printed the refusal is the answer**, and it is a better
 guide than any list of gate names, which will go out of date:
@@ -80,7 +94,19 @@ From inside your existing clone:
 ```bash
 CLONE=~/Documents/GitHub/contracts   # wherever yours lives
 git -C "$CLONE" fetch origin --tags
-git -C "$CLONE" worktree add --detach ~/contracts-escape pre-signing-2.0-baseline
+
+# The tag is movable by design (§8), so resolve it and stop if it is not the
+# commit this runbook was written against.
+EXPECTED=49f05efa948d3bd208bbdfcf34ff70ce5eb183bf
+RESOLVED=$(git -C "$CLONE" rev-parse "pre-signing-2.0-baseline^{commit}")
+if [ "$RESOLVED" = "$EXPECTED" ]; then
+  echo "✓ tag resolves to the documented commit: $RESOLVED"
+else
+  echo "✗ STOP — tag resolves to $RESOLVED, not $EXPECTED (see §8)"
+fi
+
+# Only with a ✓ above:
+git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED"
 cd ~/contracts-escape
 ln -s "$CLONE/.env" .env
 ln -s "$CLONE/node_modules" node_modules
@@ -88,6 +114,12 @@ ln -s "$CLONE/node_modules" node_modules
 
 A worktree rather than a checkout in place: the fallback runs alongside a
 normal clone, and nothing about the working repo has to be disturbed.
+
+Record the resolved SHA alongside the `safeTxHash`es of §5 — a fallback
+ceremony is only reconstructable afterwards if both are on the ticket. A
+mismatch is not automatically wrong (§8 is the procedure for moving the tag
+deliberately); it means this runbook's §4 and §7 facts were established
+against a different commit and have to be re-checked at the one you have.
 
 **Only the confirm path needs a build.** `bun confirm-safe-tx` runs
 `build:typechain-and-abi` (so `forge build src`, so the `lib/` submodules);
@@ -146,6 +178,15 @@ done
 [ -n "${SAFE_SIGNER_PRIVATE_KEY:-}" ] && echo '  ⚠ SAFE_SIGNER_PRIVATE_KEY is exported here — the export wins'
 ```
 
+**An exported `SC_MONGODB_URI` does more than win — it splits the two halves
+apart.** `with-safe-tunnel.sh` reads the URI by grepping `.env` and never
+consults the environment, so it opens the port named in the *file*, while the
+script connects to the URI in the *environment*. The failure that produces is
+a tunnel that comes up healthy (`✓ Safe Mongo tunnel already up`) in front of
+a proposal written somewhere else. If any of the three warns above, `unset` it
+and start the ceremony in a fresh shell rather than reasoning about which
+value applies where.
+
 The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer needs
 `SAFE_SIGNER_PRIVATE_KEY` or `PRIVATE_KEY_PRODUCTION`, which are the two
 `confirm-safe-tx.ts` offers. There is no `SAFE_SIGNER` variable —
@@ -168,10 +209,11 @@ likely to bite:
   the escape commit; the tag has to move first (§8).
 - **Seven networks are still `active` there that are not active on `main`** —
   `botanix`, `moonbeam`, `sophon`, `superposition`, `swellchain`, `taiko` and
-  `tronshasta` (the first six were removed from `networks.json` outright; the
-  seventh is still listed but `inactive`). The baseline will therefore accept
-  a `--network` the org has since retired, and answer with its stale
-  addresses. `--network` is required by the baseline's `propose-to-safe.ts`,
+  `tronshasta`. All seven are `active` at the baseline; on `main` the first six
+  are gone from `networks.json` outright and `tronshasta` is still listed but
+  `inactive`. The baseline will therefore accept a `--network` the org has
+  since retired, and answer with its stale addresses. `--network` is required
+  by the baseline's `propose-to-safe.ts`,
   so there is no fan-out risk — the risk is that a name it accepts no longer
   means what you think.
 - **`deployments/` is frozen too, and `--timelock` reads it.** The baseline's
@@ -202,6 +244,25 @@ From the escape worktree. The baseline's `propose-to-safe.ts` requires
 `--network` and `--to`, takes the payload as `--calldata` or `--calldataFile`,
 signs with `--privateKey` or `--ledger`, and routes through the timelock with
 `--timelock`:
+
+**§4 says the config is frozen; this is where that has to be paid for.**
+Nothing in the baseline compares its own `config/` against `main`, so before
+proposing, diff the values this run will actually resolve — for the one
+network you are targeting, not the whole file:
+
+```bash
+for f in config/networks.json config/global.json deployments/<network>.json; do
+  diff <(git show "origin/main:$f") "$f" && echo "same: $f"
+done
+```
+
+Three things make the difference between a stale value and a wrong proposal:
+the network's `status` on `main` (a name the baseline accepts may be retired),
+`safeAddress` (unchanged on every shared network as of `b7fc074df` — if this
+one differs, stop), and `LiFiTimelockController` in the deployment file, which
+`--timelock` resolves and sends to. A difference in any of the three is a stop,
+not a note: it means the baseline would address a Safe or timelock the org has
+moved on from.
 
 ```bash
 bun propose-safe-tx --network <network> --to <target> \
@@ -246,8 +307,19 @@ morning have no provenance and would otherwise be swept in:
   timestamp: { $gte: ISODate("2026-09-01T09:13:19Z") } }
 ```
 
-Record the ceremony window on the ticket anyway — it is what lets a reader
-tell one fallback from another.
+**That query does not name your rows — it names every fallback's.** It has
+only a lower bound, so a second ceremony's rows are indistinguishable from the
+first's, and there is nothing in a row that says which. Reconcile against the
+`safeTxHash`es §5 told you to record, and touch nothing outside that set:
+
+```text
+{ safeTxHash: { $in: [ "0x…", "0x…" ] } }
+```
+
+Use the unbounded form to *find* what the recorded set missed — a proposal
+whose hash never got written down is exactly the row worth knowing about — and
+never as the selector for a cleanup. Record the ceremony window on the ticket
+as well: it is what lets a later reader tell one fallback from another.
 
 **A nonce collision is reported as something else.**
 `unique_inflight_safe_nonce_ci` — keyed on `{safeAddress, network, chainId,

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -26,8 +26,8 @@ The fallback is a **commit you check out**, never a flag you set:
 | commit | `49f05efa948d3bd208bbdfcf34ff70ce5eb183bf` (2026-07-24) |
 
 A `--legacy` / `SKIP_GATES` switch was refused — decision D26, recorded on
-EXSC-976. A bypass one environment
-variable away gets reached for under exactly the pressure where the gates
+EXSC-976. A bypass one environment variable away gets reached for under
+exactly the pressure where the gates
 matter most, and every gate's threat model would then have to account for it.
 Checking out a tag is deliberately slower and deliberately visible.
 
@@ -100,7 +100,11 @@ From inside your existing clone:
 
 ```bash
 CLONE=~/Documents/GitHub/contracts   # wherever yours lives
-git -C "$CLONE" fetch origin --tags
+
+# --force matters: a plain `fetch --tags` REFUSES to update a tag you already
+# have ("would clobber existing tag") and leaves the stale one in place, so the
+# check below would compare against your old copy and pass.
+git -C "$CLONE" fetch origin --tags --force
 
 # The tag is movable by design (§8), so resolve it and stop if it is not the
 # commit this runbook was written against.
@@ -406,8 +410,11 @@ to re-establish at the candidate commit, in the order that fails fastest:
    it is non-empty from 2026-07-28 onward and most of what it names is
    unrelated tooling (a prefetch cache, a selector registry, a read-only
    client). For each candidate, ask the only question that matters: does an
-   entry point reach it on a path that can *refuse*? Grep its call sites in
-   `propose-to-safe.ts` and `confirm-safe-tx.ts`.
+   entry point reach it on a path that can *refuse*? Follow its call sites
+   transitively, not just into `propose-to-safe.ts` and `confirm-safe-tx.ts`:
+   §1's worked example is a gate reached only through `safe-utils.ts`
+   (`signTransaction`), and a grep of the two entry points alone would have
+   called it sign-only.
 2. The entry points still resolve: `propose-safe-tx` and `confirm-safe-tx` in
    `package.json`, and `with-safe-tunnel.sh`.
 3. The `ISafeTxDocument` field diff against `main`, stated — today it is

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -4,12 +4,15 @@ How to propose and sign a production Safe transaction from the pinned pre-2.0
 baseline when a check added by the Signing 2.0 work is refusing an honest
 proposal and cannot be fixed forward in time.
 
-Ticket: **EXSC-976** · D26.
+Ticket: **EXSC-976**, which carries the decision (D26) this runbook implements.
 
 Status: **written, not yet rehearsed.** The rehearsal against a testnet Safe
 and a rehearsal store is EXSC-976 item 3, and until it runs, everything below
 about how the live store behaves is read off the code rather than observed.
-Treat §7 as the part most likely to need correction.
+Treat §7 as the part most likely to need correction. §4's inventory — which
+networks, how many deployment files — is the part most likely to have gone
+stale, since networks are added and retired continuously; it is dated, and §5
+re-derives what it actually depends on rather than trusting it.
 
 ---
 
@@ -17,12 +20,13 @@ Treat §7 as the part most likely to need correction.
 
 The fallback is a **commit you check out**, never a flag you set:
 
-| | |
+| what | value |
 |---|---|
 | tag | `pre-signing-2.0-baseline` |
 | commit | `49f05efa948d3bd208bbdfcf34ff70ce5eb183bf` (2026-07-24) |
 
-A `--legacy` / `SKIP_GATES` switch was refused (D26). A bypass one environment
+A `--legacy` / `SKIP_GATES` switch was refused — decision D26, recorded on
+EXSC-976. A bypass one environment
 variable away gets reached for under exactly the pressure where the gates
 matter most, and every gate's threat model would then have to account for it.
 Checking out a tag is deliberately slower and deliberately visible.
@@ -32,7 +36,7 @@ correct and the fix cannot ship in the time available.** A gate refusing a
 proposal that is *wrong* is the system working. If the refusal is a false red
 with a known cause, prefer fixing the gate — the fallback costs a ceremony,
 freezes config as well as code (§4), and leaves rows in the store that §7 has
-to clean up.
+to reconcile.
 
 **What the fallback does not weaken.** It drops the 2.0 gate layer; it does
 not drop the multisig or the timelock. The baseline reads the threshold from
@@ -66,11 +70,14 @@ guide than any list of gate names, which will go out of date:
 | `bun confirm-safe-tx` | **the signers too** |
 
 That is a first cut, not the whole answer: **a gate can be wired on both
-paths.** `evaluateDelegateCallGate` is — three call sites in `safe-utils.ts`
-(`signTransactionWithHash`, `signTransaction`, `executeTransaction`) as well
-as in `confirm-safe-tx.ts`. Before concluding the signers can stay on `main`,
-grep the refusing gate's call sites; if the propose path reaches it too, both
-sides fall back.
+paths.** `evaluateDelegateCallGate` is — `confirm-safe-tx.ts` calls it
+directly, and so do three methods in `safe-utils.ts`
+(`signTransactionWithHash`, `signTransaction`, `executeTransaction`). The
+propose path reaches it through the third of those: `propose-safe-tx.ts` calls
+`safe.signTransaction()`, which asserts the gate before it signs. So grep the
+refusing gate's call sites *and follow them back to an entry point* — a gate
+that looks sign-only can sit behind a helper the proposer also calls, and then
+both sides fall back.
 
 Sign-time gates are the larger group and they refuse in different ways, so do
 not expect a single recognisable message: `evaluateCodehashSignGate` and
@@ -99,18 +106,20 @@ git -C "$CLONE" fetch origin --tags
 # commit this runbook was written against.
 EXPECTED=49f05efa948d3bd208bbdfcf34ff70ce5eb183bf
 RESOLVED=$(git -C "$CLONE" rev-parse "pre-signing-2.0-baseline^{commit}")
+
 if [ "$RESOLVED" = "$EXPECTED" ]; then
   echo "✓ tag resolves to the documented commit: $RESOLVED"
+  git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED"
+  cd ~/contracts-escape
+  ln -s "$CLONE/.env" .env
+  ln -s "$CLONE/node_modules" node_modules
 else
   echo "✗ STOP — tag resolves to $RESOLVED, not $EXPECTED (see §8)"
 fi
-
-# Only with a ✓ above:
-git -C "$CLONE" worktree add --detach ~/contracts-escape "$RESOLVED"
-cd ~/contracts-escape
-ln -s "$CLONE/.env" .env
-ln -s "$CLONE/node_modules" node_modules
 ```
+
+The checkout is inside the `if` on purpose: a mismatch has to leave you with no
+escape worktree at all, not with one you were told not to use.
 
 A worktree rather than a checkout in place: the fallback runs alongside a
 normal clone, and nothing about the working repo has to be disturbed.
@@ -192,7 +201,9 @@ The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer needs
 `confirm-safe-tx.ts` offers. There is no `SAFE_SIGNER` variable —
 `PrivateKeyTypeEnum.SAFE_SIGNER` is an internal enum member, and the only key
 names `getPrivateKey` accepts are `PRIVATE_KEY`, `PRIVATE_KEY_PRODUCTION` and
-`SAFE_SIGNER_PRIVATE_KEY`.
+`SAFE_SIGNER_PRIVATE_KEY`. Neither entry point asks for `PRIVATE_KEY` on this
+path, which is why the check above covers the other two — add it if a script
+you are driving takes it.
 
 The store is the same one either way: `SC_MONGODB_URI` holds
 `sc_private.pendingTransactions` at both commits, and `MONGODB_URI` is the
@@ -226,12 +237,14 @@ likely to bite:
   reachable too. `injective.json` and `sepolia.json`
   do not exist at the baseline at all — the same two networks, failing a
   second way. For the 69 files both trees share, no `LiFiTimelockController`
-  address drifted, so this is a missing-network problem rather than a
-  wrong-address one.
+  address drifted, so as of the date above this is a missing-network problem
+  rather than a wrong-address one — which is a fact with a shelf life, and why
+  §5 re-diffs the one file it will actually read.
 - `safeAddress` is unchanged on every network both files share, which is the
   one thing that would have made this unusable.
 - `config/global.json` has drifted too — diff it rather than trust this list.
-  As of `b7fc074df` the baseline still names `LiFiIntentEscrowFacet` where
+  As of `main` at `b7fc074df` (2026-09-10) the baseline still names
+  `LiFiIntentEscrowFacet` where
   `main` has `LiFiIntentEscrowFacetV2` in `coreFacets`, still carries
   `FeeCollector` in `corePeriphery`, and still approves
   `CBridgeFacet.triggerRefund` (`0x0d19e519`) in
@@ -251,15 +264,25 @@ proposing, diff the values this run will actually resolve — for the one
 network you are targeting, not the whole file:
 
 ```bash
-for f in config/networks.json config/global.json deployments/<network>.json; do
-  diff <(git show "origin/main:$f") "$f" && echo "same: $f"
-done
+NET=<network>
+
+# The target network's entry, not the whole file — §4's other drift is noise here.
+diff <(git show "origin/main:config/networks.json" | jq ".$NET") \
+     <(jq ".$NET" config/networks.json) && echo "same: networks.json[$NET]"
+
+# The deployment file --timelock reads.
+diff <(git show "origin/main:deployments/$NET.json") "deployments/$NET.json" \
+  && echo "same: deployments/$NET.json"
+
+# global.json is not per-network, so read this one rather than expecting silence.
+diff <(git show "origin/main:config/global.json") config/global.json
 ```
 
 Three things make the difference between a stale value and a wrong proposal:
 the network's `status` on `main` (a name the baseline accepts may be retired),
-`safeAddress` (unchanged on every shared network as of `b7fc074df` — if this
-one differs, stop), and `LiFiTimelockController` in the deployment file, which
+`safeAddress` (unchanged on every shared network as of `main` at `b7fc074df`,
+2026-09-10 — if this one differs, stop), and `LiFiTimelockController` in the
+deployment file, which
 `--timelock` resolves and sends to. A difference in any of the three is a stop,
 not a note: it means the baseline would address a Safe or timelock the org has
 moved on from.
@@ -294,6 +317,9 @@ that saves a Ledger tap. Neither exists at the baseline, so nothing ties the
 proposal to a ticket except what a human writes down.
 
 ## 7. Reconcile afterwards
+
+The two filters below are `mongosh` queries against
+`sc_private.pendingTransactions`, through the same tunnel §3 describes.
 
 **Name the rows.** Every row `main` has written since provenance landed
 carries a provenance block: `buildProposalProvenance` returns one

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -175,6 +175,29 @@ Nothing enforces any of this, and one `bun install` in the clone can end it. The
 slower, correct alternative is a real `bun install` in the escape worktree
 against the baseline's own lockfile.
 
+Resolve them up front, so a broken link fails here rather than at Ledger-tap
+time:
+
+```bash
+LEDGEROK=1
+for m in @ledgerhq/hw-transport-node-hid @ledgerhq/hw-app-eth @ledgerhq/hw-transport; do
+  # `node`, NOT `bun`: bun auto-installs a missing package, so `bun -e
+  # "require.resolve(...)"` reports success for a name that does not exist and
+  # for an absent node_modules alike — it cannot fail, so it proves nothing.
+  if node -e "require.resolve('$m')" >/dev/null 2>&1
+  then echo "✓ $m"
+  else echo "✗ $m DOES NOT RESOLVE"; LEDGEROK=0
+  fi
+done
+[ "$LEDGEROK" -eq 1 ] \
+  && echo "✓ Ledger path ready" \
+  || echo "✗ STOP — fix this before the ceremony, not during it"
+```
+
+Only the first two are loaded; `@ledgerhq/hw-transport` is checked because it
+is declared in neither `package.json` and survives purely as a hoisted
+transitive, which is the one most likely to vanish under a reinstall.
+
 ## 3. What the environment needs
 
 Both entry points load `.env` themselves — `import 'dotenv/config'` in
@@ -188,16 +211,28 @@ then reads `process.env[keyType]` directly. So a stale value exported earlier
 in the session silently beats the file. Check both, and never print a value:
 
 ```bash
+ENVCONFLICT=0   # an export beating the file is a stop, not a note
+
 for v in SC_MONGODB_URI PRIVATE_KEY_PRODUCTION SAFE_SIGNER_PRIVATE_KEY; do
   grep -qE "^[[:space:]]*${v}=." .env \
     && echo "$v: declared in .env" || echo "$v: MISSING from .env"
 done
 
-# An export beats the file, so check the three by name — presence only, never
-# the value.
-[ -n "${SC_MONGODB_URI:-}" ]         && echo '  ⚠ SC_MONGODB_URI is exported here — the export wins'
-[ -n "${PRIVATE_KEY_PRODUCTION:-}" ] && echo '  ⚠ PRIVATE_KEY_PRODUCTION is exported here — the export wins'
-[ -n "${SAFE_SIGNER_PRIVATE_KEY:-}" ] && echo '  ⚠ SAFE_SIGNER_PRIVATE_KEY is exported here — the export wins'
+# An export beats the file, so check the three by name. Written out rather than
+# looped on purpose: `[ -n "${VAR:-}" ]` tests presence without expanding the
+# value anywhere, which an indirect lookup cannot do without routing it through
+# a subshell's stdout first.
+[ -n "${SC_MONGODB_URI:-}" ]          && { echo '  ⚠ SC_MONGODB_URI is exported here — the export wins';          ENVCONFLICT=1; }
+[ -n "${PRIVATE_KEY_PRODUCTION:-}" ]  && { echo '  ⚠ PRIVATE_KEY_PRODUCTION is exported here — the export wins';  ENVCONFLICT=1; }
+[ -n "${SAFE_SIGNER_PRIVATE_KEY:-}" ] && { echo '  ⚠ SAFE_SIGNER_PRIVATE_KEY is exported here — the export wins'; ENVCONFLICT=1; }
+
+if [ "$ENVCONFLICT" -ne 0 ]; then
+  echo "✗ STOP — two sources disagree and the export is the one that applies."
+  echo "  unset the names flagged above and restart the ceremony in a fresh"
+  echo "  shell. Do not proceed while reasoning about which value is in play."
+else
+  echo "✓ .env is the only source for all three"
+fi
 ```
 
 **An exported `SC_MONGODB_URI` does more than win — it splits the two halves
@@ -240,7 +275,13 @@ likely to bite:
   since retired, and answer with its stale addresses. `--network` is required
   by the baseline's `propose-to-safe.ts`,
   so there is no fan-out risk — the risk is that a name it accepts no longer
-  means what you think.
+  means what you think. **Neither case announces itself.** The baseline's
+  `propose-to-safe.ts` never reads `status` at all, so a retired network and a
+  live one take the identical path and nothing is printed either way; the
+  absent-versus-`inactive` split decides what a reconciler sees on `main`
+  afterwards, not whether the proposal gets made. §5's step 1 is the only thing
+  between you and a proposal against a retired network, which is why it refuses
+  rather than warns.
 - **`deployments/` is frozen too, and `--timelock` reads it.** The baseline's
   `propose-to-safe.ts` loads `deployments/<network>.json` whenever `--timelock`
   is passed and requires `LiFiTimelockController` in it, with a different
@@ -280,34 +321,68 @@ network you are targeting, not the whole file:
 ```bash
 NET=arbitrum   # substitute your target network before pasting
 
-M=$(mktemp); B=$(mktemp)
+DRIFT=0   # any check that does not positively pass sets this to 1
+MAIN_NET=$(git show "origin/main:config/networks.json" 2>/dev/null)
 
-# 1. The network's own entry, not the whole file — §4's other drift is noise here.
-git show "origin/main:config/networks.json" | jq ".$NET" > "$M" 2>/dev/null
-jq ".$NET" config/networks.json > "$B" 2>/dev/null
-if ! [ -s "$M" ] || ! [ -s "$B" ] || grep -qx null "$M" || grep -qx null "$B"; then
-  echo "✗ no entry on one side — typo'd network, jq missing, or absent at the"
-  echo "  baseline (§4). Either way THIS CHECK PROVED NOTHING; resolve it first."
-elif diff "$M" "$B" >/dev/null; then
-  echo "✓ networks.json[$NET] identical"
-else
-  echo "✗ networks.json[$NET] differs — read it:"; diff "$M" "$B"
-fi
+# 1. The two fields in the network entry that decide correctness — NOT the whole
+#    entry. `targetEvmVersion` replaced `deployedWith{Evm,Solc}Version` on every
+#    network, so diffing the entry wholesale refuses every honest run.
+st_main=$(printf '%s' "$MAIN_NET" | jq -r ".$NET.status // \"ABSENT\"" 2>/dev/null)
+sa_main=$(printf '%s' "$MAIN_NET" | jq -r ".$NET.safeAddress // \"ABSENT\"" 2>/dev/null)
+sa_base=$(jq -r ".$NET.safeAddress // \"ABSENT\"" config/networks.json 2>/dev/null)
+
+echo "status on main:       ${st_main:-ABSENT}"
+[ "${st_main:-ABSENT}" = "active" ] \
+  && echo "✓ $NET is active on main" \
+  || { echo "✗ $NET is '${st_main:-ABSENT}' on main, not active (§4) — STOP"; DRIFT=1; }
+
+echo "safeAddress on main:  ${sa_main:-ABSENT}"
+echo "safeAddress baseline: ${sa_base:-ABSENT}"
+case "${sa_main:-ABSENT}" in
+  0x*) [ "$sa_main" = "$sa_base" ] && echo "✓ safeAddress identical" \
+         || { echo "✗ safeAddress differs — STOP"; DRIFT=1; } ;;
+  *)   echo "✗ no safeAddress on main — THIS CHECK PROVED NOTHING"; DRIFT=1 ;;
+esac
+
+# The rest of the entry, for you to read — never a gate.
+diff <(printf '%s' "$MAIN_NET" | jq ".$NET") <(jq ".$NET" config/networks.json)
 
 # 2. Only the field --timelock actually sends to. The rest of the deployment
 #    file is facet-address churn and will always differ.
 tl_main=$(git show "origin/main:deployments/$NET.json" 2>/dev/null | jq -r '.LiFiTimelockController // "KEY ABSENT"' 2>/dev/null)
 tl_base=$(jq -r '.LiFiTimelockController // "KEY ABSENT"' "deployments/$NET.json" 2>/dev/null)
-echo "timelock on main:     ${tl_main:-FILE ABSENT}"
-echo "timelock at baseline: ${tl_base:-FILE ABSENT}"
+tl_main=${tl_main:-FILE ABSENT}; tl_base=${tl_base:-FILE ABSENT}
+echo "timelock on main:     $tl_main"
+echo "timelock at baseline: $tl_base"
+case "$tl_main" in
+  0x*) [ "$tl_main" = "$tl_base" ] \
+         && echo "✓ LiFiTimelockController identical" \
+         || { echo "✗ LiFiTimelockController differs — STOP"; DRIFT=1; } ;;
+  *)   echo "✗ no timelock address on main — this check proved nothing"; DRIFT=1 ;;
+esac
 
-# 3. global.json is not per-network — expect output, and read it.
+# 3. global.json is not per-network and ALWAYS differs (§4), so it cannot gate
+#    anything mechanically — it is the one item you have to read yourself.
 diff <(git show "origin/main:config/global.json") config/global.json
+
+if [ "$DRIFT" -ne 0 ]; then
+  echo "✗ STOP — do not propose. A check above failed or proved nothing (§4)."
+else
+  echo "✓ steps 1-2 clean. Read the global.json diff above before proceeding."
+fi
 ```
 
-An empty result is not a pass. Step 1 says so out loud because the natural
-shape of that check — two substitutions into `diff` — exits 0 when *both*
-sides fail, which prints a green line for a comparison that never happened.
+An empty result is not a pass. Every branch above that could not read a value
+sets `DRIFT=1` and says "THIS CHECK PROVED NOTHING", because the natural shape
+of these checks — two substitutions into `diff`, or a bare string compare —
+passes when *both* sides are empty, printing a green line for a comparison that
+never happened. A typo'd network name reaches that branch, not the happy one.
+
+Note what is deliberately **not** gated: the full entry diff, and `global.json`.
+Both differ on every network at every commit — the baseline predates the
+`targetEvmVersion` rename — so gating on them would refuse 100% of honest runs,
+which trains you to paste past the check. They print for you to read; only the
+three fields below decide.
 
 Three things make the difference between a stale value and a wrong proposal:
 the network's `status` on `main` (a name the baseline accepts may be retired),
@@ -316,12 +391,22 @@ the network's `status` on `main` (a name the baseline accepts may be retired),
 deployment file, which
 `--timelock` resolves and sends to. A difference in any of the three is a stop,
 not a note: it means the baseline would address a Safe or timelock the org has
-moved on from.
+moved on from. `status` and `safeAddress` both live inside the entry step 1
+compares, so all three are covered — by `$DRIFT`, not by your reading.
+
+Which is why the proposal is gated on that variable rather than on having read
+the output. `${DRIFT:-1}` defaults to **1**, so pasting this without having run
+the block above refuses instead of proposing:
 
 ```bash
-bun propose-safe-tx --network <network> --to <target> \
+[ "${DRIFT:-1}" -eq 0 ] || echo "✗ refusing: §5's config check did not pass"
+[ "${DRIFT:-1}" -eq 0 ] && bun propose-safe-tx --network <network> --to <target> \
   --calldataFile <path> --timelock
 ```
+
+(Two statements rather than `exit 1`, because this is pasted into an
+interactive shell and `exit` would close it — losing the tunnel §3 set up
+along with it.)
 
 There is no `--ticket` flag: that gate does not exist at the baseline, which
 is what §6's third bullet is about.
@@ -367,13 +452,19 @@ morning have no provenance and would otherwise be swept in:
 
 ```text
 { provenance: { $exists: false },
-  timestamp: { $gte: ISODate("2026-09-01T09:13:19Z") } }
+  timestamp: { $gte: ISODate("2026-09-01T09:13:19Z"),
+               $lte: ISODate("<last safeTxHash's time, rounded up>") } }
 ```
 
-**That query does not name your rows — it names every fallback's.** It has
-only a lower bound, so a second ceremony's rows are indistinguishable from the
-first's, and there is nothing in a row that says which. Reconcile against the
-`safeTxHash`es §5 told you to record, and touch nothing outside that set:
+The upper bound is the ceremony window §5 told you to record. Without it the
+filter has only a floor and selects every fallback's rows, not yours — drop it
+only to answer "what did I fail to write down?", never to select rows to act
+on.
+
+**Even bounded, that query does not name your rows.** A window is not an
+identity: two ceremonies inside it are indistinguishable, and there is nothing
+in a row that says which one wrote it. Reconcile against the `safeTxHash`es §5
+told you to record, and touch nothing outside that set:
 
 ```text
 { safeTxHash: { $in: [ "0x…", "0x…" ] } }
@@ -413,6 +504,41 @@ and **exits 0**. That second line is the one an operator acts on, and in the
 nonce case it is simply wrong: nothing was stored, and the intent may never
 have been proposed at all. Check the Safe's in-flight nonces before believing
 it.
+
+**Telling the two apart.** List what actually occupies the Safe's in-flight
+nonces. The collation matters as much as the filter — the rows carry both
+address spellings, so an equality match on `safeAddress` silently misses
+exactly the row you are hunting:
+
+```text
+db.pendingTransactions.find(
+  { safeAddress: "<safe>", network: "<network>", chainId: <id>,
+    status: { $in: [ "pending", "submitted" ] } },
+  { _id: 0, safeTxHash: 1, status: 1, intentHash: 1, "safeTx.data.nonce": 1 }
+).collation({ locale: "en", strength: 2 }).sort({ "safeTx.data.nonce": 1 })
+```
+
+Read it against the message you got. A row whose `intentHash` equals the one
+the warning printed is a **genuine** intent-hash duplicate — the proposal is
+already there, and exit 0 was right. No row with that `intentHash`, but the
+nonce the run would have taken already occupied, is the **misreported nonce
+collision**: nothing was stored and nothing was proposed.
+
+**Recovering from it needs no database write.** The baseline already refuses a
+nonce collision correctly — but only on the explicit-override branch, which
+the §5 command never takes:
+
+- `--nonce` supplied → `propose-to-safe.ts` pre-checks the same four fields and
+  throws *"A pending proposal already occupies nonce N (safeTxHash 0x…)"*,
+  which is accurate and non-zero.
+- `--nonce` omitted (the §5 default) → `getNextNonce` picks the nonce
+  uncollated, so it hands back one it cannot see is taken, and the insert dies
+  as the mis-classified E11000 above.
+
+So re-run §5's command with `--nonce` set to the first free slot the query
+above shows, and the baseline will either accept it or tell you the truth
+about why it cannot. Correct the stored row only if the query shows a genuinely
+orphaned one; a write here is a last resort, not the routine path.
 
 The escape commit does not create that index — `getSafeMongoCollection` at the
 baseline creates only `unique_pending_intent_hash`. It refuses the insert

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -51,13 +51,22 @@ guide than any list of gate names, which will go out of date:
 | `bun propose-safe-tx` (or a deploy script that proposes) | the proposer only |
 | `bun confirm-safe-tx` | **the signers too** |
 
+That is a first cut, not the whole answer: **a gate can be wired on both
+paths.** `evaluateDelegateCallGate` is — three call sites in `safe-utils.ts`
+(`signTransactionWithHash`, `signTransaction`, `executeTransaction`) as well
+as in `confirm-safe-tx.ts`. Before concluding the signers can stay on `main`,
+grep the refusing gate's call sites; if the propose path reaches it too, both
+sides fall back.
+
 Sign-time gates are the larger group and they refuse in different ways, so do
 not expect a single recognisable message: `evaluateCodehashSignGate` and
 `runIntegrityAsserts` both block by leaving their verdict unevaluated
 (`blockingUnevaluatedGate()`, and an undefined integrity run *is* the blocking
-state), `evaluateDelegateCallGate` silently removes every signing option from
-the menu, and `evaluateTargetStateIntent` prints `✗  EXPECTED-STATE CHECK
-FAILED — NOT SIGNING OR EXECUTING` and moves to the next network.
+state), `evaluateDelegateCallGate` prints `⛔ REFUSED` with its reason and then leaves
+`Do Nothing` as the only option — it withdraws the execute choices as well as
+the signing ones — and `evaluateTargetStateIntent` prints `✗  EXPECTED-STATE
+CHECK FAILED — NOT SIGNING OR EXECUTING` and skips to the next **proposal**,
+leaving the rest of the run intact.
 
 Getting this wrong wastes the ceremony: proposing from the escape commit does
 nothing for a sign-time refusal, because the signer on `main` reaches the
@@ -97,13 +106,18 @@ mechanism has not been pinned down, so treat the flag as the remedy and
 
 **The `node_modules` symlink borrows `main`'s resolved versions, not the
 baseline's.** That works today — the baseline's propose/confirm import closure
-is `citty consola viem viem/accounts mongodb dotenv @lifi/tron-devkit tronweb
-@ledgerhq/hw-transport` plus node builtins, none of which was dropped, and the
-installed `viem` and `tronweb` both still satisfy the baseline's ranges. Note
-that `@ledgerhq/hw-transport-node-hid` and `@ledgerhq/hw-app-eth` are loaded by
-**dynamic import**, so a resolution failure there surfaces at Ledger-tap time
-rather than at startup —
-but nothing enforces it, and one `bun install` in the clone can end it. The
+is `citty consola viem viem/accounts mongodb dotenv @lifi/tron-devkit tronweb`
+plus the Ledger packages and node builtins; none was dropped, and the installed
+`viem` and `tronweb` both still satisfy the baseline's ranges.
+
+The Ledger side deserves its own note. `@ledgerhq/hw-transport-node-hid` and
+`@ledgerhq/hw-app-eth` are loaded by **dynamic import**, so a resolution
+failure there surfaces at Ledger-tap time rather than at startup —
+mid-ceremony, in other words. `@ledgerhq/hw-transport` itself is imported only
+as a type and is declared in neither `package.json`; it resolves today as a
+hoisted transitive of `hw-transport-node-hid`.
+
+Nothing enforces any of this, and one `bun install` in the clone can end it. The
 slower, correct alternative is a real `bun install` in the escape worktree
 against the baseline's own lockfile.
 
@@ -123,9 +137,13 @@ in the session silently beats the file. Check both, and never print a value:
 for v in SC_MONGODB_URI PRIVATE_KEY_PRODUCTION SAFE_SIGNER_PRIVATE_KEY; do
   grep -qE "^[[:space:]]*${v}=." .env \
     && echo "$v: declared in .env" || echo "$v: MISSING from .env"
-  eval "exported=\${$v:-}"
-  [ -n "$exported" ] && echo "  ⚠ $v is ALSO exported in this shell — the export wins"
 done
+
+# An export beats the file, so check the three by name — presence only, never
+# the value.
+[ -n "${SC_MONGODB_URI:-}" ]         && echo '  ⚠ SC_MONGODB_URI is exported here — the export wins'
+[ -n "${PRIVATE_KEY_PRODUCTION:-}" ] && echo '  ⚠ PRIVATE_KEY_PRODUCTION is exported here — the export wins'
+[ -n "${SAFE_SIGNER_PRIVATE_KEY:-}" ] && echo '  ⚠ SAFE_SIGNER_PRIVATE_KEY is exported here — the export wins'
 ```
 
 The proposer needs `PRIVATE_KEY_PRODUCTION`; a signer needs
@@ -157,9 +175,13 @@ likely to bite:
   so there is no fan-out risk — the risk is that a name it accepts no longer
   means what you think.
 - **`deployments/` is frozen too, and `--timelock` reads it.** The baseline's
-  `propose-to-safe.ts` loads `deployments/<network>.json` and requires
-  `LiFiTimelockController` in it whenever `--timelock` is passed, throwing
-  `Deployment file not found` otherwise. `injective.json` and `sepolia.json`
+  `propose-to-safe.ts` loads `deployments/<network>.json` whenever `--timelock`
+  is passed and requires `LiFiTimelockController` in it, with a different
+  message for each failure — `Deployment file not found: <path>` when the file
+  is missing, `LiFiTimelockController not found in deployments for network
+  <n>` when the file is there without the key. Four of the 69 shared files
+  carry no `LiFiTimelockController` at either commit, so the second is
+  reachable too. `injective.json` and `sepolia.json`
   do not exist at the baseline at all — the same two networks, failing a
   second way. For the 69 files both trees share, no `LiFiTimelockController`
   address drifted, so this is a missing-network problem rather than a
@@ -278,10 +300,16 @@ and so is a new network, since §4 shows config is pinned along with the code.
 Moving the tag is a recorded decision on EXSC-976, never a silent retag. What
 to re-establish at the candidate commit, in the order that fails fastest:
 
-1. No 2.0 gate module is present. Check the layer, not a list of names —
+1. No 2.0 gate module is present. Get the candidates from the layer rather
+   than from a list of names, so a gate added after this runbook was written
+   cannot be missed:
    `git ls-tree -r <sha> -- script/deploy/safe/ script/deploy/shared/` against
-   the same paths on `main`, so a gate added after this runbook was written
-   cannot be missed by a stale list.
+   the same paths on `main`. **That diff is a candidate list, not an answer** —
+   it is non-empty from 2026-07-28 onward and most of what it names is
+   unrelated tooling (a prefetch cache, a selector registry, a read-only
+   client). For each candidate, ask the only question that matters: does an
+   entry point reach it on a path that can *refuse*? Grep its call sites in
+   `propose-to-safe.ts` and `confirm-safe-tx.ts`.
 2. The entry points still resolve: `propose-safe-tx` and `confirm-safe-tx` in
    `package.json`, and `with-safe-tunnel.sh`.
 3. The `ISafeTxDocument` field diff against `main`, stated — today it is
@@ -293,8 +321,14 @@ to re-establish at the candidate commit, in the order that fails fastest:
    the borrowed `node_modules` is `main`'s, and a `bun install` in the clone
    can invalidate it without touching this repo.
 
-**One case this list cannot satisfy.** Requirement 1 wants a commit with no
-2.0 gate module, and the earliest of those landed 2026-09-02. For a network
-added after that date there is no such commit, so there is no fallback for it
-at all — the answer then is to fix the gate, not to move the tag. Say so on
-the ticket rather than retagging to something that still carries the gate.
+**One case this list cannot satisfy.** The earliest signing gates —
+`ledger-guards.ts` and `proposal-intent.ts` — landed **2026-09-02**. For a
+network added after that date, no commit both knows the network and predates
+the gates, so there is no fallback for it at all: the answer is to fix the
+gate, not to move the tag. Say so on the ticket rather than retagging to
+something that still carries the gate.
+
+Both networks §4 names predate that, so a candidate exists for each
+(`injective` 2026-07-31, `sepolia` 2026-08-25) — but requirement 1's diff is
+non-empty at either, which is why it asks whether a candidate can refuse
+rather than whether the diff is empty.

--- a/docs/SigningFallbackRunbook.md
+++ b/docs/SigningFallbackRunbook.md
@@ -382,10 +382,16 @@ DRIFT=0   # any check that does not positively pass sets this to 1
 # The baseline side of every comparison below is read cwd-relative, so pasted
 # anywhere else — the clone on `main` being the easy mistake — these compare
 # main with main and pass having proved nothing.
+# Both, because either alone is satisfiable by the wrong tree: any checkout can
+# sit at $EXPECTED, and the path alone says nothing about the commit. Physical
+# paths on both sides so a symlinked $HOME cannot make equal paths compare
+# unequal.
+[ "$(pwd -P)" = "$(cd ~/contracts-escape 2>/dev/null && pwd -P)" ] \
+  || { echo "✗ cwd is not ~/contracts-escape — cd there first"; DRIFT=1; }
 [ -n "${EXPECTED:-}" ] \
   || { echo "✗ EXPECTED is unset — re-paste §2 in this shell, then re-run §5"; DRIFT=1; }
 [ -n "${EXPECTED:-}" ] && [ "$(git rev-parse HEAD 2>/dev/null)" != "$EXPECTED" ] \
-  && { echo "✗ this tree is not the escape worktree — cd ~/contracts-escape first"; DRIFT=1; }
+  && { echo "✗ this tree is not at the escape commit — re-paste §2"; DRIFT=1; }
 MAIN_NET=$(git show "origin/main:config/networks.json" 2>/dev/null)
 
 # 1. The two fields in the network entry that decide correctness — NOT the whole
@@ -487,11 +493,14 @@ confirming, whatever `SIGNER` says here.
 ```bash
 READY=1
 [ "${ESCAPEOK:-0}"    -eq 1 ] || { echo "✗ §2 not clean: no verified escape worktree"; READY=0; }
-# ESCAPEOK says a verified tree was built, not that you are standing in it.
+# ESCAPEOK says a verified tree was built, not that you are standing in it — and
+# the commit alone does not identify which tree you are standing in.
+[ "$(pwd -P)" = "$(cd ~/contracts-escape 2>/dev/null && pwd -P)" ] \
+  || { echo "✗ cwd is not ~/contracts-escape — cd there and re-run §5"; READY=0; }
 [ -n "${EXPECTED:-}" ] \
   || { echo "✗ EXPECTED is unset — re-paste §2 in this shell"; READY=0; }
 [ -n "${EXPECTED:-}" ] && [ "$(git rev-parse HEAD 2>/dev/null)" != "$EXPECTED" ] \
-  && { echo "✗ cwd is not the escape worktree — cd there and re-run §5"; READY=0; }
+  && { echo "✗ this tree is not at the escape commit — re-paste §2"; READY=0; }
 [ "${ENVCONFLICT:-1}" -eq 0 ] || { echo "✗ §3 not clean: an export beats .env"; READY=0; }
 [ "${DRIFT:-1}"       -eq 0 ] || { echo "✗ §5 not clean: config drift or a check proved nothing"; READY=0; }
 # SIGNER names the key you will actually pass. §2's Ledger check bears on one of


### PR DESCRIPTION
# Which Linear task belongs to this PR?

[EXSC-976](https://linear.app/lifi-linear/issue/EXSC-976/wp-06-the-escape-commit-pinned-fallback-for-the-signing-path) — WP-0.6, the escape commit. Covers items 1 and 2 of its scope; item 3 (the testnet rehearsal) is not done here, see below.

# Why did I implement it this way?

`docs/SigningFallbackRunbook.md` — how to propose and sign from the pre-2.0 baseline when a Signing 2.0 gate is refusing an honest proposal and cannot be fixed forward in time. Linked from `docs/README.md`.

**The fallback is a commit you check out, never a flag you set.** D26 refused a `--legacy` / `SKIP_GATES` switch: a bypass one env var away gets reached for under exactly the pressure where the gates matter most, and every gate's threat model would then have to account for it. Checking out a tag is deliberately slower and deliberately visible.

**The tag is already pushed:** `pre-signing-2.0-baseline` → `49f05efa948d3bd208bbdfcf34ff70ce5eb183bf`, annotated. It is this repo's first tag — nothing in `.github/workflows/` triggers on tags (the `generate-tag` job in `types.yaml` pushes to `lifi-contract-types`, not here), so it is inert to CI. `git push --delete origin pre-signing-2.0-baseline` if the name is wrong; say so in review and I will redo it.

## What was verified rather than assumed

- **The baseline really is pre-2.0.** All six gate modules — `delegatecall-gate.ts`, `codehash-sign-gate.ts`, `confirm-integrity-asserts.ts`, `proposal-intent.ts`, `calldata-address-check.ts`, `pinned-target-state.ts` — are absent from `script/deploy/safe/` at `49f05efa9` and present on `main`. (`ledger-guards.ts` is deliberately not on that list: its only caller is `script/tasks/cleanUpProdDiamond.ts`, so it is not on either ceremony path and is not a gate by §8's own test.)
- **The fallback drops the gate layer, not the multisig.** The baseline reads the threshold from the Safe contract (`safe.getThreshold()`), not from the frozen `config/`, and gates every execute option against it; `--timelock` still wraps via `wrapWithTimelockSchedule`. §1 states this, because "does dropping to an old commit weaken the multisig?" is the first question a signer asks — and states the limit too: one person holding both signer keys satisfies a threshold-2 Safe alone, equally on `main`.
- **The schema gap is exactly one field.** Diffing the `ISafeTxDocument` field set at `49f05efa9` against `b7fc074df` gives one addition, `provenance`, declared optional with "every consumer must treat `undefined` as a legacy row". So a fallback proposal is confirmable by today's signers without them checking out the tag.
- **The two Mongo URIs are different stores, and neither was renamed.** `SC_MONGODB_URI` holds `sc_private.pendingTransactions` at both commits; `MONGODB_URI` is the deployment-log / timelock-queue store. A fallback proposal lands where signers already look.
- **The entry points are unchanged** — `bun propose-safe-tx` / `bun confirm-safe-tx` open the tunnel via `with-safe-tunnel.sh` at both commits.

## The finding worth reviewing hardest

`unique_inflight_safe_nonce_ci` refuses a colliding nonce from the escape commit exactly as it would from `main` — correct, and the coupling D26 predicted. But the escape commit's writer treats **every** E11000 as the intent-hash duplicate and prints `Duplicate pending proposal detected - skipping storage. Intent hash: 0x…` before returning `null`, where `main` classifies which index rejected the write (`classifyDuplicateKeyError`). During a fallback that message means *either* cause, and in both cases no proposal was created. §7 tells the operator to check in-flight nonces before concluding the intent was already proposed.

## Not done here

**Item 3 of EXSC-976, the testnet rehearsal, has not run** — it shares WP-8.2's Safe and signer slot, so it needs a ceremony. Everything in the runbook about live-store behaviour is therefore read off the code, and the doc says so at the top. The rehearsal's falsification demo (a deliberately colliding nonce refused by the index, printed) is what would turn §7 from argued to observed.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>
