### PR TITLE
chore: whitelist kyberswap arc router

### DIFF
--- a/config/whitelist.json
+++ b/config/whitelist.json
@@ -1498,6 +1498,15 @@
       "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/exchanges/kyberswap.svg",
       "webUrl": "https://kyberswap.com/",
       "contracts": {
+        "arc": [
+          {
+            "address": "0x6131b5fae19ea4f9d964eac0408e4408b66337b5",
+            "functions": {
+              "0xe21fd0e9": "swap((address,address,bytes,(address,address,address[],uint256[],address[],uint256[],address,uint256,uint256,uint256,bytes),bytes))",
+              "0x8af033fb": "swapSimpleMode(address,(address,address,address[],uint256[],address[],uint256[],address,uint256,uint256,uint256,bytes),bytes,bytes)"
+            }
+          }
+        ],
         "robinhood": [
           {
             "address": "0x6131b5fae19ea4f9d964eac0408e4408b66337b5",


### PR DESCRIPTION
## Summary

Adds the Arc entry for KyberSwap's `MetaAggregationRouterV2` to `config/whitelist.json`.

- Address: `0x6131b5fae19ea4f9d964eac0408e4408b66337b5` — the same address KyberSwap uses on all 20 chains already whitelisted here
- Selectors: `swap` (`0xe21fd0e9`) and `swapSimpleMode` (`0x8af033fb`)

The entry is byte-identical to the existing `robinhood` entry.

## Why these two selectors

The existing KyberSwap entries split into two shapes:

- **9 older chains** (mainnet, arbitrum, base, bsc, linea, optimism, polygon, avalanche, scroll) also carry `swapGeneric` (`0x59e50fed`).
- **11 newer chains** (robinhood, megaeth, monad, plasma, hyperevm, etherlink, berachain, sonic, ronin, mantle, blast) carry only `swap` and `swapSimpleMode`.

Arc is a new deployment, so it follows the newer shape.

## Context

Paired backend PR: https://github.com/lifinance/lifi-backend/pull/8954
Linear: EXBE-586 (parent EXP-670)

## ⚠️ Note for reviewers

KyberSwap has not deployed the router on Arc yet — `eth_getCode` at that address on Arc (chain 5042) returns `0x` as of 11 Sep. Controls confirm the check: the same address returns code on Base, and the Fly router and LI.FI diamond both return code on Arc.

KyberSwap confirmed day-1 support for the 16 September Arc launch, so this whitelist entry is prepared ahead of that deployment. The selector set could not be derived from Arc bytecode and was taken from KyberSwap's recent deployments instead. Worth re-checking against the deployed bytecode once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)