### PR TITLE
feat(tests): withhold endpoints, provider keys and webhooks from spawned children (EXSC-988)

### DIFF
--- a/.agents/rules/402-typescript-tests.md
+++ b/.agents/rules/402-typescript-tests.md
@@ -18,6 +18,34 @@ paths:
 - **Restore after each test**: when stubbing globals (e.g. `globalThis.fetch`), save the original in `beforeEach`/`beforeAll` and restore it in `afterEach`/`afterAll` to avoid cross-test pollution.
 - Prefer true unit tests that isolate the code under test; use mocks for any outbound calls (fetch, contract calls, file system if needed) so failures reflect logic bugs, not environment or network issues.
 
+## Withholding credentials from a spawned child ([CONV:TEST-SPAWN-CREDENTIALS])
+
+A test that spawns a child must **set** every credential name to a dummy, never
+`delete` it. Bun re-loads the repo `.env` inside the child for every name the
+passed environment leaves unset, so deleting a name hands the real value back at
+full length. Use `withholdCredentials()` from
+`script/deploy/safe/spawn-env.ts` rather than rolling your own.
+
+A name is a credential when it carries one of the cores in that module's class
+table — today `PRIVATE_KEY`, `MNEMONIC`, `MONGODB_URI`, `ETH_NODE_URI`,
+`API_KEY`, `ACCESS_KEY`, `SYNC_TOKEN`, `WEBHOOK`. The cores are anchored on the
+credential-bearing suffix, not the vendor, so a name that merely shares a prefix
+is not swept up; a name that holds no secret despite matching a core belongs in
+the same module's reviewed non-credential set, with the reason.
+
+`script/spawn-env-credentials.test.ts` derives its source scan from those same
+cores, so the guard and the withholding widen together. Two consequences:
+
+- **Deleting one of these names is red**, including in a test that never spawns.
+  When the delete is legitimate — an in-process test, or a child whose `cwd`
+  holds no `.env` — annotate it with a trailing `// spawn-env: <reason>` comment
+  on the delete's own line. The marker only counts on that line, so keep the
+  reason short enough to survive prettier at 80 columns; restructure the
+  statement rather than letting the formatter move the comment off it.
+- **A credential whose name carries no core is invisible** to both the scan and
+  the sweep. Adding a new kind of secret to the store means adding its core,
+  not assuming the pattern grew.
+
 ## Asserting rejections ([CONV:TEST-ASSERT-REJECTS])
 
 - **Never assert rejections via `expect(...).rejects`** — awaiting Bun's matcher trips `@typescript-eslint/await-thenable` because it isn't a real Promise. Use a local `async function expectRejects(promise, match)` that catches and matches the error message, as in `script/deploy/safe/parked-tasks.test.ts`.

--- a/.agents/rules/402-typescript-tests.md
+++ b/.agents/rules/402-typescript-tests.md
@@ -26,12 +26,13 @@ passed environment leaves unset, so deleting a name hands the real value back at
 full length. Use `withholdCredentials()` from
 `script/deploy/safe/spawn-env.ts` rather than rolling your own.
 
-A name is a credential when it carries one of the cores in that module's class
-table — today `PRIVATE_KEY`, `MNEMONIC`, `MONGODB_URI`, `ETH_NODE_URI`,
-`API_KEY`, `ACCESS_KEY`, `SYNC_TOKEN`, `WEBHOOK`. The cores are anchored on the
-credential-bearing suffix, not the vendor, so a name that merely shares a prefix
-is not swept up; a name that holds no secret despite matching a core belongs in
-the same module's reviewed non-credential set, with the reason.
+A name is a credential when it carries one of the cores in that module's
+`CREDENTIAL_CLASSES` — read the table, don't keep a copy. Each core spans the
+whole credential-bearing part of a name rather than the vendor alone, so a name
+that merely shares a prefix is not swept up. A name that matches a core but
+holds no secret goes in the same module's reviewed non-credential set with its
+reason, because replacing its value would change what a child does rather than
+withhold anything.
 
 `script/spawn-env-credentials.test.ts` derives its source scan from those same
 cores, so the guard and the withholding widen together. Two consequences:
@@ -39,12 +40,17 @@ cores, so the guard and the withholding widen together. Two consequences:
 - **Deleting one of these names is red**, including in a test that never spawns.
   When the delete is legitimate — an in-process test, or a child whose `cwd`
   holds no `.env` — annotate it with a trailing `// spawn-env: <reason>` comment
-  on the delete's own line. The marker only counts on that line, so keep the
-  reason short enough to survive prettier at 80 columns; restructure the
-  statement rather than letting the formatter move the comment off it.
+  on the delete's own line, and keep that delete a standalone statement: the
+  marker only counts on the line its delete ends on, and prettier relocates a
+  trailing comment when the delete is the body of an `if`/`else`, which
+  silently detaches it. Across the whole tree this costs two markers today, so
+  a widened core is not the marker tax it looks like.
 - **A credential whose name carries no core is invisible** to both the scan and
   the sweep. Adding a new kind of secret to the store means adding its core,
   not assuming the pattern grew.
+- **Only the two `withholdCredentials` callers are covered.** Other tests that
+  spawn a child build the environment by hand; nothing yet asserts that a
+  spawning test calls the helper.
 
 ## Asserting rejections ([CONV:TEST-ASSERT-REJECTS])
 

--- a/.agents/rules/402-typescript-tests.md
+++ b/.agents/rules/402-typescript-tests.md
@@ -23,8 +23,10 @@ paths:
 A test that spawns a child must **set** every credential name to a dummy, never
 `delete` it. Bun re-loads the repo `.env` inside the child for every name the
 passed environment leaves unset, so deleting a name hands the real value back at
-full length. Use `withholdCredentials()` from
-`script/deploy/safe/spawn-env.ts` rather than rolling your own.
+full length. Setting it to `undefined` does the same thing — the name is still
+unset — while an empty string is a real value the child sees as empty. Use
+`withholdCredentials()` from `script/deploy/safe/spawn-env.ts` rather than
+rolling your own.
 
 A name is a credential when it carries one of the cores in that module's
 `CREDENTIAL_CLASSES` — read the table, don't keep a copy. Each core spans the
@@ -35,22 +37,23 @@ reason, because replacing its value would change what a child does rather than
 withhold anything.
 
 `script/spawn-env-credentials.test.ts` derives its source scan from those same
-cores, so the guard and the withholding widen together. Two consequences:
+cores, so the guard and the withholding widen together. Consequences:
 
-- **Deleting one of these names is red**, including in a test that never spawns.
-  When the delete is legitimate — an in-process test, or a child whose `cwd`
-  holds no `.env` — annotate it with a trailing `// spawn-env: <reason>` comment
-  on the delete's own line, and keep that delete a standalone statement: the
-  marker only counts on the line its delete ends on, and prettier relocates a
-  trailing comment when the delete is the body of an `if`/`else`, which
-  silently detaches it. Across the whole tree this costs two markers today, so
-  a widened core is not the marker tax it looks like.
+- **Unsetting one of these names is red** — by `delete` or by `= undefined`,
+  including in a test that never spawns. When it is legitimate — an in-process
+  test, or a child whose `cwd` holds no `.env` — annotate it with a trailing
+  `// spawn-env: <reason>` comment on the statement's own line, and keep that
+  statement standalone: the marker only counts on the line its statement ends
+  on, and prettier relocates a trailing comment when the unset is the unbraced
+  body of an `if`/`else`, which silently detaches it. Brace the branch. Widening
+  the cores past the signing keys cost two markers across the whole tree, so a
+  wider core is not the marker tax it looks like.
 - **A credential whose name carries no core is invisible** to both the scan and
   the sweep. Adding a new kind of secret to the store means adding its core,
   not assuming the pattern grew.
 - **Only the two `withholdCredentials` callers are covered.** Other tests that
   spawn a child build the environment by hand; nothing yet asserts that a
-  spawning test calls the helper.
+  spawning test calls the helper. Tracked in EXSC-996.
 
 ## Asserting rejections ([CONV:TEST-ASSERT-REJECTS])
 

--- a/script/deploy/safe/spawn-env.ts
+++ b/script/deploy/safe/spawn-env.ts
@@ -7,9 +7,10 @@
  *
  * Malformed rather than merely wrong, so a child that reaches past the check
  * under test dies before it can act: a key viem cannot parse throws where a
- * valid-but-unfunded one would derive an address, and a URI the driver rejects
- * on construction throws where an unreachable host would first spend its 30 s
- * server-selection budget.
+ * valid-but-unfunded one would derive an address, a URI the driver rejects on
+ * construction throws where an unreachable host would first spend its 30 s
+ * server-selection budget, and a webhook URL `fetch` refuses never leaves the
+ * machine where a real one would post to a live channel.
  *
  * The store URIs matter as much as the keys, because a key is not always the
  * first credential a run reaches: `execute-pending-timelock-tx.ts` opens the
@@ -17,16 +18,92 @@
  */
 const MALFORMED_KEY = 'malformed-in-tests'
 const MALFORMED_STORE = 'malformed-in-tests://no-store'
