### PR TITLE
fix(config): stable's native token is USDT0, not the sunset gUSDT predeploy (EXSC-966)

### DIFF
--- a/config/networks.json
+++ b/config/networks.json
@@ -1172,8 +1172,8 @@
   "stable": {
     "name": "stable",
     "chainId": 988,
-    "nativeAddress": "0x0000000000000000000000000000000000001000",
-    "nativeCurrency": "gUSDT",
+    "nativeAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+    "nativeCurrency": "USDT0",
     "wrappedNativeAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
     "status": "active",
     "type": "mainnet",

--- a/script/deploy/immutables/getter-exemptions.json
+++ b/script/deploy/immutables/getter-exemptions.json
@@ -1,7 +1,6 @@
 {
   "EmergencyPauseFacet.pauserWallet": "a LI.FI-operated wallet rather than an external counterparty; covered by the wallet-role checks",
   "GasZipPeriphery.LIFI_DIAMOND": "resolved from the deploy log, not config; covered by the periphery presence and registry checks",
-  "GenericSwapFacetV3.NATIVE_ADDRESS": "stable binds its wrapped native instead of the configured nativeAddress sentinel, so annotating it would report a live deployment red before that mismatch is settled — blocked by EXSC-966",
   "LiFiDEXAggregator.BENTO_BOX": "no config value exists to compare against — every deployment passes address(0) for _bentoBox by design",
   "Permit2Proxy.LIFI_DIAMOND": "resolved from the deploy log, not config; covered by the periphery presence and registry checks",
   "ReceiverAcrossV3.executor": "resolved from the deploy log, not config; covered by the periphery presence and registry checks",

--- a/script/deploy/resources/deployRequirements.json
+++ b/script/deploy/resources/deployRequirements.json
@@ -231,7 +231,8 @@
       "_nativeAddress": {
         "configFileName": "networks.json",
         "keyInConfigFile": ".<NETWORK>.nativeAddress",
-        "allowToDeployWithZeroAddress": "true"
+        "allowToDeployWithZeroAddress": "true",
+        "getter": "NATIVE_ADDRESS"
       }
     }
   },


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-966](https://linear.app/lifi-linear/issue/EXSC-966/genericswapfacetv3-on-stable-binds-the-wrapped-native-as-its-native)

Stacked on #2375 (EXSC-967) — the getter annotation below needs its
`allowToDeployWithZeroAddress` path, since `nativeAddress` is `address(0)` on
most chains. Rebase onto `main` if #2375 slips.

# Why did I implement it this way?

EXSC-966 was filed as "the deployed facet binds the wrong address". It is the
other way round: **the deployment is correct and `config/networks.json` was
stale.**

Stable v1.2.0 made USDT0 the native gas token and sunset gUSDT. From the
chain's own docs (docs.stable.xyz, "USDT0 as gas"):

> With Stable v1.2.0, USDT0 becomes the native gas token on Stable, replacing
> gUSDT. […] gUSDT is being sunset.

> The native token identifier is `0x779Ded0c9e1022225f8E0630b35a9b54bE713736`,
> not `0x0000000000000000000000000000000000001000`.

> Should integrations keep the former gUSDT address? No. You can remove
> `0x0000000000000000000000000000000000001000`. It isn't used after the upgrade.

Corroboration from outside the docs:

- `GET li.quest/v1/chains` gives chain 988 `nativeToken.address` =
  `0x779Ded…3736`, `nonStandardNativeDecimals: true`.
- `GET li.quest/v1/quote` with `fromToken=0x…1000` on 988 returns
  `Token 988-0x0000000000000000000000000000000000001000 is invalid or in deny
  list` — the value config carried is deny-listed by our own backend.
- On chain, `0x…1000` is `Agusdt`/18dec (the sunset predeploy) and `0x779Ded…`
  is `USDT0`/6dec.

So the three changes:

1. `config/networks.json` — `.stable.nativeAddress` → `0x779Ded…3736` and
   `nativeCurrency` → `USDT0`. `nativeAddress` now equals
   `wrappedNativeAddress`. That is deliberate, not a copy-paste slip: it is the
   shape celo already has (CELO is both the gas asset and an ERC20), and on
   stable the docs say it explicitly — "Which token should integrations treat
   as the wrapped native token? USDT0 becomes both the native token and an
   ERC-20 token after the upgrade. Use USDT0 directly."
2. `getter-exemptions.json` — the `GenericSwapFacetV3.NATIVE_ADDRESS` row is
   removed, since the mismatch it named is resolved.
3. `deployRequirements.json` — `_nativeAddress` gains
   `"getter": "NATIVE_ADDRESS"`, so `immutable-bindings-match-config` starts
   checking it.

## Evidence the annotation is safe fleet-wide

Read `NATIVE_ADDRESS()` on every active mainnet holding `GenericSwapFacetV3`
and compared against the post-change config: **66 mainnets, 47 match, 0
mismatch, 19 unreadable.** The 19 are 16 chains still running
`GenericSwapFacetV3` v1.0.0 — which has no `NATIVE_ADDRESS` immutable at all,
so the read reverts and the invariant logs it as unverified rather than red —
plus `arc` (no public RPC) and `gravity` (403), which only private RPCs in CI
can read, and a rate-limit blip. `arctestnet` carries the same `0x3600…0000`
config as `arc` and reads back correctly.

Coverage after this PR is the 50 active mainnets on v1.0.1/v1.0.2/v2.0.0, plus
the testnets on those versions — the invariant scopes by environment
(`production`), not by mainnet-ness.

`verify-immutable-registry` exits 0 against a fresh `forge build src --ast`;
349 tests pass across `script/deploy/immutables/`,
`script/deploy/shared/immutableBindings.test.ts` and
`script/deploy/healthCheckInvariants.test.ts`.

## No production impact, and why

`NATIVE_ADDRESS` is not the execution sentinel — `_executeSwaps` dispatches on
`LibAsset.isNativeAsset`, i.e. `address(0)`. It only labels the native side of
`AssetSwapped` / `LiFiGenericSwapCompleted`, and guards
`_returnPositiveSlippageERC20`.

Because stable's native asset *is* a routable ERC20, that guard makes the
facet skip the surplus refund when `sendingAssetId == USDT0`. On-chain that
covers 577 of 611 `GenericSwapFacetV3` legs since the chain went live, so the
path is well exercised — but the diamond's USDT0 balance is 0, and no
`WithdrawFacet` selector has ever been called on it, so no surplus has ever
been stranded. The DEX calldata consumes the full input. Every call in that
history is ERC20→ERC20; no native-leg selector has ever been used on stable.

This is inherent to a chain whose native asset and ERC20 share one address,
not something a redeploy fixes — pointing `NATIVE_ADDRESS` at the sunset
`0x…1000` instead would make the events wrong and hand the same skip to a
deny-listed token. **No redeploy is warranted.**

## Left alone, deliberately

`deployments/_deployments_log_file.json` records stable's GenericSwapFacetV3 as
`0x17A1a3a8f4D77F330a53D852497d65ddcf065898` (constructor arg `0x…1000`), but
the diamond routes to `0x4531eB68FEfDCe8b80340f7238911428509815C0`. The
`0x17A1…` deployment exists on chain and was never cut in. That is a
master-log/Mongo discrepancy, not part of this fix.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [ ] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


