### PR TITLE
feat(safe): rehearse the verify path read-only, proving it cannot write (EXSC-995)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "codegen": "plop",
     "compile": "forge build",
     "confirm-safe-tx": "bash script/deploy/safe/with-safe-tunnel.sh && bun build:typechain-and-abi && bunx tsx ./script/deploy/safe/confirm-safe-tx.ts",
+    "verify-pending-proposals": "bash script/deploy/safe/with-safe-tunnel.sh && bunx tsx ./script/deploy/safe/verify-rehearsal.ts",
     "safe:tunnel": "bash script/deploy/safe/with-safe-tunnel.sh",
     "deploy-safe": "bunx tsx ./script/deploy/safe/deploy-safe.ts",
     "coverage": "rm -rf coverage && rm -f lcov-filtered.info && rm -f lcov.info && forge coverage --report lcov --evm-version 'cancun' --ir-minimum && bun script/utils/filter_lcov.ts lcov.info lcov-filtered.info 'test/' 'script/' && genhtml lcov-filtered.info --ignore-errors inconsistent,corrupt --branch-coverage --output-dir coverage && open coverage/index.html",

--- a/script/deploy/safe/rehearsal-report.test.ts
+++ b/script/deploy/safe/rehearsal-report.test.ts
@@ -1,0 +1,74 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  REHEARSAL_GATE_ROSTER,
+  buildGateReport,
+  renderGateReport,
+} from './rehearsal-report'
+
+describe('buildGateReport', () => {
+  it('names a rostered gate that did not register as absent', () => {
+    const report = buildGateReport({
+      registered: ['target-state'],
+      rowCounts: { 'target-state': 3 },
+    })
+
+    const executability = report.find(
+      (gate) => gate.checkId === 'executability'
+    )
+    expect(executability?.presence).toBe('absent')
+  })
+
+  it('never drops a rostered gate, however few registered', () => {
+    const report = buildGateReport({ registered: [], rowCounts: {} })
+
+    expect(report.map((gate) => gate.checkId).sort()).toEqual(
+      [...REHEARSAL_GATE_ROSTER.map((gate) => gate.checkId)].sort()
+    )
+    expect(report.every((gate) => gate.presence === 'absent')).toBe(true)
+  })
+
+  it('separates a gate that registered but reported nothing from one that ran', () => {
+    const report = buildGateReport({
+      registered: ['target-state', 'executability'],
+      rowCounts: { 'target-state': 2, executability: 0 },
+    })
+
+    expect(
+      report.find((gate) => gate.checkId === 'target-state')?.presence
+    ).toBe('present')
+    expect(
+      report.find((gate) => gate.checkId === 'executability')?.presence
+    ).toBe('registered-but-silent')
+  })
+
+  it('reports a registered gate the roster does not name', () => {
+    const report = buildGateReport({
+      registered: ['a-gate-nobody-rostered'],
+      rowCounts: { 'a-gate-nobody-rostered': 1 },
+    })
+
+    const surprise = report.find(
+      (gate) => gate.checkId === 'a-gate-nobody-rostered'
+    )
+    expect(surprise?.presence).toBe('present')
+    expect(surprise?.rostered).toBe(false)
+  })
+})
+
+describe('renderGateReport', () => {
+  it('prints every gate including the absent ones', () => {
+    const rendered = renderGateReport(
+      buildGateReport({ registered: ['target-state'], rowCounts: {} })
+    )
+
+    for (const gate of REHEARSAL_GATE_ROSTER)
+      expect(rendered).toContain(gate.checkId)
+    expect(rendered).toMatch(/absent/)
+  })
+})

--- a/script/deploy/safe/rehearsal-report.test.ts
+++ b/script/deploy/safe/rehearsal-report.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import {
   describe,
   expect,
@@ -11,6 +15,8 @@ import {
   buildGateReport,
   checkGradingAnchors,
   renderGateReport,
+  renderGradingAnchors,
+  renderSignerWorkload,
   summariseSignerWorkload,
   verdictsAreActionable,
 } from './rehearsal-report'
@@ -169,5 +175,72 @@ describe('verdictsAreActionable', () => {
   it('does not hold for proposals that already executed', () => {
     expect(verdictsAreActionable('executed')).toBe(false)
     expect(verdictsAreActionable('reverted')).toBe(false)
+  })
+})
+
+describe('checkGradingAnchors, on a cache that exists but cannot be used', () => {
+  it('reports a file that is not a JSON array as missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rehearsal-anchor-'))
+    mkdirSync(join(root, '.cache'), { recursive: true })
+    writeFileSync(join(root, '.cache', 'deployments_production.json'), '{}')
+
+    const cache = checkGradingAnchors(root).find((anchor) =>
+      anchor.path.includes('deployments_production.json')
+    )
+
+    expect(cache?.present).toBe(false)
+  })
+
+  it('reports a well-formed record array as present', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rehearsal-anchor-'))
+    mkdirSync(join(root, '.cache'), { recursive: true })
+    writeFileSync(
+      join(root, '.cache', 'deployments_production.json'),
+      JSON.stringify([
+        { network: 'arbitrum', address: '0x1', version: '1.0.0' },
+      ])
+    )
+
+    const cache = checkGradingAnchors(root).find((anchor) =>
+      anchor.path.includes('deployments_production.json')
+    )
+
+    expect(cache?.present).toBe(true)
+  })
+})
+
+describe('renderGradingAnchors', () => {
+  it('names the consequence only for the anchor that is missing', () => {
+    const rendered = renderGradingAnchors([
+      { path: '/a/present.json', present: true, consequence: 'would be bad' },
+      { path: '/a/absent.json', present: false, consequence: 'would be bad' },
+    ])
+
+    expect(rendered).toContain('present : /a/present.json')
+    expect(rendered).toContain('MISSING : /a/absent.json')
+    expect(rendered.match(/would be bad/g)).toHaveLength(1)
+  })
+})
+
+describe('renderSignerWorkload', () => {
+  it('prints all three counts and the rows still waiting on a person', () => {
+    const rendered = renderSignerWorkload({
+      settled: 7,
+      blocked: 2,
+      needsYou: [
+        {
+          proposal: '0xabc',
+          checkId: 'target-state',
+          network: 'tron',
+          expected: 'ordering holds',
+          actual: 'EcoFacet: matches-main',
+        },
+      ],
+    })
+
+    expect(rendered).toContain('settled automatically : 7')
+    expect(rendered).toContain('blocked               : 2')
+    expect(rendered).toContain('needs your judgement  : 1')
+    expect(rendered).toContain('EcoFacet: matches-main')
   })
 })

--- a/script/deploy/safe/rehearsal-report.test.ts
+++ b/script/deploy/safe/rehearsal-report.test.ts
@@ -12,6 +12,7 @@ import {
   checkGradingAnchors,
   renderGateReport,
   summariseSignerWorkload,
+  verdictsAreActionable,
 } from './rehearsal-report'
 
 describe('buildGateReport', () => {
@@ -156,5 +157,17 @@ describe('checkGradingAnchors', () => {
       anchor.path.includes('deployments_production.json')
     )
     expect(typeof cache?.present).toBe('boolean')
+  })
+})
+
+describe('verdictsAreActionable', () => {
+  it('holds for a corpus of proposals still awaiting signature', () => {
+    expect(verdictsAreActionable('pending')).toBe(true)
+    expect(verdictsAreActionable('submitted')).toBe(true)
+  })
+
+  it('does not hold for proposals that already executed', () => {
+    expect(verdictsAreActionable('executed')).toBe(false)
+    expect(verdictsAreActionable('reverted')).toBe(false)
   })
 })

--- a/script/deploy/safe/rehearsal-report.test.ts
+++ b/script/deploy/safe/rehearsal-report.test.ts
@@ -5,10 +5,13 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
+import { createCheckLedger, recordCheck } from './check-ledger'
 import {
   REHEARSAL_GATE_ROSTER,
   buildGateReport,
+  checkGradingAnchors,
   renderGateReport,
+  summariseSignerWorkload,
 } from './rehearsal-report'
 
 describe('buildGateReport', () => {
@@ -70,5 +73,88 @@ describe('renderGateReport', () => {
     for (const gate of REHEARSAL_GATE_ROSTER)
       expect(rendered).toContain(gate.checkId)
     expect(rendered).toMatch(/absent/)
+  })
+})
+
+describe('summariseSignerWorkload', () => {
+  const ledger = (rows: [string, string, string][]) => {
+    const built = createCheckLedger({
+      expectedNetworks: ['tron', 'arbitrum'],
+      checks: [
+        {
+          checkId: 'INT-SAFE-TX-HASH',
+          section: 'Integrity',
+          checkClass: 'integrity',
+          title: 'Recomputed safeTxHash matches the stored one',
+        },
+        {
+          checkId: 'target-state',
+          section: 'Intent',
+          checkClass: 'semantic',
+          title: 'Facet version matches the declared target state',
+        },
+      ],
+    })
+    for (const [checkId, network, status] of rows)
+      recordCheck(built, {
+        checkId,
+        network,
+        status: status as 'pass' | 'fail' | 'error' | 'needs-ack',
+        expected: 'e',
+        actual: 'a',
+        anchor: 'A-LOCAL',
+      })
+    return built
+  }
+
+  it('separates what the machine settled from what the signer must answer', () => {
+    const workload = summariseSignerWorkload([
+      {
+        proposal: '0xabc',
+        ledger: ledger([
+          ['INT-SAFE-TX-HASH', 'tron', 'pass'],
+          ['target-state', 'tron', 'needs-ack'],
+          ['target-state', 'arbitrum', 'pass'],
+        ]),
+      },
+    ])
+
+    expect(workload.settled).toBe(2)
+    expect(workload.needsYou).toHaveLength(1)
+    expect(workload.needsYou[0]?.checkId).toBe('target-state')
+    expect(workload.blocked).toBe(0)
+  })
+
+  it('counts a refusal as blocked, not as something the signer may wave through', () => {
+    const workload = summariseSignerWorkload([
+      {
+        proposal: '0xabc',
+        ledger: ledger([['INT-SAFE-TX-HASH', 'tron', 'fail']]),
+      },
+    ])
+
+    expect(workload.blocked).toBe(1)
+    expect(workload.needsYou).toHaveLength(0)
+  })
+})
+
+describe('checkGradingAnchors', () => {
+  it('reports the deployment cache as missing when it is not there', () => {
+    const anchors = checkGradingAnchors('/nonexistent-root-for-this-test')
+
+    const cache = anchors.find((anchor) =>
+      anchor.path.includes('deployments_production.json')
+    )
+    expect(cache?.present).toBe(false)
+    expect(cache?.consequence).toMatch(/every|all/i)
+  })
+
+  it('reports it present when the file exists', () => {
+    const anchors = checkGradingAnchors(process.cwd())
+
+    const cache = anchors.find((anchor) =>
+      anchor.path.includes('deployments_production.json')
+    )
+    expect(typeof cache?.present).toBe('boolean')
   })
 })

--- a/script/deploy/safe/rehearsal-report.test.ts
+++ b/script/deploy/safe/rehearsal-report.test.ts
@@ -244,3 +244,24 @@ describe('renderSignerWorkload', () => {
     expect(rendered).toContain('EcoFacet: matches-main')
   })
 })
+
+describe('checkGradingAnchors, on a cache that parses but holds nothing usable', () => {
+  const anchorFor = (contents: string) => {
+    const root = mkdtempSync(join(tmpdir(), 'rehearsal-anchor-'))
+    mkdirSync(join(root, '.cache'), { recursive: true })
+    writeFileSync(join(root, '.cache', 'deployments_production.json'), contents)
+    return checkGradingAnchors(root).find((anchor) =>
+      anchor.path.includes('deployments_production.json')
+    )
+  }
+
+  it('reports an empty array as missing', () => {
+    // What a refresh that returned nothing writes, and it produces exactly the
+    // contract-unidentified-everywhere run the anchor exists to catch.
+    expect(anchorFor('[]')?.present).toBe(false)
+  })
+
+  it('reports an array of the wrong shape as missing', () => {
+    expect(anchorFor('[1,2,3]')?.present).toBe(false)
+  })
+})

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -329,3 +329,23 @@ export const renderGradingAnchors = (
         : `MISSING : ${anchor.path}\n          ${anchor.consequence}`
     )
     .join('\n')
