### PR TITLE
feat(safe): refuse a network the run cannot check, before a ledger exists

### DIFF
--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -183,9 +183,9 @@ import {
   toSignedCodehashEntries,
 } from './signed-set-record'
 import {
-  preflight,
+  networkPreflight,
   PREFLIGHT_EXIT_CODE,
-  renderPreflight,
+  renderNetworkPreflight,
 } from './signer-preflight'
 import {
   checkSummary,
@@ -1881,14 +1881,13 @@ const main = defineCommand({
         )
       }
 
-      // Before the ownership reads, and before a ledger exists. A network
-      // without a working endpoint cannot be graded, so it is named once here
-      // with its cause rather than appearing later as a column of unverified
-      // checks that describe one unset variable. Placed ahead of
-      // `getNetworksWithActionableTransactions` because that one swallows a
-      // failed read as "not actionable", which is a true statement with a false
-      // explanation.
-      const preflightVerdict = await preflight(candidateNetworks, {
+      // Before the ownership reads and before a ledger exists, so a network
+      // that cannot be graded is named once with its cause instead of becoming
+      // a column of unverified checks. `getNetworksWithActionableTransactions`
+      // still probes it — it derives its own network list — but reports a failed
+      // read as "not actionable", a true statement with a false explanation, so
+      // the refusal has to be printed before it speaks.
+      const preflightVerdict = await networkPreflight(candidateNetworks, {
         endpointConfigured: (network) =>
           Boolean(args.rpcUrl?.trim()) ||
           Boolean(process.env[getRPCEnvVarName(network)]?.trim()),
@@ -1900,7 +1899,9 @@ const main = defineCommand({
         envVarName: getRPCEnvVarName,
       })
       refusedNetworks = [...preflightVerdict.refused]
-      renderPreflight(preflightVerdict).forEach((line) => consola.log(line))
+      renderNetworkPreflight(preflightVerdict).forEach((line) =>
+        consola.log(line)
+      )
 
       if (preflightVerdict.startable.length === 0) {
         process.exitCode = PREFLIGHT_EXIT_CODE
@@ -1910,13 +1911,12 @@ const main = defineCommand({
 
       if (args.network) networks = [...preflightVerdict.startable]
       else {
-        const allNetworksWithPendingTxs = preflightVerdict.startable
+        const startableWithPendingTxs = preflightVerdict.startable
         consola.info(`Checking ownership for signer: ${signerAddress}`)
 
-        // Filter to only networks where the user can take action (is a Safe
-        // owner), then to the ones the preflight cleared: a refused network
-        // must not re-enter here, where a failed read would be reported as
-        // "you are not a Safe owner".
+        // Filtered to the networks the preflight cleared, so a refused one
+        // cannot reach `networks` — and therefore the ledger — as "not a Safe
+        // owner", which is what its failed ownership read would otherwise say.
         networks = (
           await getNetworksWithActionableTransactions(
             pendingTransactions,
@@ -1935,8 +1935,8 @@ const main = defineCommand({
         }
 
         // Show which networks are actionable
-        if (networks.length < allNetworksWithPendingTxs.length) {
-          const nonActionableNetworks = allNetworksWithPendingTxs.filter(
+        if (networks.length < startableWithPendingTxs.length) {
+          const nonActionableNetworks = startableWithPendingTxs.filter(
             (n) => !networks.includes(n)
           )
           consola.info(
@@ -1952,8 +1952,10 @@ const main = defineCommand({
             )}`
           )
         } else {
+          // "this run can check", not "with pending transactions": the refused
+          // networks were dropped above and counted in the block that named them.
           consola.info(
-            `You can take action on all ${networks.length} network(s) with pending transactions`
+            `You can take action on all ${networks.length} network(s) this run can check`
           )
         }
       }

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -28,6 +28,7 @@ import networksData from '../../../config/networks.json'
 import { EnvironmentEnum, type SupportedChain } from '../../common/types'
 import { getDeployments } from '../../utils/deploymentHelpers'
 import { redactUrls } from '../../utils/redactUrls'
+import { getRPCEnvVarName } from '../../utils/utils'
 import {
   buildExplorerAddressUrl,
   getFallbackTransportForChain,
@@ -182,6 +183,11 @@ import {
   toSignedCodehashEntries,
 } from './signed-set-record'
 import {
+  preflight,
+  PREFLIGHT_EXIT_CODE,
+  renderPreflight,
+} from './signer-preflight'
+import {
   checkSummary,
   PROPOSAL_SEPARATOR,
   renderCheckGroups,
@@ -249,6 +255,12 @@ const readDeploymentRecords = async (): Promise<
 // Read once, at the end of the run: the verdict is rendered from these rows, so
 // a status any row below claims is a status a signer is shown.
 let checkLedger: ICheckLedger | undefined
+
+// Networks the preflight refused, kept out of the ledger's denominator and
+// therefore invisible to its verdict. Held here so the end of the run can say
+// the coverage was short: a ledger that is green for the networks it graded
+// must not read as a green run when a network was never graded at all.
+let refusedNetworks: string[] = []
 
 const recordEveryCheck = (
   network: string,
@@ -1837,6 +1849,7 @@ const main = defineCommand({
       }
 
       let networks: string[]
+      let candidateNetworks: string[]
 
       if (args.network) {
         // If a specific network is provided, validate it exists and is active
@@ -1848,13 +1861,14 @@ const main = defineCommand({
         if (networkConfig.status !== 'active')
           throw new Error(`Network ${args.network} is not active`)
 
-        networks = [args.network]
+        candidateNetworks = [args.network]
       } else {
         // First, get all networks with pending transactions (for informational purposes)
-        const allNetworksWithPendingTxs =
-          await getNetworksWithPendingTransactions(pendingTransactions)
+        candidateNetworks = await getNetworksWithPendingTransactions(
+          pendingTransactions
+        )
 
-        if (allNetworksWithPendingTxs.length === 0) {
+        if (candidateNetworks.length === 0) {
           consola.info('No networks have pending transactions')
           await mongoClient.close(true)
           return
@@ -1862,17 +1876,54 @@ const main = defineCommand({
 
         consola.info(
           `Found pending transactions on ${
-            allNetworksWithPendingTxs.length
-          } network(s): ${allNetworksWithPendingTxs.join(', ')}`
+            candidateNetworks.length
+          } network(s): ${candidateNetworks.join(', ')}`
         )
+      }
+
+      // Before the ownership reads, and before a ledger exists. A network
+      // without a working endpoint cannot be graded, so it is named once here
+      // with its cause rather than appearing later as a column of unverified
+      // checks that describe one unset variable. Placed ahead of
+      // `getNetworksWithActionableTransactions` because that one swallows a
+      // failed read as "not actionable", which is a true statement with a false
+      // explanation.
+      const preflightVerdict = await preflight(candidateNetworks, {
+        endpointConfigured: (network) =>
+          Boolean(args.rpcUrl?.trim()) ||
+          Boolean(process.env[getRPCEnvVarName(network)]?.trim()),
+        chainIdOf: (network) =>
+          buildReadOnlyClient(network, args.rpcUrl).getChainId(),
+        expectedChainId: (network) =>
+          networksData[network.toLowerCase() as keyof typeof networksData]
+            .chainId,
+        envVarName: getRPCEnvVarName,
+      })
+      refusedNetworks = [...preflightVerdict.refused]
+      renderPreflight(preflightVerdict).forEach((line) => consola.log(line))
+
+      if (preflightVerdict.startable.length === 0) {
+        process.exitCode = PREFLIGHT_EXIT_CODE
+        await mongoClient.close(true)
+        return
+      }
+
+      if (args.network) networks = [...preflightVerdict.startable]
+      else {
+        const allNetworksWithPendingTxs = preflightVerdict.startable
         consola.info(`Checking ownership for signer: ${signerAddress}`)
 
-        // Filter to only networks where the user can take action (is a Safe owner)
-        networks = await getNetworksWithActionableTransactions(
-          pendingTransactions,
-          signerAddress,
-          args.rpcUrl
-        )
+        // Filter to only networks where the user can take action (is a Safe
+        // owner), then to the ones the preflight cleared: a refused network
+        // must not re-enter here, where a failed read would be reported as
+        // "you are not a Safe owner".
+        networks = (
+          await getNetworksWithActionableTransactions(
+            pendingTransactions,
+            signerAddress,
+            args.rpcUrl
+          )
+        ).filter((network) => preflightVerdict.startable.includes(network))
 
         if (networks.length === 0) {
           consola.info(
@@ -2058,6 +2109,18 @@ const main = defineCommand({
       // signer never sees is worse than no check at all.
       if (checkLedger)
         renderCheckLedger(checkLedger).forEach((line) => consola.info(line))
+
+      // After the ledger, because it is about what the ledger does not cover.
+      // The refused networks are absent from its denominator, so its verdict is
+      // about the networks that could be graded and says nothing about these.
+      if (refusedNetworks.length > 0) {
+        consola.error(
+          `Not covered by the verdict above: ${refusedNetworks.join(
+            ', '
+          )} — the run could not start there, so nothing on those networks was checked.`
+        )
+        process.exitCode = PREFLIGHT_EXIT_CODE
+      }
 
       if (networkOutcomes.length > 0) {
         consola.info('=== Change Review Summary ===')

--- a/script/deploy/safe/signer-preflight-placement.test.ts
+++ b/script/deploy/safe/signer-preflight-placement.test.ts
@@ -29,7 +29,7 @@ const CONFIRM_SCRIPT = path.join(
   'confirm-safe-tx.ts'
 )
 
-const PREFLIGHT_CALL = 'const preflightVerdict = await preflight('
+const PREFLIGHT_CALL = 'const preflightVerdict = await networkPreflight('
 const LEDGER_CREATED = 'checkLedger = createCheckLedger({'
 const OWNERSHIP_FILTER = 'await getNetworksWithActionableTransactions('
 const EARLY_RETURN = 'if (preflightVerdict.startable.length === 0) {'

--- a/script/deploy/safe/signer-preflight-placement.test.ts
+++ b/script/deploy/safe/signer-preflight-placement.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins where the preflight sits inside `confirm-safe-tx.ts`.
+ *
+ * The decision is covered by `signer-preflight.test.ts`; what cannot be observed
+ * there is whether it runs early enough to be worth having. Three orderings
+ * carry the whole design, and all three are invisible to a unit test of the
+ * module: the preflight has to run before the ledger exists, before the
+ * ownership reads that would otherwise report a dead endpoint as "you are not a
+ * Safe owner", and the ledger's denominator has to be the networks it cleared.
+ *
+ * Source-order assertions, because the confirmation CLI cannot be spawned from a
+ * test — it reconciles the store at startup and goes on to sign — so this proves
+ * the ordering of the code and not the behaviour of a run.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  beforeAll,
+  describe,
+  expect,
+  it,
+  // eslint-disable-next-line import/no-unresolved
+} from 'bun:test'
+
+const CONFIRM_SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'confirm-safe-tx.ts'
+)
+
+const PREFLIGHT_CALL = 'const preflightVerdict = await preflight('
+const LEDGER_CREATED = 'checkLedger = createCheckLedger({'
+const OWNERSHIP_FILTER = 'await getNetworksWithActionableTransactions('
+const EARLY_RETURN = 'if (preflightVerdict.startable.length === 0) {'
+
+describe('preflight placement in confirm-safe-tx', () => {
+  let source: string
+
+  beforeAll(() => {
+    source = fs.readFileSync(CONFIRM_SCRIPT, 'utf8')
+  })
+
+  const at = (needle: string): number => {
+    const index = source.indexOf(needle)
+    expect(index, `not found in confirm-safe-tx.ts: ${needle}`).toBeGreaterThan(
+      -1
+    )
+    return index
+  }
+
+  it('runs before a ledger exists', () => {
+    expect(at(PREFLIGHT_CALL)).toBeLessThan(at(LEDGER_CREATED))
+  })
+
+  // A failed read there is swallowed as "not actionable", which is a true
+  // statement with a false explanation.
+  it('runs before the ownership reads', () => {
+    expect(at(PREFLIGHT_CALL)).toBeLessThan(at(OWNERSHIP_FILTER))
+  })
+
+  it('returns before the ledger when no network can start', () => {
+    expect(at(EARLY_RETURN)).toBeLessThan(at(LEDGER_CREATED))
+    const earlyReturn = source.slice(at(EARLY_RETURN), at(EARLY_RETURN) + 240)
+    expect(earlyReturn).toContain('PREFLIGHT_EXIT_CODE')
+    expect(earlyReturn).toContain('return')
+    expect(earlyReturn).not.toContain('createCheckLedger')
+  })
+
+  // The denominator is the whole point: a refused network left in it comes back
+  // as a column of unverified rows describing one unset variable, which is the
+  // display this preflight exists to remove.
+  it('gives the ledger only the networks the preflight cleared', () => {
+    const ownershipCall = source.slice(at(OWNERSHIP_FILTER), at(LEDGER_CREATED))
+
+    expect(ownershipCall).toContain('preflightVerdict.startable.includes(')
+    expect(source).toContain('networks = [...preflightVerdict.startable]')
+  })
+
+  it('says at the end of the run what the verdict does not cover', () => {
+    const tail = source.slice(at('renderCheckLedger(checkLedger)'))
+
+    expect(tail).toContain('refusedNetworks.length > 0')
+    expect(tail).toContain('Not covered by the verdict above')
+  })
+})

--- a/script/deploy/safe/signer-preflight.test.ts
+++ b/script/deploy/safe/signer-preflight.test.ts
@@ -1,0 +1,182 @@
+// eslint-disable-next-line import/no-unresolved
+import { describe, expect, it } from 'bun:test'
+
+import {
+  PREFLIGHT_EXIT_CODE,
+  preflight,
+  renderPreflight,
+  type IPreflightDeps,
+} from './signer-preflight'
+import { VIEW_WIDTH } from './signer-view'
+
+const ESC = String.fromCharCode(27)
+const stripAnsi = (s: string): string =>
+  s.replace(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '')
+
+const KEYED_URL = 'https://lb.drpc.org/ogrpc?network=arbitrum&dkey=NOTAREALKEY'
+
+const deps = (overrides: Partial<IPreflightDeps> = {}): IPreflightDeps => ({
+  endpointConfigured: () => true,
+  expectedChainId: (network) => (network === 'arbitrum' ? 42161 : 137),
+  chainIdOf: async (network) => (network === 'arbitrum' ? 42161 : 137),
+  envVarName: (network) => `ETH_NODE_URI_${network.toUpperCase()}`,
+  ...overrides,
+})
+
+describe('preflight', () => {
+  it('lets a network with a working endpoint start, and says nothing about it', async () => {
+    const verdict = await preflight(['arbitrum'], deps())
+
+    expect(verdict.startable).toEqual(['arbitrum'])
+    expect(verdict.refused).toEqual([])
+    expect(verdict.findings).toEqual([])
+  })
+
+  it('refuses a network whose endpoint variable is unset, naming the variable', async () => {
+    const verdict = await preflight(
+      ['arbitrum'],
+      deps({ endpointConfigured: () => false })
+    )
+
+    expect(verdict.startable).toEqual([])
+    expect(verdict.refused).toEqual(['arbitrum'])
+    expect(verdict.findings[0]?.detail).toContain('ETH_NODE_URI_ARBITRUM')
+  })
+
+  // Set is not reachable: the variable can hold a dead endpoint, and every
+  // read after it would fail one at a time.
+  it('refuses a network whose endpoint does not answer', async () => {
+    const verdict = await preflight(
+      ['arbitrum'],
+      deps({
+        chainIdOf: () => {
+          throw new Error('fetch failed')
+        },
+      })
+    )
+
+    expect(verdict.refused).toEqual(['arbitrum'])
+    expect(verdict.findings[0]?.detail).toContain('fetch failed')
+  })
+
+  // The dangerous one: every later read would answer truthfully about a
+  // different chain.
+  it('refuses an endpoint pointed at the wrong chain, naming both ids', async () => {
+    const verdict = await preflight(
+      ['arbitrum'],
+      deps({ chainIdOf: async () => 1 })
+    )
+
+    expect(verdict.refused).toEqual(['arbitrum'])
+    expect(verdict.findings[0]?.detail).toContain('1')
+    expect(verdict.findings[0]?.detail).toContain('42161')
+  })
+
+  it('refuses only the network that failed, and starts the rest', async () => {
+    const verdict = await preflight(
+      ['arbitrum', 'polygon'],
+      deps({ endpointConfigured: (network) => network !== 'polygon' })
+    )
+
+    expect(verdict.startable).toEqual(['arbitrum'])
+    expect(verdict.refused).toEqual(['polygon'])
+    expect(verdict.findings).toHaveLength(1)
+  })
+
+  it('reports every failing network in one pass, not the first one', async () => {
+    const verdict = await preflight(
+      ['arbitrum', 'polygon'],
+      deps({ endpointConfigured: () => false })
+    )
+
+    expect(verdict.refused).toEqual(['arbitrum', 'polygon'])
+    expect(verdict.findings).toHaveLength(2)
+  })
+
+  // A URL carries an API key. Nothing the preflight reports may contain one,
+  // including the node's own error text, which embeds the URL it called.
+  it('keeps the endpoint out of every finding, error text included', async () => {
+    const verdict = await preflight(
+      ['arbitrum'],
+      deps({
+        chainIdOf: () => {
+          throw new Error(`HTTP request failed. URL: ${KEYED_URL}`)
+        },
+      })
+    )
+    const printed =
+      JSON.stringify(verdict) + renderPreflight(verdict).join('\n')
+
+    expect(printed).not.toContain('dkey')
+    expect(printed).not.toContain('NOTAREALKEY')
+    expect(printed).toContain('HTTP request failed')
+  })
+
+  // §2b of 28-executability-case-table.md, as a test rather than as prose.
+  it('gives every finding a remedy and a concrete value to act on', async () => {
+    const verdict = await preflight(
+      ['arbitrum', 'polygon'],
+      deps({
+        endpointConfigured: (network) => network !== 'polygon',
+        chainIdOf: async () => 1,
+      })
+    )
+
+    expect(verdict.findings).toHaveLength(2)
+    for (const finding of verdict.findings) {
+      expect(finding.remedy.length).toBeGreaterThan(0)
+      expect(finding.detail).toMatch(/ETH_NODE_URI_|\d/u)
+    }
+  })
+})
+
+describe('renderPreflight', () => {
+  const refusedBoth = async () =>
+    preflight(
+      ['arbitrum', 'polygon'],
+      deps({ endpointConfigured: () => false })
+    )
+
+  it('gives each refused network one row, with its cause and its remedy', async () => {
+    const lines = renderPreflight(await refusedBoth()).map(stripAnsi)
+    const plain = lines.join('\n')
+
+    expect(plain).toContain('CANNOT START')
+    expect(lines.filter((line) => /⛔ arbitrum\b/u.test(line))).toHaveLength(1)
+    expect(lines.filter((line) => /⛔ polygon\b/u.test(line))).toHaveLength(1)
+    expect(plain).toContain('ETH_NODE_URI_POLYGON')
+    expect(plain.toLowerCase()).toContain('start over')
+  })
+
+  // The defect this exists to remove: one unset variable became ten identical
+  // "re-run this check" rows above the single line that named the cause.
+  it('never enumerates the checks a refused network did not run', async () => {
+    const plain = renderPreflight(await refusedBoth())
+      .map(stripAnsi)
+      .join('\n')
+
+    expect(plain).not.toContain('unverified')
+    expect(plain).not.toContain('re-run this check')
+    expect(plain.split('\n').length).toBeLessThan(12)
+  })
+
+  it('stays inside the view width', async () => {
+    for (const line of renderPreflight(await refusedBoth()))
+      expect(stripAnsi(line).length).toBeLessThanOrEqual(VIEW_WIDTH)
+  })
+
+  it('renders nothing when every network can start', async () => {
+    const verdict = await preflight(['arbitrum'], deps())
+
+    expect(renderPreflight(verdict)).toEqual([])
+  })
+})
+
+describe('PREFLIGHT_EXIT_CODE', () => {
+  // Distinct from a refusal to sign, so a caller can tell "fix your
+  // environment" from "this proposal was rejected".
+  it('is the configuration-error code, not a generic failure', () => {
+    expect(PREFLIGHT_EXIT_CODE).toBe(78)
+    expect(PREFLIGHT_EXIT_CODE).not.toBe(1)
+  })
+})

--- a/script/deploy/safe/signer-preflight.test.ts
+++ b/script/deploy/safe/signer-preflight.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'bun:test'
 
 import {
   PREFLIGHT_EXIT_CODE,
-  preflight,
-  renderPreflight,
+  networkPreflight,
+  renderNetworkPreflight,
   type IPreflightDeps,
 } from './signer-preflight'
 import { VIEW_WIDTH } from './signer-view'
@@ -25,7 +25,7 @@ const deps = (overrides: Partial<IPreflightDeps> = {}): IPreflightDeps => ({
 
 describe('preflight', () => {
   it('lets a network with a working endpoint start, and says nothing about it', async () => {
-    const verdict = await preflight(['arbitrum'], deps())
+    const verdict = await networkPreflight(['arbitrum'], deps())
 
     expect(verdict.startable).toEqual(['arbitrum'])
     expect(verdict.refused).toEqual([])
@@ -33,7 +33,7 @@ describe('preflight', () => {
   })
 
   it('refuses a network whose endpoint variable is unset, naming the variable', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum'],
       deps({ endpointConfigured: () => false })
     )
@@ -46,7 +46,7 @@ describe('preflight', () => {
   // Set is not reachable: the variable can hold a dead endpoint, and every
   // read after it would fail one at a time.
   it('refuses a network whose endpoint does not answer', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum'],
       deps({
         chainIdOf: () => {
@@ -62,18 +62,21 @@ describe('preflight', () => {
   // The dangerous one: every later read would answer truthfully about a
   // different chain.
   it('refuses an endpoint pointed at the wrong chain, naming both ids', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum'],
       deps({ chainIdOf: async () => 1 })
     )
 
     expect(verdict.refused).toEqual(['arbitrum'])
-    expect(verdict.findings[0]?.detail).toContain('1')
-    expect(verdict.findings[0]?.detail).toContain('42161')
+    // The whole clause, not each id alone: '42161' contains '1', so asserting
+    // the answered id on its own observes nothing.
+    expect(verdict.findings[0]?.detail).toContain(
+      'answered chain id 1, and arbitrum is 42161'
+    )
   })
 
   it('refuses only the network that failed, and starts the rest', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum', 'polygon'],
       deps({ endpointConfigured: (network) => network !== 'polygon' })
     )
@@ -84,7 +87,7 @@ describe('preflight', () => {
   })
 
   it('reports every failing network in one pass, not the first one', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum', 'polygon'],
       deps({ endpointConfigured: () => false })
     )
@@ -96,7 +99,7 @@ describe('preflight', () => {
   // A URL carries an API key. Nothing the preflight reports may contain one,
   // including the node's own error text, which embeds the URL it called.
   it('keeps the endpoint out of every finding, error text included', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum'],
       deps({
         chainIdOf: () => {
@@ -105,16 +108,15 @@ describe('preflight', () => {
       })
     )
     const printed =
-      JSON.stringify(verdict) + renderPreflight(verdict).join('\n')
+      JSON.stringify(verdict) + renderNetworkPreflight(verdict).join('\n')
 
     expect(printed).not.toContain('dkey')
     expect(printed).not.toContain('NOTAREALKEY')
     expect(printed).toContain('HTTP request failed')
   })
 
-  // §2b of 28-executability-case-table.md, as a test rather than as prose.
   it('gives every finding a remedy and a concrete value to act on', async () => {
-    const verdict = await preflight(
+    const verdict = await networkPreflight(
       ['arbitrum', 'polygon'],
       deps({
         endpointConfigured: (network) => network !== 'polygon',
@@ -132,13 +134,13 @@ describe('preflight', () => {
 
 describe('renderPreflight', () => {
   const refusedBoth = async () =>
-    preflight(
+    networkPreflight(
       ['arbitrum', 'polygon'],
       deps({ endpointConfigured: () => false })
     )
 
   it('gives each refused network one row, with its cause and its remedy', async () => {
-    const lines = renderPreflight(await refusedBoth()).map(stripAnsi)
+    const lines = renderNetworkPreflight(await refusedBoth()).map(stripAnsi)
     const plain = lines.join('\n')
 
     expect(plain).toContain('CANNOT START')
@@ -148,27 +150,57 @@ describe('renderPreflight', () => {
     expect(plain.toLowerCase()).toContain('start over')
   })
 
-  // The defect this exists to remove: one unset variable became ten identical
-  // "re-run this check" rows above the single line that named the cause.
+  // A refused network's checks are not the news: each would print the same
+  // unactionable remedy, burying the one line that names the cause.
   it('never enumerates the checks a refused network did not run', async () => {
-    const plain = renderPreflight(await refusedBoth())
+    const plain = renderNetworkPreflight(await refusedBoth())
       .map(stripAnsi)
       .join('\n')
 
     expect(plain).not.toContain('unverified')
     expect(plain).not.toContain('re-run this check')
-    expect(plain.split('\n').length).toBeLessThan(12)
+  })
+
+  // A short error text tests the fixture, not the property. A real viem message
+  // carries the URL it called and the provider's whole response body behind it,
+  // and that body is the least trusted text on the screen: it is chosen by
+  // whoever answers the endpoint.
+  it('cannot let a provider error repaint the terminal or fill it', async () => {
+    const body = `${ESC}[31mALL CHECKS PASSED${ESC}[0m‮plausible‬${'padding '.repeat(
+      40
+    )}`
+    const verdict = await networkPreflight(
+      ['arbitrum'],
+      deps({
+        chainIdOf: () => {
+          throw new Error(
+            `HTTP request failed. Status: 429 URL: ${KEYED_URL} Details: "${body}" Version: viem@2.55.19`
+          )
+        },
+      })
+    )
+    const rendered = renderNetworkPreflight(verdict)
+    const detail = verdict.findings[0]?.detail ?? ''
+
+    // The escapes are gone, so the only colour on these lines is the one this
+    // module put there: stripping ANSI must not shorten the detail at all.
+    expect(stripAnsi(detail)).toBe(detail)
+    expect(detail).not.toContain('‮')
+    expect(detail).not.toContain('dkey')
+    // Two rows per refused network, plus a blank line and the heading. One
+    // network's error cannot become a screenful.
+    expect(rendered.map(stripAnsi).length).toBeLessThanOrEqual(10)
   })
 
   it('stays inside the view width', async () => {
-    for (const line of renderPreflight(await refusedBoth()))
+    for (const line of renderNetworkPreflight(await refusedBoth()))
       expect(stripAnsi(line).length).toBeLessThanOrEqual(VIEW_WIDTH)
   })
 
   it('renders nothing when every network can start', async () => {
-    const verdict = await preflight(['arbitrum'], deps())
+    const verdict = await networkPreflight(['arbitrum'], deps())
 
-    expect(renderPreflight(verdict)).toEqual([])
+    expect(renderNetworkPreflight(verdict)).toEqual([])
   })
 })
 

--- a/script/deploy/safe/signer-preflight.ts
+++ b/script/deploy/safe/signer-preflight.ts
@@ -1,0 +1,177 @@
+/**
+ * What has to be true before a network can be checked at all.
+ *
+ * A precondition every check shares is not a check. One unset
+ * `ETH_NODE_URI_<NETWORK>` used to produce a ledger of ten unverified rows, each
+ * telling the signer to re-run a check that cannot run, above a single stack
+ * trace naming the variable — advice that loops forever, for a proposal nothing
+ * had read. The rule this module exists to hold: a precondition shared by every
+ * check is a preflight, and a precondition of one check is that check's own
+ * unverified reason.
+ *
+ * A refused network is therefore never graded. It contributes no rows, it is
+ * left out of the ledger's denominator, and it is named once with the cause and
+ * the remedy. That is also why this is not a gate: the gate letters describe the
+ * proposal, and red in the signer view means do not sign. An unset variable is
+ * neither.
+ */
+
+import { redactUrls } from '../../utils/redactUrls'
+
+import { VIEW_WIDTH } from './signer-view'
+
+const ESC = String.fromCharCode(27)
+const RESET = `${ESC}[0m`
+const BOLD = `${ESC}[1m`
+const RED = `${ESC}[31m`
+
+/**
+ * `EX_CONFIG` from `sysexits`. Distinct from a refusal to sign, so a caller —
+ * a wrapper script, a runbook step, a future CI job — can tell "fix your
+ * environment" from "this proposal was rejected" without parsing output.
+ */
+export const PREFLIGHT_EXIT_CODE = 78
+
+export interface IPreconditionFinding {
+  /** The network this is about; preconditions are resolved per network. */
+  network: string
+  /** What is wrong, naming the variable or the values that disagree. */
+  detail: string
+  /** What to do about it, in the second person. */
+  remedy: string
+}
+
+export interface IPreflightVerdict {
+  findings: readonly IPreconditionFinding[]
+  /** Networks whose checks may run, in the order they were given. */
+  startable: readonly string[]
+  /** Networks that will not be graded at all. */
+  refused: readonly string[]
+}
+
+/**
+ * The reads the preflight needs, as narrow as they can be made.
+ *
+ * `endpointConfigured` returns a boolean and `chainIdOf` a number: neither can
+ * hand back the endpoint itself. A provider URL carries an API key in its query
+ * string, and this module's whole output is printed — so the URL must not be
+ * able to reach a finding even by accident. The node's own error text is
+ * redacted on the way in for the same reason: viem embeds the URL it called in
+ * every message.
+ */
+export interface IPreflightDeps {
+  endpointConfigured: (network: string) => boolean
+  /** The chain id the endpoint answers with, or a throw if it does not answer. */
+  chainIdOf: (network: string) => Promise<number>
+  /** The chain id `config/networks.json` declares for this network. */
+  expectedChainId: (network: string) => number
+  envVarName: (network: string) => string
+}
+
+const reason = (error: unknown): string =>
+  redactUrls(error instanceof Error ? error.message : String(error))
+    .replace(/\s+/gu, ' ')
+    .trim()
+
+/**
+ * Resolves every network's preconditions in one pass.
+ *
+ * Every network is probed even after one has failed: a signer who discovers
+ * three environment problems across three runs is the same defect this module
+ * closes, arriving one round trip at a time.
+ *
+ * @param networks - The networks the run was asked to confirm.
+ * @param deps - The reads to make, none of which may return an endpoint.
+ * @returns Which networks may start, which are refused, and why.
+ */
+export const preflight = async (
+  networks: readonly string[],
+  deps: IPreflightDeps
+): Promise<IPreflightVerdict> => {
+  const findings: IPreconditionFinding[] = []
+  const startable: string[] = []
+  const refused: string[] = []
+
+  for (const network of networks) {
+    const variable = deps.envVarName(network)
+
+    if (!deps.endpointConfigured(network)) {
+      refused.push(network)
+      findings.push({
+        network,
+        detail: `${variable} is not set, so nothing here could be read`,
+        remedy: `set ${variable} and start over`,
+      })
+      continue
+    }
+
+    let answered: number
+    try {
+      answered = await deps.chainIdOf(network)
+    } catch (error) {
+      refused.push(network)
+      findings.push({
+        network,
+        detail: `the endpoint in ${variable} did not answer: ${reason(error)}`,
+        remedy: `check that the endpoint is reachable, then start over`,
+      })
+      continue
+    }
+
+    const expected = deps.expectedChainId(network)
+    if (answered !== expected) {
+      refused.push(network)
+      findings.push({
+        network,
+        // The dangerous case: every read after this one would answer
+        // truthfully, about the wrong chain.
+        detail: `the endpoint in ${variable} answered chain id ${answered}, and ${network} is ${expected}`,
+        remedy: `point ${variable} at ${network} and start over`,
+      })
+      continue
+    }
+
+    startable.push(network)
+  }
+
+  return { findings, startable, refused }
+}
+
+/**
+ * The refusal block, printed before anything else the run would say.
+ *
+ * One line per refused network, never one per check it did not run. The checks
+ * are not the news — a check that could not start has nothing to report, and
+ * listing them buries the one line that can be acted on.
+ *
+ * @param verdict - What {@link preflight} decided.
+ * @returns Lines to print, or nothing when every network can start.
+ */
+export const renderPreflight = (verdict: IPreflightVerdict): string[] => {
+  if (verdict.findings.length === 0) return []
+
+  const wrap = (text: string, indent: string): string[] => {
+    const budget = Math.max(20, VIEW_WIDTH - indent.length)
+    const out: string[] = []
+    let line = ''
+    for (const word of text.split(/\s+/u).filter(Boolean)) {
+      const next = line ? `${line} ${word}` : word
+      if (next.length > budget && line) {
+        out.push(`${indent}${line}`)
+        line = word
+      } else line = next
+    }
+    if (line) out.push(`${indent}${line}`)
+    return out
+  }
+
+  const out = [
+    '',
+    `  ${RED}${BOLD}CANNOT START — ${verdict.refused.length} network(s) were not checked${RESET}`,
+  ]
+  for (const finding of verdict.findings) {
+    out.push(...wrap(`⛔ ${finding.network} — ${finding.detail}`, '    '))
+    out.push(...wrap(`→ ${finding.remedy}`, '       '))
+  }
+  return out
+}

--- a/script/deploy/safe/signer-preflight.ts
+++ b/script/deploy/safe/signer-preflight.ts
@@ -1,22 +1,16 @@
 /**
- * What has to be true before a network can be checked at all.
+ * Decides which networks a confirmation run may grade at all, by resolving the
+ * preconditions every check on a network shares. Import it from a run that is
+ * about to grade proposals; a precondition of one check belongs in that check's
+ * own unverified reason instead.
  *
- * A precondition every check shares is not a check. One unset
- * `ETH_NODE_URI_<NETWORK>` used to produce a ledger of ten unverified rows, each
- * telling the signer to re-run a check that cannot run, above a single stack
- * trace naming the variable — advice that loops forever, for a proposal nothing
- * had read. The rule this module exists to hold: a precondition shared by every
- * check is a preflight, and a precondition of one check is that check's own
- * unverified reason.
- *
- * A refused network is therefore never graded. It contributes no rows, it is
- * left out of the ledger's denominator, and it is named once with the cause and
- * the remedy. That is also why this is not a gate: the gate letters describe the
- * proposal, and red in the signer view means do not sign. An unset variable is
- * neither.
+ * A refused network is never graded: it contributes no rows and stays out of the
+ * ledger's denominator. It is not a gate — the gate letters describe the
+ * proposal and red means do not sign, which an unset variable is not.
  */
 
-import { redactUrls } from '../../utils/redactUrls'
+import { redactErrorReason } from '../../utils/redactUrls'
+import { sanitizeProvenanceText } from '../shared/git-provenance'
 
 import { VIEW_WIDTH } from './signer-view'
 
@@ -52,12 +46,14 @@ export interface IPreflightVerdict {
 /**
  * The reads the preflight needs, as narrow as they can be made.
  *
- * `endpointConfigured` returns a boolean and `chainIdOf` a number: neither can
- * hand back the endpoint itself. A provider URL carries an API key in its query
- * string, and this module's whole output is printed — so the URL must not be
- * able to reach a finding even by accident. The node's own error text is
- * redacted on the way in for the same reason: viem embeds the URL it called in
- * every message.
+ * `endpointConfigured` returns a boolean and `chainIdOf` a number, so no
+ * dependency can hand an endpoint back: a provider URL carries an API key and
+ * this module's whole output is printed. The node's own error text is the one
+ * value that arrives unbounded, so it goes through `redactErrorReason` — viem
+ * embeds the URL it called, and the response body behind it, in every message.
+ * That strips `scheme://…` tokens and caps the length; a bare hostname in an
+ * error is not a URL to it, so a provider that carries its credential in the
+ * subdomain is redacted only by the cap.
  */
 export interface IPreflightDeps {
   endpointConfigured: (network: string) => boolean
@@ -68,10 +64,21 @@ export interface IPreflightDeps {
   envVarName: (network: string) => string
 }
 
+/**
+ * A node's error text, made safe to print.
+ *
+ * Sanitised before it is redacted, so a control character cannot split a
+ * `scheme://` token past the redactor, and because the text is whatever the
+ * provider's response body held: ANSI escapes in it would repaint the very
+ * refusal that reports them.
+ *
+ * @param error - Whatever the endpoint read threw.
+ * @returns One line, control-free, endpoint-free and length-capped.
+ */
 const reason = (error: unknown): string =>
-  redactUrls(error instanceof Error ? error.message : String(error))
-    .replace(/\s+/gu, ' ')
-    .trim()
+  redactErrorReason(
+    sanitizeProvenanceText(error instanceof Error ? error.message : error)
+  )
 
 /**
  * Resolves every network's preconditions in one pass.
@@ -84,7 +91,7 @@ const reason = (error: unknown): string =>
  * @param deps - The reads to make, none of which may return an endpoint.
  * @returns Which networks may start, which are refused, and why.
  */
-export const preflight = async (
+export const networkPreflight = async (
   networks: readonly string[],
   deps: IPreflightDeps
 ): Promise<IPreflightVerdict> => {
@@ -138,16 +145,18 @@ export const preflight = async (
 }
 
 /**
- * The refusal block, printed before anything else the run would say.
+ * The refusal block, printed before any check result or ownership output.
  *
- * One line per refused network, never one per check it did not run. The checks
- * are not the news — a check that could not start has nothing to report, and
- * listing them buries the one line that can be acted on.
+ * One row per refused network, never one per check it did not run: a check that
+ * could not start has nothing to report, and listing them buries the line that
+ * can be acted on.
  *
- * @param verdict - What {@link preflight} decided.
+ * @param verdict - What {@link networkPreflight} decided.
  * @returns Lines to print, or nothing when every network can start.
  */
-export const renderPreflight = (verdict: IPreflightVerdict): string[] => {
+export const renderNetworkPreflight = (
+  verdict: IPreflightVerdict
+): string[] => {
   if (verdict.findings.length === 0) return []
 
   const wrap = (text: string, indent: string): string[] => {


### PR DESCRIPTION
## What

A precondition every check shares is not a check. One unset `ETH_NODE_URI_<NETWORK>` produced a ledger of ten unverified rows — each telling the signer to re-run a check that cannot run — above a single stack trace naming the variable. Ten pieces of unactionable advice above the one actionable line (F6/F8 in the rehearsal findings).

This adds a preflight that resolves every candidate network's endpoint **before** the ownership reads and **before** the ledger is created:

- configured (`ETH_NODE_URI_<NETWORK>`, or `--rpc-url`)
- reachable (one `eth_chainId`)
- answering the chain id `config/networks.json` declares — the dangerous case, since every later read would answer truthfully about a different chain

A refused network is named once with its cause and its remedy, contributes no rows, and is left out of the ledger's denominator. When no network can start, the run exits `78` (`EX_CONFIG`) without building a ledger at all — a ledger that verified nothing is not a weaker verdict, it is no verdict.

It is a **preflight, not a gate**. The gate letters describe the proposal and red in the signer view means *do not sign*; an unset variable is neither, so it gets its own vocabulary (`CANNOT START — …`) and its own exit code.

## Where to look hardest

- **The three orderings** are the whole design and none is observable from the module, so they are pinned as source-order assertions in `signer-preflight-placement.test.ts`: before the ledger; before `getNetworksWithActionableTransactions`, which swallows a failed read as "not actionable" (a true statement with a false explanation); and the ledger fed only what the preflight cleared.
- **A partial run must not read as a clean one.** Refused networks are absent from the ledger's denominator, so its verdict says nothing about them — the run therefore names them again after the ledger and sets the exit code.
- **No endpoint can reach the output.** The deps return booleans and numbers rather than URLs, and the node's error text is redacted on the way in: viem embeds the URL it called in every message, and a provider URL carries an API key.

## Verification

- `bun test script/deploy/safe/signer-preflight.test.ts script/deploy/safe/signer-preflight-placement.test.ts` → 18 pass.
- Six mutations, each killed by the intended assertion: ledger fed every candidate again; the early return building a ledger anyway; the end-of-run coverage line dropped; stopping at the first failing network; trusting the endpoint's own chain id; passing the node's error through unredacted.
- `bun test script/deploy/safe/` → 2377 pass / 8 fail; the 8 are the pre-existing `storage-authority` registration failures already present at the base commit.

## Not in this PR

The preflight checks endpoints only. The deployment record and the pinned target-state ref are preconditions of *particular* checks rather than of every check, so by the dividing line above they belong as those checks' own unverified reasons — but reporting them here too would save a signer a round trip, and the collection shape takes another probe as one entry. Design and the full case table: `28-executability-case-table.md` §7 in the signing-process project.

Wiring is pinned by source order, not exercised end to end: spawning `confirm-safe-tx` from a test would reconcile the store and go on to sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)