+const MALFORMED_ENDPOINT = 'malformed-in-tests://no-endpoint'
+const MALFORMED_WEBHOOK = 'malformed-in-tests://no-webhook'
 
-const SIGNING_KEYS = [
-  'PRIVATE_KEY',
-  'PRIVATE_KEY_PRODUCTION',
-  'SAFE_SIGNER_PRIVATE_KEY',
-] as const
+/**
+ * The names withheld whether or not the spawning process happens to hold them.
+ *
+ * Every other class below is swept out of the environment actually being
+ * passed, which cannot cover a name the parent does not have — and a child
+ * re-loads the repo `.env` for exactly those names. These five are the ones
+ * whose exposure is a signature rather than a quota, so they are pinned by
+ * name and do not depend on the parent having been started with a `.env`.
+ */
+const ALWAYS_WITHHELD: readonly (readonly [string, string])[] = [
+  ['PRIVATE_KEY', MALFORMED_KEY],
+  ['PRIVATE_KEY_PRODUCTION', MALFORMED_KEY],
+  ['SAFE_SIGNER_PRIVATE_KEY', MALFORMED_KEY],
+  ['MONGODB_URI', MALFORMED_STORE],
+  ['SC_MONGODB_URI', MALFORMED_STORE],
+]
 
-const PROPOSAL_STORES = ['MONGODB_URI', 'SC_MONGODB_URI'] as const
+/**
+ * What counts as a credential, by the substring its name carries.
+ *
+ * Matched by substring rather than enumerated because every class comes in
+ * open-ended families: the wallet keys come in generations (pauser, refund and
+ * withdraw sit alongside several retired deployer ones), the endpoints come one
+ * per network, and the explorer keys one per chain — 225 names in the store
+ * today, of which 87 are `ETH_NODE_URI_*`. An enumeration would silently stop
+ * covering the next network added, on the day it was added.
+ *
+ * `spawn-env-credentials.test.ts` derives its source-scanning pattern from
+ * these same cores, so widening one widens the guard with it. That is the point
+ * of the table: a guard that no longer matches what this function withholds
+ * reports a clean tree while the fix has stopped covering it.
+ *
+ * The cores are anchored on the full credential-bearing suffix, never on the
+ * vendor alone, so a name that merely shares a prefix is not swept up:
+ * `MONGODB_URI` rather than `MONGODB` keeps `ENABLE_MONGODB_LOGGING` out, and
+ * `SYNC_TOKEN` rather than `TOKEN` keeps `ALLOW_TOKEN_CONTRACTS` out.
+ */
+const CREDENTIAL_CLASSES: readonly {
+  readonly cores: readonly string[]
+  readonly value: string
+}[] = [
+  { cores: ['PRIVATE_KEY', 'MNEMONIC'], value: MALFORMED_KEY },
+  { cores: ['MONGODB_URI'], value: MALFORMED_STORE },
+  { cores: ['ETH_NODE_URI'], value: MALFORMED_ENDPOINT },
+  { cores: ['API_KEY', 'ACCESS_KEY', 'SYNC_TOKEN'], value: MALFORMED_KEY },
+  { cores: ['WEBHOOK'], value: MALFORMED_WEBHOOK },
+]
+
+/**
+ * Names a class core matches that hold no credential.
+ *
+ * `NO_ETHERSCAN_API_KEY_REQUIRED` is the name of a marker, not a key: the
+ * verification helper compares the *name* against this literal to decide that
+ * an empty key is legitimate (`script/helperFunctions.sh`). Giving it a
+ * malformed value would make it look like a key that is present, which is a
+ * behaviour change rather than a withholding.
+ */
+const NOT_A_CREDENTIAL: ReadonlySet<string> = new Set([
+  'NO_ETHERSCAN_API_KEY_REQUIRED',
+])
+
+/** The substrings that make a name a credential, for the guard to scan for. */
+export const CREDENTIAL_CORES: readonly string[] = CREDENTIAL_CLASSES.flatMap(
+  (credentialClass) => credentialClass.cores
+)
+
+/** The names the guard must treat as clean even though a core matches them. */
+export const NON_CREDENTIAL_NAMES: readonly string[] = [...NOT_A_CREDENTIAL]
+
+/** The class value for `name`, or `undefined` if no class claims it. */
+export const withheldValueFor = (name: string): string | undefined => {
+  if (NOT_A_CREDENTIAL.has(name)) return undefined
+
+  return CREDENTIAL_CLASSES.find((credentialClass) =>
+    credentialClass.cores.some((core) => name.includes(core))
+  )?.value
+}
 
 export const withholdCredentials = (env: Record<string, string>): void => {
-  for (const name of SIGNING_KEYS) env[name] = MALFORMED_KEY
-  for (const name of PROPOSAL_STORES) env[name] = MALFORMED_STORE
+  for (const [name, value] of ALWAYS_WITHHELD) env[name] = value
+
+  for (const name of Object.keys(env)) {
+    const value = withheldValueFor(name)
+    if (value !== undefined) env[name] = value
+  }
 }

--- a/script/deploy/safe/spawn-env.ts
+++ b/script/deploy/safe/spawn-env.ts
@@ -6,11 +6,13 @@
  * hands the real one back instead of withholding it.
  *
  * Malformed rather than merely wrong, so a child that reaches past the check
- * under test dies before it can act: a key viem cannot parse throws where a
+ * under test cannot act on the value: a key viem cannot parse throws where a
  * valid-but-unfunded one would derive an address, a URI the driver rejects on
  * construction throws where an unreachable host would first spend its 30 s
- * server-selection budget, and a webhook URL `fetch` refuses never leaves the
- * machine where a real one would post to a live channel.
+ * server-selection budget, and a scheme `fetch` refuses never reaches the
+ * network where a real webhook would post to a live channel. The endpoint is
+ * the weakest of the four: viem builds a transport from it without complaint
+ * and only the first request fails, after its retries.
  *
  * The store URIs matter as much as the keys, because a key is not always the
  * first credential a run reaches: `execute-pending-timelock-tx.ts` opens the
@@ -22,41 +24,39 @@ const MALFORMED_ENDPOINT = 'malformed-in-tests://no-endpoint'
 const MALFORMED_WEBHOOK = 'malformed-in-tests://no-webhook'
 
 /**
- * The names withheld whether or not the spawning process happens to hold them.
+ * The names withheld whether or not the spawning process holds them.
  *
- * Every other class below is swept out of the environment actually being
- * passed, which cannot cover a name the parent does not have — and a child
- * re-loads the repo `.env` for exactly those names. These five buy a signature
- * or the proposal store rather than a provider quota, so they are pinned by
- * name and do not depend on the parent having been started with a `.env`.
+ * Every class below is swept out of the environment being passed, which cannot
+ * reach a name the parent does not have — and the child re-loads the file for
+ * exactly those names. The Safe signer key is unset in the store, so the sweep
+ * never sees it and this list is its only cover.
+ *
+ * Names only: each still takes its value from the class that claims it, so
+ * there is no second copy of the value here to disagree with that one.
  */