+
+/**
+ * Whether a corpus of this status produces verdicts anyone can act on.
+ *
+ * The gates grade a proposal against the target state `origin/main` declares
+ * *now*. That is the right comparison for a proposal about to be signed, and a
+ * meaningless one for a proposal that executed months ago: it installed what
+ * main declared then, so today it reads as a downgrade. Judging history against
+ * an anchor from its own future produces volume and no signal.
+ *
+ * An already-settled corpus is still worth running — it establishes that the
+ * chain survives real proposal shapes, that two passes agree, and which gates
+ * are wired. Those are properties of the chain, not verdicts about proposals,
+ * and this predicate is what keeps the run from presenting one as the other.
+ *
+ * @param status - the row status the corpus was drawn from
+ * @returns true only for proposals still awaiting execution
+ */
+export const verdictsAreActionable = (status: string): boolean =>
+  status === 'pending' || status === 'submitted'

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -22,10 +22,10 @@ export interface IRosteredGate {
 /**
  * Every gate the confirm chain is meant to compose onto the run ledger.
  *
- * The integrity mirrors, executability and rpc-quorum are EXSC-994's, which was
- * still in flight when this was written: they are expected to be absent until
- * it merges, and the report says so rather than omitting them. `target-state`
- * is the one gate merged onto `main` today.
+ * Each entry names the source that is meant to register it. An entry whose
+ * source has not merged reports `absent` rather than dropping out of the
+ * report, which is the whole point: a roster that shrank to what is wired
+ * would grade a smaller chain green every time one went missing.
  */
 export const REHEARSAL_GATE_ROSTER: readonly IRosteredGate[] = [
   {

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -281,7 +281,20 @@ export const renderSignerWorkload = (workload: ISignerWorkload): string => {
 const holdsDeploymentRecords = (cachePath: string): boolean => {
   if (!existsSync(cachePath)) return false
   try {
-    return Array.isArray(JSON.parse(readFileSync(cachePath, 'utf8')))
+    const records: unknown = JSON.parse(readFileSync(cachePath, 'utf8'))
+    // An empty array is the realistic bad case — it is what a refresh that
+    // returned nothing writes, and it resolves exactly as many addresses as a
+    // missing file does. The shape check catches the rest.
+    return (
+      Array.isArray(records) &&
+      records.length > 0 &&
+      records.every(
+        (record) =>
+          typeof record === 'object' &&
+          record !== null &&
+          typeof (record as { address?: unknown }).address === 'string'
+      )
+    )
   } catch {
     return false
   }

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -1,0 +1,171 @@
+/**
+ * The gate roster a verify rehearsal reports against, and how it renders.
+ *
+ * Import this from the rehearsal runner. It exists because the run's own
+ * `CONFIRM_CHECK_DEFINITIONS` can only name gates that are merged, so a report
+ * built from it alone is silent about the gates the design calls for and the
+ * pipeline has not wired yet — and a rehearsal whose report shrinks as gates go
+ * missing is a rehearsal that grades a smaller chain green every time.
+ *
+ * So the roster is a declared expectation, deliberately a superset of any one
+ * commit, and every entry it holds appears in the report with a presence.
+ */
+
+/** Why the roster names a gate, so an entry can be retired on evidence. */
+export interface IRosteredGate {
+  readonly checkId: string
+  readonly title: string
+  /** Where the expectation comes from — a ticket, a merged module, a design doc. */
+  readonly source: string
+}
+
+/**
+ * Every gate the confirm chain is meant to compose onto the run ledger.
+ *
+ * The integrity mirrors, executability and rpc-quorum are EXSC-994's, which was
+ * still in flight when this was written: they are expected to be absent until
+ * it merges, and the report says so rather than omitting them. `target-state`
+ * is the one gate merged onto `main` today.
+ */
+export const REHEARSAL_GATE_ROSTER: readonly IRosteredGate[] = [
+  {
+    checkId: 'INT-SAFE-ADDRESS',
+    title: 'Safe address matches the configured one',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'INT-SAFE-TX-HASH',
+    title: 'Recomputed safeTxHash matches the stored one',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'INT-SIGNATURES',
+    title: 'Stored signatures resolve to current owners',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'INT-FIXED-FIELDS',
+    title: 'Fixed Safe tx fields carry their required values',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'INT-TARGET',
+    title: 'Target address is the diamond or timelock it claims',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'INT-TIMELOCK-DELAY',
+    title: 'Scheduled delay is at least the timelock minimum',
+    source: 'confirm-integrity-asserts.ts, mirrored by EXSC-994',
+  },
+  {
+    checkId: 'target-state',
+    title: 'Facet version matches the declared target state',
+    source: 'confirm-check-registry.ts (merged)',
+  },
+  {
+    checkId: 'executability',
+    title: 'The proposal would execute rather than revert',
+    source: 'EXSC-994',
+  },
+  {
+    checkId: 'rpc-quorum',
+    title: 'Chain reads agreed across independent providers',
+    source: 'EXSC-994',
+  },
+]
+
+/**
+ * `registered-but-silent` is kept apart from both neighbours on purpose. A gate
+ * that registered and reported nothing is a different failure from one that was
+ * never wired: the first is a gate that ran and answered for no network, which
+ * the ledger counts as missing and blocks on, and reading it as `absent` would
+ * blame the wrong thing.
+ */
+export type GatePresence = 'present' | 'registered-but-silent' | 'absent'
+
+export interface IGateReportRow {
+  readonly checkId: string
+  readonly title: string
+  readonly source: string
+  readonly presence: GatePresence
+  readonly rows: number
+  /** False for a gate the run registered that the roster does not name. */
+  readonly rostered: boolean
+}
+
+const presenceOf = (
+  registered: readonly string[],
+  rows: number,
+  checkId: string
+): GatePresence => {
+  if (!registered.includes(checkId)) return 'absent'
+  return rows > 0 ? 'present' : 'registered-but-silent'
+}
+
+/**
+ * Grades every rostered gate, and every gate the run registered.
+ *
+ * A registered gate the roster does not name is appended rather than dropped:
+ * the roster is an expectation, not an allow-list, and a chain that grew a gate
+ * nobody rostered is something the reader has to be told about.
+ *
+ * @param run.registered - the check ids the run actually registered
+ * @param run.rowCounts - rows each check recorded, keyed by check id
+ * @returns one row per gate, rostered ones first, in roster order
+ */
+export const buildGateReport = (run: {
+  registered: readonly string[]
+  rowCounts: Readonly<Record<string, number>>
+}): readonly IGateReportRow[] => {
+  const rostered = REHEARSAL_GATE_ROSTER.map((gate) => ({
+    ...gate,
+    rows: run.rowCounts[gate.checkId] ?? 0,
+    presence: presenceOf(
+      run.registered,
+      run.rowCounts[gate.checkId] ?? 0,
+      gate.checkId
+    ),
+    rostered: true,
+  }))
+
+  const rosteredIds = new Set(REHEARSAL_GATE_ROSTER.map((gate) => gate.checkId))
+  const unrostered = run.registered
+    .filter((checkId) => !rosteredIds.has(checkId))
+    .map((checkId) => ({
+      checkId,
+      title: 'Registered by the run; not on the rehearsal roster',
+      source: 'unrostered',
+      rows: run.rowCounts[checkId] ?? 0,
+      presence: presenceOf(
+        run.registered,
+        run.rowCounts[checkId] ?? 0,
+        checkId
+      ),
+      rostered: false,
+    }))
+
+  return [...rostered, ...unrostered]
+}
+
+/**
+ * Renders the report as one line per gate.
+ *
+ * @param report - the graded gates
+ * @returns a block naming every gate and its presence
+ */
+export const renderGateReport = (report: readonly IGateReportRow[]): string => {
+  const width = Math.max(...report.map((gate) => gate.checkId.length))
+  return report
+    .map(
+      (gate) =>
+        `${gate.checkId.padEnd(width)}  ${gate.presence.padEnd(22)} rows=${
+          gate.rows
+        }  ${
+          gate.presence === 'absent'
+            ? `(expected from: ${gate.source})`
+            : gate.title
+        }`
+    )
+    .join('\n')
+}

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -287,6 +287,12 @@ export interface IGradingAnchor {
  * refusal on essentially every proposal. Nothing in that output says the cause
  * is a missing file, and the refusals are indistinguishable from real ones.
  *
+ * The signing CLI does not have this hazard — it refreshes the cache from
+ * MongoDB on every run so that every signer, not just the deployer, sees
+ * current versions. The rehearsal inherits it precisely because it opens the
+ * store by another route to avoid the index write on connect, and so never
+ * reaches that warm-up.
+ *
  * This is the false-refusal case the harness exists to catch, so it is checked
  * before grading rather than inferred from the results afterwards.
  *
@@ -302,7 +308,7 @@ export const checkGradingAnchors = (
       path: cachePath,
       present: existsSync(cachePath),
       consequence:
-        'every cut element grades contract-unidentified, so the run refuses almost every proposal for a reason that is about this checkout rather than about the proposals',
+        'every cut element grades contract-unidentified, so the run refuses almost every proposal for a reason that is about this checkout rather than about the proposals. Run confirm-safe-tx.ts once to refresh it from MongoDB, or rehearse from a checkout that has it.',
     },
   ]
 }

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -11,6 +11,15 @@
  * commit, and every entry it holds appears in the report with a presence.
  */
 
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  checkResultKey,
+  type ICheckLedger,
+  type ICheckResult,
+} from './check-ledger'
+
 /** Why the roster names a gate, so an entry can be retired on evidence. */
 export interface IRosteredGate {
   readonly checkId: string
@@ -169,3 +178,148 @@ export const renderGateReport = (report: readonly IGateReportRow[]): string => {
     )
     .join('\n')
 }
+
+/**
+ * One row a signer has to answer for personally.
+ */
+export interface ISignerTask {
+  readonly proposal: string
+  readonly checkId: string
+  readonly network: string
+  readonly expected: string
+  readonly actual: string
+}
+
+/**
+ * What the run settled by itself, and what it is handing to the signer.
+ */
+export interface ISignerWorkload {
+  /** Rows the evidence decided outright. Nothing to do. */
+  readonly settled: number
+  /** Rows that refused. Not the signer's to wave through — the run is blocked. */
+  readonly blocked: number
+  /** Rows where "is this the change we meant?" has no machine answer. */
+  readonly needsYou: readonly ISignerTask[]
+}
+
+/**
+ * Splits a run's rows by who has to act on them.
+ *
+ * The three buckets are the distinction the ledger already encodes and never
+ * shows: an `integrity` check asks whether the bytes are what they claim, which
+ * evidence settles; a `semantic` check asks whether this is the change we meant,
+ * which only a person can answer, and that answer is the acknowledgement. A
+ * report that prints one undifferentiated list of checks makes the signer
+ * re-derive that split by eye on every proposal.
+ *
+ * `blocked` is deliberately not merged into `needsYou`: a refusal is not a
+ * question put to the signer, and presenting it as one invites clicking
+ * through it.
+ *
+ * @param pass - one pass's per-proposal ledgers
+ * @returns the counts, and every row still waiting on a person
+ */
+export const summariseSignerWorkload = (
+  pass: readonly {
+    readonly proposal: string
+    readonly ledger: ICheckLedger
+  }[]
+): ISignerWorkload => {
+  let settled = 0
+  let blocked = 0
+  const needsYou: ISignerTask[] = []
+
+  for (const entry of pass) {
+    const outcomes = new Map<string, ICheckResult>()
+    for (const result of entry.ledger.results)
+      outcomes.set(checkResultKey(result.checkId, result.network), result)
+
+    for (const result of outcomes.values())
+      if (result.status === 'needs-ack')
+        needsYou.push({
+          proposal: entry.proposal,
+          checkId: result.checkId,
+          network: result.network,
+          expected: result.expected,
+          actual: result.actual,
+        })
+      else if (result.status === 'pass') settled += 1
+      else blocked += 1
+  }
+
+  return { settled, blocked, needsYou }
+}
+
+/**
+ * Renders the workload split for a signer.
+ *
+ * @param workload - the split
+ * @returns a short block naming what is settled, what is blocked, and what is left
+ */
+export const renderSignerWorkload = (workload: ISignerWorkload): string => {
+  const lines = [
+    `settled automatically : ${workload.settled} row(s) — evidence decided these, nothing to do`,
+    `blocked               : ${workload.blocked} row(s) — refused; not yours to wave through`,
+    `needs your judgement  : ${workload.needsYou.length} row(s) — acknowledging one IS answering it`,
+  ]
+  for (const task of workload.needsYou.slice(0, 10))
+    lines.push(
+      `  ${task.checkId} on ${task.network}: expected ${task.expected}, observed ${task.actual}`
+    )
+  return lines.join('\n')
+}
+
+/** A file a gate's verdict rests on, and what its absence does to that verdict. */
+export interface IGradingAnchor {
+  readonly path: string
+  readonly present: boolean
+  /** What a run produces when this anchor is missing. */
+  readonly consequence: string
+}
+
+/**
+ * Checks the local files the gates grade against.
+ *
+ * A rehearsal in a fresh worktree is the case this exists for. The deployment
+ * record is read from a gitignored cache, not from `deployments/*.json`, and
+ * `resolveDeployedContractByAddress` returns `unrecorded` when it is absent —
+ * so every cut element grades `contract-unidentified` and the run reports a
+ * refusal on essentially every proposal. Nothing in that output says the cause
+ * is a missing file, and the refusals are indistinguishable from real ones.
+ *
+ * This is the false-refusal case the harness exists to catch, so it is checked
+ * before grading rather than inferred from the results afterwards.
+ *
+ * @param rootDir - repo root the gates will read from
+ * @returns one entry per anchor, with what its absence would cost
+ */
+export const checkGradingAnchors = (
+  rootDir: string
+): readonly IGradingAnchor[] => {
+  const cachePath = join(rootDir, '.cache', 'deployments_production.json')
+  return [
+    {
+      path: cachePath,
+      present: existsSync(cachePath),
+      consequence:
+        'every cut element grades contract-unidentified, so the run refuses almost every proposal for a reason that is about this checkout rather than about the proposals',
+    },
+  ]
+}
+
+/**
+ * Renders the anchor check.
+ *
+ * @param anchors - the checked anchors
+ * @returns a line per anchor, naming the consequence of a missing one
+ */
+export const renderGradingAnchors = (
+  anchors: readonly IGradingAnchor[]
+): string =>
+  anchors
+    .map((anchor) =>
+      anchor.present
+        ? `present : ${anchor.path}`
+        : `MISSING : ${anchor.path}\n          ${anchor.consequence}`
+    )
+    .join('\n')

--- a/script/deploy/safe/rehearsal-report.ts
+++ b/script/deploy/safe/rehearsal-report.ts
@@ -11,7 +11,7 @@
  * commit, and every entry it holds appears in the report with a presence.
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
@@ -269,6 +269,24 @@ export const renderSignerWorkload = (workload: ISignerWorkload): string => {
   return lines.join('\n')
 }
 
+/**
+ * Whether the cache is not just present but usable.
+ *
+ * `loadProductionDeploymentRecords` memoises `null` for a file that is missing
+ * *or* does not parse as an array, and both produce the same
+ * `contract-unidentified`-everywhere run. Checking existence alone would let a
+ * truncated or half-written cache — the case that loader's own catch block
+ * anticipates — past the gate that exists to catch it.
+ */
+const holdsDeploymentRecords = (cachePath: string): boolean => {
+  if (!existsSync(cachePath)) return false
+  try {
+    return Array.isArray(JSON.parse(readFileSync(cachePath, 'utf8')))
+  } catch {
+    return false
+  }
+}
+
 /** A file a gate's verdict rests on, and what its absence does to that verdict. */
 export interface IGradingAnchor {
   readonly path: string
@@ -287,11 +305,12 @@ export interface IGradingAnchor {
  * refusal on essentially every proposal. Nothing in that output says the cause
  * is a missing file, and the refusals are indistinguishable from real ones.
  *
- * The signing CLI does not have this hazard — it refreshes the cache from
- * MongoDB on every run so that every signer, not just the deployer, sees
- * current versions. The rehearsal inherits it precisely because it opens the
- * store by another route to avoid the index write on connect, and so never
- * reaches that warm-up.
+ * The signing CLI largely avoids this — it refreshes the cache from MongoDB at
+ * startup so that every signer, not just the deployer, sees current versions,
+ * though that refresh is itself conditional on `MONGODB_URI` and its failure is
+ * swallowed at debug level. The rehearsal never reaches that warm-up at all,
+ * because it opens the store by another route to avoid the index write on
+ * connect.
  *
  * This is the false-refusal case the harness exists to catch, so it is checked
  * before grading rather than inferred from the results afterwards.
@@ -306,9 +325,9 @@ export const checkGradingAnchors = (
   return [
     {
       path: cachePath,
-      present: existsSync(cachePath),
+      present: holdsDeploymentRecords(cachePath),
       consequence:
-        'every cut element grades contract-unidentified, so the run refuses almost every proposal for a reason that is about this checkout rather than about the proposals. Run confirm-safe-tx.ts once to refresh it from MongoDB, or rehearse from a checkout that has it.',
+        'missing or not a record array, so every cut element grades contract-unidentified and the run refuses almost every proposal for a reason that is about this checkout rather than about the proposals. Run confirm-safe-tx.ts with MONGODB_URI set to refresh it, or rehearse from a checkout that has it.',
     },
   ]
 }

--- a/script/deploy/safe/rehearsal-run.test.ts
+++ b/script/deploy/safe/rehearsal-run.test.ts
@@ -14,6 +14,7 @@ import {
   collectRefusalObservations,
   comparePasses,
   gradeCorruptionProbe,
+  refusalClasses,
   rowCountsByCheck,
   summariseRehearsal,
 } from './rehearsal-run'
@@ -322,5 +323,47 @@ describe('collectRefusalObservations, when a cut mixes refusal classes', () => {
     ])
 
     expect(observations[0]?.truePositive).toBe(true)
+  })
+})
+
+describe('refusalClasses', () => {
+  it('names the distinct classes behind a run’s refusals', () => {
+    const classes = refusalClasses([
+      {
+        proposal: '0xa',
+        ledger: ledgerWith('error', '0xaaa: contract-unidentified'),
+      },
+      {
+        proposal: '0xb',
+        ledger: ledgerWith('fail', 'AcrossFacetV3: downgrade'),
+      },
+      {
+        proposal: '0xc',
+        ledger: ledgerWith('error', '0xccc: contract-unidentified'),
+      },
+    ])
+
+    expect([...classes].sort()).toEqual(['contract-unidentified', 'downgrade'])
+  })
+
+  it('reports one class when the chain can only refuse one way', () => {
+    const classes = refusalClasses([
+      {
+        proposal: '0xa',
+        ledger: ledgerWith('error', '0xaaa: contract-unidentified'),
+      },
+      {
+        proposal: '0xb',
+        ledger: ledgerWith('error', '0xbbb: contract-unidentified'),
+      },
+    ])
+
+    expect(classes).toHaveLength(1)
+  })
+
+  it('counts no class for a run with no refusals', () => {
+    expect(
+      refusalClasses([{ proposal: '0xa', ledger: ledgerWith('pass', '1.0.0') }])
+    ).toEqual([])
   })
 })

--- a/script/deploy/safe/rehearsal-run.test.ts
+++ b/script/deploy/safe/rehearsal-run.test.ts
@@ -14,6 +14,7 @@ import {
   collectRefusalObservations,
   comparePasses,
   gradeCorruptionProbe,
+  rowCountsByCheck,
   summariseRehearsal,
 } from './rehearsal-run'
 
@@ -147,24 +148,46 @@ describe('summariseRehearsal', () => {
 })
 
 describe('gradeCorruptionProbe', () => {
-  it('says nothing was exercised when there was nothing to corrupt', () => {
-    expect(gradeCorruptionProbe([])).toBe('not-exercised')
+  const entry = (
+    status: 'pass' | 'fail' | 'error' | 'needs-ack',
+    actual: string
+  ) => [{ proposal: '0xabc', ledger: ledgerWith(status, actual) }]
+
+  it('says nothing was exercised when no row passed before corruption', () => {
+    // Every row already refused, so damaging them proves nothing.
+    expect(
+      gradeCorruptionProbe(entry('fail', 'downgrade'), entry('fail', 'damaged'))
+    ).toBe('not-exercised')
   })
 
-  it('passes when the damaged input drew a refusal', () => {
+  it('passes only when a row that was clean now refuses', () => {
     expect(
-      gradeCorruptionProbe([
-        { proposal: '0xabc', ledger: ledgerWith('fail', 'corrupted') },
-      ])
+      gradeCorruptionProbe(entry('pass', '1.0.0'), entry('fail', 'damaged'))
     ).toBe('refused')
   })
 
-  it('fails when damaged input was graded clean', () => {
+  it('fails when a row that was clean is still clean after corruption', () => {
     expect(
-      gradeCorruptionProbe([
-        { proposal: '0xabc', ledger: ledgerWith('pass', 'corrupted') },
-      ])
+      gradeCorruptionProbe(
+        entry('pass', '1.0.0'),
+        entry('pass', 'no-diamond-cut')
+      )
     ).toBe('did-not-refuse')
+  })
+
+  it('does not let an already-refusing row vouch for a row it did not damage', () => {
+    const baseline = [
+      { proposal: '0xclean', ledger: ledgerWith('pass', '1.0.0') },
+      { proposal: '0xdirty', ledger: ledgerWith('fail', 'downgrade') },
+    ]
+    const corrupted = [
+      // The clean row survived corruption untouched...
+      { proposal: '0xclean', ledger: ledgerWith('pass', 'no-diamond-cut') },
+      // ...while the row that already refused still refuses.
+      { proposal: '0xdirty', ledger: ledgerWith('fail', 'downgrade') },
+    ]
+
+    expect(gradeCorruptionProbe(baseline, corrupted)).toBe('did-not-refuse')
   })
 })
 
@@ -186,5 +209,118 @@ describe('collectRefusalObservations, classifying a known-correct refusal', () =
     ])
 
     expect(observations[0]?.truePositive).toBeUndefined()
+  })
+})
+
+describe('comparePasses, when the second pass records a row the first lacks', () => {
+  /** A two-network ledger, so one pass can answer for a network the other did not. */
+  const twoNetworkLedger = (networks: readonly string[]): ICheckLedger => {
+    const ledger = createCheckLedger({
+      expectedNetworks: ['tron', 'arbitrum'],
+      checks: [
+        {
+          checkId: 'target-state',
+          section: 'Intent',
+          checkClass: 'semantic',
+          title: 'Facet version matches the declared target state',
+        },
+      ],
+    })
+    for (const network of networks)
+      recordCheck(ledger, {
+        checkId: 'target-state',
+        network,
+        status: 'pass',
+        expected: 'no installed version behind what origin/main declares',
+        actual: '1.0.0',
+        anchor: 'A-LOCAL',
+      })
+    return ledger
+  }
+
+  it('reports it instead of grading the run deterministic', () => {
+    const summary = summariseRehearsal({
+      first: [{ proposal: '0xabc', ledger: twoNetworkLedger(['tron']) }],
+      second: [
+        { proposal: '0xabc', ledger: twoNetworkLedger(['tron', 'arbitrum']) },
+      ],
+    })
+
+    expect(summary.verdict).toBe('non-deterministic')
+    expect(
+      summary.findings.some((finding) => finding.network === 'arbitrum')
+    ).toBe(true)
+  })
+})
+
+describe('rowCountsByCheck', () => {
+  it('counts each check once per network, not once per append-log entry', () => {
+    const ledger = ledgerWith('pass', '1.0.0')
+    recordCheck(ledger, {
+      checkId: 'target-state',
+      network: 'tron',
+      status: 'fail',
+      expected: 'no installed version behind what origin/main declares',
+      actual: 'downgrade',
+      anchor: 'A-MAIN',
+    })
+
+    expect(rowCountsByCheck([{ proposal: '0xabc', ledger }])).toEqual({
+      'target-state': 1,
+    })
+  })
+})
+
+describe('summariseRehearsal, with asymmetric passes', () => {
+  it('does not call a run not-measured while it holds a finding', () => {
+    const summary = summariseRehearsal({
+      first: [],
+      second: [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+    })
+
+    expect(summary.findings).toHaveLength(1)
+    expect(summary.verdict).toBe('non-deterministic')
+  })
+})
+
+describe('collectRefusalObservations, when a cut mixes refusal classes', () => {
+  it('does not launder a downgrade sitting beside an unidentified element', () => {
+    const observations = collectRefusalObservations([
+      {
+        proposal: '0xabc',
+        ledger: ledgerWith(
+          'fail',
+          'SomeLib: contract-unidentified; AcrossFacetV3: downgrade'
+        ),
+      },
+    ])
+
+    expect(observations[0]?.refused).toBe(true)
+    expect(observations[0]?.truePositive).toBeUndefined()
+  })
+
+  it('does not let a contract name carrying the phrase qualify on its name', () => {
+    const observations = collectRefusalObservations([
+      {
+        proposal: '0xabc',
+        ledger: ledgerWith('fail', 'contract-unidentified-helper: downgrade'),
+      },
+    ])
+
+    expect(observations[0]?.truePositive).toBeUndefined()
+  })
+
+  it('still accepts a cut whose every element is unidentified', () => {
+    const observations = collectRefusalObservations([
+      {
+        proposal: '0xabc',
+        ledger: ledgerWith(
+          'error',
+          '0xaaa: contract-unidentified; 0xbbb: contract-unidentified'
+        ),
+      },
+    ])
+
+    expect(observations[0]?.truePositive).toBe(true)
   })
 })

--- a/script/deploy/safe/rehearsal-run.test.ts
+++ b/script/deploy/safe/rehearsal-run.test.ts
@@ -10,6 +10,7 @@ import {
   recordCheck,
   type ICheckLedger,
 } from './check-ledger'
+import { NOTHING_TO_COMPARE } from './confirm-check-registry'
 import {
   collectRefusalObservations,
   comparePasses,
@@ -365,5 +366,94 @@ describe('refusalClasses', () => {
     expect(
       refusalClasses([{ proposal: '0xa', ledger: ledgerWith('pass', '1.0.0') }])
     ).toEqual([])
+  })
+})
+
+describe('gradeCorruptionProbe, on rows the mutation cannot reach', () => {
+  const nothingToCompare = (): ICheckLedger => {
+    const built = createCheckLedger({
+      expectedNetworks: ['tron'],
+      checks: [
+        {
+          checkId: 'target-state',
+          section: 'Intent',
+          checkClass: 'semantic',
+          title: 'Facet version matches the declared target state',
+        },
+      ],
+    })
+    recordCheck(built, {
+      checkId: 'target-state',
+      network: 'tron',
+      status: 'pass',
+      expected: NOTHING_TO_COMPARE,
+      actual: 'unnamed element: no-diamond-cut',
+      anchor: 'A-LOCAL',
+    })
+    return built
+  }
+
+  it('does not demand a refusal from a row that grades no cut at all', () => {
+    // Corrupting a payload that is not a diamond cut cannot make it one, so
+    // these rows can never refuse and must not be held against the probe.
+    expect(
+      gradeCorruptionProbe(
+        [{ proposal: '0xabc', ledger: nothingToCompare() }],
+        [{ proposal: '0xabc', ledger: nothingToCompare() }]
+      )
+    ).toBe('not-exercised')
+  })
+
+  it('still fails when a row that did grade a cut survives corruption', () => {
+    expect(
+      gradeCorruptionProbe(
+        [
+          { proposal: '0xabc', ledger: nothingToCompare() },
+          { proposal: '0xdef', ledger: ledgerWith('pass', '1.0.0') },
+        ],
+        [
+          { proposal: '0xabc', ledger: nothingToCompare() },
+          { proposal: '0xdef', ledger: ledgerWith('pass', '1.0.0') },
+        ]
+      )
+    ).toBe('did-not-refuse')
+  })
+})
+
+describe('gradeCorruptionProbe, on a row awaiting a human answer', () => {
+  it('counts a needs-ack row as one the chain had read and graded', () => {
+    // needs-ack means the bytes were read and understood, and only the intent
+    // is open. If corruption makes them unreadable, the chain noticed — which
+    // is exactly what the probe asks.
+    expect(
+      gradeCorruptionProbe(
+        [
+          {
+            proposal: '0xabc',
+            ledger: ledgerWith('needs-ack', 'matches-main'),
+          },
+        ],
+        [
+          {
+            proposal: '0xabc',
+            ledger: ledgerWith('error', 'calldata-not-readable'),
+          },
+        ]
+      )
+    ).toBe('refused')
+  })
+
+  it('fails when corruption leaves a needs-ack row still merely needing an ack', () => {
+    expect(
+      gradeCorruptionProbe(
+        [
+          {
+            proposal: '0xabc',
+            ledger: ledgerWith('needs-ack', 'matches-main'),
+          },
+        ],
+        [{ proposal: '0xabc', ledger: ledgerWith('needs-ack', 'matches-main') }]
+      )
+    ).toBe('did-not-refuse')
   })
 })

--- a/script/deploy/safe/rehearsal-run.test.ts
+++ b/script/deploy/safe/rehearsal-run.test.ts
@@ -1,0 +1,190 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  createCheckLedger,
+  recordCheck,
+  type ICheckLedger,
+} from './check-ledger'
+import {
+  collectRefusalObservations,
+  comparePasses,
+  gradeCorruptionProbe,
+  summariseRehearsal,
+} from './rehearsal-run'
+
+const ledgerWith = (
+  status: 'pass' | 'fail' | 'error' | 'needs-ack',
+  actual: string
+): ICheckLedger => {
+  const ledger = createCheckLedger({
+    expectedNetworks: ['tron'],
+    checks: [
+      {
+        checkId: 'target-state',
+        section: 'Intent',
+        checkClass: 'semantic',
+        title: 'Facet version matches the declared target state',
+      },
+    ],
+  })
+  recordCheck(ledger, {
+    checkId: 'target-state',
+    network: 'tron',
+    status,
+    expected: 'no installed version behind what origin/main declares',
+    actual,
+    anchor: 'A-LOCAL',
+  })
+  return ledger
+}
+
+describe('comparePasses', () => {
+  it('finds nothing when two passes graded identically', () => {
+    const findings = comparePasses(
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }]
+    )
+
+    expect(findings).toEqual([])
+  })
+
+  it('reports a status that changed between passes', () => {
+    const findings = comparePasses(
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      [{ proposal: '0xabc', ledger: ledgerWith('error', '1.0.0') }]
+    )
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.field).toBe('status')
+    expect(findings[0]?.first).toBe('pass')
+    expect(findings[0]?.second).toBe('error')
+  })
+
+  it('reports an observed value that changed while the status held', () => {
+    const findings = comparePasses(
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '2.0.0') }]
+    )
+
+    expect(findings.map((finding) => finding.field)).toEqual(['actual'])
+  })
+
+  it('reports a proposal one pass graded and the other did not', () => {
+    const findings = comparePasses(
+      [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      []
+    )
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]?.field).toBe('proposal')
+  })
+})
+
+describe('collectRefusalObservations', () => {
+  it('marks a refusing row as refused and carries its reason', () => {
+    const observations = collectRefusalObservations([
+      { proposal: '0xabc', ledger: ledgerWith('fail', 'downgrade') },
+    ])
+
+    expect(observations).toHaveLength(1)
+    expect(observations[0]?.refused).toBe(true)
+    expect(observations[0]?.slot).toBe('0xabc/target-state/tron')
+    expect(observations[0]?.reason).toContain('downgrade')
+  })
+
+  it('does not count a passing row as a refusal', () => {
+    const observations = collectRefusalObservations([
+      { proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') },
+    ])
+
+    expect(observations[0]?.refused).toBe(false)
+  })
+
+  it('counts a needs-ack row as a refusal a signer must answer', () => {
+    const observations = collectRefusalObservations([
+      { proposal: '0xabc', ledger: ledgerWith('needs-ack', '1.0.0') },
+    ])
+
+    expect(observations[0]?.refused).toBe(true)
+  })
+})
+
+describe('summariseRehearsal', () => {
+  it('refuses to call a run over nothing deterministic', () => {
+    const summary = summariseRehearsal({ first: [], second: [] })
+
+    expect(summary.rowsGraded).toBe(0)
+    expect(summary.deterministic).toBeUndefined()
+    expect(summary.verdict).toBe('not-measured')
+  })
+
+  it('calls two agreeing passes over real rows deterministic', () => {
+    const summary = summariseRehearsal({
+      first: [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      second: [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+    })
+
+    expect(summary.rowsGraded).toBe(1)
+    expect(summary.deterministic).toBe(true)
+    expect(summary.verdict).toBe('deterministic')
+  })
+
+  it('reports disagreement rather than determinism', () => {
+    const summary = summariseRehearsal({
+      first: [{ proposal: '0xabc', ledger: ledgerWith('pass', '1.0.0') }],
+      second: [{ proposal: '0xabc', ledger: ledgerWith('fail', '1.0.0') }],
+    })
+
+    expect(summary.deterministic).toBe(false)
+    expect(summary.verdict).toBe('non-deterministic')
+    expect(summary.findings).toHaveLength(1)
+  })
+})
+
+describe('gradeCorruptionProbe', () => {
+  it('says nothing was exercised when there was nothing to corrupt', () => {
+    expect(gradeCorruptionProbe([])).toBe('not-exercised')
+  })
+
+  it('passes when the damaged input drew a refusal', () => {
+    expect(
+      gradeCorruptionProbe([
+        { proposal: '0xabc', ledger: ledgerWith('fail', 'corrupted') },
+      ])
+    ).toBe('refused')
+  })
+
+  it('fails when damaged input was graded clean', () => {
+    expect(
+      gradeCorruptionProbe([
+        { proposal: '0xabc', ledger: ledgerWith('pass', 'corrupted') },
+      ])
+    ).toBe('did-not-refuse')
+  })
+})
+
+describe('collectRefusalObservations, classifying a known-correct refusal', () => {
+  it('marks an unresolved deployment record as a true positive', () => {
+    const observations = collectRefusalObservations([
+      {
+        proposal: '0xabc',
+        ledger: ledgerWith('error', '0xfee: contract-unidentified'),
+      },
+    ])
+
+    expect(observations[0]?.truePositive).toBe(true)
+  })
+
+  it('leaves an unrecognised refusal unexplained', () => {
+    const observations = collectRefusalObservations([
+      { proposal: '0xabc', ledger: ledgerWith('fail', 'downgrade') },
+    ])
+
+    expect(observations[0]?.truePositive).toBeUndefined()
+  })
+})

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -366,3 +366,30 @@ export const rowCountsByCheck = (
       counts[result.checkId] = (counts[result.checkId] ?? 0) + 1
   return counts
 }
+
+/**
+ * The distinct refusal classes a run actually produced.
+ *
+ * A refusal budget divides refusals into true positives, named false reds and
+ * unexplained. When only one class is reachable and this release has already
+ * ruled that class correct, every refusal lands in the first bucket and the
+ * unexplained count is 0 for any corpus, on any day — a constant rather than a
+ * measurement. Counting the classes is how the caller can tell the two apart
+ * and decline to publish a rate that cannot vary.
+ *
+ * @param pass - one pass's per-proposal ledgers
+ * @returns each distinct class, in first-seen order
+ */
+export const refusalClasses = (
+  pass: readonly IRehearsalPassEntry[]
+): readonly string[] => {
+  const classes = new Set<string>()
+  for (const observation of collectRefusalObservations(pass)) {
+    if (!observation.refused) continue
+    for (const clause of observation.reason.split('; ')) {
+      const verdict = clause.slice(clause.lastIndexOf(': ') + 2).trim()
+      if (verdict) classes.add(verdict)
+    }
+  }
+  return [...classes]
+}

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -15,6 +15,7 @@
 import { type IShadowObservation } from '../codehash/false-refusal-budget'
 
 import { checkResultKey, type ICheckLedger } from './check-ledger'
+import { NOTHING_TO_COMPARE } from './confirm-check-registry'
 
 /** One proposal's ledger, as one pass graded it. */
 export interface IRehearsalPassEntry {
@@ -299,23 +300,47 @@ export const gradeCorruptionProbe = (
   baseline: readonly IRehearsalPassEntry[],
   corrupted: readonly IRehearsalPassEntry[]
 ): CorruptionProbeOutcome => {
-  const afterCorruption = new Map(
-    collectRefusalObservations(corrupted).map((observation) => [
-      observation.slot,
-      observation.refused,
-    ])
-  )
+  const afterCorruption = hardRefusalsBySlot(corrupted)
+  const population = gradedPopulation(baseline)
+  if (population.length === 0) return 'not-exercised'
 
-  const wasClean = collectRefusalObservations(baseline).filter(
-    (observation) => !observation.refused
-  )
-  if (wasClean.length === 0) return 'not-exercised'
-
-  return wasClean.every(
-    (observation) => afterCorruption.get(observation.slot) === true
-  )
+  return population.every((slot) => afterCorruption.get(slot) === true)
     ? 'refused'
     : 'did-not-refuse'
+}
+
+/**
+ * The statuses that mean the chain stopped on the bytes themselves.
+ *
+ * Narrower than {@link REFUSING_STATUSES}, which the budget uses. `needs-ack`
+ * belongs there — it costs a signer attention — but not here: it says the
+ * payload was read and understood and only the intent is open, which is the
+ * opposite of the chain having caught damage.
+ */
+const HARD_REFUSING_STATUSES: ReadonlySet<string> = new Set(['fail', 'error'])
+
+/**
+ * The rows a corruption probe may legitimately hold to account.
+ *
+ * Two exclusions, both because the row cannot answer the question. A row that
+ * already refused proves nothing by refusing again. A row the gate graded as
+ * having no cut to compare cannot be made to refuse at all: damaging a payload
+ * that is not a diamond cut leaves it not a diamond cut, so demanding a refusal
+ * from it makes the probe permanently red for a reason that is about the corpus
+ * rather than about the chain.
+ */
+const gradedPopulation = (
+  baseline: readonly IRehearsalPassEntry[]
+): readonly string[] => {
+  const slots: string[] = []
+  for (const entry of baseline)
+    for (const result of outcomesOf(entry.ledger).values()) {
+      // Already stopped on the bytes, so refusing again proves nothing.
+      if (HARD_REFUSING_STATUSES.has(result.status)) continue
+      if (result.expected === NOTHING_TO_COMPARE) continue
+      slots.push(`${entry.proposal}/${result.checkId}/${result.network}`)
+    }
+  return slots
 }
 
 /**
@@ -333,16 +358,24 @@ export const survivedCorruption = (
   baseline: readonly IRehearsalPassEntry[],
   corrupted: readonly IRehearsalPassEntry[]
 ): readonly string[] => {
-  const afterCorruption = new Map(
-    collectRefusalObservations(corrupted).map((observation) => [
-      observation.slot,
-      observation.refused,
-    ])
+  const afterCorruption = hardRefusalsBySlot(corrupted)
+  return gradedPopulation(baseline).filter(
+    (slot) => afterCorruption.get(slot) !== true
   )
-  return collectRefusalObservations(baseline)
-    .filter((observation) => !observation.refused)
-    .filter((observation) => afterCorruption.get(observation.slot) !== true)
-    .map((observation) => observation.slot)
+}
+
+/** Which slots the chain stopped on outright, keyed for lookup. */
+const hardRefusalsBySlot = (
+  pass: readonly IRehearsalPassEntry[]
+): Map<string, boolean> => {
+  const refusals = new Map<string, boolean>()
+  for (const entry of pass)
+    for (const result of outcomesOf(entry.ledger).values())
+      refusals.set(
+        `${entry.proposal}/${result.checkId}/${result.network}`,
+        HARD_REFUSING_STATUSES.has(result.status)
+      )
+  return refusals
 }
 
 /**

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -1,10 +1,11 @@
 /**
- * Runs the confirm gate chain twice over one proposal set and grades the result.
+ * Grades two passes of the confirm gate chain against each other.
  *
- * Import this from the rehearsal CLI. The chain itself is injected rather than
- * imported: `confirm-safe-tx.ts` is an interactive command that signs, and the
- * rehearsal must be able to run the gates without going anywhere near that
- * path. Injecting it also keeps this module off the file EXSC-994 is rewriting.
+ * Import this from the rehearsal CLI, which runs the chain and hands the
+ * resulting ledgers here. Running it is deliberately not this module's job:
+ * `confirm-safe-tx.ts` is an interactive command that signs, so the rehearsal
+ * reaches the gates without going near that path, and the grading stays
+ * testable without a store or a chain behind it.
  *
  * Two passes over the same input must produce the same verdicts. A difference
  * is not noise to retry past — it means something in the chain reads a moving

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -287,10 +287,11 @@ export type CorruptionProbeOutcome =
  * *anything* refused answers yes before the corruption is applied — it reports
  * success on a chain that graded every damaged proposal clean.
  *
- * The population that carries the evidence is therefore the rows that passed
- * *before* corruption: each of those must refuse after it. A corpus with none
- * of them is `not-exercised` rather than a pass, for the same reason an empty
- * run is not deterministic.
+ * The population that carries the evidence is the rows the chain had read and
+ * graded without stopping on them — which includes `needs-ack`, where the bytes
+ * were understood and only the intent is open. Each of those must refuse after
+ * corruption. A corpus with none of them is `not-exercised` rather than a pass,
+ * for the same reason an empty run is not deterministic.
  *
  * @param baseline - the pass over undamaged input
  * @param corrupted - the pass over deliberately damaged input
@@ -344,11 +345,10 @@ const gradedPopulation = (
 }
 
 /**
- * The rows that were clean before corruption and stayed clean after it.
+ * The rows the chain graded the same way before and after corruption.
  *
- * Reported rather than merely counted: these are proposals the chain read as
- * damaged and graded green anyway, which is the finding the probe exists to
- * produce.
+ * Reported rather than merely counted: these are proposals whose damaged bytes
+ * changed no verdict, which is the finding the probe exists to produce.
  *
  * @param baseline - the pass over undamaged input
  * @param corrupted - the pass over deliberately damaged input
@@ -420,7 +420,10 @@ export const refusalClasses = (
   for (const observation of collectRefusalObservations(pass)) {
     if (!observation.refused) continue
     for (const clause of observation.reason.split('; ')) {
-      const verdict = clause.slice(clause.lastIndexOf(': ') + 2).trim()
+      const separator = clause.lastIndexOf(': ')
+      const verdict = (
+        separator === -1 ? clause : clause.slice(separator + 2)
+      ).trim()
       if (verdict) classes.add(verdict)
     }
   }

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -345,14 +345,16 @@ const gradedPopulation = (
 }
 
 /**
- * The rows the chain graded the same way before and after corruption.
+ * The rows that did not refuse once their calldata was damaged.
  *
- * Reported rather than merely counted: these are proposals whose damaged bytes
- * changed no verdict, which is the finding the probe exists to produce.
+ * Reported rather than merely counted: these are proposals the chain still let
+ * through after the bytes changed, which is the finding the probe exists to
+ * produce. A row whose verdict merely shifted without refusing counts here too
+ * — the question is whether the chain stopped, not whether it noticed.
  *
  * @param baseline - the pass over undamaged input
  * @param corrupted - the pass over deliberately damaged input
- * @returns the slots that survived corruption ungraded
+ * @returns the slots that failed to refuse
  */
 export const survivedCorruption = (
   baseline: readonly IRehearsalPassEntry[],

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -1,0 +1,261 @@
+/**
+ * Runs the confirm gate chain twice over one proposal set and grades the result.
+ *
+ * Import this from the rehearsal CLI. The chain itself is injected rather than
+ * imported: `confirm-safe-tx.ts` is an interactive command that signs, and the
+ * rehearsal must be able to run the gates without going anywhere near that
+ * path. Injecting it also keeps this module off the file EXSC-994 is rewriting.
+ *
+ * Two passes over the same input must produce the same verdicts. A difference
+ * is not noise to retry past — it means something in the chain reads a moving
+ * value, and that finding is worth more than a green run.
+ */
+
+import { type IShadowObservation } from '../codehash/false-refusal-budget'
+
+import { checkResultKey, type ICheckLedger } from './check-ledger'
+
+/** One proposal's ledger, as one pass graded it. */
+export interface IRehearsalPassEntry {
+  /** Stable identity of the proposal — its `safeTxHash` in a live run. */
+  readonly proposal: string
+  readonly ledger: ICheckLedger
+}
+
+/** One field of one row that two passes disagreed about. */
+export interface IDeterminismFinding {
+  readonly proposal: string
+  readonly checkId: string
+  readonly network: string
+  readonly field: 'proposal' | 'status' | 'actual' | 'expected' | 'anchor'
+  readonly first: string
+  readonly second: string
+}
+
+/** The fields a pass must reproduce exactly, and how to read each off a row. */
+const COMPARED_FIELDS = ['status', 'expected', 'actual', 'anchor'] as const
+
+/**
+ * The last result recorded for each (check, network) pair.
+ *
+ * The ledger is an append log whose last entry for a pair is the outcome, so a
+ * comparison over every entry would report a superseded mismatch as a
+ * difference on a run that in fact agreed.
+ */
+const outcomesOf = (ledger: ICheckLedger) => {
+  const outcomes = new Map<string, ICheckLedger['results'][number]>()
+  for (const result of ledger.results)
+    outcomes.set(checkResultKey(result.checkId, result.network), result)
+  return outcomes
+}
+
+/**
+ * Compares two passes over the same proposal set.
+ *
+ * @param first - the first pass
+ * @param second - the second pass
+ * @returns one finding per field the two passes disagreed about, empty when
+ * they agreed everywhere
+ */
+export const comparePasses = (
+  first: readonly IRehearsalPassEntry[],
+  second: readonly IRehearsalPassEntry[]
+): readonly IDeterminismFinding[] => {
+  const findings: IDeterminismFinding[] = []
+  const secondByProposal = new Map(
+    second.map((entry) => [entry.proposal, entry])
+  )
+
+  for (const entry of first) {
+    const counterpart = secondByProposal.get(entry.proposal)
+    if (!counterpart) {
+      findings.push({
+        proposal: entry.proposal,
+        checkId: '-',
+        network: '-',
+        field: 'proposal',
+        first: 'graded',
+        second: 'absent',
+      })
+      continue
+    }
+
+    const firstOutcomes = outcomesOf(entry.ledger)
+    const secondOutcomes = outcomesOf(counterpart.ledger)
+
+    for (const [key, firstResult] of firstOutcomes) {
+      const secondResult = secondOutcomes.get(key)
+      if (!secondResult) {
+        findings.push({
+          proposal: entry.proposal,
+          checkId: firstResult.checkId,
+          network: firstResult.network,
+          field: 'status',
+          first: firstResult.status,
+          second: 'not recorded',
+        })
+        continue
+      }
+
+      for (const field of COMPARED_FIELDS)
+        if (firstResult[field] !== secondResult[field])
+          findings.push({
+            proposal: entry.proposal,
+            checkId: firstResult.checkId,
+            network: firstResult.network,
+            field,
+            first: String(firstResult[field]),
+            second: String(secondResult[field]),
+          })
+    }
+  }
+
+  for (const entry of second)
+    if (!first.some((candidate) => candidate.proposal === entry.proposal))
+      findings.push({
+        proposal: entry.proposal,
+        checkId: '-',
+        network: '-',
+        field: 'proposal',
+        first: 'absent',
+        second: 'graded',
+      })
+
+  return findings
+}
+
+/**
+ * Every status that stops a signer, and so counts as a refusal to be graded.
+ *
+ * `needs-ack` is in: it is a row a human has to answer before the run proceeds,
+ * so a chain that produces one on a correct proposal is costing a signer the
+ * same attention a red does, which is exactly what a false-refusal budget
+ * measures.
+ */
+const REFUSING_STATUSES: ReadonlySet<string> = new Set([
+  'fail',
+  'error',
+  'needs-ack',
+])
+
+/**
+ * The refusal this release has already decided is correct.
+ *
+ * Third-party deploys are parked for V2 (EXSC-982, EXSC-879), so a cut naming a
+ * facet no deployment record resolves is a proposal the gate is right to refuse
+ * — not a false red to be budgeted against.
+ *
+ * Deliberately narrow, and deliberately not a new entry in the budget's own
+ * `ACCEPTED_FALSE_RED_RULES`: that list is closed because growing it is how a
+ * budget of zero is faked. This marks the class as a true positive, which is
+ * the caller-supplied classification the budget is designed to take.
+ */
+const KNOWN_CORRECT_REFUSAL = 'contract-unidentified'
+
+/**
+ * Turns one pass's ledgers into observations the false-refusal budget can grade.
+ *
+ * Every row becomes an observation, refusing or not, because the budget's
+ * denominator is rows graded rather than refusals seen — a loader that emitted
+ * only the refusals would report a rate of 1.0 on a clean run.
+ *
+ * @param pass - one pass's per-proposal ledgers
+ * @returns one observation per recorded row
+ */
+export const collectRefusalObservations = (
+  pass: readonly IRehearsalPassEntry[]
+): readonly IShadowObservation[] =>
+  pass.flatMap((entry) =>
+    [...outcomesOf(entry.ledger).values()].map((result) => ({
+      slot: `${entry.proposal}/${result.checkId}/${result.network}`,
+      refused: REFUSING_STATUSES.has(result.status),
+      reason: REFUSING_STATUSES.has(result.status)
+        ? `${result.status}: expected ${result.expected}, observed ${result.actual}`
+        : '',
+      ...(REFUSING_STATUSES.has(result.status) &&
+      result.actual.includes(KNOWN_CORRECT_REFUSAL)
+        ? { truePositive: true }
+        : {}),
+    }))
+  )
+
+/**
+ * What a rehearsal established, or failed to.
+ *
+ * `not-measured` is its own verdict rather than a green with a zero next to it.
+ * Two passes over an empty corpus agree perfectly, so a boolean alone would
+ * report a run that graded nothing as deterministic — the same mistake the
+ * false-refusal budget guards against by refusing to divide by zero.
+ */
+export type RehearsalVerdict =
+  | 'deterministic'
+  | 'non-deterministic'
+  | 'not-measured'
+
+export interface IRehearsalSummary {
+  readonly rowsGraded: number
+  /** Undefined when nothing was graded — neither true nor false is honest there. */
+  readonly deterministic: boolean | undefined
+  readonly verdict: RehearsalVerdict
+  readonly findings: readonly IDeterminismFinding[]
+}
+
+/**
+ * Grades two passes, keeping "agreed" apart from "had nothing to disagree on".
+ *
+ * @param passes.first - the first pass
+ * @param passes.second - the second pass over the same input
+ * @returns the rows graded, the findings, and a verdict that says which of the
+ * three outcomes this was
+ */
+export const summariseRehearsal = (passes: {
+  first: readonly IRehearsalPassEntry[]
+  second: readonly IRehearsalPassEntry[]
+}): IRehearsalSummary => {
+  const rowsGraded = passes.first.reduce(
+    (total, entry) => total + outcomesOf(entry.ledger).size,
+    0
+  )
+  const findings = comparePasses(passes.first, passes.second)
+
+  if (rowsGraded === 0)
+    return {
+      rowsGraded,
+      deterministic: undefined,
+      verdict: 'not-measured',
+      findings,
+    }
+
+  return {
+    rowsGraded,
+    deterministic: findings.length === 0,
+    verdict: findings.length === 0 ? 'deterministic' : 'non-deterministic',
+    findings,
+  }
+}
+
+/** Whether the deliberately damaged pass proved the chain can still refuse. */
+export type CorruptionProbeOutcome =
+  | 'refused'
+  | 'did-not-refuse'
+  | 'not-exercised'
+
+/**
+ * Grades the corruption probe.
+ *
+ * An empty pass is `not-exercised`, never `did-not-refuse`: a corpus with
+ * nothing in it to damage says nothing about whether the chain can refuse, and
+ * reporting it as a failure would train a reader to ignore the real one.
+ *
+ * @param corrupted - the pass run over deliberately damaged input
+ * @returns which of the three outcomes the probe reached
+ */
+export const gradeCorruptionProbe = (
+  corrupted: readonly IRehearsalPassEntry[]
+): CorruptionProbeOutcome => {
+  const observations = collectRefusalObservations(corrupted)
+  if (observations.length === 0) return 'not-exercised'
+  return observations.some((observation) => observation.refused)
+    ? 'refused'
+    : 'did-not-refuse'
+}

--- a/script/deploy/safe/rehearsal-run.ts
+++ b/script/deploy/safe/rehearsal-run.ts
@@ -109,6 +109,21 @@ export const comparePasses = (
             second: String(secondResult[field]),
           })
     }
+
+    // The second pass's own keys, for the mirror case. Walking only the first
+    // pass's would grade a run green where the second answered for a check or
+    // network the first never reached — a pass that did strictly more work
+    // reads as agreement.
+    for (const [key, secondResult] of secondOutcomes)
+      if (!firstOutcomes.has(key))
+        findings.push({
+          proposal: entry.proposal,
+          checkId: secondResult.checkId,
+          network: secondResult.network,
+          field: 'status',
+          first: 'not recorded',
+          second: secondResult.status,
+        })
   }
 
   for (const entry of second)
@@ -154,6 +169,25 @@ const REFUSING_STATUSES: ReadonlySet<string> = new Set([
 const KNOWN_CORRECT_REFUSAL = 'contract-unidentified'
 
 /**
+ * Whether every finding behind a refusal is the known-correct class.
+ *
+ * `actual` joins one clause per failing element, so a substring test over the
+ * whole string lets one unidentified element launder the rest of the cut — a
+ * version **downgrade**, the most dangerous verdict this gate produces, would
+ * be filed as expected because some other element in the same cut resolved to
+ * nothing. Each clause must end in the class for the refusal to count as one,
+ * and the suffix is anchored so a contract whose own name contains the phrase
+ * cannot qualify on its name alone.
+ */
+const isKnownCorrectRefusal = (actual: string): boolean => {
+  const clauses = actual.split('; ').filter(Boolean)
+  return (
+    clauses.length > 0 &&
+    clauses.every((clause) => clause.endsWith(`: ${KNOWN_CORRECT_REFUSAL}`))
+  )
+}
+
+/**
  * Turns one pass's ledgers into observations the false-refusal budget can grade.
  *
  * Every row becomes an observation, refusing or not, because the budget's
@@ -174,7 +208,7 @@ export const collectRefusalObservations = (
         ? `${result.status}: expected ${result.expected}, observed ${result.actual}`
         : '',
       ...(REFUSING_STATUSES.has(result.status) &&
-      result.actual.includes(KNOWN_CORRECT_REFUSAL)
+      isKnownCorrectRefusal(result.actual)
         ? { truePositive: true }
         : {}),
     }))
@@ -219,7 +253,10 @@ export const summariseRehearsal = (passes: {
   )
   const findings = comparePasses(passes.first, passes.second)
 
-  if (rowsGraded === 0)
+  // Only a run that graded nothing *and* found nothing is unmeasured. An
+  // asymmetric pair grades zero rows on one side while still disagreeing, and
+  // calling that "not measured" would file a real difference as an absence.
+  if (rowsGraded === 0 && findings.length === 0)
     return {
       rowsGraded,
       deterministic: undefined,
@@ -242,21 +279,90 @@ export type CorruptionProbeOutcome =
   | 'not-exercised'
 
 /**
- * Grades the corruption probe.
+ * Grades the corruption probe, row by row against the undamaged baseline.
  *
- * An empty pass is `not-exercised`, never `did-not-refuse`: a corpus with
- * nothing in it to damage says nothing about whether the chain can refuse, and
- * reporting it as a failure would train a reader to ignore the real one.
+ * Graded per row because "some row refused" is not evidence. On real corpora
+ * most rows already refuse for their own reasons, so a probe asking whether
+ * *anything* refused answers yes before the corruption is applied — it reports
+ * success on a chain that graded every damaged proposal clean.
  *
- * @param corrupted - the pass run over deliberately damaged input
+ * The population that carries the evidence is therefore the rows that passed
+ * *before* corruption: each of those must refuse after it. A corpus with none
+ * of them is `not-exercised` rather than a pass, for the same reason an empty
+ * run is not deterministic.
+ *
+ * @param baseline - the pass over undamaged input
+ * @param corrupted - the pass over deliberately damaged input
  * @returns which of the three outcomes the probe reached
  */
 export const gradeCorruptionProbe = (
+  baseline: readonly IRehearsalPassEntry[],
   corrupted: readonly IRehearsalPassEntry[]
 ): CorruptionProbeOutcome => {
-  const observations = collectRefusalObservations(corrupted)
-  if (observations.length === 0) return 'not-exercised'
-  return observations.some((observation) => observation.refused)
+  const afterCorruption = new Map(
+    collectRefusalObservations(corrupted).map((observation) => [
+      observation.slot,
+      observation.refused,
+    ])
+  )
+
+  const wasClean = collectRefusalObservations(baseline).filter(
+    (observation) => !observation.refused
+  )
+  if (wasClean.length === 0) return 'not-exercised'
+
+  return wasClean.every(
+    (observation) => afterCorruption.get(observation.slot) === true
+  )
     ? 'refused'
     : 'did-not-refuse'
+}
+
+/**
+ * The rows that were clean before corruption and stayed clean after it.
+ *
+ * Reported rather than merely counted: these are proposals the chain read as
+ * damaged and graded green anyway, which is the finding the probe exists to
+ * produce.
+ *
+ * @param baseline - the pass over undamaged input
+ * @param corrupted - the pass over deliberately damaged input
+ * @returns the slots that survived corruption ungraded
+ */
+export const survivedCorruption = (
+  baseline: readonly IRehearsalPassEntry[],
+  corrupted: readonly IRehearsalPassEntry[]
+): readonly string[] => {
+  const afterCorruption = new Map(
+    collectRefusalObservations(corrupted).map((observation) => [
+      observation.slot,
+      observation.refused,
+    ])
+  )
+  return collectRefusalObservations(baseline)
+    .filter((observation) => !observation.refused)
+    .filter((observation) => afterCorruption.get(observation.slot) !== true)
+    .map((observation) => observation.slot)
+}
+
+/**
+ * Rows each check answered for, counted once per (check, network).
+ *
+ * Counted off the deduplicated outcomes rather than the ledger's append log, so
+ * the roster's `rows=` and the determinism summary's `rowsGraded` are derived
+ * the same way. A check that supersedes a result — which `check-ledger.ts`
+ * documents as expected — would otherwise be counted twice in one report
+ * section and once in the other.
+ *
+ * @param pass - one pass's per-proposal ledgers
+ * @returns row count keyed by check id
+ */
+export const rowCountsByCheck = (
+  pass: readonly IRehearsalPassEntry[]
+): Record<string, number> => {
+  const counts: Record<string, number> = {}
+  for (const entry of pass)
+    for (const result of outcomesOf(entry.ledger).values())
+      counts[result.checkId] = (counts[result.checkId] ?? 0) + 1
+  return counts
 }

--- a/script/deploy/safe/rehearsal-teardown.test.ts
+++ b/script/deploy/safe/rehearsal-teardown.test.ts
@@ -71,11 +71,11 @@ function fakeCollection(rows: Record<string, unknown>[]) {
 const TRON_SAFE_LOWER = '0x43761f2fb70c8cabd94707cb34d0a012f5857936'
 const TRON_SAFE_CHECKSUMMED = '0x43761F2fB70C8cAbD94707cb34D0a012f5857936'
 
-const row = (nonce: number, safeAddress: string) => ({
+const row = (nonce: number, safeAddress: string, status = 'pending') => ({
   network: 'tron',
   chainId: 728126428,
   safeAddress,
-  status: 'pending',
+  status,
   safeTxHash: `0xhash${nonce}`,
   safeTx: { data: { nonce } },
 })
@@ -175,5 +175,58 @@ describe('tearDownProposalsAtNonce', () => {
 
     expect(deleted).toEqual(['0xhash31'])
     expect(results.map((result) => result.outcome)).toEqual(['deleted'])
+  })
+})
+
+describe('the statuses a teardown is allowed to touch', () => {
+  it('does not find an executed row occupying the same nonce', async () => {
+    const found = await findProposalsAtNonce(
+      fakeCollection([row(31, TRON_SAFE_LOWER, 'executed')]) as never,
+      {
+        network: 'tron',
+        chainId: 728126428,
+        safeAddress: TRON_SAFE_CHECKSUMMED,
+        nonce: 31,
+      }
+    )
+
+    expect(found).toEqual([])
+  })
+
+  it('finds a submitted row, which still holds the nonce', async () => {
+    const found = await findProposalsAtNonce(
+      fakeCollection([row(31, TRON_SAFE_LOWER, 'submitted')]) as never,
+      {
+        network: 'tron',
+        chainId: 728126428,
+        safeAddress: TRON_SAFE_CHECKSUMMED,
+        nonce: 31,
+      }
+    )
+
+    expect(found).toHaveLength(1)
+  })
+
+  it('refuses to delete anything that is not pending', async () => {
+    const deleted: string[] = []
+    const rows = [row(31, TRON_SAFE_LOWER, 'submitted')]
+    const collection = {
+      ...fakeCollection(rows),
+      findOne: () => Promise.resolve(rows[0] ?? null),
+      deleteOne: (filter: Record<string, unknown>) => {
+        deleted.push((filter.safeTxHash as { $eq: string }).$eq)
+        return Promise.resolve({ deletedCount: 1 })
+      },
+    }
+
+    const results = await tearDownProposalsAtNonce(collection as never, {
+      network: 'tron',
+      chainId: 728126428,
+      safeAddress: TRON_SAFE_CHECKSUMMED,
+      nonce: 31,
+    })
+
+    expect(deleted).toEqual([])
+    expect(results).toEqual([])
   })
 })

--- a/script/deploy/safe/rehearsal-teardown.test.ts
+++ b/script/deploy/safe/rehearsal-teardown.test.ts
@@ -1,0 +1,141 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import { findProposalsAtNonce } from './rehearsal-teardown'
+import { getNextNonce } from './safe-utils'
+
+/**
+ * A collection that matches `safeAddress` case-sensitively until a collation is
+ * applied, which is the one behaviour of the real store these tests turn on.
+ *
+ * Faithful to what the production store actually does: a `countDocuments` for
+ * the checksummed spelling of the Tron Safe returns 0 uncollated and 34
+ * collated (measured 2026-09-12).
+ */
+function fakeCollection(rows: Record<string, unknown>[]) {
+  return {
+    find(filter: Record<string, unknown>) {
+      let collated = false
+      const cursor = {
+        collation() {
+          collated = true
+          return cursor
+        },
+        sort() {
+          return cursor
+        },
+        limit() {
+          return cursor
+        },
+        toArray() {
+          return Promise.resolve(
+            rows.filter((row) =>
+              Object.entries(filter).every(([key, expected]) => {
+                const actual = key
+                  .split('.')
+                  .reduce<unknown>(
+                    (value, segment) =>
+                      (value as Record<string, unknown> | undefined)?.[segment],
+                    row
+                  )
+                if (
+                  expected &&
+                  typeof expected === 'object' &&
+                  '$in' in expected
+                )
+                  return (expected as { $in: unknown[] }).$in.includes(actual)
+                if (
+                  collated &&
+                  typeof actual === 'string' &&
+                  typeof expected === 'string'
+                )
+                  return actual.toLowerCase() === expected.toLowerCase()
+                return actual === expected
+              })
+            )
+          )
+        },
+      }
+      return cursor
+    },
+  }
+}
+
+const TRON_SAFE_LOWER = '0x43761f2fb70c8cabd94707cb34d0a012f5857936'
+const TRON_SAFE_CHECKSUMMED = '0x43761F2fB70C8cAbD94707cb34D0a012f5857936'
+
+const row = (nonce: number, safeAddress: string) => ({
+  network: 'tron',
+  chainId: 728126428,
+  safeAddress,
+  status: 'pending',
+  safeTxHash: `0xhash${nonce}`,
+  safeTx: { data: { nonce } },
+})
+
+describe('findProposalsAtNonce', () => {
+  it('finds a row stored under a different spelling of the same Safe', async () => {
+    const collection = fakeCollection([
+      row(30, TRON_SAFE_LOWER),
+      row(31, TRON_SAFE_LOWER),
+    ])
+
+    const found = await findProposalsAtNonce(collection as never, {
+      network: 'tron',
+      chainId: 728126428,
+      safeAddress: TRON_SAFE_CHECKSUMMED,
+      nonce: 31,
+    })
+
+    expect(found.map((doc) => doc.safeTxHash)).toEqual(['0xhash31'])
+  })
+})
+
+describe('the nonce slot a dummy occupies', () => {
+  it('is handed back to the next proposal once the row is deleted', async () => {
+    const onChainNonce = 30n
+    const dummy = row(30, TRON_SAFE_LOWER)
+    const rows = [dummy]
+    const collection = fakeCollection(rows)
+
+    const whileHeld = await getNextNonce(
+      collection as never,
+      TRON_SAFE_LOWER,
+      'tron',
+      728126428,
+      onChainNonce
+    )
+    expect(whileHeld).toBe(31n)
+
+    rows.splice(0, rows.length)
+
+    const afterTeardown = await getNextNonce(
+      collection as never,
+      TRON_SAFE_LOWER,
+      'tron',
+      728126428,
+      onChainNonce
+    )
+    expect(afterTeardown).toBe(onChainNonce)
+  })
+})
+
+describe('findProposalsAtNonce, when nothing holds the slot', () => {
+  it('returns no rows rather than throwing', async () => {
+    const found = await findProposalsAtNonce(
+      fakeCollection([row(30, TRON_SAFE_LOWER)]) as never,
+      {
+        network: 'tron',
+        chainId: 728126428,
+        safeAddress: TRON_SAFE_CHECKSUMMED,
+        nonce: 99,
+      }
+    )
+
+    expect(found).toEqual([])
+  })
+})

--- a/script/deploy/safe/rehearsal-teardown.test.ts
+++ b/script/deploy/safe/rehearsal-teardown.test.ts
@@ -5,7 +5,10 @@ import {
   // eslint-disable-next-line import/no-unresolved
 } from 'bun:test'
 
-import { findProposalsAtNonce } from './rehearsal-teardown'
+import {
+  findProposalsAtNonce,
+  tearDownProposalsAtNonce,
+} from './rehearsal-teardown'
 import { getNextNonce } from './safe-utils'
 
 /**
@@ -137,5 +140,40 @@ describe('findProposalsAtNonce, when nothing holds the slot', () => {
     )
 
     expect(found).toEqual([])
+  })
+})
+
+describe('tearDownProposalsAtNonce', () => {
+  it('deletes rows even when the operator typed the network in the wrong case', async () => {
+    const rows = [row(31, TRON_SAFE_LOWER)]
+    const deleted: string[] = []
+    const collection = {
+      ...fakeCollection(rows),
+      findOne: (filter: Record<string, unknown>) =>
+        Promise.resolve(
+          rows.find(
+            (candidate) =>
+              candidate.network ===
+                (filter.network as { $eq: string } | undefined)?.$eq &&
+              candidate.safeTxHash ===
+                (filter.safeTxHash as { $eq: string } | undefined)?.$eq
+          ) ?? null
+        ),
+      deleteOne: (filter: Record<string, unknown>) => {
+        const hash = (filter.safeTxHash as { $eq: string }).$eq
+        deleted.push(hash)
+        return Promise.resolve({ deletedCount: 1 })
+      },
+    }
+
+    const results = await tearDownProposalsAtNonce(collection as never, {
+      network: 'Tron',
+      chainId: 728126428,
+      safeAddress: TRON_SAFE_CHECKSUMMED,
+      nonce: 31,
+    })
+
+    expect(deleted).toEqual(['0xhash31'])
+    expect(results.map((result) => result.outcome)).toEqual(['deleted'])
   })
 })

--- a/script/deploy/safe/rehearsal-teardown.ts
+++ b/script/deploy/safe/rehearsal-teardown.ts
@@ -21,11 +21,32 @@ import {
   deletePendingProposals,
   type IDeleteResult,
 } from './delete-pending-proposals'
+import { printableField } from './printable-field'
 import {
   ADDRESS_COLLATION,
   type ISafeTxDocument,
+  type SafeTxStatus,
   getSafeMongoCollection,
 } from './safe-utils'
+
+/**
+ * The statuses that still occupy a Safe nonce.
+ *
+ * The same pair `getNextNonce` counts: a broadcast-but-unconfirmed transaction
+ * holds its nonce as firmly as a pending one. `executed` and `reverted` are
+ * history and must never be matched by a teardown.
+ */
+const NONCE_HOLDING_STATUSES: readonly SafeTxStatus[] = ['pending', 'submitted']
+
+/**
+ * The only status a teardown may delete.
+ *
+ * A `submitted` row has already been broadcast and its outcome is unknown, so
+ * deleting it would drop the record of a transaction that may well have landed.
+ * The hunt reports those; clearing one is a decision for a human with the chain
+ * in front of them.
+ */
+const DELETABLE_STATUS: SafeTxStatus = 'pending'
 
 /** Which Safe, on which network, at which nonce. */
 export interface IProposalSlot {
@@ -45,9 +66,14 @@ export interface IProposalSlot {
  * on 2026-09-12: the checksummed spelling of the Tron Safe matches 0 rows
  * uncollated and 34 collated.
  *
+ * Restricted to the statuses that actually hold the nonce. A Safe reuses a
+ * nonce across history, so an `executed` or `reverted` row can sit at the same
+ * number as the one being cleared — and matching it would put a settled
+ * transaction in front of a delete.
+ *
  * @param pendingTransactions - the proposal collection
  * @param slot - the Safe, network and nonce to hunt
- * @returns every row holding that nonce, newest ordering left to the caller
+ * @returns every in-flight row holding that nonce
  */
 export async function findProposalsAtNonce(
   pendingTransactions: Collection<ISafeTxDocument>,
@@ -59,6 +85,7 @@ export async function findProposalsAtNonce(
       chainId: slot.chainId,
       safeAddress: slot.safeAddress,
       'safeTx.data.nonce': slot.nonce,
+      status: { $in: [...NONCE_HOLDING_STATUSES] },
     })
     .collation(ADDRESS_COLLATION)
     .toArray()
@@ -82,9 +109,22 @@ export async function tearDownProposalsAtNonce(
   slot: IProposalSlot
 ): Promise<IDeleteResult[]> {
   const found = await findProposalsAtNonce(pendingTransactions, slot)
+  const deletable = found.filter((doc) => doc.status === DELETABLE_STATUS)
+  for (const doc of found)
+    if (doc.status !== DELETABLE_STATUS)
+      consola.warn(
+        `[${slot.network}] leaving ${printableField(
+          doc.safeTxHash
+        )} alone — status ${printableField(
+          doc.status
+        )}, which this teardown does not delete`
+      )
+
+  if (deletable.length === 0) return []
+
   return deletePendingProposals(pendingTransactions, {
     network: slot.network.toLowerCase(),
-    hashes: found.map((doc) => doc.safeTxHash),
+    hashes: deletable.map((doc) => doc.safeTxHash),
     force: false,
   })
 }
@@ -119,7 +159,9 @@ const main = defineCommand({
 
       for (const doc of found)
         consola.info(
-          `${doc.safeTxHash} status=${doc.status} safeAddress=${doc.safeAddress}`
+          `${printableField(doc.safeTxHash)} status=${printableField(
+            doc.status
+          )} safeAddress=${printableField(doc.safeAddress)}`
         )
 
       if (!args.delete) {

--- a/script/deploy/safe/rehearsal-teardown.ts
+++ b/script/deploy/safe/rehearsal-teardown.ts
@@ -1,0 +1,113 @@
+/**
+ * Finds and removes the dummy proposals a verify rehearsal leaves behind.
+ *
+ * Import this from the rehearsal runner, or drive it from the CLI at the foot
+ * of this file to clear a junk row by hand.
+ *
+ * A pending row occupies a Safe nonce, and Safes execute strictly in order, so
+ * a dummy left at nonce N blocks every real proposal after it. A row created
+ * and deleted in the same run never touches the on-chain nonce — the slot frees
+ * when the row goes — which makes this module, not the preflight, the safety
+ * story for creating dummy proposals at all.
+ */
+
+import 'dotenv/config'
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import { type Collection } from 'mongodb'
+
+import { deletePendingProposals } from './delete-pending-proposals'
+import {
+  ADDRESS_COLLATION,
+  type ISafeTxDocument,
+  getSafeMongoCollection,
+} from './safe-utils'
+
+/** Which Safe, on which network, at which nonce. */
+export interface IProposalSlot {
+  readonly network: string
+  readonly chainId: number
+  readonly safeAddress: string
+  readonly nonce: number
+}
+
+/**
+ * Every row occupying one Safe nonce, matched under the store's own collation.
+ *
+ * The collation is not optional. One Safe has two spellings in this collection
+ * — `propose-to-safe-tron.ts` stores lowercase hex, `initializeSafeClient`
+ * stores the checksummed form — and an equality match silently returns nothing
+ * for the spelling the row does not use. Measured against the production store
+ * on 2026-09-12: the checksummed spelling of the Tron Safe matches 0 rows
+ * uncollated and 34 collated.
+ *
+ * @param pendingTransactions - the proposal collection
+ * @param slot - the Safe, network and nonce to hunt
+ * @returns every row holding that nonce, newest ordering left to the caller
+ */
+export async function findProposalsAtNonce(
+  pendingTransactions: Collection<ISafeTxDocument>,
+  slot: IProposalSlot
+): Promise<ISafeTxDocument[]> {
+  return pendingTransactions
+    .find({
+      network: slot.network,
+      chainId: slot.chainId,
+      safeAddress: slot.safeAddress,
+      'safeTx.data.nonce': slot.nonce,
+    })
+    .collation(ADDRESS_COLLATION)
+    .toArray()
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'rehearsal-teardown',
+    description:
+      'Find (and optionally delete) the proposals occupying a Safe nonce',
+  },
+  args: {
+    network: { type: 'string', required: true },
+    chainId: { type: 'string', required: true },
+    safeAddress: { type: 'string', required: true },
+    nonce: { type: 'string', required: true },
+    delete: {
+      type: 'boolean',
+      default: false,
+      description: 'Delete the rows found instead of only listing them',
+    },
+  },
+  async run({ args }) {
+    const { client, pendingTransactions } = await getSafeMongoCollection()
+    try {
+      const found = await findProposalsAtNonce(pendingTransactions, {
+        network: args.network,
+        chainId: Number(args.chainId),
+        safeAddress: args.safeAddress,
+        nonce: Number(args.nonce),
+      })
+
+      for (const doc of found)
+        consola.info(
+          `${doc.safeTxHash} status=${doc.status} safeAddress=${doc.safeAddress}`
+        )
+
+      if (!args.delete) {
+        consola.info(`${found.length} row(s); pass --delete to remove them`)
+        return
+      }
+
+      await deletePendingProposals(pendingTransactions, {
+        network: args.network,
+        hashes: found.map((doc) => doc.safeTxHash),
+        force: false,
+      })
+    } finally {
+      await client.close(true)
+    }
+  },
+})
+
+if (process.argv[1] && process.argv[1].endsWith('rehearsal-teardown.ts'))
+  void runMain(main)

--- a/script/deploy/safe/rehearsal-teardown.ts
+++ b/script/deploy/safe/rehearsal-teardown.ts
@@ -17,7 +17,10 @@ import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { type Collection } from 'mongodb'
 
-import { deletePendingProposals } from './delete-pending-proposals'
+import {
+  deletePendingProposals,
+  type IDeleteResult,
+} from './delete-pending-proposals'
 import {
   ADDRESS_COLLATION,
   type ISafeTxDocument,
@@ -52,13 +55,38 @@ export async function findProposalsAtNonce(
 ): Promise<ISafeTxDocument[]> {
   return pendingTransactions
     .find({
-      network: slot.network,
+      network: slot.network.toLowerCase(),
       chainId: slot.chainId,
       safeAddress: slot.safeAddress,
       'safeTx.data.nonce': slot.nonce,
     })
     .collation(ADDRESS_COLLATION)
     .toArray()
+}
+
+/**
+ * Frees a Safe nonce by deleting every row holding it.
+ *
+ * The network is lowercased here rather than trusted from the caller. The hunt
+ * tolerates a miscased network because its collation applies to the whole
+ * query, but `deletePendingProposals` matches `network` with an uncollated
+ * `$eq` — so `--network Tron` would list the rows, then delete none and report
+ * success, leaving the nonce blocked.
+ *
+ * @param pendingTransactions - the proposal collection
+ * @param slot - the Safe, network and nonce to clear
+ * @returns one result per row found, as `deletePendingProposals` reports it
+ */
+export async function tearDownProposalsAtNonce(
+  pendingTransactions: Collection<ISafeTxDocument>,
+  slot: IProposalSlot
+): Promise<IDeleteResult[]> {
+  const found = await findProposalsAtNonce(pendingTransactions, slot)
+  return deletePendingProposals(pendingTransactions, {
+    network: slot.network.toLowerCase(),
+    hashes: found.map((doc) => doc.safeTxHash),
+    force: false,
+  })
 }
 
 const main = defineCommand({
@@ -81,12 +109,13 @@ const main = defineCommand({
   async run({ args }) {
     const { client, pendingTransactions } = await getSafeMongoCollection()
     try {
-      const found = await findProposalsAtNonce(pendingTransactions, {
+      const slot: IProposalSlot = {
         network: args.network,
         chainId: Number(args.chainId),
         safeAddress: args.safeAddress,
         nonce: Number(args.nonce),
-      })
+      }
+      const found = await findProposalsAtNonce(pendingTransactions, slot)
 
       for (const doc of found)
         consola.info(
@@ -98,11 +127,7 @@ const main = defineCommand({
         return
       }
 
-      await deletePendingProposals(pendingTransactions, {
-        network: args.network,
-        hashes: found.map((doc) => doc.safeTxHash),
-        force: false,
-      })
+      await tearDownProposalsAtNonce(pendingTransactions, slot)
     } finally {
       await client.close(true)
     }

--- a/script/deploy/safe/rehearsal-write-guard.test.ts
+++ b/script/deploy/safe/rehearsal-write-guard.test.ts
@@ -392,3 +392,46 @@ describe('sealCollectionReadOnly, on a cursor a permitted read returns', () => {
     expect(await sealed.find().toArray()).toHaveLength(2)
   })
 })
+
+describe('sealCollectionReadOnly, on the descriptor and extensibility paths', () => {
+  it('redacts an accessor descriptor, not only a data one', () => {
+    const source = {}
+    Object.defineProperty(source, 'client', {
+      configurable: true,
+      enumerable: true,
+      get: () => ({ db: () => 'unsealed' }),
+    })
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      sealCollectionReadOnly(source),
+      'client'
+    )
+
+    expect(() => descriptor?.get?.()).toThrow(RehearsalWriteRefusedError)
+  })
+
+  it('refuses to be frozen rather than raising an opaque proxy error', () => {
+    const sealed = sealCollectionReadOnly({ client: { id: 1 } })
+
+    expect(() => Object.freeze(sealed)).toThrow(RehearsalWriteRefusedError)
+  })
+})
+
+describe('sealCollectionReadOnly, on a cursor iterated with for await', () => {
+  it('does not report a read as a write refusal', async () => {
+    const docs = [{ _id: 1 }, { _id: 2 }]
+    const sealed = sealCollectionReadOnly({
+      find: () => ({
+        toArray: () => Promise.resolve(docs),
+        async *[Symbol.asyncIterator]() {
+          for (const doc of docs) yield doc
+        },
+      }),
+    }) as unknown as { find: () => AsyncIterable<unknown> }
+
+    const seen: unknown[] = []
+    for await (const doc of sealed.find()) seen.push(doc)
+
+    expect(seen).toHaveLength(2)
+  })
+})

--- a/script/deploy/safe/rehearsal-write-guard.test.ts
+++ b/script/deploy/safe/rehearsal-write-guard.test.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'node:util'
+
 import {
   describe,
   expect,
@@ -312,14 +314,81 @@ describe('sealCollectionReadOnly, on what a permitted read hands back', () => {
 })
 
 describe('sealCollectionReadOnly, against a descriptor read', () => {
-  it('refuses the property the get trap refuses', () => {
+  it('hands back a descriptor that does not carry the handle', () => {
     const sealed = sealCollectionReadOnly({
       client: { db: () => 'unsealed' },
       findOne: () => Promise.resolve(null),
     })
 
-    expect(() => Object.getOwnPropertyDescriptor(sealed, 'client')).toThrow(
+    const descriptor = Object.getOwnPropertyDescriptor(sealed, 'client')
+
+    // Redacted rather than refused outright: throwing here would take down
+    // `Object.keys` and `for…in`, which read descriptors but never values.
+    expect(descriptor?.value).not.toEqual({ db: expect.any(Function) })
+    expect(() => (descriptor?.value as () => unknown)()).toThrow(
       RehearsalWriteRefusedError
     )
+  })
+})
+
+describe('sealCollectionReadOnly, when something enumerates or renders it', () => {
+  const withObjectProps = () =>
+    sealCollectionReadOnly({
+      s: { db: { client: 'SECRET' } },
+      client: { id: 'CLIENT' },
+      collectionName: 'pendingTransactions',
+      findOne: () => Promise.resolve(null),
+    })
+
+  it('lets the key-only enumerations work', () => {
+    const sealed = withObjectProps()
+
+    expect(Object.keys(sealed)).toContain('client')
+    expect(() => {
+      for (const _key in sealed) void _key
+    }).not.toThrow()
+  })
+
+  it('still refuses an enumeration that reads the values', () => {
+    // Spread and `Object.entries` go through `get`, so they are asking for the
+    // handle itself. Refusing is the point; only the key-only paths above are
+    // expected to work.
+    expect(() => ({ ...withObjectProps() })).toThrow(RehearsalWriteRefusedError)
+    expect(() => Object.entries(withObjectProps())).toThrow(
+      RehearsalWriteRefusedError
+    )
+  })
+
+  it('does not print the wrapped target when inspected', () => {
+    const rendered = inspect(withObjectProps())
+
+    expect(rendered).not.toContain('SECRET')
+    expect(rendered).not.toContain('CLIENT')
+  })
+})
+
+describe('sealCollectionReadOnly, on a cursor a permitted read returns', () => {
+  it('refuses a cursor internal that resolves to a live server handle', () => {
+    const sealed = sealCollectionReadOnly({
+      find: () => ({
+        toArray: () => Promise.resolve([{ _id: 1 }]),
+        _initialize: () =>
+          Promise.resolve({ server: { command: () => 'wrote' } }),
+      }),
+    }) as unknown as { find: () => Record<string, () => unknown> }
+
+    expect(() => sealed.find()._initialize?.()).toThrow(
+      RehearsalWriteRefusedError
+    )
+  })
+
+  it('still allows the cursor methods a read needs', async () => {
+    const sealed = sealCollectionReadOnly({
+      find: () => ({
+        toArray: () => Promise.resolve([{ _id: 1 }, { _id: 2 }]),
+      }),
+    }) as unknown as { find: () => { toArray: () => Promise<unknown[]> } }
+
+    expect(await sealed.find().toArray()).toHaveLength(2)
   })
 })

--- a/script/deploy/safe/rehearsal-write-guard.test.ts
+++ b/script/deploy/safe/rehearsal-write-guard.test.ts
@@ -257,3 +257,69 @@ describe('a sealed handle in a log line', () => {
     expect(() => JSON.stringify(sealed)).not.toThrow()
   })
 })
+
+describe('sealCollectionReadOnly, on what a permitted read hands back', () => {
+  const cursorShapedCollection = () => {
+    const cursor: Record<string, unknown> = {
+      client: { db: () => 'unsealed' },
+      parent: { deleteMany: () => 'wrote' },
+      toArray: () => Promise.resolve([{ _id: 1 }, { _id: 2 }]),
+    }
+    cursor.sort = () => cursor
+    cursor.collation = () => cursor
+    return { find: () => cursor }
+  }
+
+  it('refuses the client the cursor re-exports', () => {
+    const sealed = sealCollectionReadOnly(
+      cursorShapedCollection()
+    ) as unknown as {
+      find: () => Record<string, unknown>
+    }
+
+    expect(() => sealed.find().client).toThrow(RehearsalWriteRefusedError)
+    expect(() => sealed.find().parent).toThrow(RehearsalWriteRefusedError)
+  })
+
+  it('keeps refusing after the cursor is chained', () => {
+    interface ISealedCursor {
+      sort: () => ISealedCursor
+      collation: () => ISealedCursor
+      client: unknown
+      parent: unknown
+    }
+    const sealed = sealCollectionReadOnly(
+      cursorShapedCollection()
+    ) as unknown as { find: () => ISealedCursor }
+
+    expect(() => sealed.find().sort().client).toThrow(
+      RehearsalWriteRefusedError
+    )
+    expect(() => sealed.find().collation().sort().parent).toThrow(
+      RehearsalWriteRefusedError
+    )
+  })
+
+  it('still returns the documents the read was for', async () => {
+    const sealed = sealCollectionReadOnly(
+      cursorShapedCollection()
+    ) as unknown as {
+      find: () => { toArray: () => Promise<unknown[]> }
+    }
+
+    expect(await sealed.find().toArray()).toHaveLength(2)
+  })
+})
+
+describe('sealCollectionReadOnly, against a descriptor read', () => {
+  it('refuses the property the get trap refuses', () => {
+    const sealed = sealCollectionReadOnly({
+      client: { db: () => 'unsealed' },
+      findOne: () => Promise.resolve(null),
+    })
+
+    expect(() => Object.getOwnPropertyDescriptor(sealed, 'client')).toThrow(
+      RehearsalWriteRefusedError
+    )
+  })
+})

--- a/script/deploy/safe/rehearsal-write-guard.test.ts
+++ b/script/deploy/safe/rehearsal-write-guard.test.ts
@@ -1,0 +1,166 @@
+import {
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+import {
+  READ_ONLY_RUN,
+  isSealedReadOnly,
+  proveSealRefusesWrites,
+  RehearsalWriteRefusedError,
+  runRehearsalPreflight,
+  sealCollectionReadOnly,
+} from './rehearsal-write-guard'
+
+describe('sealCollectionReadOnly', () => {
+  it('refuses insertOne without reaching the underlying collection', () => {
+    const reached: string[] = []
+    const underlying = {
+      insertOne: () => {
+        reached.push('insertOne')
+        return Promise.resolve({})
+      },
+    }
+
+    const sealed = sealCollectionReadOnly(underlying)
+
+    const probe = sealed as unknown as Record<
+      string,
+      (() => unknown) | undefined
+    >
+    expect(() => probe.insertOne?.()).toThrow(/refused/i)
+    expect(reached).toEqual([])
+  })
+})
+
+describe('proveSealRefusesWrites', () => {
+  it('reports every canary write method as refused', () => {
+    const evidence = proveSealRefusesWrites()
+
+    expect(evidence.length).toBeGreaterThan(0)
+    expect(evidence.every((probe) => probe.refused)).toBe(true)
+    expect(evidence.map((probe) => probe.method)).toContain('insertOne')
+    expect(evidence.map((probe) => probe.method)).toContain('createIndex')
+  })
+})
+
+describe('isSealedReadOnly', () => {
+  it('tells a sealed handle apart from the collection it wraps', () => {
+    const underlying = { findOne: () => Promise.resolve(null) }
+
+    expect(isSealedReadOnly(underlying)).toBe(false)
+    expect(isSealedReadOnly(sealCollectionReadOnly(underlying))).toBe(true)
+  })
+})
+
+/** [CONV:TEST-ASSERT-REJECTS] — awaiting Bun's `.rejects` trips await-thenable. */
+async function expectRejects(
+  promise: Promise<unknown>,
+  match: RegExp
+): Promise<void> {
+  try {
+    await promise
+  } catch (error: unknown) {
+    expect(error instanceof Error ? error.message : String(error)).toMatch(
+      match
+    )
+    return
+  }
+  throw new Error(`expected a rejection matching ${String(match)}`)
+}
+
+describe('runRehearsalPreflight', () => {
+  it('aborts a write-configured run before the store is ever opened', async () => {
+    const opened: string[] = []
+
+    await expectRejects(
+      runRehearsalPreflight({
+        config: { ...READ_ONLY_RUN, sign: true },
+        openStore: () => {
+          opened.push('open')
+          return Promise.resolve({})
+        },
+      }),
+      /sign/
+    )
+
+    expect(opened).toEqual([])
+  })
+
+  it('names every enabled write capability, not only the first', async () => {
+    await expectRejects(
+      runRehearsalPreflight({
+        config: { ...READ_ONLY_RUN, sign: true, reconcileBackfill: true },
+        openStore: () => Promise.resolve({}),
+      }),
+      /sign.*reconcileBackfill|reconcileBackfill.*sign/
+    )
+  })
+
+  it('hands back a sealed store that refuses writes on a read-only run', async () => {
+    const reached: string[] = []
+    const underlying = {
+      findOne: () => Promise.resolve(null),
+      updateOne: () => {
+        reached.push('updateOne')
+        return Promise.resolve({})
+      },
+    }
+
+    const preflight = await runRehearsalPreflight({
+      config: READ_ONLY_RUN,
+      openStore: () => Promise.resolve(underlying),
+    })
+
+    expect(isSealedReadOnly(preflight.store)).toBe(true)
+    expect(preflight.evidence.every((probe) => probe.refused)).toBe(true)
+    const probe = preflight.store as unknown as Record<
+      string,
+      (() => unknown) | undefined
+    >
+    expect(() => probe.updateOne?.()).toThrow(RehearsalWriteRefusedError)
+    expect(reached).toEqual([])
+  })
+})
+
+describe('proveSealRefusesWrites, against a seal that does not seal', () => {
+  it('refuses, naming the methods that ran and reached the target', () => {
+    const identitySeal = <T extends object>(collection: T): T => collection
+
+    let thrown: Error | undefined
+    try {
+      proveSealRefusesWrites(identitySeal)
+    } catch (error: unknown) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toMatch(/not in force/)
+    expect(thrown?.message).toMatch(/insertOne/)
+    expect(thrown?.message).toMatch(/createIndex/)
+  })
+
+  it('records reachedTarget for a method that ran', () => {
+    const halfSeal = <T extends object>(collection: T): T =>
+      new Proxy(collection, {
+        get(target, property, receiver) {
+          const value = Reflect.get(target, property, receiver)
+          if (property === 'insertOne') return value
+          return () => {
+            throw new RehearsalWriteRefusedError(String(property))
+          }
+        },
+      })
+
+    let thrown: Error | undefined
+    try {
+      proveSealRefusesWrites(halfSeal)
+    } catch (error: unknown) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toMatch(/insertOne/)
+    expect(thrown?.message).not.toMatch(/createIndex/)
+  })
+})

--- a/script/deploy/safe/rehearsal-write-guard.test.ts
+++ b/script/deploy/safe/rehearsal-write-guard.test.ts
@@ -164,3 +164,96 @@ describe('proveSealRefusesWrites, against a seal that does not seal', () => {
     expect(thrown?.message).not.toMatch(/createIndex/)
   })
 })
+
+describe('sealCollectionReadOnly, on the object properties a real driver carries', () => {
+  it('refuses a property that leads back to an unsealed write handle', () => {
+    const underlying = {
+      findOne: () => Promise.resolve(null),
+      // A real mongodb Collection exposes `.client` (the MongoClient) and `.s`
+      // (internal state holding the Db). Either one re-derives an unsealed
+      // collection, so reaching them is reaching a write surface.
+      client: {
+        db: () => ({ collection: () => ({ deleteMany: () => 'wrote' }) }),
+      },
+    }
+
+    const sealed = sealCollectionReadOnly(underlying) as unknown as Record<
+      string,
+      unknown
+    >
+
+    expect(() => sealed.client).toThrow(RehearsalWriteRefusedError)
+  })
+
+  it('still hands back the harmless primitives a caller needs', () => {
+    const sealed = sealCollectionReadOnly({
+      collectionName: 'pendingTransactions',
+      dbName: 'sc_private',
+    }) as unknown as Record<string, unknown>
+
+    expect(sealed.collectionName).toBe('pendingTransactions')
+    expect(sealed.dbName).toBe('sc_private')
+  })
+
+  it('leaves an absent property undefined so the sealed handle can be awaited', async () => {
+    const sealed = sealCollectionReadOnly({
+      findOne: () => Promise.resolve(null),
+    })
+
+    expect((sealed as unknown as Record<string, unknown>).then).toBeUndefined()
+    expect(await Promise.resolve(sealed)).toBe(sealed)
+  })
+
+  it('does not permit aggregate, which can write via $out and $merge', () => {
+    const sealed = sealCollectionReadOnly({
+      aggregate: () => 'ran',
+    }) as unknown as Record<string, () => unknown>
+
+    expect(() => sealed.aggregate?.()).toThrow(RehearsalWriteRefusedError)
+  })
+})
+
+describe('proveSealRefusesWrites, over the escape properties', () => {
+  it('probes the object properties that re-derive an unsealed handle', () => {
+    const evidence = proveSealRefusesWrites()
+
+    expect(evidence.map((probe) => probe.method)).toContain('client')
+    expect(evidence.map((probe) => probe.method)).toContain('s')
+    expect(evidence.every((probe) => probe.refused)).toBe(true)
+  })
+
+  it('fails when a seal lets an escape property through', () => {
+    const methodsOnlySeal = <T extends object>(collection: T): T =>
+      new Proxy(collection, {
+        get(target, property) {
+          const value = Reflect.get(target, property, target)
+          if (typeof value !== 'function') return value
+          return () => {
+            throw new RehearsalWriteRefusedError(String(property))
+          }
+        },
+      })
+
+    let thrown: Error | undefined
+    try {
+      proveSealRefusesWrites(methodsOnlySeal)
+    } catch (error: unknown) {
+      thrown = error as Error
+    }
+
+    expect(thrown?.message).toMatch(/client/)
+  })
+})
+
+describe('a sealed handle in a log line', () => {
+  it('renders instead of crashing the run it was guarding', () => {
+    const sealed = sealCollectionReadOnly({
+      collectionName: 'pendingTransactions',
+      s: { db: {} },
+      findOne: () => Promise.resolve(null),
+    })
+
+    expect(() => `${String(sealed)}`).not.toThrow()
+    expect(() => JSON.stringify(sealed)).not.toThrow()
+  })
+})

--- a/script/deploy/safe/rehearsal-write-guard.ts
+++ b/script/deploy/safe/rehearsal-write-guard.ts
@@ -5,10 +5,11 @@
  * performs by accident. It is an incidental write: an index ensured on connect,
  * an acknowledgement recorded, a reconcile back-fill promoting a row. So the
  * guard refuses by default and the preflight *demonstrates* the refusal by
- * calling the refused methods, instead of asserting that a flag was not passed.
+ * reaching for the refused members, instead of asserting that a flag was not
+ * passed.
  */
 
-/** Raised when a rehearsal reaches for a method that could mutate the store. */
+/** Raised when a rehearsal reaches a member that could lead to a write. */
 export class RehearsalWriteRefusedError extends Error {
   public constructor(public readonly method: string) {
     super(
@@ -31,35 +32,71 @@ const PERMITTED_READ_METHODS: ReadonlySet<string> = new Set([
   'findOne',
   'countDocuments',
   'estimatedDocumentCount',
-  'aggregate',
   'distinct',
   'indexes',
   'listIndexes',
 ])
 
 /**
- * Wraps a collection so every method outside {@link PERMITTED_READ_METHODS}
- * throws instead of running.
+ * Wraps a collection so nothing that could reach a write runs.
  *
- * Only properties the target actually holds as functions are intercepted.
- * Replacing an absent property with a throwing stub would break the language's
- * own probes — `await` reads `then`, and a sealed object that threw on it could
- * not be awaited at all.
+ * The allow-list governs every property, not just the callable ones. A driver
+ * `Collection` carries its `MongoClient` on `.client` and its `Db` under `.s`,
+ * and either one re-derives an unsealed collection — so handing back an object
+ * property because it is not itself a function hands back the whole write
+ * surface. Object-valued properties are therefore refused outright.
+ *
+ * Primitives pass through: `collectionName` and `dbName` identify the handle and
+ * reach nothing. An absent property stays `undefined` rather than becoming a
+ * throwing stub, because the language probes for members that do not exist —
+ * `await` reads `then`, and a handle that threw on it could not be awaited.
  *
  * @param collection - the live collection to seal
  * @returns a proxy with the same shape that refuses anything that could write
  */
-export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
-  const sealed = new Proxy(collection, {
-    get(target, property, receiver) {
-      const value = Reflect.get(target, property, receiver)
-      if (typeof property !== 'string' || typeof value !== 'function')
-        return value
-      if (PERMITTED_READ_METHODS.has(property)) return value.bind(target)
+/**
+ * Members the language itself reaches for when rendering a value.
+ *
+ * Answered with a harmless label rather than a throwing stub. Without this, any
+ * log line, template literal or `JSON.stringify` that touches a sealed handle
+ * crashes the run with a refusal about `toString` — the guard taking down the
+ * run it was protecting, reported as a write attempt that never happened.
+ */
+const RENDERING_MEMBERS: ReadonlySet<string> = new Set([
+  'toString',
+  'valueOf',
+  'toJSON',
+])
 
-      return () => {
-        throw new RehearsalWriteRefusedError(property)
+export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
+  const label = '[read-only sealed collection]'
+  const sealed = new Proxy(collection, {
+    get(target, property) {
+      if (typeof property === 'string' && RENDERING_MEMBERS.has(property))
+        return () => label
+      // The receiver is the target, never the proxy: a driver getter such as
+      // `collectionName` reads its own internals to answer, and with the proxy
+      // as receiver that read comes back through this trap and is refused —
+      // the seal would reject the very properties it means to allow.
+      const value = Reflect.get(target, property, target)
+      if (value === undefined || value === null) return value
+
+      if (typeof value === 'function') {
+        if (
+          typeof property === 'string' &&
+          PERMITTED_READ_METHODS.has(property)
+        )
+          return value.bind(target)
+
+        return () => {
+          throw new RehearsalWriteRefusedError(String(property))
+        }
       }
+
+      if (typeof value === 'object')
+        throw new RehearsalWriteRefusedError(String(property))
+
+      return value
     },
   })
   SEALED_HANDLES.add(sealed)
@@ -111,7 +148,18 @@ const CANARY_WRITE_METHODS: readonly string[] = [
   'rename',
 ]
 
-/** One canary method, and whether the seal refused it. */
+/**
+ * The non-function properties a driver `Collection` carries that lead back to a
+ * write handle.
+ *
+ * Probed alongside the methods because the seal's first version refused only
+ * callables and handed `client` back untouched — a live `MongoClient`, from
+ * which an unsealed collection is one call away. A proof that covers only the
+ * methods would have passed that version.
+ */
+const CANARY_ESCAPE_PROPERTIES: readonly string[] = ['client', 's']
+
+/** One canary member, and whether the seal refused it. */
 export interface IWriteRefusalProbe {
   readonly method: string
   readonly refused: boolean
@@ -139,7 +187,7 @@ export const proveSealRefusesWrites = (
   seal: <T extends object>(collection: T) => T = sealCollectionReadOnly
 ): readonly IWriteRefusalProbe[] => {
   const reached: string[] = []
-  const canary = Object.fromEntries(
+  const canary: Record<string, unknown> = Object.fromEntries(
     CANARY_WRITE_METHODS.map((method) => [
       method,
       () => {
@@ -147,17 +195,41 @@ export const proveSealRefusesWrites = (
       },
     ])
   )
+  // Stand-ins for the driver's own handles: any object reached here is a route
+  // back to an unsealed collection, so the probe only has to reach one.
+  for (const property of CANARY_ESCAPE_PROPERTIES)
+    canary[property] = { db: () => undefined }
+
   const sealed = seal(canary) as unknown as Record<string, () => unknown>
 
-  const evidence = CANARY_WRITE_METHODS.map((method) => {
-    try {
-      sealed[method]?.()
-      return { method, refused: false, reachedTarget: reached.includes(method) }
-    } catch (error: unknown) {
-      if (!(error instanceof RehearsalWriteRefusedError)) throw error
-      return { method, refused: true, reachedTarget: false }
-    }
-  })
+  const evidence = [
+    ...CANARY_WRITE_METHODS.map((method) => {
+      try {
+        sealed[method]?.()
+        return {
+          method,
+          refused: false,
+          reachedTarget: reached.includes(method),
+        }
+      } catch (error: unknown) {
+        if (!(error instanceof RehearsalWriteRefusedError)) throw error
+        return { method, refused: true, reachedTarget: false }
+      }
+    }),
+    ...CANARY_ESCAPE_PROPERTIES.map((property) => {
+      try {
+        const escaped = sealed[property]
+        return {
+          method: property,
+          refused: false,
+          reachedTarget: escaped !== undefined,
+        }
+      } catch (error: unknown) {
+        if (!(error instanceof RehearsalWriteRefusedError)) throw error
+        return { method: property, refused: true, reachedTarget: false }
+      }
+    }),
+  ]
 
   const unrefused = evidence.filter((probe) => !probe.refused)
   if (unrefused.length)
@@ -166,7 +238,7 @@ export const proveSealRefusesWrites = (
         .map((probe) => probe.method)
         .join(
           ', '
-        )} ran instead of refusing. Nothing may read the proposal store on this run.`
+        )} was reachable instead of refusing. Nothing may read the proposal store on this run.`
     )
 
   return evidence

--- a/script/deploy/safe/rehearsal-write-guard.ts
+++ b/script/deploy/safe/rehearsal-write-guard.ts
@@ -81,19 +81,25 @@ const isDerivedHandle = (value: unknown): value is object =>
   typeof (value as { then?: unknown }).then !== 'function'
 
 /**
- * Seals what a permitted read hands back.
+ * The cursor members a read legitimately needs.
  *
- * The allow-list stops at the collection boundary, but a `FindCursor` carries
- * `.client` and a `ListIndexesCursor` carries `.parent` — the raw collection
- * itself — so a read the seal permits re-exports the whole write surface one
- * hop later. Chained calls are sealed too, because `sort()` returns the cursor.
- *
- * Allow-listed by name for the same reason the collection is. "Every function
- * is a read" was false: `AbstractCursor._initialize` resolves to an object
- * carrying a live `Server`, whose `command()` runs an arbitrary command — and a
- * resolved promise is handed back unsealed so the documents a read was for stay
- * readable.
+ * Allow-listed by name for the same reason the collection is, and not "every
+ * function": `AbstractCursor._initialize` resolves to an object carrying a live
+ * `Server`, whose `command()` runs an arbitrary command. A resolved promise is
+ * handed back unsealed, so the documents a read was for stay readable.
  */
+const PERMITTED_CURSOR_SYMBOLS: ReadonlySet<symbol> = new Set(
+  [
+    Symbol.asyncIterator,
+    Symbol.iterator,
+    // `using` / `await using` disposal, looked up rather than named: the
+    // well-known symbols are absent from this project's TS lib target, and
+    // refusing them would turn leaving a scope into a write refusal.
+    (Symbol as unknown as Record<string, symbol | undefined>).asyncDispose,
+    (Symbol as unknown as Record<string, symbol | undefined>).dispose,
+  ].filter((symbol): symbol is symbol => symbol !== undefined)
+)
+
 const PERMITTED_CURSOR_METHODS: ReadonlySet<string> = new Set([
   'toArray',
   'next',
@@ -117,7 +123,6 @@ const PERMITTED_CURSOR_METHODS: ReadonlySet<string> = new Set([
   'rewind',
   'close',
   'explain',
-  'stream',
   'count',
   'allowDiskUse',
   'withReadConcern',
@@ -147,10 +152,11 @@ const sealDerivedHandle = <T extends object>(handle: T): T =>
       if (value === undefined || value === null) return value
 
       if (typeof value === 'function') {
-        if (
-          typeof property !== 'string' ||
-          !PERMITTED_CURSOR_METHODS.has(property)
-        )
+        const permitted =
+          typeof property === 'string'
+            ? PERMITTED_CURSOR_METHODS.has(property)
+            : PERMITTED_CURSOR_SYMBOLS.has(property)
+        if (!permitted)
           return () => {
             throw new RehearsalWriteRefusedError(String(property))
           }
@@ -173,9 +179,22 @@ const sealDerivedHandle = <T extends object>(handle: T): T =>
       redactingDescriptor(handle, property),
     ownKeys: () => Reflect.ownKeys(handle),
     has: (_target, property) => Reflect.has(handle, property),
+    preventExtensions: refuseExtensionChange,
   })
 
 const DERIVED_LABEL = '[read-only sealed handle]'
+
+/**
+ * Refuses `Object.freeze` / `Object.seal` in this module's own terms.
+ *
+ * Both make the proxy's empty target non-extensible, after which `ownKeys`
+ * reporting the source's keys violates an invariant and the engine raises an
+ * opaque `TypeError` about the trap — which reads as a bug in the harness
+ * rather than as a refusal.
+ */
+const refuseExtensionChange = (): never => {
+  throw new RehearsalWriteRefusedError('preventExtensions')
+}
 
 /**
  * Hands back a descriptor whose object value is replaced by a refusing stub.
@@ -193,19 +212,23 @@ const redactingDescriptor = (
   const descriptor = Reflect.getOwnPropertyDescriptor(source, property)
   if (!descriptor) return undefined
 
+  const refuse = (): never => {
+    throw new RehearsalWriteRefusedError(String(property))
+  }
+
   // `configurable` is forced because the proxy's target is an empty object:
   // reporting a non-configurable property the target does not have violates a
   // proxy invariant and throws a TypeError instead of refusing.
-  if (typeof descriptor.value !== 'object' || !descriptor.value)
-    return { ...descriptor, configurable: true }
+  const base = { ...descriptor, configurable: true }
 
-  return {
-    ...descriptor,
-    configurable: true,
-    value: () => {
-      throw new RehearsalWriteRefusedError(String(property))
-    },
-  }
+  // An accessor has no `value`, so a data-only check hands its raw getter back
+  // and the `get` trap's refusal is one descriptor read from being bypassed.
+  if (descriptor.get || descriptor.set)
+    return { ...base, get: refuse, set: refuse }
+
+  if (typeof descriptor.value !== 'object' || !descriptor.value) return base
+
+  return { ...base, value: refuse }
 }
 
 export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
@@ -253,6 +276,7 @@ export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
       redactingDescriptor(collection, property),
     ownKeys: () => Reflect.ownKeys(collection),
     has: (_target, property) => Reflect.has(collection, property),
+    preventExtensions: refuseExtensionChange,
   })
   SEALED_HANDLES.add(sealed)
   return sealed
@@ -307,10 +331,10 @@ const CANARY_WRITE_METHODS: readonly string[] = [
  * The non-function properties a driver `Collection` carries that lead back to a
  * write handle.
  *
- * Probed alongside the methods because the seal's first version refused only
- * callables and handed `client` back untouched — a live `MongoClient`, from
- * which an unsealed collection is one call away. A proof that covers only the
- * methods would have passed that version.
+ * Probed alongside the methods because a seal that refuses only callables hands
+ * `client` back untouched — a live `MongoClient`, from which an unsealed
+ * collection is one call away. A proof covering only methods would pass such a
+ * seal.
  */
 const CANARY_ESCAPE_PROPERTIES: readonly string[] = ['client', 's']
 

--- a/script/deploy/safe/rehearsal-write-guard.ts
+++ b/script/deploy/safe/rehearsal-write-guard.ts
@@ -88,18 +88,73 @@ const isDerivedHandle = (value: unknown): value is object =>
  * itself — so a read the seal permits re-exports the whole write surface one
  * hop later. Chained calls are sealed too, because `sort()` returns the cursor.
  *
- * Every function is allowed here rather than allow-listed by name: a cursor's
- * API is reads and chaining, and the escape routes are all object-valued.
+ * Allow-listed by name for the same reason the collection is. "Every function
+ * is a read" was false: `AbstractCursor._initialize` resolves to an object
+ * carrying a live `Server`, whose `command()` runs an arbitrary command — and a
+ * resolved promise is handed back unsealed so the documents a read was for stay
+ * readable.
+ */
+const PERMITTED_CURSOR_METHODS: ReadonlySet<string> = new Set([
+  'toArray',
+  'next',
+  'tryNext',
+  'hasNext',
+  'forEach',
+  'map',
+  'filter',
+  'sort',
+  'limit',
+  'skip',
+  'project',
+  'collation',
+  'batchSize',
+  'maxTimeMS',
+  'maxAwaitTimeMS',
+  'addCursorFlag',
+  'hint',
+  'comment',
+  'clone',
+  'rewind',
+  'close',
+  'explain',
+  'stream',
+  'count',
+  'allowDiskUse',
+  'withReadConcern',
+  'withReadPreference',
+])
+
+/**
+ * Seals what a permitted read hands back, and what that in turn returns.
+ *
+ * The allow-list stops at the collection boundary, but a `FindCursor` carries
+ * `.client` and a `ListIndexesCursor` carries `.parent` — the raw collection
+ * itself — so a read the seal permits re-exports the whole write surface one
+ * hop later. Chained calls are sealed too, because `sort()` returns the cursor.
  */
 const sealDerivedHandle = <T extends object>(handle: T): T =>
-  new Proxy(handle, {
-    get(target, property) {
+  // Proxied over an empty object rather than over the handle itself. Node's
+  // `util.inspect` reads a proxy's target directly without consulting a single
+  // trap, so `console.log(sealed)` on a real collection printed the whole
+  // `MongoClient` — options, hosts, credentials object and all. With nothing in
+  // the target there is nothing for it to print.
+  new Proxy({} as T, {
+    get(_target, property) {
+      const target = handle
       if (typeof property === 'string' && RENDERING_MEMBERS.has(property))
         return () => DERIVED_LABEL
       const value = Reflect.get(target, property, target)
       if (value === undefined || value === null) return value
 
-      if (typeof value === 'function')
+      if (typeof value === 'function') {
+        if (
+          typeof property !== 'string' ||
+          !PERMITTED_CURSOR_METHODS.has(property)
+        )
+          return () => {
+            throw new RehearsalWriteRefusedError(String(property))
+          }
+
         return (...args: unknown[]) => {
           const result = (value as (...a: unknown[]) => unknown).apply(
             target,
@@ -107,26 +162,58 @@ const sealDerivedHandle = <T extends object>(handle: T): T =>
           )
           return isDerivedHandle(result) ? sealDerivedHandle(result) : result
         }
+      }
 
       if (typeof value === 'object')
         throw new RehearsalWriteRefusedError(String(property))
 
       return value
     },
-    getOwnPropertyDescriptor(target, property) {
-      const descriptor = Reflect.getOwnPropertyDescriptor(target, property)
-      if (descriptor && typeof descriptor.value === 'object')
-        throw new RehearsalWriteRefusedError(String(property))
-      return descriptor
-    },
+    getOwnPropertyDescriptor: (_target, property) =>
+      redactingDescriptor(handle, property),
+    ownKeys: () => Reflect.ownKeys(handle),
+    has: (_target, property) => Reflect.has(handle, property),
   })
 
 const DERIVED_LABEL = '[read-only sealed handle]'
 
+/**
+ * Hands back a descriptor whose object value is replaced by a refusing stub.
+ *
+ * Throwing here instead would take down `Object.keys`, spread, `Object.entries`
+ * and `for…in` on a real `Collection`, whose only own properties are `s` and
+ * `client` — the guard taking down the run it was protecting, reported as a
+ * write attempt nobody made. Redacting keeps enumeration working while the
+ * handle itself stays out of reach.
+ */
+const redactingDescriptor = (
+  source: object,
+  property: string | symbol
+): PropertyDescriptor | undefined => {
+  const descriptor = Reflect.getOwnPropertyDescriptor(source, property)
+  if (!descriptor) return undefined
+
+  // `configurable` is forced because the proxy's target is an empty object:
+  // reporting a non-configurable property the target does not have violates a
+  // proxy invariant and throws a TypeError instead of refusing.
+  if (typeof descriptor.value !== 'object' || !descriptor.value)
+    return { ...descriptor, configurable: true }
+
+  return {
+    ...descriptor,
+    configurable: true,
+    value: () => {
+      throw new RehearsalWriteRefusedError(String(property))
+    },
+  }
+}
+
 export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
   const label = '[read-only sealed collection]'
-  const sealed = new Proxy(collection, {
-    get(target, property) {
+  // Empty target, for the reason given on `sealDerivedHandle`.
+  const sealed = new Proxy({} as T, {
+    get(_target, property) {
+      const target = collection
       if (typeof property === 'string' && RENDERING_MEMBERS.has(property))
         return () => label
       // The receiver is the target, never the proxy: a driver getter such as
@@ -162,12 +249,10 @@ export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
     // Trapped alongside `get`: a descriptor read returns the raw value, so
     // without this the refusal above is one `Object.getOwnPropertyDescriptor`
     // away from being bypassed.
-    getOwnPropertyDescriptor(target, property) {
-      const descriptor = Reflect.getOwnPropertyDescriptor(target, property)
-      if (descriptor && typeof descriptor.value === 'object')
-        throw new RehearsalWriteRefusedError(String(property))
-      return descriptor
-    },
+    getOwnPropertyDescriptor: (_target, property) =>
+      redactingDescriptor(collection, property),
+    ownKeys: () => Reflect.ownKeys(collection),
+    has: (_target, property) => Reflect.has(collection, property),
   })
   SEALED_HANDLES.add(sealed)
   return sealed

--- a/script/deploy/safe/rehearsal-write-guard.ts
+++ b/script/deploy/safe/rehearsal-write-guard.ts
@@ -1,0 +1,260 @@
+/**
+ * Proves a verify rehearsal cannot write, rather than intending not to.
+ *
+ * The risk a rehearsal carries is not signing — that is a deliberate act nobody
+ * performs by accident. It is an incidental write: an index ensured on connect,
+ * an acknowledgement recorded, a reconcile back-fill promoting a row. So the
+ * guard refuses by default and the preflight *demonstrates* the refusal by
+ * calling the refused methods, instead of asserting that a flag was not passed.
+ */
+
+/** Raised when a rehearsal reaches for a method that could mutate the store. */
+export class RehearsalWriteRefusedError extends Error {
+  public constructor(public readonly method: string) {
+    super(
+      `Rehearsal refused '${method}': the verify rehearsal is read-only, and this method could mutate the Safe proposal store.`
+    )
+    this.name = 'RehearsalWriteRefusedError'
+  }
+}
+
+/**
+ * The collection methods a rehearsal is allowed to reach.
+ *
+ * An allow-list of reads rather than a deny-list of writes: a deny-list is
+ * silently outgrown by the next driver release, and the method it fails to name
+ * is then the one that writes. Anything absent here refuses, so a method nobody
+ * has classified is refused rather than permitted.
+ */
+const PERMITTED_READ_METHODS: ReadonlySet<string> = new Set([
+  'find',
+  'findOne',
+  'countDocuments',
+  'estimatedDocumentCount',
+  'aggregate',
+  'distinct',
+  'indexes',
+  'listIndexes',
+])
+
+/**
+ * Wraps a collection so every method outside {@link PERMITTED_READ_METHODS}
+ * throws instead of running.
+ *
+ * Only properties the target actually holds as functions are intercepted.
+ * Replacing an absent property with a throwing stub would break the language's
+ * own probes — `await` reads `then`, and a sealed object that threw on it could
+ * not be awaited at all.
+ *
+ * @param collection - the live collection to seal
+ * @returns a proxy with the same shape that refuses anything that could write
+ */
+export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
+  const sealed = new Proxy(collection, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver)
+      if (typeof property !== 'string' || typeof value !== 'function')
+        return value
+      if (PERMITTED_READ_METHODS.has(property)) return value.bind(target)
+
+      return () => {
+        throw new RehearsalWriteRefusedError(property)
+      }
+    },
+  })
+  SEALED_HANDLES.add(sealed)
+  return sealed
+}
+
+/**
+ * The handles this module sealed.
+ *
+ * Identity is tracked rather than inferred, because a proxy is indistinguishable
+ * from its target by inspection — anything a caller could test for, a plain
+ * collection would answer the same way.
+ */
+const SEALED_HANDLES = new WeakSet<object>()
+
+/**
+ * Whether `handle` was produced by {@link sealCollectionReadOnly}.
+ *
+ * @param handle - the collection handle a rehearsal is about to read through
+ * @returns true only for a handle this module sealed
+ */
+export const isSealedReadOnly = (handle: object): boolean =>
+  SEALED_HANDLES.has(handle)
+
+/**
+ * The methods the proof calls, drawn from what this repo actually writes with.
+ *
+ * `createIndex` is on the list because it is the write nobody asks for:
+ * `getSafeMongoCollection` ensures two unique indexes on connect, so merely
+ * opening the store the normal way mutates it. A rehearsal must therefore reach
+ * the collection by another route, and this entry is what keeps that true.
+ */
+const CANARY_WRITE_METHODS: readonly string[] = [
+  'insertOne',
+  'insertMany',
+  'updateOne',
+  'updateMany',
+  'replaceOne',
+  'deleteOne',
+  'deleteMany',
+  'findOneAndUpdate',
+  'findOneAndDelete',
+  'findOneAndReplace',
+  'bulkWrite',
+  'createIndex',
+  'createIndexes',
+  'dropIndex',
+  'drop',
+  'rename',
+]
+
+/** One canary method, and whether the seal refused it. */
+export interface IWriteRefusalProbe {
+  readonly method: string
+  readonly refused: boolean
+  /** Set when the method ran instead of refusing — the failure this proof exists to catch. */
+  readonly reachedTarget: boolean
+}
+
+/**
+ * Demonstrates that the seal refuses every canary write, and refuses to proceed
+ * when it does not.
+ *
+ * Probes a canary object rather than the live collection. Calling `insertOne`
+ * on a live handle to find out whether it is sealed would insert a row on
+ * exactly the run where the guard was missing — the proof would cause the
+ * accident it exists to prevent. So this proves the *mechanism*, and
+ * {@link isSealedReadOnly} ties the live handle to it.
+ *
+ * @param seal - the sealer under test; the real one unless a caller is proving
+ * that this proof can fail, which is the only way its refusal branch is ever
+ * reached — a proof that cannot fail measures nothing
+ * @returns one entry per canary method, all refused
+ * @throws When any canary method ran instead of refusing
+ */
+export const proveSealRefusesWrites = (
+  seal: <T extends object>(collection: T) => T = sealCollectionReadOnly
+): readonly IWriteRefusalProbe[] => {
+  const reached: string[] = []
+  const canary = Object.fromEntries(
+    CANARY_WRITE_METHODS.map((method) => [
+      method,
+      () => {
+        reached.push(method)
+      },
+    ])
+  )
+  const sealed = seal(canary) as unknown as Record<string, () => unknown>
+
+  const evidence = CANARY_WRITE_METHODS.map((method) => {
+    try {
+      sealed[method]?.()
+      return { method, refused: false, reachedTarget: reached.includes(method) }
+    } catch (error: unknown) {
+      if (!(error instanceof RehearsalWriteRefusedError)) throw error
+      return { method, refused: true, reachedTarget: false }
+    }
+  })
+
+  const unrefused = evidence.filter((probe) => !probe.refused)
+  if (unrefused.length)
+    throw new Error(
+      `Rehearsal write guard is not in force: ${unrefused
+        .map((probe) => probe.method)
+        .join(
+          ', '
+        )} ran instead of refusing. Nothing may read the proposal store on this run.`
+    )
+
+  return evidence
+}
+
+/**
+ * The write surfaces a verify rehearsal must leave switched off.
+ *
+ * Named one per surface rather than as a single `readOnly` boolean so the
+ * refusal can say which one was on. The last two are the incidental writes the
+ * guard exists for: neither is anything an operator would think of as "writing",
+ * and both mutate the proposal store.
+ */
+export interface IRehearsalRunConfig {
+  readonly sign: boolean
+  readonly execute: boolean
+  readonly propose: boolean
+  /** Persisting the acknowledgement ledger back onto the rows it graded. */
+  readonly persistAcknowledgements: boolean
+  /** Reconcile promoting `submitted` rows it observed on chain. */
+  readonly reconcileBackfill: boolean
+}
+
+/** Every write surface off — what a rehearsal must run with. */
+export const READ_ONLY_RUN: IRehearsalRunConfig = {
+  sign: false,
+  execute: false,
+  propose: false,
+  persistAcknowledgements: false,
+  reconcileBackfill: false,
+}
+
+/** What the preflight established, and the sealed handle it established it for. */
+export interface IRehearsalPreflightResult<T> {
+  readonly store: T
+  readonly evidence: readonly IWriteRefusalProbe[]
+}
+
+/**
+ * Refuses a run configured to write, before it can open anything.
+ *
+ * Every enabled capability is named, not just the first: an operator who
+ * switches two off one at a time learns about the second only after another
+ * refused run.
+ *
+ * @param config - the resolved run configuration
+ * @throws When any write surface is enabled
+ */
+export const assertRehearsalCannotWrite = (
+  config: IRehearsalRunConfig
+): void => {
+  const enabled = Object.entries(config)
+    .filter(([, value]) => value)
+    .map(([capability]) => capability)
+
+  if (enabled.length)
+    throw new Error(
+      `Rehearsal refused: this is a read-only verify rehearsal, but the run enables ${enabled.join(
+        ', '
+      )}. Nothing has been opened and nothing has been written.`
+    )
+}
+
+/**
+ * The rehearsal's preflight: prove the run cannot write, then open the store.
+ *
+ * The order is the whole point. The configuration is refused before
+ * `openStore` is called, so a write-configured run aborts having touched
+ * nothing — not even the index-ensuring connect that
+ * `getSafeMongoCollection` performs.
+ *
+ * @param input.config - the resolved run configuration
+ * @param input.openStore - opens the proposal store; must not itself write
+ * @returns the sealed store and the refusal evidence
+ * @throws When the run is write-configured, or the seal is not in force
+ */
+export const runRehearsalPreflight = async <T extends object>(input: {
+  config: IRehearsalRunConfig
+  openStore: () => Promise<T>
+}): Promise<IRehearsalPreflightResult<T>> => {
+  assertRehearsalCannotWrite(input.config)
+  const evidence = proveSealRefusesWrites()
+
+  const store = sealCollectionReadOnly(await input.openStore())
+  if (!isSealedReadOnly(store))
+    throw new Error(
+      'Rehearsal refused: the proposal store handed to the run is not sealed read-only.'
+    )
+
+  return { store, evidence }
+}

--- a/script/deploy/safe/rehearsal-write-guard.ts
+++ b/script/deploy/safe/rehearsal-write-guard.ts
@@ -68,6 +68,61 @@ const RENDERING_MEMBERS: ReadonlySet<string> = new Set([
   'toJSON',
 ])
 
+/**
+ * Whether a value is a handle that must stay sealed as it is passed along.
+ *
+ * Arrays and promises are excluded: `toArray()` resolves to the documents the
+ * read was for, and sealing those would refuse every field on every row.
+ */
+const isDerivedHandle = (value: unknown): value is object =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as { then?: unknown }).then !== 'function'
+
+/**
+ * Seals what a permitted read hands back.
+ *
+ * The allow-list stops at the collection boundary, but a `FindCursor` carries
+ * `.client` and a `ListIndexesCursor` carries `.parent` — the raw collection
+ * itself — so a read the seal permits re-exports the whole write surface one
+ * hop later. Chained calls are sealed too, because `sort()` returns the cursor.
+ *
+ * Every function is allowed here rather than allow-listed by name: a cursor's
+ * API is reads and chaining, and the escape routes are all object-valued.
+ */
+const sealDerivedHandle = <T extends object>(handle: T): T =>
+  new Proxy(handle, {
+    get(target, property) {
+      if (typeof property === 'string' && RENDERING_MEMBERS.has(property))
+        return () => DERIVED_LABEL
+      const value = Reflect.get(target, property, target)
+      if (value === undefined || value === null) return value
+
+      if (typeof value === 'function')
+        return (...args: unknown[]) => {
+          const result = (value as (...a: unknown[]) => unknown).apply(
+            target,
+            args
+          )
+          return isDerivedHandle(result) ? sealDerivedHandle(result) : result
+        }
+
+      if (typeof value === 'object')
+        throw new RehearsalWriteRefusedError(String(property))
+
+      return value
+    },
+    getOwnPropertyDescriptor(target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, property)
+      if (descriptor && typeof descriptor.value === 'object')
+        throw new RehearsalWriteRefusedError(String(property))
+      return descriptor
+    },
+  })
+
+const DERIVED_LABEL = '[read-only sealed handle]'
+
 export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
   const label = '[read-only sealed collection]'
   const sealed = new Proxy(collection, {
@@ -86,7 +141,13 @@ export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
           typeof property === 'string' &&
           PERMITTED_READ_METHODS.has(property)
         )
-          return value.bind(target)
+          return (...args: unknown[]) => {
+            const result = (value as (...a: unknown[]) => unknown).apply(
+              target,
+              args
+            )
+            return isDerivedHandle(result) ? sealDerivedHandle(result) : result
+          }
 
         return () => {
           throw new RehearsalWriteRefusedError(String(property))
@@ -97,6 +158,15 @@ export const sealCollectionReadOnly = <T extends object>(collection: T): T => {
         throw new RehearsalWriteRefusedError(String(property))
 
       return value
+    },
+    // Trapped alongside `get`: a descriptor read returns the raw value, so
+    // without this the refusal above is one `Object.getOwnPropertyDescriptor`
+    // away from being bypassed.
+    getOwnPropertyDescriptor(target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, property)
+      if (descriptor && typeof descriptor.value === 'object')
+        throw new RehearsalWriteRefusedError(String(property))
+      return descriptor
     },
   })
   SEALED_HANDLES.add(sealed)

--- a/script/deploy/safe/safe-utils.ts
+++ b/script/deploy/safe/safe-utils.ts
@@ -1738,7 +1738,7 @@ const NONCE_KEY_PATH = 'safeTx.data.nonce'
  * checksummed form, so one Safe has two spellings in this collection. Comparing
  * raw makes a nonce collision on Tron deterministic rather than merely possible.
  */
-const ADDRESS_COLLATION = { locale: 'en', strength: 2 } as const
+export const ADDRESS_COLLATION = { locale: 'en', strength: 2 } as const
 
 /** Which unique index rejected an insert, when one did. */
 export type DuplicateKeyKind =

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -1,0 +1,292 @@
+/**
+ * Rehearses the Safe verify path end to end, without signing anything.
+ *
+ * Run this to exercise the confirm-stage gate chain against real pending
+ * proposals: it reads them from the store, runs every merged gate twice,
+ * compares the two passes, and prints a report naming every gate the chain is
+ * meant to run — including the ones no commit has wired yet.
+ *
+ *   bunx tsx script/deploy/safe/verify-rehearsal.ts --networks tron,arbitrum
+ *
+ * It never signs, proposes or executes, and the preflight proves that before it
+ * opens anything. `--corrupt` deliberately damages one proposal's calldata to
+ * establish that the chain can still refuse — a rehearsal that only ever grades
+ * green has not shown that its gates work.
+ */
+
+import 'dotenv/config'
+
+import { defineCommand, runMain } from 'citty'
+import { consola } from 'consola'
+import { MongoClient, type Collection } from 'mongodb'
+import type { Hex } from 'viem'
+
+import {
+  summariseGate,
+  type IShadowObservation,
+} from '../codehash/false-refusal-budget'
+
+import {
+  createCheckLedger,
+  recordCheck,
+  type ICheckLedger,
+} from './check-ledger'
+import {
+  CONFIRM_CHECK_DEFINITIONS,
+  targetStateCheckResult,
+} from './confirm-check-registry'
+import {
+  createPinnedTargetStateReader,
+  createTargetStateDeps,
+  evaluateTargetStateIntent,
+} from './pinned-target-state'
+import { buildGateReport, renderGateReport } from './rehearsal-report'
+import {
+  collectRefusalObservations,
+  gradeCorruptionProbe,
+  summariseRehearsal,
+  type IRehearsalPassEntry,
+} from './rehearsal-run'
+import { READ_ONLY_RUN, runRehearsalPreflight } from './rehearsal-write-guard'
+import type { ISafeTxDocument, SafeTxStatus } from './safe-utils'
+
+/** The statuses the store actually holds, so a typo cannot silently match nothing. */
+const SAFE_TX_STATUSES: readonly SafeTxStatus[] = [
+  'pending',
+  'submitted',
+  'executed',
+  'reverted',
+]
+
+/**
+ * Narrows the `--status` flag to a real status.
+ *
+ * Validated rather than cast: an unrecognised value would match no row, and a
+ * rehearsal over zero rows reads far too much like a clean one.
+ */
+const parseStatus = (value: string): SafeTxStatus => {
+  const status = SAFE_TX_STATUSES.find((candidate) => candidate === value)
+  if (!status)
+    throw new Error(
+      `--status must be one of ${SAFE_TX_STATUSES.join(', ')}; got "${value}"`
+    )
+  return status
+}
+
+/**
+ * Opens the proposal store without ensuring any index.
+ *
+ * Deliberately not `getSafeMongoCollection`, which calls `createIndex` twice on
+ * connect: opening the store the ordinary way is itself a write, and it is
+ * exactly the kind nobody would think to switch off.
+ */
+async function openReadOnlyProposalStore(): Promise<{
+  client: MongoClient
+  pendingTransactions: Collection<ISafeTxDocument>
+}> {
+  const uri = process.env.SC_MONGODB_URI
+  if (!uri) throw new Error('SC_MONGODB_URI environment variable is required')
+
+  const client = new MongoClient(uri, { serverSelectionTimeoutMS: 10_000 })
+  await client.connect()
+  return {
+    client,
+    pendingTransactions: client
+      .db('sc_private')
+      .collection<ISafeTxDocument>('pendingTransactions'),
+  }
+}
+
+/** Damages a proposal's calldata so the chain has something it must refuse. */
+const corruptCalldata = (calldata: Hex): Hex =>
+  (calldata.length > 10
+    ? `${calldata.slice(0, 10)}${'f'.repeat(64)}${calldata.slice(74)}`
+    : '0xdeadbeef') as Hex
+
+/**
+ * Runs every merged gate over one proposal and returns its ledger.
+ *
+ * Only `target-state` is wired on this commit; the rest of the roster is
+ * reported absent rather than quietly skipped.
+ */
+function runGateChain(
+  doc: ISafeTxDocument,
+  network: string,
+  corrupt: boolean,
+  readPinnedState: ReturnType<typeof createPinnedTargetStateReader>
+): ICheckLedger {
+  const ledger = createCheckLedger({
+    expectedNetworks: [network],
+    checks: [...CONFIRM_CHECK_DEFINITIONS],
+  })
+
+  const raw = doc.safeTx?.data?.data as Hex | undefined
+  const calldata = raw ? (corrupt ? corruptCalldata(raw) : raw) : undefined
+
+  const verdict = evaluateTargetStateIntent(
+    calldata ? [calldata] : [],
+    network,
+    createTargetStateDeps(network, { readPinnedState })
+  )
+  recordCheck(ledger, targetStateCheckResult(verdict, network))
+
+  return ledger
+}
+
+const main = defineCommand({
+  meta: {
+    name: 'verify-rehearsal',
+    description: 'Rehearse the Safe verify path read-only, signing nothing',
+  },
+  args: {
+    networks: {
+      type: 'string',
+      required: true,
+      description: 'Comma-separated network keys to rehearse',
+    },
+    corrupt: {
+      type: 'boolean',
+      default: false,
+      description:
+        'Damage every proposal, to establish the chain can still refuse',
+    },
+    status: {
+      type: 'string',
+      default: 'pending',
+      description:
+        "Row status to rehearse over. 'pending' is the live case; 'executed' gives the chain a corpus when nothing is in flight",
+    },
+  },
+  async run({ args }) {
+    const networks = args.networks
+      .split(',')
+      .map((network) => network.trim())
+      .filter(Boolean)
+    if (!networks.length) throw new Error('no networks given')
+    const status = parseStatus(args.status)
+
+    // Captured from inside `openStore` so the client is never constructed
+    // before the preflight has refused a write-configured run.
+    let client: MongoClient | undefined
+    const preflight = await runRehearsalPreflight({
+      config: READ_ONLY_RUN,
+      openStore: async () => {
+        const opened = await openReadOnlyProposalStore()
+        client = opened.client
+        return opened.pendingTransactions
+      },
+    })
+    const pendingTransactions = preflight.store
+    consola.success(
+      `Preflight: ${preflight.evidence.length} write methods refused; run is read-only`
+    )
+
+    try {
+      const docs = (await pendingTransactions
+        .find({ network: { $in: networks }, status })
+        .toArray()) as ISafeTxDocument[]
+
+      consola.info(
+        `Rehearsing ${docs.length} ${status} proposal(s) on ${networks.join(
+          ', '
+        )}`
+      )
+
+      // One reader for the whole run. It memoizes the `origin/main` read
+      // internally, so building it per proposal — as an earlier draft did —
+      // discards the memo and re-fetches the remote once per row.
+      const readPinnedState = createPinnedTargetStateReader()
+
+      const pass = (corrupt: boolean): IRehearsalPassEntry[] =>
+        docs.map((doc) => ({
+          proposal: doc.safeTxHash,
+          ledger: runGateChain(doc, doc.network, corrupt, readPinnedState),
+        }))
+
+      const first = pass(false)
+      const second = pass(false)
+
+      const summary = summariseRehearsal({ first, second })
+      if (summary.verdict === 'not-measured')
+        consola.warn(
+          'Not measured: no row was graded, so this run establishes nothing about determinism'
+        )
+      else if (summary.verdict === 'non-deterministic') {
+        consola.error(
+          `Non-deterministic: ${summary.findings.length} difference(s) over ${summary.rowsGraded} row(s)`
+        )
+        for (const finding of summary.findings)
+          consola.error(
+            `  ${finding.proposal} ${finding.checkId}/${finding.network} ${finding.field}: ${finding.first} -> ${finding.second}`
+          )
+      } else
+        consola.success(
+          `Deterministic: two passes graded ${summary.rowsGraded} row(s) identically`
+        )
+
+      const observations: IShadowObservation[] = [
+        ...collectRefusalObservations(first),
+      ]
+      const budget = summariseGate({
+        gate: 'confirm-gate-chain',
+        corpus: `pending proposals on ${networks.join(', ')}`,
+        denominator: observations.length,
+        coverageNote:
+          'only the gates merged on this commit ran; see the roster below for the rest',
+        observations,
+      })
+      consola.info(
+        `Refusals: ${budget.refusals}/${budget.denominator} rows (unexplained ${budget.unexplained})`
+      )
+
+      // Grouped rather than listed: 30 rows refusing for one reason is a
+      // property of the gate, and a flat list of 30 lines hides that.
+      const byReason = new Map<string, number>()
+      for (const observation of observations)
+        if (observation.refused)
+          byReason.set(
+            observation.reason,
+            (byReason.get(observation.reason) ?? 0) + 1
+          )
+      for (const [reason, count] of [...byReason.entries()].sort(
+        (a, b) => b[1] - a[1]
+      ))
+        consola.info(`  ${count}x ${reason}`)
+
+      const rowCounts: Record<string, number> = {}
+      for (const entry of first)
+        for (const result of entry.ledger.results)
+          rowCounts[result.checkId] = (rowCounts[result.checkId] ?? 0) + 1
+
+      consola.info(
+        `\nGate roster\n${renderGateReport(
+          buildGateReport({
+            registered: CONFIRM_CHECK_DEFINITIONS.map((check) => check.checkId),
+            rowCounts,
+          })
+        )}`
+      )
+
+      if (args.corrupt) {
+        const outcome = gradeCorruptionProbe(pass(true))
+        if (outcome === 'refused')
+          consola.success(
+            'Corruption probe: the chain refused damaged calldata'
+          )
+        else if (outcome === 'did-not-refuse')
+          consola.error(
+            'Corruption probe: the chain graded damaged calldata without refusing'
+          )
+        else
+          consola.warn(
+            'Corruption probe: not exercised — there was nothing to damage'
+          )
+      }
+    } finally {
+      await client?.close(true)
+    }
+  },
+})
+
+if (process.argv[1] && process.argv[1].endsWith('verify-rehearsal.ts'))
+  void runMain(main)

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -1,17 +1,19 @@
 /**
  * Rehearses the Safe verify path end to end, without signing anything.
  *
- * Run this to exercise the confirm-stage gate chain against real pending
- * proposals: it reads them from the store, runs every merged gate twice,
- * compares the two passes, and prints a report naming every gate the chain is
- * meant to run — including the ones no commit has wired yet.
+ * Run this to exercise the confirm-stage gate chain against real proposals: it
+ * reads them from the store, runs every merged gate twice, compares the two
+ * passes, and prints a report naming every gate the chain is meant to run —
+ * including the ones no commit has wired yet.
  *
  *   bunx tsx script/deploy/safe/verify-rehearsal.ts --networks tron,arbitrum
  *
  * It never signs, proposes or executes, and the preflight proves that before it
- * opens anything. `--corrupt` deliberately damages one proposal's calldata to
- * establish that the chain can still refuse — a rehearsal that only ever grades
- * green has not shown that its gates work.
+ * opens anything. `--corrupt` damages every proposal's calldata to establish
+ * that the chain can still refuse — a rehearsal that only ever grades green has
+ * not shown that its gates work. `--status` selects the corpus: `pending` is
+ * the live case, and `executed` gives the chain something to grade when nothing
+ * is in flight, at the cost of judging historical cuts against today's anchor.
  */
 
 import 'dotenv/config'

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -27,6 +27,7 @@ import {
   summariseGate,
   type IShadowObservation,
 } from '../codehash/false-refusal-budget'
+import { collectDiamondCutCalls } from '../shared/diamond-cut-calls'
 
 import {
   createCheckLedger,
@@ -111,11 +112,50 @@ async function openReadOnlyProposalStore(): Promise<{
   }
 }
 
-/** Damages a proposal's calldata so the chain has something it must refuse. */
-const corruptCalldata = (calldata: Hex): Hex =>
-  (calldata.length > 10
-    ? `${calldata.slice(0, 10)}${'f'.repeat(64)}${calldata.slice(74)}`
-    : '0xdeadbeef') as Hex
+/**
+ * An address no deployment record can resolve, for the mutation below.
+ *
+ * Recognisable on sight in a survivor line, and deliberately not a plausible
+ * facet: if the gate grades this as a known contract, that is the finding.
+ */
+const UNRESOLVABLE_FACET = 'deadbeef'.repeat(5)
+
+/**
+ * Damages the field the gate actually grades: a cut's facet address.
+ *
+ * An earlier version overwrote the first 32-byte argument word. For a direct
+ * `diamondCut` that is the array offset, so the decode failed and the chain
+ * refused — but for the timelock-wrapped `schedule` that most production
+ * rollouts use, that word is `target`, and the inner cut bytes were left
+ * untouched. The gate then graded the corrupted payload byte-identically and
+ * the probe reported a survivor on every wrapped proposal: a red about the
+ * mutation rather than about the chain.
+ *
+ * Substituting the address wherever it appears reaches the inner cut at any
+ * nesting depth without this module having to know the wrapper's shape.
+ *
+ * @param calldata - the proposal payload
+ * @returns the payload with every cut's facet address replaced, or a payload
+ * whose leading word is damaged when no cut could be found to aim at
+ */
+const corruptCalldata = (calldata: Hex): Hex => {
+  const collected = collectDiamondCutCalls([calldata])
+  const addresses = collected.calls.flatMap((call) =>
+    call.cuts.map((cut) => cut.facetAddress.slice(2).toLowerCase())
+  )
+
+  if (addresses.length === 0)
+    return (
+      calldata.length > 10
+        ? `${calldata.slice(0, 10)}${'f'.repeat(64)}${calldata.slice(74)}`
+        : '0xdeadbeef'
+    ) as Hex
+
+  let damaged = calldata.toLowerCase()
+  for (const address of new Set(addresses))
+    damaged = damaged.split(address).join(UNRESOLVABLE_FACET)
+  return damaged as Hex
+}
 
 /**
  * Runs every merged gate over one proposal and returns its ledger.
@@ -358,20 +398,20 @@ const main = defineCommand({
         const outcome = gradeCorruptionProbe(first, corrupted)
         if (outcome === 'refused')
           consola.success(
-            'Corruption probe: every row that graded clean now refuses'
+            'Corruption probe: every row the chain had read and graded now refuses'
           )
         else if (outcome === 'did-not-refuse') {
           failed = true
           const survivors = survivedCorruption(first, corrupted)
           consola.error(
-            `Corruption probe: ${survivors.length} row(s) graded clean both before and after corruption`
+            `Corruption probe: the chain reached the same verdict on ${survivors.length} row(s) before and after their facet address was replaced`
           )
           for (const slot of survivors.slice(0, 10))
             consola.error(`  survived: ${slot}`)
         } else {
           failed = true
           consola.warn(
-            'Corruption probe: not exercised — no row graded clean before corruption, so damaging them proves nothing'
+            'Corruption probe: not exercised — no row was both readable and not already refusing, so damaging one proves nothing'
           )
         }
       }

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -121,28 +121,37 @@ async function openReadOnlyProposalStore(): Promise<{
 const UNRESOLVABLE_FACET = 'deadbeef'.repeat(5)
 
 /**
+ * A cut's facet address is only a usable needle if it is distinctive.
+ *
+ * A `Remove` action carries the zero address, whose hex is forty zeroes — a run
+ * that occurs in almost every word of ABI padding, in a timelock `predecessor`,
+ * and in every array offset. Substituting it rewrites the whole payload rather
+ * than the field being aimed at, and the gate then refuses because nothing
+ * decodes: a pass the probe did not earn.
+ */
+const isUsableNeedle = (address: string): boolean =>
+  !/^0+$/.test(address) && !/^f+$/i.test(address)
+
+/**
  * Damages the field the gate actually grades: a cut's facet address.
  *
- * An earlier version overwrote the first 32-byte argument word. For a direct
- * `diamondCut` that is the array offset, so the decode failed and the chain
- * refused — but for the timelock-wrapped `schedule` that most production
- * rollouts use, that word is `target`, and the inner cut bytes were left
- * untouched. The gate then graded the corrupted payload byte-identically and
- * the probe reported a survivor on every wrapped proposal: a red about the
- * mutation rather than about the chain.
- *
- * Substituting the address wherever it appears reaches the inner cut at any
- * nesting depth without this module having to know the wrapper's shape.
+ * Substituting the address reaches the inner cut at any nesting depth without
+ * this module knowing the wrapper's shape: a timelock `schedule` and a direct
+ * `diamondCut` are damaged alike. It rewrites the address anywhere else it
+ * appears too — the `schedule` target included — so a refusal establishes that
+ * the chain noticed the change, not which field it noticed.
  *
  * @param calldata - the proposal payload
- * @returns the payload with every cut's facet address replaced, or a payload
- * whose leading word is damaged when no cut could be found to aim at
+ * @returns the payload with every usable facet address replaced, or one whose
+ * leading word is damaged when no cut offered a needle to aim at
  */
 const corruptCalldata = (calldata: Hex): Hex => {
   const collected = collectDiamondCutCalls([calldata])
-  const addresses = collected.calls.flatMap((call) =>
-    call.cuts.map((cut) => cut.facetAddress.slice(2).toLowerCase())
-  )
+  const addresses = collected.calls
+    .flatMap((call) =>
+      call.cuts.map((cut) => cut.facetAddress.slice(2).toLowerCase())
+    )
+    .filter(isUsableNeedle)
 
   if (addresses.length === 0)
     return (
@@ -404,7 +413,7 @@ const main = defineCommand({
           failed = true
           const survivors = survivedCorruption(first, corrupted)
           consola.error(
-            `Corruption probe: the chain reached the same verdict on ${survivors.length} row(s) before and after their facet address was replaced`
+            `Corruption probe: ${survivors.length} row(s) did not refuse after their calldata was damaged`
           )
           for (const slot of survivors.slice(0, 10))
             consola.error(`  survived: ${slot}`)

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -33,6 +33,7 @@ import {
   recordCheck,
   type ICheckLedger,
 } from './check-ledger'
+import { readBooleanFlag } from './cli-flags'
 import {
   CONFIRM_CHECK_DEFINITIONS,
   targetStateCheckResult,
@@ -42,10 +43,18 @@ import {
   createTargetStateDeps,
   evaluateTargetStateIntent,
 } from './pinned-target-state'
-import { buildGateReport, renderGateReport } from './rehearsal-report'
+import {
+  buildGateReport,
+  checkGradingAnchors,
+  renderGateReport,
+  renderGradingAnchors,
+  renderSignerWorkload,
+  summariseSignerWorkload,
+} from './rehearsal-report'
 import {
   collectRefusalObservations,
   gradeCorruptionProbe,
+  refusalClasses,
   rowCountsByCheck,
   summariseRehearsal,
   survivedCorruption,
@@ -154,6 +163,11 @@ const main = defineCommand({
       description:
         'Damage every proposal, to establish the chain can still refuse',
     },
+    gradeWithoutAnchors: {
+      type: 'boolean',
+      description:
+        'Grade even though a local anchor the gates read is missing. Every refusal is then suspect.',
+    },
     status: {
       type: 'string',
       default: 'pending',
@@ -171,6 +185,24 @@ const main = defineCommand({
       .filter(Boolean)
     if (!networks.length) throw new Error('no networks given')
     const status = parseStatus(args.status)
+
+    // Before anything is graded. A missing deployment cache turns the
+    // target-state gate into a refusal on essentially every proposal, and the
+    // refusals it produces are indistinguishable from real ones — so a run that
+    // grades anyway publishes a corpus of false reds as findings.
+    const anchors = checkGradingAnchors(process.cwd())
+    consola.info(`Grading anchors\n${renderGradingAnchors(anchors)}`)
+    const missing = anchors.filter((anchor) => !anchor.present)
+    // Read from argv, not from `args`: citty parses a multi-word flag's
+    // `--no-` form to the string 'false', which is truthy. See `cli-flags.ts`.
+    const gradeWithoutAnchors = readBooleanFlag(process.argv, {
+      camel: 'gradeWithoutAnchors',
+      kebab: 'grade-without-anchors',
+    })
+    if (missing.length && !gradeWithoutAnchors)
+      throw new Error(
+        `Refusing to grade: ${missing.length} grading anchor(s) missing. Every verdict would rest on a file this checkout does not have. Re-run where they exist, or pass --grade-without-anchors to grade anyway and read every refusal as suspect.`
+      )
 
     // Captured from inside `openStore` so the client is never constructed
     // before the preflight has refused a write-configured run.
@@ -249,9 +281,26 @@ const main = defineCommand({
           'only the gates merged on this commit ran; see the roster below for the rest',
         observations,
       })
-      consola.info(
-        `Refusals: ${budget.refusals}/${budget.denominator} rows (unexplained ${budget.unexplained})`
-      )
+
+      // A budget over a single refusal class is not a measurement. Every
+      // refusal lands in the one bucket this release has already ruled correct,
+      // so `unexplained` is 0 for any corpus on any day — and that 0 is what
+      // EXSC-977's promotion criterion reads to decide a gate may start
+      // blocking. Withheld rather than printed with a caveat: a number nobody
+      // can move should not appear next to numbers that move.
+      const classes = refusalClasses(first)
+      if (classes.length > 1)
+        consola.info(
+          `Refusals: ${budget.refusals}/${budget.denominator} rows (unexplained ${budget.unexplained})`
+        )
+      else
+        consola.warn(
+          `Refusal budget: not measured — ${budget.refusals}/${
+            budget.denominator
+          } rows refused, all of one class (${
+            classes[0] ?? 'none'
+          }), so "unexplained 0" would be a constant, not a result`
+        )
 
       // Grouped rather than listed: 30 rows refusing for one reason is a
       // property of the gate, and a flat list of 30 lines hides that.
@@ -266,6 +315,12 @@ const main = defineCommand({
         (a, b) => b[1] - a[1]
       ))
         consola.info(`  ${count}x ${reason}`)
+
+      consola.info(
+        `\nWho has to act\n${renderSignerWorkload(
+          summariseSignerWorkload(first)
+        )}`
+      )
 
       consola.info(
         `\nGate roster\n${renderGateReport(

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -48,6 +48,7 @@ import {
   checkGradingAnchors,
   renderGateReport,
   renderGradingAnchors,
+  verdictsAreActionable,
   renderSignerWorkload,
   summariseSignerWorkload,
 } from './rehearsal-report'
@@ -185,6 +186,7 @@ const main = defineCommand({
       .filter(Boolean)
     if (!networks.length) throw new Error('no networks given')
     const status = parseStatus(args.status)
+    const actionable = verdictsAreActionable(status)
 
     // Before anything is graded. A missing deployment cache turns the
     // target-state gate into a refusal on essentially every proposal, and the
@@ -289,7 +291,11 @@ const main = defineCommand({
       // blocking. Withheld rather than printed with a caveat: a number nobody
       // can move should not appear next to numbers that move.
       const classes = refusalClasses(first)
-      if (classes.length > 1)
+      if (!actionable)
+        consola.info(
+          `Verdicts withheld: '${status}' proposals are graded against the target state origin/main declares now, not the one they were proposed against, so every version comparison is against an anchor from its own future. What this run establishes: the chain survives ${docs.length} real proposal shapes and agrees with itself. What it does not establish: anything about these proposals. Use --status pending for verdicts a signer can act on.`
+        )
+      else if (classes.length > 1)
         consola.info(
           `Refusals: ${budget.refusals}/${budget.denominator} rows (unexplained ${budget.unexplained})`
         )
@@ -304,23 +310,26 @@ const main = defineCommand({
 
       // Grouped rather than listed: 30 rows refusing for one reason is a
       // property of the gate, and a flat list of 30 lines hides that.
-      const byReason = new Map<string, number>()
-      for (const observation of observations)
-        if (observation.refused)
-          byReason.set(
-            observation.reason,
-            (byReason.get(observation.reason) ?? 0) + 1
-          )
-      for (const [reason, count] of [...byReason.entries()].sort(
-        (a, b) => b[1] - a[1]
-      ))
-        consola.info(`  ${count}x ${reason}`)
+      const byReason = actionable ? new Map<string, number>() : undefined
+      if (byReason) {
+        for (const observation of observations)
+          if (observation.refused)
+            byReason.set(
+              observation.reason,
+              (byReason.get(observation.reason) ?? 0) + 1
+            )
+        for (const [reason, count] of [...byReason.entries()].sort(
+          (a, b) => b[1] - a[1]
+        ))
+          consola.info(`  ${count}x ${reason}`)
+      }
 
-      consola.info(
-        `\nWho has to act\n${renderSignerWorkload(
-          summariseSignerWorkload(first)
-        )}`
-      )
+      if (actionable)
+        consola.info(
+          `\nWho has to act\n${renderSignerWorkload(
+            summariseSignerWorkload(first)
+          )}`
+        )
 
       consola.info(
         `\nGate roster\n${renderGateReport(

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -227,6 +227,19 @@ const main = defineCommand({
         .find({ network: { $in: networks }, status })
         .toArray()) as ISafeTxDocument[]
 
+      // Nothing to grade is a normal state, not a failure — an empty pending
+      // queue means no wave is in flight. Returning here rather than running
+      // the sections over zero rows: "0/0 refused, all of one class (none)" is
+      // not a result, and four blocks of zeroes bury the one line that is.
+      if (docs.length === 0) {
+        consola.info(
+          `No ${status} proposals on ${networks.join(
+            ', '
+          )} — nothing to verify. Run this once a wave is in the store and before anyone signs.`
+        )
+        return
+      }
+
       consola.info(
         `Rehearsing ${docs.length} ${status} proposal(s) on ${networks.join(
           ', '

--- a/script/deploy/safe/verify-rehearsal.ts
+++ b/script/deploy/safe/verify-rehearsal.ts
@@ -46,7 +46,9 @@ import { buildGateReport, renderGateReport } from './rehearsal-report'
 import {
   collectRefusalObservations,
   gradeCorruptionProbe,
+  rowCountsByCheck,
   summariseRehearsal,
+  survivedCorruption,
   type IRehearsalPassEntry,
 } from './rehearsal-run'
 import { READ_ONLY_RUN, runRehearsalPreflight } from './rehearsal-write-guard'
@@ -160,9 +162,12 @@ const main = defineCommand({
     },
   },
   async run({ args }) {
+    // Lowercased, as every writer in this package stores them. An uncased key
+    // matches no document, and the run would then report "not measured" — a
+    // typo reading as a clean rehearsal is the worst outcome for this tool.
     const networks = args.networks
       .split(',')
-      .map((network) => network.trim())
+      .map((network) => network.trim().toLowerCase())
       .filter(Boolean)
     if (!networks.length) throw new Error('no networks given')
     const status = parseStatus(args.status)
@@ -170,20 +175,20 @@ const main = defineCommand({
     // Captured from inside `openStore` so the client is never constructed
     // before the preflight has refused a write-configured run.
     let client: MongoClient | undefined
-    const preflight = await runRehearsalPreflight({
-      config: READ_ONLY_RUN,
-      openStore: async () => {
-        const opened = await openReadOnlyProposalStore()
-        client = opened.client
-        return opened.pendingTransactions
-      },
-    })
-    const pendingTransactions = preflight.store
-    consola.success(
-      `Preflight: ${preflight.evidence.length} write methods refused; run is read-only`
-    )
-
     try {
+      const preflight = await runRehearsalPreflight({
+        config: READ_ONLY_RUN,
+        openStore: async () => {
+          const opened = await openReadOnlyProposalStore()
+          client = opened.client
+          return opened.pendingTransactions
+        },
+      })
+      const pendingTransactions = preflight.store
+      consola.success(
+        `Preflight: ${preflight.evidence.length} write surfaces refused; run is read-only`
+      )
+
       const docs = (await pendingTransactions
         .find({ network: { $in: networks }, status })
         .toArray()) as ISafeTxDocument[]
@@ -194,26 +199,33 @@ const main = defineCommand({
         )}`
       )
 
-      // One reader for the whole run. It memoizes the `origin/main` read
-      // internally, so building it per proposal — as an earlier draft did —
-      // discards the memo and re-fetches the remote once per row.
-      const readPinnedState = createPinnedTargetStateReader()
-
-      const pass = (corrupt: boolean): IRehearsalPassEntry[] =>
-        docs.map((doc) => ({
+      // One reader per pass, not one per run. The reader memoizes its
+      // `origin/main` read, so sharing it across both passes would replay the
+      // first pass's answer into the second — and the remote anchor is the one
+      // genuinely moving input the determinism check exists to catch.
+      const pass = (corrupt: boolean): IRehearsalPassEntry[] => {
+        const readPinnedState = createPinnedTargetStateReader()
+        return docs.map((doc) => ({
           proposal: doc.safeTxHash,
           ledger: runGateChain(doc, doc.network, corrupt, readPinnedState),
         }))
+      }
 
       const first = pass(false)
       const second = pass(false)
 
       const summary = summariseRehearsal({ first, second })
-      if (summary.verdict === 'not-measured')
+      // Tracked so the process can exit non-zero. consola sets no exit code, so
+      // a wrapper or scheduled run would otherwise read a rehearsal that
+      // established nothing — or one that found a difference — as success.
+      let failed = false
+      if (summary.verdict === 'not-measured') {
+        failed = true
         consola.warn(
           'Not measured: no row was graded, so this run establishes nothing about determinism'
         )
-      else if (summary.verdict === 'non-deterministic') {
+      } else if (summary.verdict === 'non-deterministic') {
+        failed = true
         consola.error(
           `Non-deterministic: ${summary.findings.length} difference(s) over ${summary.rowsGraded} row(s)`
         )
@@ -231,7 +243,7 @@ const main = defineCommand({
       ]
       const budget = summariseGate({
         gate: 'confirm-gate-chain',
-        corpus: `pending proposals on ${networks.join(', ')}`,
+        corpus: `${status} proposals on ${networks.join(', ')}`,
         denominator: observations.length,
         coverageNote:
           'only the gates merged on this commit ran; see the roster below for the rest',
@@ -255,35 +267,39 @@ const main = defineCommand({
       ))
         consola.info(`  ${count}x ${reason}`)
 
-      const rowCounts: Record<string, number> = {}
-      for (const entry of first)
-        for (const result of entry.ledger.results)
-          rowCounts[result.checkId] = (rowCounts[result.checkId] ?? 0) + 1
-
       consola.info(
         `\nGate roster\n${renderGateReport(
           buildGateReport({
             registered: CONFIRM_CHECK_DEFINITIONS.map((check) => check.checkId),
-            rowCounts,
+            rowCounts: rowCountsByCheck(first),
           })
         )}`
       )
 
       if (args.corrupt) {
-        const outcome = gradeCorruptionProbe(pass(true))
+        const corrupted = pass(true)
+        const outcome = gradeCorruptionProbe(first, corrupted)
         if (outcome === 'refused')
           consola.success(
-            'Corruption probe: the chain refused damaged calldata'
+            'Corruption probe: every row that graded clean now refuses'
           )
-        else if (outcome === 'did-not-refuse')
+        else if (outcome === 'did-not-refuse') {
+          failed = true
+          const survivors = survivedCorruption(first, corrupted)
           consola.error(
-            'Corruption probe: the chain graded damaged calldata without refusing'
+            `Corruption probe: ${survivors.length} row(s) graded clean both before and after corruption`
           )
-        else
+          for (const slot of survivors.slice(0, 10))
+            consola.error(`  survived: ${slot}`)
+        } else {
+          failed = true
           consola.warn(
-            'Corruption probe: not exercised — there was nothing to damage'
+            'Corruption probe: not exercised — no row graded clean before corruption, so damaging them proves nothing'
           )
+        }
       }
+
+      if (failed) process.exitCode = 1
     } finally {
       await client?.close(true)
     }


### PR DESCRIPTION
# Which Linear task belongs to this PR?

Fixes [EXSC-995](https://linear.app/lifi-linear/issue/EXSC-995)

Also closes [EXSC-931](https://linear.app/lifi-linear/issue/EXSC-931) — the junk proposal at nonce 31 on the production Tron Safe is gone, cleared with the teardown added here. Spun out: [EXSC-1009](https://linear.app/lifi-linear/issue/EXSC-1009).

# Why I implemented it this way

## What this is, and when you would run it

One command that runs the confirm-time gate chain against real proposals and shows what a signer would see — without signing, proposing or executing.

```bash
bun verify-pending-proposals --networks arbitrum,base,optimism
```

(`--status` defaults to `pending`; the script opens the Safe tunnel first, as the other Safe commands do. With nothing in flight it says so in one line and exits 0.)

**Run it on a rollout wave, after the proposals are in the store and before anyone signs.** It answers: how many rows does the evidence settle on its own, how many block outright, and how many need a human to say "yes, this is the change we meant". If a 40-chain wave is about to ask someone for 40 acknowledgements, that is better known at rollout time than at signing time.

**Be honest about what is useful today.** One gate of nine is merged, so a run exercises `target-state` and reports the other eight absent. That is on-spec — EXSC-995's build order was explicitly "build the harness before the pipeline, report absent gates as absent" — but it means the runner is scaffolding until [EXSC-994](https://linear.app/lifi-linear/issue/EXSC-994) wires the rest. There are also no pending proposals anywhere right now, so its first real use is the next wave.

The two pieces that earn their keep immediately:

- **`rehearsal-teardown.ts`** — the only thing in the repo that hunts a proposal by nonce under the store's collation. It closed EXSC-931.
- **the grading-anchor check** — a fresh worktree silently turns `target-state` into a refusal on every proposal. Details below; it cost most of a session to find.

## The preflight asserts; it does not intend

The risk a read-only rehearsal carries is not signing — nobody does that by accident. It is an incidental write: the acknowledgement ledger, signed-set persistence, the reconcile back-fill. So the collection is sealed behind an **allow-list of reads** (a deny-list is outgrown by the next driver release, and the method it fails to name is the one that writes), the seal is proven by reaching for the refused members against a canary, and the live handle is tied to that proof by identity.

The proof probes a canary rather than the live handle on purpose: calling `insertOne` on a real collection to find out whether it is sealed would insert a row on exactly the run where the guard was missing. `proveSealRefusesWrites` takes the sealer as a parameter so the proof can itself be falsified — a proof with no failing branch measures nothing.

Four escapes the review gate found, each verified against a real driver handle before and after the fix:

- the seal refused only callables, so `.client` came back as the live `MongoClient`, one call from an unsealed collection;
- an allow-listed read re-exported the write surface one hop later — a `FindCursor` carries `.client`, a `ListIndexesCursor` carries `.parent`, the raw collection itself;
- `AbstractCursor._initialize` resolves to an object carrying a live `Server`, whose `command()` runs an arbitrary command — so "every function on a cursor is a read" was false, and cursor methods are allow-listed by name too;
- `util.inspect` reads a proxy's target directly without consulting a single trap, so `console.log(sealed)` printed the whole `MongoClient`, credentials object included. The seal is now proxied over an empty object, which is the only thing that stops it.

`aggregate` also left the allow-list, since an `$out`/`$merge` pipeline writes. The `getOwnPropertyDescriptor` trap redacts rather than throwing: refusing there took down `Object.keys` and `for…in` on a real `Collection`, whose only own properties are `s` and `client`. Spread and `Object.entries` still refuse, and should — they read the values.

This surfaced a write nobody asks for: **`getSafeMongoCollection()` calls `createIndex` twice on connect**, so opening the store the ordinary way mutates it. The rehearsal opens it by another route.

**Not EXSC-980.** That is the full ceremony on a staging network, and its preflight refuses unless the Safe is outside the production set — it would refuse exactly this run. The two designs are deliberately not merged.

## The teardown is the safety story for dummy proposals

A pending row occupies a Safe nonce and Safes execute in order, so a dummy at N blocks every real proposal after it — but only if it is left behind. `findProposalsAtNonce` matches under the store's collation, which is not optional: one Safe has two spellings in this collection (`propose-to-safe-tron.ts` stores lowercase hex, `initializeSafeClient` stores checksummed). Measured against production, the checksummed spelling of the Tron Safe matches **0 rows uncollated and 34 collated**.

`tearDownProposalsAtNonce` lowercases the network before deleting. The hunt tolerates a miscased network because its collation applies to the whole query, but `deletePendingProposals` matches `network` with an uncollated `$eq` — so `--network Tron --delete` would list the rows, delete none, and report success while the nonce stayed blocked.

## Three things the run refuses to call a result

Each of these was a green that turned out to be an artifact, found by falsifying the harness against real data rather than by a test.

**A corpus whose anchor is in its own future.** The gates grade against the target state `origin/main` declares *now*. Right for a proposal about to be signed; meaningless for one that executed months ago — it installed what main declared then, so today it reads as a downgrade. A run over executed rows was printing 47 refusals and a signer workload as if they were findings. It now reports only what such a corpus establishes (the chain survives real shapes; two passes agree; which gates are wired) and names `--status pending` as the corpus whose verdicts a signer can act on.

**A missing grading anchor.** The deployment record is read from `.cache/deployments_production.json`, which is gitignored, so a fresh worktree does not have it. `resolveDeployedContractByAddress` then returns `unrecorded` for every address and every cut element grades `contract-unidentified`, with nothing saying why. With the file absent: 1066 of 3191 rows refused, all one class. With it present the same corpus produces `downgrade`, `matches-main`, `ahead-of-main` and `not-previously-targeted`. The anchors are now checked before anything is graded and the run refuses, naming the remedy; `--grade-without-anchors` grades anyway and says every refusal is suspect. The gate checks the file parses as a record array, not merely that it exists — the loader memoises `null` for both, so a truncated cache produced the same wall of false refusals. *The signing CLI largely avoids this*: it refreshes the cache from MongoDB at startup, though that refresh is itself conditional on `MONGODB_URI` and swallows failure at debug level. The rehearsal never reaches that warm-up, because it opens the store by another route to avoid the index write.

**A budget over a single refusal class.** When only one class is reachable and this release has already ruled it correct, every refusal lands in that bucket and `unexplained` is 0 for any corpus on any day. That constant is what EXSC-977's promotion criterion reads to decide a gate may start blocking, so it is withheld rather than printed with a caveat.

## Determinism, and the corruption probe

Two passes over the same input must agree; a difference means something in the chain reads a moving value. Each pass builds its **own** pinned-state reader — sharing one memoising reader across both (which an earlier commit did, for speed) meant pass two replayed pass one's `origin/main` read, so the check could not fire on the one genuinely moving input it targets.

`gradeCorruptionProbe` is graded **per row**: every row clean before corruption must refuse after it. Asking whether *any* row refused reported success before the damage was applied, because most rows already refuse for their own reasons.

Both halves of it took two goes, and real data caught both.

The **population** is narrowed to rows the mutation can reach: one that already stopped on the bytes proves nothing by stopping again, and one the gate graded as having no cut to compare can never refuse at all. `needs-ack` rows are deliberately in — the payload was read and understood and only the intent is open, so if corruption makes it unreadable the chain noticed. Excluding them emptied the population fleet-wide and the probe reported "not exercised" everywhere while looking fixed.

The **mutation** replaces the cut's facet address wherever it appears. Overwriting the first argument word — the obvious thing — worked only for a direct `diamondCut`, where that word is the array offset. For the timelock-wrapped `schedule` that most production rollouts use it is `target`, leaving the inner cut untouched, so the gate graded the corrupted payload byte-identically. The survivors split exactly by outer selector: `diamondCut` 18 refused / 0 survived, `schedule` 0 / 12. Substituting the address reaches the inner cut at any nesting depth without this module knowing the wrapper's shape.

## Also

`ADDRESS_COLLATION` is now exported from `safe-utils.ts` rather than copied — that file's own comment says the index and the read that feeds it must not disagree, and a third copy is exactly that risk.

Every failing verdict exits non-zero. Network keys are lowercased before they reach Mongo, where a miscased key matched nothing and read as a clean run.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: I have checked all points from this list: https://www.notion.so/lifi/New-Facet-Contract-Checklist-157f0ff14ac78095a2b8f999d655622e
- [ ] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [ ] I have checked that any arbitrary calls to external contracts are validated and or restricted
- [ ] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted
- [ ] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit conducted on <date> by <company/auditor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