-const ALWAYS_WITHHELD: readonly (readonly [string, string])[] = [
-  ['PRIVATE_KEY', MALFORMED_KEY],
-  ['PRIVATE_KEY_PRODUCTION', MALFORMED_KEY],
-  ['SAFE_SIGNER_PRIVATE_KEY', MALFORMED_KEY],
-  ['MONGODB_URI', MALFORMED_STORE],
-  ['SC_MONGODB_URI', MALFORMED_STORE],
+export const ALWAYS_WITHHELD: readonly string[] = [
+  'PRIVATE_KEY',
+  'PRIVATE_KEY_PRODUCTION',
+  'SAFE_SIGNER_PRIVATE_KEY',
+  'MONGODB_URI',
+  'SC_MONGODB_URI',
 ]
 
 /**
  * What counts as a credential, by the substring its name carries.
  *
  * Matched by substring rather than enumerated because every class comes in
- * open-ended families: the wallet keys come in generations (pauser, refund and
- * withdraw sit alongside several retired deployer ones), the endpoints come one
- * per network, and the explorer keys one per chain — 225 names in the store
- * today, of which 87 are `ETH_NODE_URI_*`. An enumeration would silently stop
- * covering the next network added, on the day it was added.
+ * open-ended families — the wallet keys by generation, the endpoints and
+ * explorer keys one per network — so an enumeration stops covering the next
+ * network on the day it is added.
  *
  * `spawn-env-credentials.test.ts` derives its source-scanning pattern from
- * these same cores, so widening one widens the guard with it. That is the point
- * of the table: a guard that no longer matches what this function withholds
- * reports a clean tree while the fix has stopped covering it.
+ * these cores, so widening one widens the guard with it.
  *
- * The cores are anchored on the full credential-bearing suffix, never on the
- * vendor alone, so a name that merely shares a prefix is not swept up:
- * `MONGODB_URI` rather than `MONGODB` keeps `ENABLE_MONGODB_LOGGING` out, and
- * `SYNC_TOKEN` rather than `TOKEN` keeps `ALLOW_TOKEN_CONTRACTS` out.
+ * Each core spans the whole credential-bearing part of the name, never the
+ * vendor alone: `MONGODB_URI` rather than `MONGODB` leaves a logging toggle
+ * alone, and `SYNC_TOKEN` rather than `TOKEN` leaves a token-contract list
+ * alone.
  */
 const CREDENTIAL_CLASSES: readonly {
   readonly cores: readonly string[]
@@ -70,16 +70,19 @@ const CREDENTIAL_CLASSES: readonly {
 ]
 
 /**
- * Names a class core matches that hold no credential.
+ * Names a core matches that hold no secret, so replacing their value would
+ * change what a child does rather than withhold anything from it.
  *
- * `NO_ETHERSCAN_API_KEY_REQUIRED` is the name of a marker, not a key: the
- * verification helper compares the *name* against this literal to decide that
- * an empty key is legitimate (`script/helperFunctions.sh`). Giving it a
- * malformed value would make it look like a key that is present, which is a
- * behaviour change rather than a withholding.
+ * `NO_ETHERSCAN_API_KEY_REQUIRED` names a marker rather than holding a key:
+ * `helperFunctions.sh` compares the name against this literal to allow an
+ * empty key, and exports the value as the explorer key when it is set, so a
+ * malformed value would be sent as a present one. The two anvil entries are
+ * the publicly known local-node key and `127.0.0.1`.
  */
 const NOT_A_CREDENTIAL: ReadonlySet<string> = new Set([
   'NO_ETHERSCAN_API_KEY_REQUIRED',
+  'PRIVATE_KEY_ANVIL',
+  'ETH_NODE_URI_LOCALANVIL',
 ])
 
 /** The substrings that make a name a credential, for the guard to scan for. */
@@ -87,10 +90,16 @@ export const CREDENTIAL_CORES: readonly string[] = CREDENTIAL_CLASSES.flatMap(
   (credentialClass) => credentialClass.cores
 )
 
-/** The names the guard must treat as clean even though a core matches them. */
+/** The names both the guard and the sweep must treat as holding no credential. */
 export const NON_CREDENTIAL_NAMES: readonly string[] = [...NOT_A_CREDENTIAL]
 
-/** The class value for `name`, or `undefined` if no class claims it. */
+/**
+ * Decides what a child may see in place of `name`.
+ *
+ * @param name - an environment variable name
+ * @returns the malformed stand-in for the class that claims `name`, or
+ * `undefined` when no class claims it or it is a reviewed non-credential
+ */
 export const withheldValueFor = (name: string): string | undefined => {
   if (NOT_A_CREDENTIAL.has(name)) return undefined
 
@@ -99,10 +108,16 @@ export const withheldValueFor = (name: string): string | undefined => {
   )?.value
 }
 
+/**
+ * Replaces every credential in a child's environment with a malformed value.
+ *
+ * @param env - the environment about to be handed to a spawned child, mutated
+ * in place. Names it does not hold cannot be swept, so a caller that built it
+ * from something other than a `.env`-loaded parent is covered only by
+ * {@link ALWAYS_WITHHELD}.
+ */
 export const withholdCredentials = (env: Record<string, string>): void => {
-  for (const [name, value] of ALWAYS_WITHHELD) env[name] = value
-
-  for (const name of Object.keys(env)) {
+  for (const name of [...ALWAYS_WITHHELD, ...Object.keys(env)]) {
     const value = withheldValueFor(name)
     if (value !== undefined) env[name] = value
   }

--- a/script/deploy/safe/spawn-env.ts
+++ b/script/deploy/safe/spawn-env.ts
@@ -75,9 +75,10 @@ const CREDENTIAL_CLASSES: readonly {
  *
  * `NO_ETHERSCAN_API_KEY_REQUIRED` names a marker rather than holding a key:
  * `helperFunctions.sh` compares the name against this literal to allow an
- * empty key, and exports the value as the explorer key when it is set, so a
- * malformed value would be sent as a present one. The two anvil entries are
- * the publicly known local-node key and `127.0.0.1`.
+ * empty key, and exports it so `foundry.toml` — which substitutes it as the
+ * explorer key on every network that needs none — has something to read. A
+ * malformed value would therefore be sent as a present key. The two anvil
+ * entries are the publicly known local-node key and the local node's endpoint.
  */
 const NOT_A_CREDENTIAL: ReadonlySet<string> = new Set([
   'NO_ETHERSCAN_API_KEY_REQUIRED',

--- a/script/deploy/safe/spawn-env.ts
+++ b/script/deploy/safe/spawn-env.ts
@@ -26,8 +26,8 @@ const MALFORMED_WEBHOOK = 'malformed-in-tests://no-webhook'
  *
  * Every other class below is swept out of the environment actually being
  * passed, which cannot cover a name the parent does not have — and a child
- * re-loads the repo `.env` for exactly those names. These five are the ones
- * whose exposure is a signature rather than a quota, so they are pinned by
+ * re-loads the repo `.env` for exactly those names. These five buy a signature
+ * or the proposal store rather than a provider quota, so they are pinned by
  * name and do not depend on the parent having been started with a `.env`.
  */
 const ALWAYS_WITHHELD: readonly (readonly [string, string])[] = [

--- a/script/deploy/safe/ticket-gate-placement.test.ts
+++ b/script/deploy/safe/ticket-gate-placement.test.ts
@@ -37,9 +37,10 @@ const run = (
   // `bun test` sets NODE_ENV=test; these children are exercised as CLIs, so they
   // must not run as if under a test harness.
   delete env.NODE_ENV
-  // Bun auto-loads the repo env file into this process, so the child inherits any
-  // local value through process.env. Cleared, or a developer's own decides these.
-  delete env.SAFE_PROPOSAL_TICKET
+  // Set empty rather than deleted: the child re-loads the repo env file for
+  // every name this environment leaves unset, so a delete here would hand a
+  // developer's own ticket to the run and decide the cases below for them.
+  env.SAFE_PROPOSAL_TICKET = ''
   if (ticket !== undefined) env.SAFE_PROPOSAL_TICKET = ticket
   // One case below asserts a run is NOT refused, which means letting it go on to
   // a branch that sends directly — with a real key that branch signs, and with a

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -9,13 +9,13 @@
  * testing will, the moment that refusal is mutated away, run a real CLI with a
  * real production key.
  *
- * Four checks, because no one of them is enough. A source assertion catches the
- * spelling across the whole tree but cannot tell whether the replacement
- * actually works; a pairing against the class table in
+ * Several checks, because no one of them is enough. A source assertion catches
+ * the spelling across the whole tree but cannot tell whether the replacement
+ * works; a pairing against the class table in
  * `script/deploy/safe/spawn-env.ts` catches the scan and the withholding
- * drifting apart; and two spawns against fixture `.env` files pin the bun
- * behaviour the replacement depends on and the withholding of each class
- * end to end, without any real credential taking part.
+ * drifting apart; and spawns against fixture `.env` files pin the bun
+ * behaviour the replacement depends on, and the endpoint, provider-key and
+ * webhook classes end to end, without any real credential taking part.
  */
 import { execFileSync } from 'child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
@@ -24,8 +24,11 @@ import { join } from 'path'
 
 // eslint-disable-next-line import/no-unresolved
 import { afterAll, describe, expect, it } from 'bun:test'
+import type { Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 
 import {
+  ALWAYS_WITHHELD,
   CREDENTIAL_CORES,
   NON_CREDENTIAL_NAMES,
   withheldValueFor,
@@ -118,15 +121,20 @@ const blankBlockComments = (source: string): string =>
  * comment with it, which keeps the exemption attached to its own delete.
  *
  * The whole member expression is collapsed, not just the gap after the
- * keyword, because prettier breaks a long `delete` across the dot on its own:
- * `delete process.env\n  .PRIVATE_KEY` leaves `delete process.env` as the
- * statement, which carries no name for the pattern to match. That form is
- * reachable by adding a trailing comment and re-running the formatter, so it
- * is the likeliest way for the scan to go quietly blind.
+ * keyword, because prettier breaks a `delete` whose code alone passes 80
+ * columns — across the dot, and across the brackets for a computed key.
+ * Either leaves the holder alone as the statement (`delete process.env`),
+ * carrying no name for the pattern to match.
+ *
+ * One limit the collapse introduces: a marker on a continuation line now
+ * exempts the delete it was joined to. That is what carries the marker back
+ * onto a statement prettier split, and there is no way to tell that case from
+ * a marker parked on a continuation line to silence a neighbour. Reaching it
+ * needs code no formatter would leave, and no shipped test is affected.
  */
 const joinDeleteOperands = (source: string): string =>
   source.replace(
-    /\bdelete\s+[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+|\s*\??\.?\s*\[[^\]\n]*\])*/gu,
+    /\bdelete\s+[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+|\s*\??\.?\s*\[[^\]]*\])*/gu,
     (expression) =>
       `delete ${expression.replace(/^delete\s+/u, '').replace(/\s+/gu, '')}`
   )
@@ -141,6 +149,10 @@ const statements = (source: string): string[] =>
     .split('\n')
     .flatMap((line) => line.split(';'))
 
+/** Matches a delete of exactly `name`, not of a longer name starting with it. */
+const DELETES_EXACTLY = (name: string): RegExp =>
+  new RegExp(`\\.${name}\\b|['"\`]${name}['"\`]`, 'u')
+
 /**
  * Statements that delete a credential and carry no marker.
  *
@@ -149,11 +161,20 @@ const statements = (source: string): string[] =>
  * a "never do this" example, say — from being reported as one.
  */
 const unexemptedDeletions = (source: string): string[] =>
-  statements(source).filter(
-    (statement) =>
+  statements(source).filter((statement) => {
+    const code = statement.replace(/\/\/.*$/u, '')
+
+    return (
       !statement.includes(EXEMPTION_MARKER) &&
-      DELETES_A_CREDENTIAL.test(statement.replace(/\/\/.*$/u, ''))
-  )
+      DELETES_A_CREDENTIAL.test(code) &&
+      // A reviewed non-credential is not withheld either, so flagging its
+      // deletion would demand a marker for something no class claims — the
+      // scan and the sweep have to agree about a name or the pairing below
+      // means nothing. Anchored, so a longer name that merely starts with one
+      // of these is still judged on its own cores.
+      !NON_CREDENTIAL_NAMES.some((name) => DELETES_EXACTLY(name).test(code))
+    )
+  })
 
 describe('no shipped test deletes a credential from a child environment', () => {
   it('enumerates the tree, so a clean result is not vacuous', () => {
@@ -177,6 +198,30 @@ describe('no shipped test deletes a credential from a child environment', () => 
 
     expect(all).toContain(SELF)
     expect(all.length - shippedTests().length).toBe(1)
+  })
+
+  it('sees a delete prettier broke across the brackets', () => {
+    // The computed-key half of the same formatter break. The first version of
+    // the collapse excluded newlines inside the brackets, so this form read as
+    // `delete holder` — a clean result for the very shape it claimed to cover.
+    expect(
+      unexemptedDeletions(
+        "  delete childEnv[\n    'PRIVATE_KEY_PRODUCTION'\n  ]\n"
+      )
+    ).toEqual(["  delete childEnv['PRIVATE_KEY_PRODUCTION']"])
+  })
+
+  it('leaves a reviewed non-credential deletable without a marker', () => {
+    // The scan and the sweep have to agree: this name matches a core but is
+    // not withheld, so demanding a marker for it would be asking for a reason
+    // to withhold something no class claims.
+    expect(
+      unexemptedDeletions('  delete env.NO_ETHERSCAN_API_KEY_REQUIRED\n')
+    ).toEqual([])
+    // Anchored, so a longer name is still judged on its cores.
+    expect(
+      unexemptedDeletions('  delete env.PRIVATE_KEY_ANVIL_PRODUCTION\n')
+    ).toEqual(['  delete env.PRIVATE_KEY_ANVIL_PRODUCTION'])
   })
 
   it('sees a delete prettier broke across the dot', () => {
@@ -258,9 +303,8 @@ describe('no shipped test deletes a credential from a child environment', () => 
       'delete env.MNEMONIC',
       'delete env?.PRIVATE_KEY',
       "delete process.env?.['PRIVATE_KEY_PRODUCTION']",
-      // The classes this file widened to. One real name per class, so a class
-      // dropped from the table in `spawn-env.ts` goes red here rather than
-      // quietly narrowing the scan.
+      // One real name per class, so a class dropped from the table in
+      // `spawn-env.ts` goes red here rather than quietly narrowing the scan.
       'delete env.ETH_NODE_URI',
       'delete env.ETH_NODE_URI_ARBITRUM',
       'delete env.MAINNET_ETHERSCAN_API_KEY',
@@ -284,9 +328,9 @@ describe('no shipped test deletes a credential from a child environment', () => 
       'delete env.SAFE_PROPOSAL_TICKET',
       'delete env.ENVIRONMENT',
       'delete env.ENABLE_MONGODB_LOGGING',
-      // The near misses each widened core must not swallow: a list of token
-      // contracts is not a `SYNC_TOKEN`, and neither a verification toggle nor
-      // a network exclusion list is a key or an endpoint.
+      // The near misses no core must swallow: a list of token contracts is
+      // not a `SYNC_TOKEN`, and neither a verification toggle nor a network
+      // exclusion list is a key or an endpoint.
       'delete env.ALLOW_TOKEN_CONTRACTS',
       'delete env.DO_NOT_VERIFY_IN_THESE_NETWORKS',
       'delete env.ZKSYNC_NATIVE_VERIFIER',
@@ -320,18 +364,42 @@ describe('the guard and the withholding cannot disagree about a name', () => {
       expect(withheldValueFor(name), name).toBeUndefined()
   })
 
-  it('gives each class a value that cannot be used as the real thing', () => {
-    // A plausible-looking stand-in is the hazard: a parseable key derives an
-    // address and a routable URL posts to a live channel, so every class value
-    // has to be something its consumer refuses outright.
+  it('gives every URL-shaped class a scheme fetch refuses', () => {
+    // The property, not the spelling: asserting the sentinel substring would
+    // pass just as well for `https://hooks.slack.com/services/malformed-…`,
+    // which a run that got past the check under test would really post to.
     for (const name of [
-      'PRIVATE_KEY_PRODUCTION',
       'SC_MONGODB_URI',
       'ETH_NODE_URI_ARBITRUM',
-      'MAINNET_ETHERSCAN_API_KEY',
       'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS',
-    ])
-      expect(withheldValueFor(name), name).toContain('malformed-in-tests')
+    ]) {
+      const withheld = withheldValueFor(name)
+      expect(withheld, name).toBeDefined()
+      expect(new URL(withheld as string).protocol, name).not.toMatch(
+        /^https?:$/u
+      )
+    }
+  })
+
+  it('gives the signing class a value viem cannot parse', () => {
+    // The provider keys share this value, so one refusal covers both classes;
+    // what a given explorer rejects is not decidable here.
+    const signing = withheldValueFor('PRIVATE_KEY_PRODUCTION')
+    if (signing === undefined)
+      throw new Error('no class claims the signing key, so nothing is withheld')
+
+    expect(() => privateKeyToAccount(signing as Hex)).toThrow()
+    expect(withheldValueFor('MAINNET_ETHERSCAN_API_KEY')).toBe(signing)
+  })
+
+  it('pins every name the sweep cannot reach', () => {
+    // Each pinned name must be claimed by a class, or the pin sets nothing.
+    // Looped rather than spot-checked: four of the five were unasserted, and
+    // the one that matters most holds a key the store leaves unset, so this
+    // list is its only cover.
+    expect(ALWAYS_WITHHELD.length).toBeGreaterThan(0)
+    for (const name of ALWAYS_WITHHELD)
+      expect(withheldValueFor(name), name).toBeDefined()
   })
 })
 
@@ -373,7 +441,7 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
       stdin: 'ignore',
       stdout: 'pipe',
       stderr: 'pipe',
-      timeout: 20_000,
+      timeout: 20_000, // 20 seconds: a hermetic child that has to spawn bun
     })
     if (result.signalCode)
       throw new Error(
@@ -400,9 +468,9 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
   })
 })
 
-describe('withholdCredentials withholds each widened class from a real child', () => {
+describe('withholdCredentials withholds each class from a real child', () => {
   /**
-   * The classes this change added, end to end: a fixture `.env` a child would
+   * End to end: a fixture `.env` a child would
    * re-load, a `withholdCredentials` pass over the environment it is handed,
    * and the child reporting back what it actually sees. Synthetic values
    * throughout, lengths only.
@@ -412,7 +480,9 @@ describe('withholdCredentials withholds each widened class from a real child', (
    * while the child in the real probes would be re-loading the store.
    */
   const FIXTURE = {
-    ETH_NODE_URI_ZZPROBE: 'endpoint-from-fixture',
+    // A query string, which is the shape most of the store's endpoints have;
+    // the writer below quotes every value so the `&` survives the re-load.
+    ETH_NODE_URI_ZZPROBE: 'https://probe.invalid/x?chain=1&dkey=from-fixture',
     MAINNET_ETHERSCAN_API_KEY: 'explorer-key-from-fixture',
     WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS: 'webhook-from-fixture',
     NO_ETHERSCAN_API_KEY_REQUIRED: 'true',
@@ -422,7 +492,7 @@ describe('withholdCredentials withholds each widened class from a real child', (
   writeFileSync(
     join(fixture, '.env'),
     Object.entries(FIXTURE)
-      .map(([name, value]) => `${name}=${value}\n`)
+      .map(([name, value]) => `${name}="${value}"\n`)
       .join('')
   )
   const child = join(fixture, 'report-lengths.ts')
@@ -460,7 +530,7 @@ describe('withholdCredentials withholds each widened class from a real child', (
       stdin: 'ignore',
       stdout: 'pipe',
       stderr: 'pipe',
-      timeout: 20_000,
+      timeout: 20_000, // 20 seconds: a hermetic child that has to spawn bun
     })
     if (result.signalCode)
       throw new Error(

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -9,10 +9,13 @@
  * testing will, the moment that refusal is mutated away, run a real CLI with a
  * real production key.
  *
- * Two checks, because either alone is weak. A source assertion catches the
+ * Four checks, because no one of them is enough. A source assertion catches the
  * spelling across the whole tree but cannot tell whether the replacement
- * actually works; a spawn against a fixture `.env` pins the bun behaviour the
- * replacement depends on, without any real credential taking part.
+ * actually works; a pairing against the class table in
+ * `script/deploy/safe/spawn-env.ts` catches the scan and the withholding
+ * drifting apart; and two spawns against fixture `.env` files pin the bun
+ * behaviour the replacement depends on and the withholding of each class
+ * end to end, without any real credential taking part.
  */
 import { execFileSync } from 'child_process'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -22,25 +22,31 @@ import { join } from 'path'
 // eslint-disable-next-line import/no-unresolved
 import { afterAll, describe, expect, it } from 'bun:test'
 
+import {
+  CREDENTIAL_CORES,
+  NON_CREDENTIAL_NAMES,
+  withheldValueFor,
+  withholdCredentials,
+} from './deploy/safe/spawn-env'
+
 const REPO_ROOT = join(import.meta.dir, '..')
 
 /**
- * Names holding a signing secret or a proposal-store URI. Matched by substring
- * rather than enumerated because the wallet keys come in generations — pauser,
- * refund and withdraw wallets sit alongside several retired deployer ones — so
- * an enumeration would silently stop covering the next name added.
+ * Names holding a credential, by the substring the name carries.
  *
- * The keyed RPC endpoints, explorer and provider API keys and Slack webhooks
- * are deliberately outside this: deleting one of those is often how a fallback
- * gets tested, and matching them would put a marker on every such test to
- * withhold something no signature depends on.
+ * Derived from the cores `withholdCredentials` withholds by, rather than
+ * spelled out again here, because the two drifting apart is the failure this
+ * file exists to prevent: a guard that reports a clean tree while the fix it
+ * guards has stopped covering a class is worse than no guard. Widening one now
+ * widens both, and a class dropped from the table goes red below.
  *
- * The store half anchors on the full URI suffix rather than on the driver name
- * alone, so the logging toggle that shares that prefix is not mistaken for a
- * credential.
+ * What this cannot see is a credential whose name carries none of those cores —
+ * a `FOO_SECRET_SAUCE` is invisible to the scan here and to the sweep there
+ * alike. Naming the classes is therefore a decision that has to be revisited
+ * when a new kind of secret enters the store, not a pattern that grows by
+ * itself.
  */
-const CREDENTIAL_NAME =
-  '[A-Z0-9_]*(?:PRIVATE_KEY|MNEMONIC|MONGODB_URI)[A-Z0-9_]*'
+const CREDENTIAL_NAME = `[A-Z0-9_]*(?:${CREDENTIAL_CORES.join('|')})[A-Z0-9_]*`
 
 /**
  * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']`,
@@ -107,9 +113,20 @@ const blankBlockComments = (source: string): string =>
  * scan would walk straight past `delete\n  env.PRIVATE_KEY`. Joining the
  * operand onto the keyword's line first also carries any trailing marker
  * comment with it, which keeps the exemption attached to its own delete.
+ *
+ * The whole member expression is collapsed, not just the gap after the
+ * keyword, because prettier breaks a long `delete` across the dot on its own:
+ * `delete process.env\n  .PRIVATE_KEY` leaves `delete process.env` as the
+ * statement, which carries no name for the pattern to match. That form is
+ * reachable by adding a trailing comment and re-running the formatter, so it
+ * is the likeliest way for the scan to go quietly blind.
  */
 const joinDeleteOperands = (source: string): string =>
-  source.replace(/\bdelete\s+/gu, 'delete ')
+  source.replace(
+    /\bdelete\s+[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+|\s*\??\.?\s*\[[^\]\n]*\])*/gu,
+    (expression) =>
+      `delete ${expression.replace(/^delete\s+/u, '').replace(/\s+/gu, '')}`
+  )
 
 /**
  * One entry per statement, not per line: a marker earns an exemption for the
@@ -157,6 +174,17 @@ describe('no shipped test deletes a credential from a child environment', () => 
 
     expect(all).toContain(SELF)
     expect(all.length - shippedTests().length).toBe(1)
+  })
+
+  it('sees a delete prettier broke across the dot', () => {
+    // What the formatter produces from `delete process.env.X // marker` once
+    // the comment pushes the line past 80 columns. Before this was handled the
+    // statement read `delete process.env`, and the scan reported it clean.
+    expect(
+      unexemptedDeletions(
+        '        delete process.env\n          .PRIVATE_KEY\n'
+      )
+    ).toEqual(['        delete process.env.PRIVATE_KEY'])
   })
 
   it('sees a delete whose operand is on the next line', () => {
@@ -227,6 +255,17 @@ describe('no shipped test deletes a credential from a child environment', () => 
       'delete env.MNEMONIC',
       'delete env?.PRIVATE_KEY',
       "delete process.env?.['PRIVATE_KEY_PRODUCTION']",
+      // The classes this file widened to. One real name per class, so a class
+      // dropped from the table in `spawn-env.ts` goes red here rather than
+      // quietly narrowing the scan.
+      'delete env.ETH_NODE_URI',
+      'delete env.ETH_NODE_URI_ARBITRUM',
+      'delete env.MAINNET_ETHERSCAN_API_KEY',
+      'delete env.TRONGRID_API_KEY',
+      'delete env.TENDERLY_ACCESS_KEY',
+      'delete env.LEDGER_SYNC_TOKEN',
+      'delete env.WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS',
+      'delete env.SLACK_WEBHOOK_SC_GENERAL',
     ])
       expect(DELETES_A_CREDENTIAL.test(source), source).toBe(true)
   })
@@ -242,8 +281,54 @@ describe('no shipped test deletes a credential from a child environment', () => 
       'delete env.SAFE_PROPOSAL_TICKET',
       'delete env.ENVIRONMENT',
       'delete env.ENABLE_MONGODB_LOGGING',
+      // The near misses each widened core must not swallow: a list of token
+      // contracts is not a `SYNC_TOKEN`, and neither a verification toggle nor
+      // a network exclusion list is a key or an endpoint.
+      'delete env.ALLOW_TOKEN_CONTRACTS',
+      'delete env.DO_NOT_VERIFY_IN_THESE_NETWORKS',
+      'delete env.ZKSYNC_NATIVE_VERIFIER',
     ])
       expect(DELETES_A_CREDENTIAL.test(source), source).toBe(false)
+  })
+})
+
+describe('the guard and the withholding cannot disagree about a name', () => {
+  it('withholds something for every core it scans for', () => {
+    // The drift this pairing exists to stop, in the direction that matters: a
+    // core the scan enforces but the sweep does not act on would put markers
+    // on tests while handing children the real value.
+    for (const core of CREDENTIAL_CORES)
+      expect(withheldValueFor(`PREFIX_${core}_SUFFIX`), core).toBeDefined()
+  })
+
+  it('withholds nothing for a name no core claims', () => {
+    // The paired absence: a `withheldValueFor` that returned a value for
+    // everything would satisfy the assertion above while clobbering the whole
+    // environment.
+    for (const name of ['NODE_ENV', 'PRODUCTION', 'SALT', 'FOO_SECRET_SAUCE'])
+      expect(withheldValueFor(name), name).toBeUndefined()
+  })
+
+  it('exempts the reviewed non-credentials from the sweep as well', () => {
+    // These match a core and are deliberately not withheld, so the sweep must
+    // leave them alone; the scan's own tolerance for them is asserted above.
+    expect(NON_CREDENTIAL_NAMES.length).toBeGreaterThan(0)
+    for (const name of NON_CREDENTIAL_NAMES)
+      expect(withheldValueFor(name), name).toBeUndefined()
+  })
+
+  it('gives each class a value that cannot be used as the real thing', () => {
+    // A plausible-looking stand-in is the hazard: a parseable key derives an
+    // address and a routable URL posts to a live channel, so every class value
+    // has to be something its consumer refuses outright.
+    for (const name of [
+      'PRIVATE_KEY_PRODUCTION',
+      'SC_MONGODB_URI',
+      'ETH_NODE_URI_ARBITRUM',
+      'MAINNET_ETHERSCAN_API_KEY',
+      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS',
+    ])
+      expect(withheldValueFor(name), name).toContain('malformed-in-tests')
   })
 })
 
@@ -309,5 +394,125 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
     expect(lengthInChild((env) => (env[NAME] = PASSED_VALUE))).toBe(
       String(PASSED_VALUE.length)
     )
+  })
+})
+
+describe('withholdCredentials withholds each widened class from a real child', () => {
+  /**
+   * The classes this change added, end to end: a fixture `.env` a child would
+   * re-load, a `withholdCredentials` pass over the environment it is handed,
+   * and the child reporting back what it actually sees. Synthetic values
+   * throughout, lengths only.
+   *
+   * Asserted against the class values rather than against "not the fixture",
+   * because a child that saw `undefined` would also satisfy the weaker form
+   * while the child in the real probes would be re-loading the store.
+   */
+  const FIXTURE = {
+    ETH_NODE_URI_ZZPROBE: 'endpoint-from-fixture',
+    MAINNET_ETHERSCAN_API_KEY: 'explorer-key-from-fixture',
+    WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS: 'webhook-from-fixture',
+    NO_ETHERSCAN_API_KEY_REQUIRED: 'true',
+  } as const
+
+  const fixture = mkdtempSync(join(tmpdir(), 'spawn-env-classes-'))
+  writeFileSync(
+    join(fixture, '.env'),
+    Object.entries(FIXTURE)
+      .map(([name, value]) => `${name}=${value}\n`)
+      .join('')
+  )
+  const child = join(fixture, 'report-lengths.ts')
+  writeFileSync(
+    child,
+    `const names = ${JSON.stringify(Object.keys(FIXTURE))}\n` +
+      'console.log(\n' +
+      '  JSON.stringify(\n' +
+      '    Object.fromEntries(\n' +
+      '      names.map((n) => [\n' +
+      '        n,\n' +
+      "        process.env[n] === undefined ? 'undefined' : process.env[n].length,\n" +
+      '      ])\n' +
+      '    )\n' +
+      '  )\n' +
+      ')\n'
+  )
+
+  afterAll(() => rmSync(fixture, { force: true, recursive: true }))
+
+  /** What the child reports each name's length to be, given `present` in env. */
+  const lengthsInChild = (
+    present: Record<string, string>
+  ): Record<string, number | string> => {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ...present,
+    }
+    delete env.NODE_ENV
+    withholdCredentials(env)
+
+    const result = Bun.spawnSync([process.execPath, child], {
+      cwd: fixture,
+      env,
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+      timeout: 20_000,
+    })
+    if (result.signalCode)
+      throw new Error(
+        `child killed by ${result.signalCode}, so its output proves nothing`
+      )
+
+    return JSON.parse(result.stdout.toString().trim())
+  }
+
+  it('replaces an endpoint, a provider key and a webhook the parent holds', () => {
+    const lengths = lengthsInChild(FIXTURE)
+
+    for (const name of [
+      'ETH_NODE_URI_ZZPROBE',
+      'MAINNET_ETHERSCAN_API_KEY',
+      'WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS',
+    ] as const) {
+      const withheld = withheldValueFor(name)
+      expect(withheld, name).toBeDefined()
+      expect(lengths[name], name).toBe((withheld as string).length)
+      // The paired negative: equal lengths would let a coincidence pass.
+      expect(lengths[name], name).not.toBe(FIXTURE[name].length)
+    }
+  })
+
+  it('leaves a reviewed non-credential at the value it was given', () => {
+    // Withholding this one would hand a verification run a key that looks
+    // present, which is a behaviour change rather than a withholding.
+    expect(lengthsInChild(FIXTURE).NO_ETHERSCAN_API_KEY_REQUIRED).toBe(
+      FIXTURE.NO_ETHERSCAN_API_KEY_REQUIRED.length
+    )
+  })
+
+  it('does NOT cover a name the spawning process does not hold', () => {
+    // The documented limit of the sweep, asserted rather than described: it can
+    // only replace names in the environment it is handed, and the child
+    // re-loads the file for every name that environment leaves unset. The five
+    // names in `ALWAYS_WITHHELD` are the ones pinned against this; every other
+    // class depends on the parent having loaded the store.
+    const lengths = lengthsInChild({})
+
+    expect(lengths.ETH_NODE_URI_ZZPROBE).toBe(
+      FIXTURE.ETH_NODE_URI_ZZPROBE.length
+    )
+  })
+
+  it('withholds the pinned names even when the parent does not hold them', () => {
+    // The other side of that limit: these five do not depend on the parent, so
+    // a child spawned from a process with no store loaded still cannot re-load
+    // them.
+    const pinned = 'PRIVATE_KEY_PRODUCTION'
+    const env: Record<string, string> = {}
+    withholdCredentials(env)
+
+    expect(env[pinned]).toBeDefined()
+    expect(env[pinned]).toContain('malformed-in-tests')
   })
 })

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -392,12 +392,19 @@ describe('the guard and the withholding cannot disagree about a name', () => {
     expect(withheldValueFor('MAINNET_ETHERSCAN_API_KEY')).toBe(signing)
   })
 
-  it('pins every name the sweep cannot reach', () => {
-    // Each pinned name must be claimed by a class, or the pin sets nothing.
-    // Looped rather than spot-checked: four of the five were unasserted, and
-    // the one that matters most holds a key the store leaves unset, so this
-    // list is its only cover.
-    expect(ALWAYS_WITHHELD.length).toBeGreaterThan(0)
+  it('pins exactly the names the sweep cannot be trusted to reach', () => {
+    // The set, not a property of its members: a loop over the list cannot see
+    // a name dropped FROM the list, and dropping one is the whole failure —
+    // the Safe signer key is unset in the store, so the sweep never sees it
+    // and this list is the only thing withholding it.
+    expect([...ALWAYS_WITHHELD].sort()).toEqual([
+      'MONGODB_URI',
+      'PRIVATE_KEY',
+      'PRIVATE_KEY_PRODUCTION',
+      'SAFE_SIGNER_PRIVATE_KEY',
+      'SC_MONGODB_URI',
+    ])
+    // And each must still be claimed by a class, or the pin sets nothing.
     for (const name of ALWAYS_WITHHELD)
       expect(withheldValueFor(name), name).toBeDefined()
   })

--- a/script/spawn-env-credentials.test.ts
+++ b/script/spawn-env-credentials.test.ts
@@ -55,21 +55,43 @@ const REPO_ROOT = join(import.meta.dir, '..')
 const CREDENTIAL_NAME = `[A-Z0-9_]*(?:${CREDENTIAL_CORES.join('|')})[A-Z0-9_]*`
 
 /**
- * Matches `delete env.PRIVATE_KEY`, `delete env['PRIVATE_KEY']`,
- * `delete process.env.PRIVATE_KEY` and the optional-chained forms, whatever the
- * holder is called.
+ * A `holder.NAME` or `holder['NAME']` access, with the name captured, whatever
+ * the holder is called and through an optional chain.
  *
- * Only literal member access is visible here. A computed key
- * (`delete env[name]`), a concatenated one, `Reflect.deleteProperty`, and
- * dropping a name by rest-destructuring all withhold nothing in the same way
- * and are all invisible to a source scan — deciding them needs a parser and a
+ * Only literal member access is visible here. A computed key (`env[name]`), a
+ * concatenated one, `Reflect.deleteProperty`, and dropping a name by
+ * rest-destructuring all withhold nothing in the same way and are all
+ * invisible to a source scan — deciding them needs a parser and a
  * constant-folding pass. The hermetic spawn below is what covers the mechanism
- * itself; this pattern only catches the spelling people actually reach for.
+ * itself; this pattern only catches the spellings people actually reach for.
  */
-const DELETES_A_CREDENTIAL = new RegExp(
-  `delete\\s+[A-Za-z_$][\\w$.?]*(?:\\.${CREDENTIAL_NAME}\\b|\\[['"\`]${CREDENTIAL_NAME}['"\`]\\])`,
+const CREDENTIAL_ACCESS = `[A-Za-z_$][\\w$.?]*(?:\\.(${CREDENTIAL_NAME})\\b|\\[['"\`](${CREDENTIAL_NAME})['"\`]\\])`
+
+/** Matches `delete env.PRIVATE_KEY` and its bracketed and optional-chained forms. */
+const DELETES_A_CREDENTIAL = new RegExp(`delete\\s+${CREDENTIAL_ACCESS}`, 'u')
+
+/**
+ * Matches `env.PRIVATE_KEY = undefined`, which leaves the name unset for the
+ * child's re-load exactly as a `delete` does — measured, not assumed: a child
+ * reports the fixture value's full length for both, and length 0 only for
+ * `= ''`.
+ *
+ * Covered because the convention this file enforces says to *set* a name
+ * rather than delete it, and `undefined` is the one value that obeys the
+ * letter of that while reopening the hole it closes.
+ */
+const BLANKS_A_CREDENTIAL = new RegExp(
+  `${CREDENTIAL_ACCESS}\\s*=\\s*undefined\\b`,
   'u'
 )
+
+/** The credential `code` unsets, by either spelling, or `undefined` for none. */
+const credentialUnsetBy = (code: string): string | undefined => {
+  const match =
+    DELETES_A_CREDENTIAL.exec(code) ?? BLANKS_A_CREDENTIAL.exec(code)
+
+  return match?.[1] ?? match?.[2]
+}
 
 /**
  * Marks a delete whose reason is written down next to it. The reason is free
@@ -133,28 +155,29 @@ const blankBlockComments = (source: string): string =>
  * needs code no formatter would leave, and no shipped test is affected.
  */
 const joinDeleteOperands = (source: string): string =>
-  source.replace(
-    /\bdelete\s+[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+|\s*\??\.?\s*\[[^\]]*\])*/gu,
-    (expression) =>
-      `delete ${expression.replace(/^delete\s+/u, '').replace(/\s+/gu, '')}`
-  )
+  source
+    .replace(
+      /\bdelete\s+[A-Za-z_$][\w$]*(?:\s*\??\.\s*[\w$]+|\s*\??\.?\s*\[[^\]]*\])*/gu,
+      (expression) =>
+        `delete ${expression.replace(/^delete\s+/u, '').replace(/\s+/gu, '')}`
+    )
+    // The same break on the other spelling: prettier puts `undefined` on its
+    // own line when the assignment passes 80 columns, leaving a statement that
+    // ends at the `=` and carries no value to judge.
+    .replace(/=\s*\n\s*undefined\b/gu, '= undefined')
 
 /**
  * One entry per statement, not per line: a marker earns an exemption for the
- * delete it sits beside, and `a; b` on one line is two deletes of which only
- * the annotated one may pass.
+ * unset it sits beside, and `a; b` on one line is two unsets of which only the
+ * annotated one may pass.
  */
 const statements = (source: string): string[] =>
   joinDeleteOperands(blankBlockComments(source))
     .split('\n')
     .flatMap((line) => line.split(';'))
 
-/** Matches a delete of exactly `name`, not of a longer name starting with it. */
-const DELETES_EXACTLY = (name: string): RegExp =>
-  new RegExp(`\\.${name}\\b|['"\`]${name}['"\`]`, 'u')
-
 /**
- * Statements that delete a credential and carry no marker.
+ * Statements that unset a credential and carry no marker.
  *
  * The marker is read before line comments are dropped, because the marker IS a
  * line comment; the drop then keeps prose that merely mentions a deletion —
@@ -162,17 +185,16 @@ const DELETES_EXACTLY = (name: string): RegExp =>
  */
 const unexemptedDeletions = (source: string): string[] =>
   statements(source).filter((statement) => {
-    const code = statement.replace(/\/\/.*$/u, '')
+    const unset = credentialUnsetBy(statement.replace(/\/\/.*$/u, ''))
 
     return (
+      unset !== undefined &&
       !statement.includes(EXEMPTION_MARKER) &&
-      DELETES_A_CREDENTIAL.test(code) &&
-      // A reviewed non-credential is not withheld either, so flagging its
-      // deletion would demand a marker for something no class claims — the
-      // scan and the sweep have to agree about a name or the pairing below
-      // means nothing. Anchored, so a longer name that merely starts with one
-      // of these is still judged on its own cores.
-      !NON_CREDENTIAL_NAMES.some((name) => DELETES_EXACTLY(name).test(code))
+      // Judged on the name actually unset, never on the statement's text: a
+      // reviewed non-credential mentioned anywhere else in the same statement
+      // — a sibling condition, say — would otherwise exempt the real
+      // credential being unset beside it.
+      !NON_CREDENTIAL_NAMES.includes(unset)
     )
   })
 
@@ -201,9 +223,9 @@ describe('no shipped test deletes a credential from a child environment', () => 
   })
 
   it('sees a delete prettier broke across the brackets', () => {
-    // The computed-key half of the same formatter break. The first version of
-    // the collapse excluded newlines inside the brackets, so this form read as
-    // `delete holder` — a clean result for the very shape it claimed to cover.
+    // The computed-key half of the same formatter break. The collapse has to
+    // reach across a newline inside the brackets, or this form reads as
+    // `delete holder` — a clean result for the very shape it claims to cover.
     expect(
       unexemptedDeletions(
         "  delete childEnv[\n    'PRIVATE_KEY_PRODUCTION'\n  ]\n"
@@ -224,10 +246,37 @@ describe('no shipped test deletes a credential from a child environment', () => 
     ).toEqual(['  delete env.PRIVATE_KEY_ANVIL_PRODUCTION'])
   })
 
+  it('does not let a non-credential elsewhere in the statement excuse one', () => {
+    // The exemption is keyed on the name actually unset. Read off the
+    // statement's text instead, a reviewed non-credential in a sibling
+    // condition silently exempts the real credential being deleted beside it.
+    expect(
+      unexemptedDeletions(
+        '  if (env.PRIVATE_KEY_ANVIL) delete env.PRIVATE_KEY_PRODUCTION\n'
+      )
+    ).toEqual([
+      '  if (env.PRIVATE_KEY_ANVIL) delete env.PRIVATE_KEY_PRODUCTION',
+    ])
+  })
+
+  it('sees a credential set to undefined, which unsets it as a delete does', () => {
+    // The convention says to set rather than delete, and `undefined` is the
+    // one value that keeps the letter of that while leaving the name unset for
+    // the child's re-load. Both the flat and the prettier-broken spelling.
+    expect(unexemptedDeletions('  env.PRIVATE_KEY = undefined\n')).toEqual([
+      '  env.PRIVATE_KEY = undefined',
+    ])
+    expect(
+      unexemptedDeletions(
+        "  childEnv['PRIVATE_KEY_PRODUCTION'] =\n    undefined\n"
+      )
+    ).toEqual(["  childEnv['PRIVATE_KEY_PRODUCTION'] = undefined"])
+  })
+
   it('sees a delete prettier broke across the dot', () => {
     // What the formatter produces from `delete process.env.X // marker` once
-    // the comment pushes the line past 80 columns. Before this was handled the
-    // statement read `delete process.env`, and the scan reported it clean.
+    // the comment pushes the line past 80 columns. Uncollapsed, the statement
+    // reads `delete process.env`, which carries no name for the scan to match.
     expect(
       unexemptedDeletions(
         '        delete process.env\n          .PRIVATE_KEY\n'
@@ -324,6 +373,10 @@ describe('no shipped test deletes a credential from a child environment', () => 
     // is the near miss the store half must not swallow.
     for (const source of [
       "env.PRIVATE_KEY = 'malformed-in-tests'",
+      // The empty string is a real value to the child, not an unset one —
+      // pinned against a spawn below — so it is a legitimate way to clear a
+      // name and must stay distinguishable from `= undefined`.
+      "env.PRIVATE_KEY = ''",
       'delete env.NODE_ENV',
       'delete env.SAFE_PROPOSAL_TICKET',
       'delete env.ENVIRONMENT',
@@ -472,6 +525,16 @@ describe('setting a credential, unlike deleting it, withholds it from a child', 
     expect(lengthInChild((env) => (env[NAME] = PASSED_VALUE))).toBe(
       String(PASSED_VALUE.length)
     )
+  })
+
+  it('re-loads a name set to undefined, and does not for an empty string', () => {
+    // Why the scan treats `= undefined` as a deletion and `= ''` as a value.
+    // Both obey the convention's letter — neither is a `delete` — but only one
+    // of them actually keeps the file's value out of the child.
+    expect(lengthInChild((env) => (env[NAME] = undefined as never))).toBe(
+      String(FIXTURE_VALUE.length)
+    )
+    expect(lengthInChild((env) => (env[NAME] = ''))).toBe('0')
   })
 })
 

--- a/script/utils/utils.test.ts
+++ b/script/utils/utils.test.ts
@@ -198,7 +198,7 @@ describe('endpoint redaction', () => {
   it('keeps the endpoint out of the unsubstituted-template error', () => {
     const previousUri = process.env.ETH_NODE_URI
     const previousNetworkUri = process.env.ETH_NODE_URI_TESTNET
-    delete process.env.ETH_NODE_URI_TESTNET // spawn-env: in-process; the fallback is the case under test
+    delete process.env.ETH_NODE_URI_TESTNET // spawn-env: in-process; left set, node_url returns early and the assertion never runs
     process.env.ETH_NODE_URI =
       'https://lb.drpc.org/ogrpc?chain={{chain}}&dkey=SYNTHETIC-NOT-REAL-abc123'
 

--- a/script/utils/utils.test.ts
+++ b/script/utils/utils.test.ts
@@ -198,7 +198,7 @@ describe('endpoint redaction', () => {
   it('keeps the endpoint out of the unsubstituted-template error', () => {
     const previousUri = process.env.ETH_NODE_URI
     const previousNetworkUri = process.env.ETH_NODE_URI_TESTNET
-    delete process.env.ETH_NODE_URI_TESTNET
+    delete process.env.ETH_NODE_URI_TESTNET // spawn-env: in-process; the fallback is the case under test
     process.env.ETH_NODE_URI =
       'https://lb.drpc.org/ogrpc?chain={{chain}}&dkey=SYNTHETIC-NOT-REAL-abc123'
 
@@ -212,8 +212,8 @@ describe('endpoint redaction', () => {
       expect(message).toContain('[redacted-url]')
       expect(message).not.toContain('dkey')
     } finally {
-      if (previousUri === undefined) delete process.env.ETH_NODE_URI
-      else process.env.ETH_NODE_URI = previousUri
+      if (previousUri !== undefined) process.env.ETH_NODE_URI = previousUri
+      else delete process.env.ETH_NODE_URI // spawn-env: in-process restore
       if (previousNetworkUri !== undefined)
         process.env.ETH_NODE_URI_TESTNET = previousNetworkUri
     }

--- a/script/utils/utils.test.ts
+++ b/script/utils/utils.test.ts
@@ -198,7 +198,7 @@ describe('endpoint redaction', () => {
   it('keeps the endpoint out of the unsubstituted-template error', () => {
     const previousUri = process.env.ETH_NODE_URI
     const previousNetworkUri = process.env.ETH_NODE_URI_TESTNET
-    delete process.env.ETH_NODE_URI_TESTNET // spawn-env: in-process; left set, node_url returns early and the assertion never runs
+    delete process.env.ETH_NODE_URI_TESTNET // spawn-env: in-process; set, node_url returns early and the assertion never runs
     process.env.ETH_NODE_URI =
       'https://lb.drpc.org/ogrpc?chain={{chain}}&dkey=SYNTHETIC-NOT-REAL-abc123'
 
@@ -213,7 +213,9 @@ describe('endpoint redaction', () => {
       expect(message).not.toContain('dkey')
     } finally {
       if (previousUri !== undefined) process.env.ETH_NODE_URI = previousUri
-      else delete process.env.ETH_NODE_URI // spawn-env: in-process restore
+      else {
+        delete process.env.ETH_NODE_URI // spawn-env: in-process restore
+      }
       if (previousNetworkUri !== undefined)
         process.env.ETH_NODE_URI_TESTNET = previousNetworkUri
     }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-988](https://linear.app/lifi-linear/issue/EXSC-988)

# Why did I implement it this way?

#2364 established that deleting a name from a spawned child's environment does not
withhold it — bun re-loads the repo `.env` inside the child for every name the passed
environment leaves unset — and fixed it by *setting* dummies. Its match covered the
signing keys, the seed phrase and the two proposal-store URIs.

**Classes added:** keyed RPC endpoints (`ETH_NODE_URI`), provider and explorer keys
(`API_KEY`, `ACCESS_KEY`, `SYNC_TOKEN`), Slack webhooks (`WEBHOOK`).

**The guard and the fix now share one definition.** The class table lives in
`spawn-env.ts`; `spawn-env-credentials.test.ts` derives its source-scanning pattern
from the same cores, so widening one widens both and a class dropped from the table
goes red in the scan *and* in the withholding. A guard that no longer matches what the
fix withholds reports a clean tree while the protection is gone, which is the whole
point of the pairing.

**Substring cores, not a name list.** A list cannot see a name that is not on it: the
`ETH_NODE_URI_*` entries grow by one per network and the explorer keys by one per
chain. The sweep walks the keys of the environment it is handed and matches by core, so
a network added tomorrow is covered the day it is added. Cores span the whole
credential-bearing part of a name, never the vendor alone — `MONGODB_URI` not
`MONGODB`, `SYNC_TOKEN` not `TOKEN` — so a logging toggle and a token-contract list
stay out.

Three names match a core and hold no secret, so they are withheld from the sweep *and*
from the scan: `NO_ETHERSCAN_API_KEY_REQUIRED` names a marker the verification helper
compares against (and exports as the explorer key when set, so a value would look like
a present key), and the two anvil entries are the publicly known local-node key and
`127.0.0.1`. Replacing any of those changes what a child does rather than withholding
anything from it.

## Scope of the coverage

Measured against the real store, which holds 225 names:

| class | names |
|---|---|
| `ETH_NODE_URI*` endpoints | 87 |
| provider / explorer keys | 63 |
| signing keys + proposal stores (#2364) | 18 |
| webhooks | 9 |
| **withheld** | **177** |
| non-credentials (paths, flags, limits, lists, salts) | 48 |

This applies to the two callers of `withholdCredentials`
(`strict-flag-placement.test.ts`, `ticket-gate-placement.test.ts`). It is a no-op in
CI: `ts-unit-tests.yml` passes no `env:` block and runners have no `.env`, so there is
nothing to withhold there. The protection bites on a developer machine, which is where
the store actually is — `bun test` loads `.env` into the parent, so the sweep sees all
225 names.

## What this does not cover

Stated here because a scanner that walks names cannot see what is not named:

- **A credential whose name carries no core** (a `FOO_SECRET_SAUCE`) is invisible to
  both halves. Adding a new kind of secret means adding its core — pinned by a test.
- **A name the spawning process does not hold** cannot be swept out of an environment
  it is not in, and the child re-loads the file for exactly those names. Only the five
  pinned names are immune, and the set is asserted rather than the members, because a
  loop over the list cannot see a name dropped from it. This matters most for
  `SAFE_SIGNER_PRIVATE_KEY`, which the store leaves unset — the sweep never sees it, so
  the pin is its only cover.
- **Five other tests spawn children and never call `withholdCredentials`**, building
  the environment by hand instead: `ticket-flag-channel`, `funnel-deploy-gate`,
  `update-deployment-logs`, `helperFunctions.gate`, `ledger-refusal-placement`. They
  are unchanged here, and each has its own load-bearing assertions — `funnel-deploy-gate`
  asserts `'Private key is missing'`, so setting a malformed key there would break it.
  The enforceable invariant is "a test that spawns calls the helper", and nothing
  asserts it yet. Recorded in the rule and tracked in
  [EXSC-996](https://linear.app/lifi-linear/issue/EXSC-996).
- **`GH_TOKEN` / `GITHUB_TOKEN` / `HEXAGATE_PAUSER_PAT` carry no core**, so the sweep
  passes them through. They are the most reachable uncovered class — developers export
  `GH_TOKEN=$(gh auth token)` and `checkCronLiveness.ts` reads it — but a bare `TOKEN`
  core would falsely sweep `ALLOW_TOKEN_CONTRACTS`, so which spelling to add is a
  judgement call rather than a widening. Left for EXSC-996.
- The two `TARGET_STATE_SPREADSHEET_ID_*` entries are the one judgement call in the
  residual 48: a Sheets ID is a locator, not an authenticator, so it is not withheld.

## Sweep of existing deletes

Two statements across the whole tree unset one of the *newly* covered names, both in
`script/utils/utils.test.ts`, both legitimate — that test is in-process and never
spawns, and the unset is what forces the fallback branch whose redaction is asserted
(set, `node_url` returns early and the assertion never runs). Both carry a
`// spawn-env:` marker with the reason. So the widened cores cost two markers, not the
marker tax on every fallback test that #2364 was right to worry about. The tree holds
five marked unsets in total; the other three predate this PR.

## The exposure the ticket asked me to confirm first

`execute-pending-timelock-tx.ts` reads `WEBHOOK_DEV_SC_GITHUB_CI_NOTIFICATIONS` and
POSTs to the live channel in `handleRevertedExecution`. Still unreachable from the
probe, and still only by control flow: `readBooleanFlag` refuses at the top of `run()`,
and the `--executeAll`/`--rejectAll` conflict check `process.exit(1)`s three statements
later — both before any Mongo or webhook read. Reaching the POST needs the queue opened
and a batch reverted on-chain past the retry threshold. It is now withheld by design
rather than by ordering.

## One incidental fix

Prettier breaks a `delete` whose *code* passes 80 columns — across the dot, and across
the brackets for a computed key — leaving the holder alone as the statement
(`delete process.env`), which carries no name to match. The scan joined only the gap
after the keyword, so both forms read as clean. It now collapses the whole member
expression, with a test per form. Separately, prettier relocates a trailing comment when
the delete is the body of an `if`/`else`, which detaches a marker from its delete; that
is why the `utils.test.ts` restore braces its `else`, and why the rule says to keep the
unset a standalone statement.

## Note for review

The comments here name env vars, which `200-typescript.md` discourages as volatile
detail. Kept deliberately: in a guard whose subject *is* the set of names, the names are
the functional content, and this matches the file #2364 established.

## Review-gate round

A pre-ready review pass found two defects in the guard itself, both now fixed and
mutation-covered:

- The reviewed-non-credential exemption was matched against the whole statement rather
  than the name being unset, so `if (env.PRIVATE_KEY_ANVIL) delete env.PRIVATE_KEY_PRODUCTION`
  read as clean. It is now keyed on the captured name.
- `env.X = undefined` leaves a name unset for the child's re-load exactly as `delete`
  does, and the guard asserted that *setting* is always safe — so following the rule to
  the letter could reopen the hole it closes. Measured in a hermetic child: `delete` and
  `= undefined` both hand back the fixture value at full length, `= ''` gives length 0.
  The scan now covers `= undefined` (including the line prettier breaks), `= ''` stays
  legitimate, and both behaviours are pinned by a real spawn.

Separately, `ticket-gate-placement.test.ts` deleted `SAFE_PROPOSAL_TICKET` under a
comment claiming it was cleared. It is in `.env.example`, so the child re-loaded a
developer's own ticket and decided the gate cases for them — now set empty.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

