### PR TITLE
fix(safe): stop a run that graded nothing from closing all-green

### DIFF
--- a/script/deploy/safe/check-ledger-wiring-placement.test.ts
+++ b/script/deploy/safe/check-ledger-wiring-placement.test.ts
@@ -225,9 +225,18 @@ describe('a network the run skipped does not block it', () => {
    * status free — flipping `recordNothingToGrade` to `error` kept the whole
    * directory green while reinstating the spurious hard block it exists to
    * prevent.
+   *
+   * `not-applicable` rather than `pass`: a pass is a verified network result and
+   * counts toward the verified coverage, so recording one for a network nothing
+   * was graded on is what closed a real run `10/10 network results verified`
+   * with a pending proposal untouched on it.
    */
   const RECORDERS = [
-    ['const recordNothingToGrade = (', "status: 'pass'", "anchor: 'A-LOCAL'"],
+    [
+      'const recordNothingToGrade = (',
+      "status: 'not-applicable'",
+      "anchor: 'A-LOCAL'",
+    ],
     [
       'const recordCouldNotGrade = (',
       "status: 'error'",
@@ -235,7 +244,7 @@ describe('a network the run skipped does not block it', () => {
     ],
   ] as const
 
-  it('writes a verified row for one and an unverified row for the other', () => {
+  it('writes an ungraded row for one and an unverified row for the other', () => {
     for (const [declaration, status, anchor] of RECORDERS) {
       const helper = SOURCE.indexOf(declaration)
       expect(helper).toBeGreaterThan(-1)

--- a/script/deploy/safe/check-ledger-wiring-placement.test.ts
+++ b/script/deploy/safe/check-ledger-wiring-placement.test.ts
@@ -127,9 +127,9 @@ describe('one row per network, not one per proposal', () => {
     expect(body).toContain('proposalChecks.push(')
 
     // Position, not just presence. Below the operator's own `continue` the push
-    // is skipped for a declined proposal, and a network whose only proposal was
-    // declined then reaches `proposalChecks.length === 0` and records a pass —
-    // a green row for a real proposal nothing graded.
+    // is skipped for a declined proposal, so a network whose only proposal was
+    // declined reaches `proposalChecks.length === 0` and that proposal's own
+    // grade never reaches the ledger.
     const graded = body.indexOf('proposalChecks.push(')
     const declined = body.indexOf("if (action === 'Do Nothing') continue")
 
@@ -155,6 +155,18 @@ describe('one row per network, not one per proposal', () => {
     // before the one surviving row is written.
     expect(reduce).toBeGreaterThan(end)
     expect(SOURCE.slice(end)).toContain('recordCheck(checkLedger, result)')
+  })
+
+  it('records a prepared network with no proposal as unverified', () => {
+    // A `ready` network always carries at least one proposal, so this branch is
+    // a broken invariant rather than an outcome — `recordNothingToGrade` would
+    // file it as a network the run positively established had nothing on it.
+    const empty = SOURCE.indexOf('if (proposalChecks.length === 0)')
+    expect(empty).toBeGreaterThan(-1)
+    const branch = SOURCE.slice(empty, SOURCE.indexOf('else', empty))
+
+    expect(branch).toContain('recordCouldNotGrade(')
+    expect(branch).not.toContain('recordNothingToGrade(')
   })
 })
 
@@ -226,10 +238,9 @@ describe('a network the run skipped does not block it', () => {
    * directory green while reinstating the spurious hard block it exists to
    * prevent.
    *
-   * `not-applicable` rather than `pass`: a pass is a verified network result and
-   * counts toward the verified coverage, so recording one for a network nothing
-   * was graded on is what closed a real run `10/10 network results verified`
-   * with a pending proposal untouched on it.
+   * `not-applicable` rather than `pass`: a pass counts toward the verified
+   * coverage, so a network nothing was graded on would be counted as one this
+   * run verified.
    */
   const RECORDERS = [
     [
@@ -269,8 +280,7 @@ describe('the verdict stays withheld', () => {
   it('does not render the ledger', () => {
     // Only a `pass` counts toward the verified coverage while every status a
     // correct Add/Replace cut produces is `needs-ack`, so a correct rollout
-    // grades 0/N and a run that graded nothing grades green. EXSC-994 owns
-    // fixing that before any of it is printed.
+    // grades 0/N. EXSC-994 owns fixing that before any of it is printed.
     //
     // `summariseLedger` is pinned alongside the renderer because it is where
     // the inversion lives: the render is a thin wrapper over it, this file

--- a/script/deploy/safe/check-ledger.test.ts
+++ b/script/deploy/safe/check-ledger.test.ts
@@ -1143,6 +1143,57 @@ describe('a network that had nothing to grade', () => {
     expect(verdict.nothingGraded).toBe(false)
   })
 
+  it('never erases a result the same network could not grade', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(
+      ledger,
+      result({ status: 'error', actual: 'unread', detail: 'rpc down' })
+    )
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    const [rollup] = rollUpChecks(ledger)
+    const verdict = summariseLedger(ledger)
+
+    expect(rollup?.errored).toBe(1)
+    expect(rollup?.notApplicable).toBe(0)
+    expect(verdict.hardBlocked).toBe(true)
+    expect(verdict.totals.error).toBe(1)
+  })
+
+  it('never erases an acknowledgement the same network is owed', () => {
+    const ledger = ledgerOf(['mainnet'], [TARGET_STATE])
+    recordCheck(
+      ledger,
+      result({ checkId: 'target-state', status: 'needs-ack' })
+    )
+    recordCheck(
+      ledger,
+      result({ ...nothingToGrade('mainnet'), checkId: 'target-state' })
+    )
+
+    const [rollup] = rollUpChecks(ledger)
+    const verdict = summariseLedger(ledger)
+
+    expect(rollup?.needsAck).toBe(1)
+    expect(rollup?.notApplicable).toBe(0)
+    expect(verdict.requiresAcknowledgement).toHaveLength(1)
+    expect(verdict.nothingGraded).toBe(false)
+  })
+
+  it('is itself superseded by a result that did grade the network', () => {
+    // The paired positive: the guard protects what was graded, so it must not
+    // freeze a network the run went on to reach.
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+    recordCheck(ledger, result({ status: 'pass' }))
+
+    const [rollup] = rollUpChecks(ledger)
+
+    expect(rollup?.passed).toBe(1)
+    expect(rollup?.notApplicable).toBe(0)
+    expect(rollup?.green).toBe(true)
+  })
+
   it('is recorded in the attestation as a check that went ungraded', () => {
     const ledger = ledgerOf(['mainnet'], [CODEHASH])
     recordCheck(ledger, result(nothingToGrade('mainnet')))

--- a/script/deploy/safe/check-ledger.test.ts
+++ b/script/deploy/safe/check-ledger.test.ts
@@ -320,6 +320,7 @@ describe('summariseLedger', () => {
       error: 0,
       needsAck: 0,
       missing: 1,
+      notApplicable: 0,
     })
   })
 })
@@ -547,6 +548,7 @@ describe('buildReviewAttestation', () => {
         checkId: 'codehash',
         checkClass: 'integrity',
         expected: 2,
+        notApplicable: 0,
         passed: 1,
         failed: 1,
         needsAck: 0,
@@ -857,6 +859,7 @@ describe('a result that reached the log without recordCheck', () => {
       error: 0,
       needsAck: 0,
       missing: 0,
+      notApplicable: 0,
     })
   })
 
@@ -1038,5 +1041,119 @@ describe('nothing that would soften the verdict may erase a mismatch', () => {
 
     expect(rollup?.errored).toBe(1)
     expect(rollup?.unverified).toBe(1)
+  })
+})
+
+describe('a network that had nothing to grade', () => {
+  /**
+   * The row `confirm-safe-tx.ts` writes for a network it positively established
+   * carries no proposal for this signer — a pending proposal the signer has
+   * already signed is the case that produced it in production.
+   */
+  const nothingToGrade = (network: string): Partial<ICheckResult> => ({
+    network,
+    status: 'not-applicable',
+    expected: 'every proposal this run would sign graded before signing',
+    actual: `no proposal was graded on ${network} — nothing actionable was left once the network was prepared`,
+    anchor: 'A-LOCAL',
+  })
+
+  it('is recorded as its own state, not as a pass', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    expect(ledger.results.map((entry) => entry.status)).toEqual([
+      'not-applicable',
+    ])
+  })
+
+  it('satisfies no verified counter', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    const [rollup] = rollUpChecks(ledger)
+
+    expect(rollup?.passed).toBe(0)
+    expect(rollup?.notApplicable).toBe(1)
+    // The denominator the verified count is measured against, so `0/0` is what
+    // a vacuous check reads as rather than a full house.
+    expect(rollup?.graded).toBe(0)
+    expect(rollup?.green).toBe(false)
+  })
+
+  it('leaves the run unblocked while saying nothing was verified', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    const verdict = summariseLedger(ledger)
+
+    // Unblocked because nothing was wrong, and `nothingGraded` because nothing
+    // was right either: the two facts a single boolean cannot carry.
+    expect(verdict.hardBlocked).toBe(false)
+    expect(verdict.nothingGraded).toBe(true)
+    expect(verdict.totals.pass).toBe(0)
+    expect(verdict.totals.notApplicable).toBe(1)
+    expect(verdict.requiresAcknowledgement).toHaveLength(0)
+  })
+
+  it('does not suppress the verdict of a run that did grade something', () => {
+    const ledger = ledgerOf(['mainnet', 'polygon'], [CODEHASH])
+    recordCheck(ledger, result({ network: 'mainnet' }))
+    recordCheck(ledger, result({ network: 'polygon' }))
+
+    const verdict = summariseLedger(ledger)
+    const [rollup] = rollUpChecks(ledger)
+
+    expect(verdict.nothingGraded).toBe(false)
+    expect(verdict.totals.pass).toBe(2)
+    expect(verdict.totals.notApplicable).toBe(0)
+    expect(rollup?.graded).toBe(2)
+    expect(rollup?.green).toBe(true)
+  })
+
+  it('measures the graded networks against themselves, not against the fleet', () => {
+    const ledger = ledgerOf(['mainnet', 'polygon'], [CODEHASH])
+    recordCheck(ledger, result({ network: 'mainnet' }))
+    recordCheck(ledger, result(nothingToGrade('polygon')))
+
+    const [rollup] = rollUpChecks(ledger)
+
+    expect(rollup?.passed).toBe(1)
+    expect(rollup?.graded).toBe(1)
+    expect(rollup?.notApplicable).toBe(1)
+    // Still the declared denominator, so the shrink is recoverable from the
+    // rollup rather than lost.
+    expect(rollup?.expected).toBe(2)
+    expect(rollup?.green).toBe(true)
+    expect(summariseLedger(ledger).nothingGraded).toBe(false)
+  })
+
+  it('never erases a mismatch the same network already recorded', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(ledger, result({ status: 'fail', actual: '0xbbb' }))
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    const [rollup] = rollUpChecks(ledger)
+    const verdict = summariseLedger(ledger)
+
+    expect(rollup?.failed).toBe(1)
+    expect(rollup?.notApplicable).toBe(0)
+    expect(verdict.hardBlocked).toBe(true)
+    expect(verdict.nothingGraded).toBe(false)
+  })
+
+  it('is recorded in the attestation as a check that went ungraded', () => {
+    const ledger = ledgerOf(['mainnet'], [CODEHASH])
+    recordCheck(ledger, result(nothingToGrade('mainnet')))
+
+    const [attested] = buildReviewAttestation(ledger, {
+      reviewer: '0xsigner',
+      reviewedAt: '2026-09-13T00:00:00.000Z',
+    }).checks
+
+    expect(attested?.passed).toBe(0)
+    expect(attested?.notApplicable).toBe(1)
+    expect(attested?.green).toBe(false)
   })
 })

--- a/script/deploy/safe/check-ledger.ts
+++ b/script/deploy/safe/check-ledger.ts
@@ -8,7 +8,9 @@
  *
  * A check that could not run is not a check that passed: it is recorded as
  * `error`, counted as unverified, and the verdict comes back blocked with no
- * acknowledgement path.
+ * acknowledgement path. A check that had nothing to grade is neither: it is
+ * recorded as `not-applicable`, counted outside both numerator and denominator,
+ * and a run made only of those closes as having reviewed nothing.
  */
 
 import { keccak256, stringToHex, type Hex } from 'viem'
@@ -17,8 +19,18 @@ import { keccak256, stringToHex, type Hex } from 'viem'
  * `error` means the check could not run — unreachable store, failed RPC,
  * unreadable anchor. It is never a synonym for `fail`, which is a real
  * mismatch, and never collapses into `pass`.
+ *
+ * `not-applicable` means the run established there was nothing here to grade —
+ * a network whose only pending proposal this signer had already signed. It does
+ * not block, because nothing is wrong, and it never counts as verified, because
+ * nothing was checked.
  */
-export type CheckStatus = 'pass' | 'fail' | 'error' | 'needs-ack'
+export type CheckStatus =
+  | 'pass'
+  | 'fail'
+  | 'error'
+  | 'needs-ack'
+  | 'not-applicable'
 
 /**
  * `integrity` checks answer "is the code/authority what it claims to be" and
@@ -62,6 +74,7 @@ const CHECK_STATUSES: ReadonlySet<string> = new Set<CheckStatus>([
   'fail',
   'error',
   'needs-ack',
+  'not-applicable',
 ])
 
 /** Every anchor a result may name, for validating a value that bypassed the type. */
@@ -274,8 +287,20 @@ function coerceStatus(
 }
 
 export interface ICheckRollup extends ICheckDefinition {
-  /** The coverage denominator: how many networks this check had to answer for. */
+  /** The declared denominator: how many networks this check had to answer for. */
   expected: number
+  /** Networks that had nothing for this check to grade. */
+  notApplicable: number
+  /**
+   * The coverage denominator `passed` is measured against: `expected` less the
+   * networks that had nothing to grade.
+   *
+   * A shrunk denominator is the module's own stated hazard, so it is never
+   * shrunk silently — `expected` stays on the rollup and every line that prints
+   * `passed/graded` prints the not-applicable count beside it, which is what
+   * makes the shrink recoverable rather than invisible.
+   */
+  graded: number
   passed: number
   failed: number
   errored: number
@@ -376,7 +401,12 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
 
     const expected = ledger.expectedNetworks.length
     const passed = countOf('pass')
-    // Anything outside the four statuses counts here, because that is how the
+    const notApplicable = countOf('not-applicable')
+    // A network that reported nothing at all stays in here, so it still rolls
+    // up as missing and blocks; only a network that positively answered "there
+    // was nothing to grade" leaves the denominator.
+    const graded = expected - notApplicable
+    // Anything outside this module's statuses counts here, because that is how the
     // verdict grades it — otherwise such a status sits in the denominator and in
     // no numerator.
     const errored = results.filter(
@@ -390,13 +420,18 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
     return {
       ...definition,
       expected,
+      notApplicable,
+      graded,
       passed,
       failed: countOf('fail'),
       errored,
       needsAck: countOf('needs-ack'),
       missing: missingNetworks.length,
       unverified: errored + missingNetworks.length,
-      green: expected > 0 && passed === expected,
+      // `graded > 0` is the half that matters: `passed === graded` is `0 === 0`
+      // for a check that graded nothing, which is the reading that closed a run
+      // green over a proposal it never looked at.
+      green: graded > 0 && passed === graded,
       anchors: [...new Set(results.map((result) => result.anchor))].sort(),
       missingNetworks,
       results,
@@ -468,11 +503,22 @@ export interface ILedgerTotals {
   error: number
   needsAck: number
   missing: number
+  /** Results the run established there was nothing to grade for. */
+  notApplicable: number
 }
 
 export interface ILedgerVerdict {
   /** True when something blocks with no acknowledgement path available. */
   hardBlocked: boolean
+  /**
+   * True when no result was graded at all — every one of them was
+   * `not-applicable`.
+   *
+   * Carried separately from `hardBlocked` because the two answer different
+   * questions, and a consumer reading only "nothing blocks" would read a run
+   * that reviewed nothing as a run that reviewed everything.
+   */
+  nothingGraded: boolean
   blocking: IBlockingResult[]
   /** Semantic non-passes a human may acknowledge; the caller must ask before proceeding. */
   requiresAcknowledgement: ICheckResult[]
@@ -490,10 +536,15 @@ export interface ILedgerVerdict {
  * acknowledgement path at all. Only a semantic non-pass is acknowledgeable, and
  * triage can drop one on a subtractive op alone.
  *
- * A status outside the four is treated as unverified and blocks. `recordCheck`
- * refuses one, so this is only reachable by a result that entered the log some
- * other way — and the safe reading of a status nothing recognises is that
- * nothing was verified.
+ * `not-applicable` blocks nothing and is owed to nobody, so it lands in its own
+ * total and in `nothingGraded`. It is the one status that is neither a finding
+ * nor a verification, which is why a caller reading `hardBlocked` alone cannot
+ * tell a clear run from an empty one.
+ *
+ * A status this module does not define is treated as unverified and blocks.
+ * `recordCheck` refuses one, so this is only reachable by a result that entered
+ * the log some other way — and the safe reading of a status nothing recognises
+ * is that nothing was verified.
  * @param ledger - The run's ledger.
  * @param options - `triageProfile` enables the narrowed relaxation.
  * @returns The verdict, the blocking rows, what awaits acknowledgement, and the totals.
@@ -520,12 +571,22 @@ export const summariseLedger = (
     error: 0,
     needsAck: 0,
     missing: 0,
+    notApplicable: 0,
   }
 
   for (const rollup of rollUpChecks(ledger)) {
     for (const result of rollup.results) {
       if (result.status === 'pass') {
         totals.pass += 1
+        continue
+      }
+
+      // Ahead of the unrecognised-status branch and of the acknowledgement
+      // fall-through below: a status that lands in neither numerator would be
+      // graded by whichever branch happens to catch it, and the one under this
+      // would file it as awaiting a human acknowledgement that nobody owes.
+      if (result.status === 'not-applicable') {
+        totals.notApplicable += 1
         continue
       }
 
@@ -595,6 +656,16 @@ export const summariseLedger = (
 
   return {
     hardBlocked: blocking.length > 0,
+    // Every result the run graded, whichever way it graded it, plus the ones it
+    // never recorded — so this is false the moment anything at all was looked
+    // at, and cannot mask a run that had both skipped and graded networks.
+    nothingGraded:
+      totals.pass +
+        totals.fail +
+        totals.error +
+        totals.needsAck +
+        totals.missing ===
+      0,
     blocking,
     requiresAcknowledgement,
     relaxed,
@@ -606,6 +677,8 @@ export interface IReviewAttestationCheck {
   checkId: string
   checkClass: CheckClass
   expected: number
+  /** Without it, a check that graded nothing reads as one that graded and failed. */
+  notApplicable: number
   passed: number
   failed: number
   needsAck: number
@@ -714,6 +787,7 @@ export const buildReviewAttestation = (
       checkId: rollup.checkId,
       checkClass: rollup.checkClass,
       expected: rollup.expected,
+      notApplicable: rollup.notApplicable,
       passed: rollup.passed,
       failed: rollup.failed,
       needsAck: rollup.needsAck,

--- a/script/deploy/safe/check-ledger.ts
+++ b/script/deploy/safe/check-ledger.ts
@@ -211,8 +211,8 @@ export const createCheckLedger = (init: {
 }
 
 /**
- * Records one check's outcome on one network, coercing the two statuses that
- * would otherwise overstate what was verified.
+ * Records one check's outcome on one network, coercing the statuses that would
+ * otherwise overstate what was verified.
  *
  * A `pass` whose anchor can only report is stored as `error`, and a `needs-ack`
  * on an integrity check is stored as `fail`. Both rules live here rather than in
@@ -294,11 +294,6 @@ export interface ICheckRollup extends ICheckDefinition {
   /**
    * The coverage denominator `passed` is measured against: `expected` less the
    * networks that had nothing to grade.
-   *
-   * A shrunk denominator is the module's own stated hazard, so it is never
-   * shrunk silently — `expected` stays on the rollup and every line that prints
-   * `passed/graded` prints the not-applicable count beside it, which is what
-   * makes the shrink recoverable rather than invisible.
    */
   graded: number
   passed: number
@@ -323,9 +318,9 @@ export interface ICheckRollup extends ICheckDefinition {
  * reported — a check that ran nowhere is the most important row in the report
  * and must not be absent from it. Where a check reported twice for one network
  * the last entry wins, so a run may record a provisional result and supersede
- * it; the one exception is a mismatch, which nothing that would soften the
- * verdict may erase — only another mismatch, or an `error`, which blocks the
- * same way.
+ * it; the exceptions are a mismatch, which only another mismatch or an `error`
+ * may replace, and any finding at all, which a `not-applicable` may never
+ * remove from the denominator.
  *
  * The status coercions are re-applied here rather than trusted from write time,
  * so a result that reached the log some other way — a rehydrated document, a
@@ -338,6 +333,7 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
   [...ledger.checks.values()].map((definition) => {
     const latest = new Map<string, ICheckResult>()
     const mismatched = new Set<string>()
+    const withFinding = new Set<string>()
     // What each network's last disagreement was, kept for the whole run: the
     // note belongs to the network, not to whichever row happens to be displaced,
     // so it survives any number of failed retries.
@@ -355,6 +351,12 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
       // below or absent.
       const { supersededMismatch: _incoming, ...clean } = raw
       const result = coerceStatus(clean as ICheckResult, definition)
+      if (
+        result.status === 'fail' ||
+        result.status === 'error' ||
+        result.status === 'needs-ack'
+      )
+        withFinding.add(result.network)
       if (result.status === 'fail') {
         mismatched.add(result.network)
         lastMismatch.set(
@@ -377,6 +379,13 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
         result.status !== 'error' &&
         mismatched.has(result.network)
       )
+        continue
+
+      // A later "there was nothing to grade" does not supersede a finding, it
+      // deletes it: the network leaves the coverage denominator, so nothing
+      // records that the check disagreed, could not run, or is owed an
+      // acknowledgement there.
+      if (result.status === 'not-applicable' && withFinding.has(result.network))
         continue
 
       // One row per network is what the verdict needs, and it cannot hold both
@@ -428,9 +437,7 @@ export const rollUpChecks = (ledger: ICheckLedger): ICheckRollup[] =>
       needsAck: countOf('needs-ack'),
       missing: missingNetworks.length,
       unverified: errored + missingNetworks.length,
-      // `graded > 0` is the half that matters: `passed === graded` is `0 === 0`
-      // for a check that graded nothing, which is the reading that closed a run
-      // green over a proposal it never looked at.
+      // `passed === graded` is `0 === 0` for a check that graded nothing.
       green: graded > 0 && passed === graded,
       anchors: [...new Set(results.map((result) => result.anchor))].sort(),
       missingNetworks,
@@ -553,10 +560,9 @@ export const summariseLedger = (
   ledger: ICheckLedger,
   options: { triageProfile?: OpProfile } = {}
 ): ILedgerVerdict => {
-  // A ledger that verified nothing is not a clear result, and `passed ===
-  // expected` is `0 === 0`. The factory refuses to build one, but every
-  // consumer here takes a plain `ICheckLedger`, which a rehydrated document or
-  // a direct push reaches without passing the factory.
+  // The factory refuses to build one, but every consumer here takes a plain
+  // `ICheckLedger`, which a rehydrated document or a direct push reaches
+  // without passing the factory.
   if (ledger.checks.size === 0 || ledger.expectedNetworks.length === 0)
     throw new Error(
       `Refusing to summarise a ledger that verifies nothing: ${ledger.checks.size} checks over ${ledger.expectedNetworks.length} networks. A verdict about no results is not a pass, and reporting one as green is the failure this ledger exists to prevent.`

--- a/script/deploy/safe/confirm-check-registry.test.ts
+++ b/script/deploy/safe/confirm-check-registry.test.ts
@@ -353,7 +353,7 @@ describe('targetStateCheckResult', () => {
 
 describe('worstResultPerCheck', () => {
   const resultWith = (
-    status: 'pass' | 'fail' | 'error' | 'needs-ack',
+    status: 'pass' | 'fail' | 'error' | 'needs-ack' | 'not-applicable',
     anchor: 'A-LOCAL' | 'A-MAIN' | 'A-MONGO' = 'A-LOCAL'
   ) => ({
     checkId: TARGET_STATE_CHECK_ID,
@@ -412,6 +412,26 @@ describe('worstResultPerCheck', () => {
 
   it('returns nothing for a network that graded nothing', () => {
     expect(worstResultPerCheck([])).toEqual([])
+  })
+
+  // A status `SEVERITY` does not list gets -1 from `indexOf`, which ranks it
+  // ahead of `fail` — so dropping the entry is a silent inversion, not a type
+  // error. Both orders, because the reducer keeps the row it already holds on a
+  // tie and a one-sided case passes against the inverted ranking.
+  it('never lets a proposal with nothing to grade displace a finding', () => {
+    const skipped = resultWith('not-applicable')
+
+    expect(
+      worstResultPerCheck([resultWith('fail', 'A-MAIN'), skipped])[0]?.status
+    ).toBe('fail')
+    expect(
+      worstResultPerCheck([skipped, resultWith('fail', 'A-MAIN')])[0]?.status
+    ).toBe('fail')
+    expect(
+      worstResultPerCheck([skipped, resultWith('error', 'A-MONGO')])[0]?.status
+    ).toBe('error')
+    // Paired present: with nothing beside it, the skipped row is still the row.
+    expect(worstResultPerCheck([skipped])[0]?.status).toBe('not-applicable')
   })
 })
 

--- a/script/deploy/safe/confirm-check-registry.ts
+++ b/script/deploy/safe/confirm-check-registry.ts
@@ -170,6 +170,10 @@ const SEVERITY: readonly ICheckResult['status'][] = [
   'error',
   'needs-ack',
   'pass',
+  // Least severe, and listed rather than left out: a status this array omits
+  // gets -1 from `indexOf`, which ranks it ahead of `fail` — "there was nothing
+  // to grade" would then displace a mismatch on a network that had both.
+  'not-applicable',
 ]
 
 const worstOf = (

--- a/script/deploy/safe/confirm-check-registry.ts
+++ b/script/deploy/safe/confirm-check-registry.ts
@@ -170,9 +170,8 @@ const SEVERITY: readonly ICheckResult['status'][] = [
   'error',
   'needs-ack',
   'pass',
-  // Least severe, and listed rather than left out: a status this array omits
-  // gets -1 from `indexOf`, which ranks it ahead of `fail` — "there was nothing
-  // to grade" would then displace a mismatch on a network that had both.
+  // Listed rather than left out: a status this array omits gets -1 from
+  // `indexOf`, which ranks it ahead of `fail`.
   'not-applicable',
 ]
 

--- a/script/deploy/safe/confirm-integrity-asserts.test.ts
+++ b/script/deploy/safe/confirm-integrity-asserts.test.ts
@@ -1009,9 +1009,9 @@ describe('what the signer sees before the prompt', () => {
   })
 
   it('prints a status it does not recognise as unverified, never as a pass', async () => {
-    // `recordCheck` refuses a status outside the four, so this state cannot be
-    // reached through the module's own path — only by a rehydrated document or
-    // a direct push into the results log, which is exactly what is built here.
+    // `recordCheck` refuses a status the ledger does not define, so this state
+    // cannot be reached through the module's own path — only by a rehydrated
+    // document or a direct push into the results log, built here.
     // Left untested, the renderer's fallback would be code nothing had ever
     // exercised, sitting on the one path where being wrong prints green.
     const run = await runIntegrityAsserts(makeInput(), makeDeps())

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -172,9 +172,13 @@ const recordEveryCheck = (
  *
  * The denominator is fixed before the run can learn that a network it listed as
  * actionable carries no proposal for this operator. Left unrecorded it rolls up
- * as missing and hard-blocks a run on which nothing was wrong. A pass on
- * `A-LOCAL` is the reading `no-diamond-cut` already gets: the run read its input
- * and found nothing to compare, which is a verified fact about this network.
+ * as missing and hard-blocks a run on which nothing was wrong.
+ *
+ * `not-applicable` on `A-LOCAL`, never a pass: the run read its input and found
+ * nothing to compare, which is a verified fact about the network but not a
+ * verified proposal. Recorded as a pass it satisfied the verified counter, and a
+ * run whose every network was skipped closed `ALL CHECKS GREEN — 10/10 network
+ * results verified` with a pending proposal on one of them.
  *
  * Only for outcomes that answered. A read that *failed* has not established
  * anything and belongs in `recordCouldNotGrade` — mixing the two is how a fully
@@ -184,7 +188,7 @@ const recordEveryCheck = (
  */
 const recordNothingToGrade = (network: string, reason: string): void =>
   recordEveryCheck(network, {
-    status: 'pass',
+    status: 'not-applicable',
     actual: `no proposal was graded on ${network} — ${reason}`,
     anchor: 'A-LOCAL',
   })

--- a/script/deploy/safe/confirm-safe-tx.ts
+++ b/script/deploy/safe/confirm-safe-tx.ts
@@ -174,11 +174,8 @@ const recordEveryCheck = (
  * actionable carries no proposal for this operator. Left unrecorded it rolls up
  * as missing and hard-blocks a run on which nothing was wrong.
  *
- * `not-applicable` on `A-LOCAL`, never a pass: the run read its input and found
- * nothing to compare, which is a verified fact about the network but not a
- * verified proposal. Recorded as a pass it satisfied the verified counter, and a
- * run whose every network was skipped closed `ALL CHECKS GREEN — 10/10 network
- * results verified` with a pending proposal on one of them.
+ * `not-applicable` on `A-LOCAL`, never a pass: nothing on this network was
+ * compared, so the row must satisfy no verified counter.
  *
  * Only for outcomes that answered. A read that *failed* has not established
  * anything and belongs in `recordCouldNotGrade` — mixing the two is how a fully
@@ -1188,11 +1185,11 @@ const processTxs = async (
 
   // One row per network, written once every proposal on it has been graded and
   // reduced worst-first. A `ready` network always carries at least one proposal,
-  // so the empty branch is the unreachable case made explicit rather than left
-  // to roll up as a missing row and block the run.
+  // so the empty branch records a broken invariant — unverified, never a network
+  // the run established had nothing on it.
   if (checkLedger) {
     if (proposalChecks.length === 0)
-      recordNothingToGrade(network, 'the prepared network carried no proposal')
+      recordCouldNotGrade(network, 'the prepared network carried no proposal')
     else
       for (const result of worstResultPerCheck(proposalChecks))
         recordCheck(checkLedger, result)

--- a/script/deploy/safe/render-check-ledger.test.ts
+++ b/script/deploy/safe/render-check-ledger.test.ts
@@ -772,3 +772,104 @@ describe('the superseded mismatch survives more than one retry', () => {
     )
   })
 })
+
+describe('a run that graded nothing', () => {
+  /**
+   * The row `confirm-safe-tx.ts` writes for a network it positively established
+   * carries no proposal for this signer. Measured in production: one pending
+   * proposal on arbitrum, already signed by the reviewing signer, and the run
+   * closed `ALL CHECKS GREEN — 10/10 checks, 10/10 network results verified`
+   * having graded none of it.
+   */
+  const nothingToGrade = (network: string): Partial<ICheckResult> => ({
+    network,
+    status: 'not-applicable',
+    expected: 'every proposal this run would sign graded before signing',
+    actual: `no proposal was graded on ${network} — nothing actionable was left once the network was prepared`,
+    anchor: 'A-LOCAL',
+  })
+
+  const vacuous = (): ICheckLedger => {
+    const ledger = ledgerOf(['arbitrum'], [CODEHASH])
+    recordCheck(ledger, result(nothingToGrade('arbitrum')))
+
+    return ledger
+  }
+
+  it('does not close with a green verdict', () => {
+    const verdict = renderCheckLedger(vacuous()).at(-1) as string
+
+    expect(verdict).not.toContain('ALL CHECKS GREEN')
+    expect(verdict).not.toContain(GREEN)
+  })
+
+  it('prints no verified count at all, rather than a vacuous one', () => {
+    // `1/1 network results verified` over a set of size zero is the claim that
+    // produced the defect, and `0/0` is the same claim in a quieter font.
+    expect(renderCheckLedger(vacuous()).at(-1) as string).not.toMatch(
+      /\d+\/\d+ network results verified/
+    )
+  })
+
+  it('names the skipped networks and why they were skipped', () => {
+    const verdict = renderCheckLedger(vacuous()).at(-1) as string
+
+    expect(verdict).toContain('NOTHING TO REVIEW')
+    expect(verdict).toContain('1 network')
+    expect(verdict).toContain('nothing actionable was left')
+  })
+
+  it('does not mark the section green either', () => {
+    const section = renderCheckLedger(vacuous()).filter((line) =>
+      line.includes('Integrity')
+    )
+
+    expect(section).toHaveLength(1)
+    expect(section[0]).not.toContain(GREEN)
+    expect(section[0]).not.toContain('checks green')
+    expect(section[0]).not.toMatch(/\d+\/\d+ network results verified/)
+    expect(section[0]).toContain('not applicable')
+  })
+
+  it('still closes an all-green run with the green verdict', () => {
+    const ledger = ledgerOf(['mainnet', 'polygon'], [CODEHASH])
+    recordCheck(ledger, result({ network: 'mainnet' }))
+    recordCheck(ledger, result({ network: 'polygon' }))
+
+    const verdict = renderCheckLedger(ledger).at(-1) as string
+
+    expect(verdict).toContain('ALL CHECKS GREEN')
+    expect(verdict).toContain('2/2 network results verified')
+    expect(verdict).toContain(GREEN)
+  })
+
+  it('still blocks when a graded network failed beside a skipped one', () => {
+    const ledger = ledgerOf(['mainnet', 'arbitrum'], [CODEHASH])
+    recordCheck(ledger, result({ network: 'mainnet', status: 'fail' }))
+    recordCheck(ledger, result(nothingToGrade('arbitrum')))
+
+    const verdict = renderCheckLedger(ledger).at(-1) as string
+
+    expect(verdict).toContain('VERDICT: BLOCKED')
+    expect(verdict).not.toContain('NOTHING TO REVIEW')
+    expect(verdict).toContain(RED)
+  })
+
+  it('keeps a skipped network out of the verified count of a mixed run', () => {
+    const ledger = ledgerOf(['mainnet', 'arbitrum'], [CODEHASH])
+    recordCheck(ledger, result({ network: 'mainnet' }))
+    recordCheck(ledger, result(nothingToGrade('arbitrum')))
+
+    const lines = renderCheckLedger(ledger)
+    const section = lines.filter((line) => line.includes('Integrity'))
+
+    // One network graded, one verified — never `2/2`, which reads the skipped
+    // network as one this run checked.
+    expect(section[0]).toContain('1/1 network results verified')
+    expect(section[0]).toContain('1 not applicable')
+    expect(section[0]).not.toContain('2/2')
+    expect(lines.at(-1)).toContain('1/1 network results verified')
+    expect(lines.at(-1)).toContain('1 not applicable')
+    expect(lines.at(-1)).not.toContain('2/2')
+  })
+})

--- a/script/deploy/safe/render-check-ledger.test.ts
+++ b/script/deploy/safe/render-check-ledger.test.ts
@@ -32,6 +32,14 @@ const TARGET_STATE: ICheckDefinition = {
   title: 'Facet version matches the declared target state',
 }
 
+/** A second check in `CODEHASH`'s section, so a section can be partly green. */
+const AUTHORITY: ICheckDefinition = {
+  checkId: 'authority',
+  section: 'Integrity',
+  checkClass: 'integrity',
+  title: 'Timelock owns the diamond',
+}
+
 const ledgerOf = (
   networks: string[],
   checks: ICheckDefinition[] = [CODEHASH, TARGET_STATE]
@@ -500,8 +508,8 @@ describe('what the ledger must never soften or hide', () => {
 
   it('refuses to summarise a ledger that verified nothing', () => {
     // `createCheckLedger` guards this, but every consumer takes a plain
-    // `ICheckLedger`, so a rehydrated document reached the verdict with
-    // `passed === expected` as `0 === 0` and rendered ALL CHECKS GREEN.
+    // `ICheckLedger`, so a rehydrated document reaches the verdict with an empty
+    // network set and every count over it is a count over nothing.
     const empty = {
       expectedNetworks: [],
       checks: new Map([[CODEHASH.checkId, CODEHASH]]),
@@ -776,10 +784,8 @@ describe('the superseded mismatch survives more than one retry', () => {
 describe('a run that graded nothing', () => {
   /**
    * The row `confirm-safe-tx.ts` writes for a network it positively established
-   * carries no proposal for this signer. Measured in production: one pending
-   * proposal on arbitrum, already signed by the reviewing signer, and the run
-   * closed `ALL CHECKS GREEN — 10/10 checks, 10/10 network results verified`
-   * having graded none of it.
+   * carries no proposal for this signer — a pending proposal the signer has
+   * already signed is the case that produces it.
    */
   const nothingToGrade = (network: string): Partial<ICheckResult> => ({
     network,
@@ -866,10 +872,82 @@ describe('a run that graded nothing', () => {
     // One network graded, one verified — never `2/2`, which reads the skipped
     // network as one this run checked.
     expect(section[0]).toContain('1/1 network results verified')
-    expect(section[0]).toContain('1 not applicable')
+    expect(section[0]).toContain('1 network not applicable')
     expect(section[0]).not.toContain('2/2')
     expect(lines.at(-1)).toContain('1/1 network results verified')
-    expect(lines.at(-1)).toContain('1 not applicable')
+    expect(lines.at(-1)).toContain('1 network not applicable')
     expect(lines.at(-1)).not.toContain('2/2')
+  })
+
+  it('counts the skipped networks, not the rows they produced', () => {
+    // One network, two checks: the section and the verdict have to agree with
+    // the closing line's `1 network had nothing to grade` rather than report
+    // the two check×network rows behind it as two networks.
+    const ledger = ledgerOf(['arbitrum'], [CODEHASH, AUTHORITY])
+    recordCheck(ledger, result(nothingToGrade('arbitrum')))
+    recordCheck(
+      ledger,
+      result({ ...nothingToGrade('arbitrum'), checkId: 'authority' })
+    )
+
+    const lines = renderCheckLedger(ledger)
+
+    expect(lines.filter((line) => line.includes('Integrity'))[0]).toContain(
+      '1 network not applicable'
+    )
+    expect(lines.at(-1)).toContain('1 network had nothing to grade')
+    expect(lines.at(-1)).not.toContain('2 network')
+  })
+})
+
+describe('a check that graded nothing beside one that graded', () => {
+  const mixed = (): ICheckLedger => {
+    const ledger = ledgerOf(['arbitrum'], [CODEHASH, AUTHORITY])
+    recordCheck(ledger, result({ network: 'arbitrum' }))
+    recordCheck(
+      ledger,
+      result({
+        checkId: 'authority',
+        network: 'arbitrum',
+        status: 'not-applicable',
+        actual: 'no proposal was graded on arbitrum',
+        anchor: 'A-LOCAL',
+      })
+    )
+
+    return ledger
+  }
+
+  it('does not close green while one of the checks graded nothing', () => {
+    const verdict = renderCheckLedger(mixed()).at(-1) as string
+
+    // The section line above it reads `1/2 checks green`, so a closing line
+    // claiming every check is green contradicts the report it closes.
+    expect(verdict).not.toContain('ALL CHECKS GREEN')
+    expect(verdict).not.toContain(GREEN)
+    expect(verdict).toContain('1/2 checks green')
+  })
+
+  it('expands the check that graded nothing rather than suppressing it', () => {
+    const authority = renderCheckLedger(mixed()).filter((line) =>
+      line.includes('Timelock owns the diamond')
+    )
+
+    expect(authority).toHaveLength(1)
+    // Named, but never with a count over an empty set.
+    expect(authority[0]).not.toMatch(/\d+\/\d+/)
+    expect(authority[0]).toContain('nothing to grade')
+  })
+
+  it('still closes green when every check graded something', () => {
+    const ledger = ledgerOf(['arbitrum'], [CODEHASH, AUTHORITY])
+    recordCheck(ledger, result({ network: 'arbitrum' }))
+    recordCheck(ledger, result({ checkId: 'authority', network: 'arbitrum' }))
+
+    const verdict = renderCheckLedger(ledger).at(-1) as string
+
+    expect(verdict).toContain('ALL CHECKS GREEN')
+    expect(verdict).toContain('2/2 checks')
+    expect(verdict).toContain(GREEN)
   })
 })

--- a/script/deploy/safe/render-check-ledger.ts
+++ b/script/deploy/safe/render-check-ledger.ts
@@ -6,9 +6,11 @@
  * expanded per network only where a section is not green, and a single closing
  * verdict.
  *
- * Every count is printed as `N/N` against the declared denominator, and a
- * result that could not run is labelled `UNVERIFIED`, never folded into a green
- * line — the two states a signer must not be able to confuse.
+ * Every count is printed as `N/N` against the networks that were graded, always
+ * beside the count of those that had nothing to grade. A result that could not
+ * run is labelled `UNVERIFIED`, never folded into a green line, and a run that
+ * graded nothing closes `NOTHING TO REVIEW` with no verified count at all —
+ * the states a signer must not be able to confuse.
  */
 
 import { sanitizeProvenanceText } from '../shared/git-provenance'
@@ -110,10 +112,10 @@ function rowKind(result: ICheckResult): RowKind {
   if (result.status === 'fail') return 'fail'
   if (result.status === 'needs-ack') return 'needs-ack'
 
-  // `error`, and anything the ledger's four statuses do not cover: the verdict
+  // `error`, and anything the ledger's own statuses do not cover: the verdict
   // grades an unrecognised status as unverified with no acknowledgement path,
-  // and the row has to say the same. Passes never reach here; the caller
-  // filters them.
+  // and the row has to say the same. A pass and a not-applicable never reach
+  // here; the caller filters both.
   return 'error'
 }
 
@@ -122,10 +124,13 @@ function renderCheck(
   relaxed: ReadonlySet<string>
 ): string[] {
   const counts = [
-    `pass ${rollup.passed}/${rollup.expected}`,
+    `pass ${rollup.passed}/${rollup.graded}`,
     rollup.failed > 0 ? `fail ${rollup.failed}` : '',
     rollup.needsAck > 0 ? `needs review ${rollup.needsAck}` : '',
     rollup.unverified > 0 ? `unverified ${rollup.unverified}` : '',
+    // Printed whenever the denominator above is smaller than the declared one,
+    // so `pass 1/1` on a two-network run can never be read as full coverage.
+    rollup.notApplicable > 0 ? `not applicable ${rollup.notApplicable}` : '',
     `anchors ${clean(rollup.anchors.join(', ')) || 'none'}`,
   ]
     .filter(Boolean)
@@ -139,7 +144,10 @@ function renderCheck(
   ]
 
   for (const result of rollup.results) {
-    if (result.status === 'pass') continue
+    // A network with nothing to grade has no action attached to it and is
+    // already counted on the line above; expanded here it would put a row that
+    // needs nothing among the rows that do.
+    if (result.status === 'pass' || result.status === 'not-applicable') continue
 
     lines.push(
       renderRow(
@@ -178,7 +186,11 @@ function renderSection(
 ): string[] {
   const greenChecks = rollups.filter((rollup) => rollup.green).length
   const passed = rollups.reduce((sum, rollup) => sum + rollup.passed, 0)
-  const expected = rollups.reduce((sum, rollup) => sum + rollup.expected, 0)
+  const graded = rollups.reduce((sum, rollup) => sum + rollup.graded, 0)
+  const notApplicable = rollups.reduce(
+    (sum, rollup) => sum + rollup.notApplicable,
+    0
+  )
   const unverified = rollups.reduce((sum, rollup) => sum + rollup.unverified, 0)
   const needsAck = rollups.reduce((sum, rollup) => sum + rollup.needsAck, 0)
   // Every recorded mismatch, integrity and semantic alike — `verdict.blocking`
@@ -188,32 +200,81 @@ function renderSection(
   // keeps its own term, so one problem row still reads as one.
   const mismatched = rollups.reduce((sum, rollup) => sum + rollup.failed, 0)
 
+  // Nothing in this section was graded, so it has neither a verified count nor
+  // a share of checks green: printing either would be a count over an empty
+  // set, and `0/0` reads as coverage.
+  const nothingGraded = graded === 0
   const allGreen = greenChecks === rollups.length
-  const summary = [
-    `${greenChecks}/${rollups.length} checks green`,
-    `${passed}/${expected} network results verified`,
-    mismatched > 0 ? `${mismatched} mismatch` : '',
-    unverified > 0 ? `${unverified} unverified` : '',
-    needsAck > 0 ? `${needsAck} needs review` : '',
-  ]
+  const summary = (
+    nothingGraded
+      ? [
+          'nothing to grade',
+          `${plural(notApplicable, 'network result')} not applicable`,
+        ]
+      : [
+          `${greenChecks}/${rollups.length} checks green`,
+          `${passed}/${graded} network results verified`,
+          mismatched > 0 ? `${mismatched} mismatch` : '',
+          unverified > 0 ? `${unverified} unverified` : '',
+          needsAck > 0 ? `${needsAck} needs review` : '',
+          notApplicable > 0 ? `${notApplicable} not applicable` : '',
+        ]
+  )
     .filter(Boolean)
     .join(' · ')
 
   const lines = [
     color(
-      allGreen ? GREEN : mismatched > 0 ? RED : YELLOW,
-      `${allGreen ? '✓' : '✗'} ${clean(section).padEnd(
+      nothingGraded ? CYAN : allGreen ? GREEN : mismatched > 0 ? RED : YELLOW,
+      // Neither tick nor cross: a section with nothing to grade is not a
+      // success, and marking it as a failure would send a signer hunting for a
+      // problem that is not there.
+      `${nothingGraded ? '·' : allGreen ? '✓' : '✗'} ${clean(section).padEnd(
         SECTION_WIDTH
       )}${summary}`
     ),
   ]
 
   // A green check is fully described by the section line. Naming its networks
-  // there would put 71 rows between the signer and the rows that need them.
+  // there would put 71 rows between the signer and the rows that need them —
+  // and so is a check that graded nothing, whose every row is an absence.
   for (const rollup of rollups)
-    if (!rollup.green) lines.push(...renderCheck(rollup, relaxed))
+    if (!rollup.green && rollup.graded > 0)
+      lines.push(...renderCheck(rollup, relaxed))
 
   return lines
+}
+
+/** How many distinct reasons a closing line names before it stops listing them. */
+const MAX_SKIP_REASONS = 3
+
+/**
+ * The closing line for a run that graded nothing at all.
+ *
+ * It carries no count of what was verified, in either direction: `10/10` was the
+ * defect and `0/0` is the same sentence in a quieter font. What it carries
+ * instead is the number of networks that offered nothing and what each of them
+ * said, because that is the fact a signer needs — a proposal can be pending on a
+ * network this run had nothing to do on.
+ */
+function renderNothingToReview(rollups: ICheckRollup[]): string {
+  const skipped = rollups
+    .flatMap((rollup) => rollup.results)
+    .filter((result) => result.status === 'not-applicable')
+  const networks = new Set(skipped.map((result) => result.network))
+  const reasons = [...new Set(skipped.map((result) => clean(result.actual)))]
+  const shown = reasons.slice(0, MAX_SKIP_REASONS)
+  const elided = reasons.length - shown.length
+
+  return color(
+    YELLOW,
+    `VERDICT: NOTHING TO REVIEW — nothing was graded, so nothing was verified · ${plural(
+      networks.size,
+      'network'
+    )} had nothing to grade · ${shown.join(' · ')}${
+      elided > 0 ? ` · +${elided} more` : ''
+    }`
+  )
 }
 
 function renderVerdict(
@@ -221,10 +282,17 @@ function renderVerdict(
   rollups: ICheckRollup[]
 ): string {
   const passed = rollups.reduce((sum, rollup) => sum + rollup.passed, 0)
-  const expected = rollups.reduce((sum, rollup) => sum + rollup.expected, 0)
+  const graded = rollups.reduce((sum, rollup) => sum + rollup.graded, 0)
+  const notApplicable = rollups.reduce(
+    (sum, rollup) => sum + rollup.notApplicable,
+    0
+  )
+  const skippedNote =
+    notApplicable > 0 ? ` · ${notApplicable} not applicable` : ''
   // Carried by every verdict: the run that verified 56 of 57 is the one whose
-  // denominator has to be visible.
-  const coverage = `${passed}/${expected} network results verified`
+  // denominator has to be visible — and the skipped count travels with it, so a
+  // denominator smaller than the declared network set always says why.
+  const coverage = `${passed}/${graded} network results verified${skippedNote}`
 
   const relaxedNote =
     verdict.relaxed.length > 0
@@ -256,6 +324,11 @@ function renderVerdict(
       )} awaiting review${relaxedNote} · ${coverage}`
     )
 
+  // After the two verdicts that carry a finding, never before them: both rest
+  // on a graded result, so neither can coexist with this branch — and ordering
+  // it last of the three is what makes that structural rather than argued.
+  if (verdict.nothingGraded) return renderNothingToReview(rollups)
+
   if (verdict.relaxed.length > 0)
     return color(
       YELLOW,
@@ -269,7 +342,7 @@ function renderVerdict(
     GREEN,
     `VERDICT: ALL CHECKS GREEN — ${
       rollups.filter((rollup) => rollup.green).length
-    }/${rollups.length} checks, ${passed}/${expected} network results verified`
+    }/${rollups.length} checks, ${coverage}`
   )
 }
 

--- a/script/deploy/safe/render-check-ledger.ts
+++ b/script/deploy/safe/render-check-ledger.ts
@@ -86,6 +86,20 @@ const RELAXED_ACTION =
 const plural = (count: number, noun: string): string =>
   `${count} ${noun}${count === 1 ? '' : 's'}`
 
+/**
+ * The networks a set of checks had nothing to grade on.
+ *
+ * Counted as networks everywhere a line aggregates across checks, so the same
+ * skip is not reported as one number by the section and another by the verdict.
+ */
+const skippedNetworks = (rollups: readonly ICheckRollup[]): Set<string> =>
+  new Set(
+    rollups
+      .flatMap((rollup) => rollup.results)
+      .filter((result) => result.status === 'not-applicable')
+      .map((result) => result.network)
+  )
+
 function renderRow(
   network: string,
   kind: RowKind,
@@ -123,14 +137,21 @@ function renderCheck(
   rollup: ICheckRollup,
   relaxed: ReadonlySet<string>
 ): string[] {
+  // A check that graded nothing has no count to print: `pass 0/0` is the
+  // vacuous claim this report exists to keep off the screen.
+  const nothingGraded = rollup.graded === 0
   const counts = [
-    `pass ${rollup.passed}/${rollup.graded}`,
+    nothingGraded
+      ? 'nothing to grade'
+      : `pass ${rollup.passed}/${rollup.graded}`,
     rollup.failed > 0 ? `fail ${rollup.failed}` : '',
     rollup.needsAck > 0 ? `needs review ${rollup.needsAck}` : '',
     rollup.unverified > 0 ? `unverified ${rollup.unverified}` : '',
     // Printed whenever the denominator above is smaller than the declared one,
     // so `pass 1/1` on a two-network run can never be read as full coverage.
-    rollup.notApplicable > 0 ? `not applicable ${rollup.notApplicable}` : '',
+    rollup.notApplicable > 0
+      ? `${plural(rollup.notApplicable, 'network')} not applicable`
+      : '',
     `anchors ${clean(rollup.anchors.join(', ')) || 'none'}`,
   ]
     .filter(Boolean)
@@ -138,8 +159,12 @@ function renderCheck(
 
   const lines = [
     color(
-      rollup.failed > 0 ? RED : YELLOW,
-      `  ✗ ${clean(rollup.checkId)} — ${clean(rollup.title)}  ${counts}`
+      nothingGraded ? CYAN : rollup.failed > 0 ? RED : YELLOW,
+      // Neither tick nor cross for a check with nothing to grade, for the same
+      // reason the section line carries neither.
+      `  ${nothingGraded ? '·' : '✗'} ${clean(rollup.checkId)} — ${clean(
+        rollup.title
+      )}  ${counts}`
     ),
   ]
 
@@ -187,10 +212,7 @@ function renderSection(
   const greenChecks = rollups.filter((rollup) => rollup.green).length
   const passed = rollups.reduce((sum, rollup) => sum + rollup.passed, 0)
   const graded = rollups.reduce((sum, rollup) => sum + rollup.graded, 0)
-  const notApplicable = rollups.reduce(
-    (sum, rollup) => sum + rollup.notApplicable,
-    0
-  )
+  const notApplicable = skippedNetworks(rollups).size
   const unverified = rollups.reduce((sum, rollup) => sum + rollup.unverified, 0)
   const needsAck = rollups.reduce((sum, rollup) => sum + rollup.needsAck, 0)
   // Every recorded mismatch, integrity and semantic alike — `verdict.blocking`
@@ -209,7 +231,7 @@ function renderSection(
     nothingGraded
       ? [
           'nothing to grade',
-          `${plural(notApplicable, 'network result')} not applicable`,
+          `${plural(notApplicable, 'network')} not applicable`,
         ]
       : [
           `${greenChecks}/${rollups.length} checks green`,
@@ -217,7 +239,9 @@ function renderSection(
           mismatched > 0 ? `${mismatched} mismatch` : '',
           unverified > 0 ? `${unverified} unverified` : '',
           needsAck > 0 ? `${needsAck} needs review` : '',
-          notApplicable > 0 ? `${notApplicable} not applicable` : '',
+          notApplicable > 0
+            ? `${plural(notApplicable, 'network')} not applicable`
+            : '',
         ]
   )
     .filter(Boolean)
@@ -236,40 +260,35 @@ function renderSection(
   ]
 
   // A green check is fully described by the section line. Naming its networks
-  // there would put 71 rows between the signer and the rows that need them —
-  // and so is a check that graded nothing, whose every row is an absence.
+  // there would put 71 rows between the signer and the rows that need them.
+  // Every other check is expanded, including one that graded nothing: the
+  // section line counts it as not green, so suppressing it leaves a `✗` section
+  // whose shortfall has no row explaining it.
   for (const rollup of rollups)
-    if (!rollup.green && rollup.graded > 0)
-      lines.push(...renderCheck(rollup, relaxed))
+    if (!rollup.green) lines.push(...renderCheck(rollup, relaxed))
 
   return lines
 }
 
-/** How many distinct reasons a closing line names before it stops listing them. */
-const MAX_SKIP_REASONS = 3
+/** How many skip notes a closing line names before it stops listing them. */
+const MAX_SKIP_NOTES = 3
 
-/**
- * The closing line for a run that graded nothing at all.
- *
- * It carries no count of what was verified, in either direction: `10/10` was the
- * defect and `0/0` is the same sentence in a quieter font. What it carries
- * instead is the number of networks that offered nothing and what each of them
- * said, because that is the fact a signer needs — a proposal can be pending on a
- * network this run had nothing to do on.
- */
 function renderNothingToReview(rollups: ICheckRollup[]): string {
-  const skipped = rollups
-    .flatMap((rollup) => rollup.results)
-    .filter((result) => result.status === 'not-applicable')
-  const networks = new Set(skipped.map((result) => result.network))
-  const reasons = [...new Set(skipped.map((result) => clean(result.actual)))]
-  const shown = reasons.slice(0, MAX_SKIP_REASONS)
-  const elided = reasons.length - shown.length
+  const notes = [
+    ...new Set(
+      rollups
+        .flatMap((rollup) => rollup.results)
+        .filter((result) => result.status === 'not-applicable')
+        .map((result) => clean(result.actual))
+    ),
+  ]
+  const shown = notes.slice(0, MAX_SKIP_NOTES)
+  const elided = notes.length - shown.length
 
   return color(
     YELLOW,
     `VERDICT: NOTHING TO REVIEW — nothing was graded, so nothing was verified · ${plural(
-      networks.size,
+      skippedNetworks(rollups).size,
       'network'
     )} had nothing to grade · ${shown.join(' · ')}${
       elided > 0 ? ` · +${elided} more` : ''
@@ -283,12 +302,11 @@ function renderVerdict(
 ): string {
   const passed = rollups.reduce((sum, rollup) => sum + rollup.passed, 0)
   const graded = rollups.reduce((sum, rollup) => sum + rollup.graded, 0)
-  const notApplicable = rollups.reduce(
-    (sum, rollup) => sum + rollup.notApplicable,
-    0
-  )
+  const notApplicable = skippedNetworks(rollups).size
   const skippedNote =
-    notApplicable > 0 ? ` · ${notApplicable} not applicable` : ''
+    notApplicable > 0
+      ? ` · ${plural(notApplicable, 'network')} not applicable`
+      : ''
   // Carried by every verdict: the run that verified 56 of 57 is the one whose
   // denominator has to be visible — and the skipped count travels with it, so a
   // denominator smaller than the declared network set always says why.
@@ -324,9 +342,6 @@ function renderVerdict(
       )} awaiting review${relaxedNote} · ${coverage}`
     )
 
-  // After the two verdicts that carry a finding, never before them: both rest
-  // on a graded result, so neither can coexist with this branch — and ordering
-  // it last of the three is what makes that structural rather than argued.
   if (verdict.nothingGraded) return renderNothingToReview(rollups)
 
   if (verdict.relaxed.length > 0)
@@ -338,11 +353,25 @@ function renderVerdict(
       )} · ${coverage}`
     )
 
+  const green = rollups.filter((rollup) => rollup.green).length
+
+  // Nothing blocks and nothing is owed, but a check that graded nothing is not
+  // a green check: `passed === graded` is measured over the graded networks
+  // alone, so it cannot see one whose networks all dropped out of it.
+  if (green < rollups.length)
+    return color(
+      YELLOW,
+      `VERDICT: COVERAGE INCOMPLETE — ${green}/${
+        rollups.length
+      } checks green, ${plural(
+        rollups.filter((rollup) => rollup.graded === 0).length,
+        'check'
+      )} graded nothing · ${coverage}`
+    )
+
   return color(
     GREEN,
-    `VERDICT: ALL CHECKS GREEN — ${
-      rollups.filter((rollup) => rollup.green).length
-    }/${rollups.length} checks, ${coverage}`
+    `VERDICT: ALL CHECKS GREEN — ${green}/${rollups.length} checks, ${coverage}`
   )
 }
 


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-686 (found during the 2026-09-12 signing rehearsal)

# Why did I implement it this way?

A run that graded **nothing** closed all-green.

`recordNothingToGrade` wrote `status: 'pass'` on `A-LOCAL` for every registered check on a
network the run skipped. A pass is a verified network result, so `rollUpChecks`'s
`green: passed === expected` was satisfied by `0 === 0`, and the verdict claimed
`ALL CHECKS GREEN — N/N network results verified` over an empty result set.

How this was found, stated precisely, because the two branches differ. The faulty **recording**
is what `main` has. The rendered verdict was observed on `signing2-integration-0912`, which
registers ten checks and wires the ledger; on `main` `confirm-safe-tx.ts` never calls
`renderCheckLedger` at all (`b5799792f`, pending EXSC-994) and `CONFIRM_CHECK_DEFINITIONS` holds
one check, so no `10/10` line is producible there. What was measured on the real production
Arbitrum store is that `list-pending-proposals --network arbitrum --json` returned `count: 1`
at the moment the walk reported `No actionable pending transactions` — a genuine pending
proposal, graded by nothing. The green verdict over that empty set was rendered on the
integration branch.

Rather than special-casing the renderer, this adds a `not-applicable` `CheckStatus` that is
strictly weaker than the `pass` it replaces: it blocks nothing (nothing is wrong) and satisfies
no counter (nothing was checked). `green` becomes `graded > 0 && passed === graded`, so
`0 === 0` can no longer be green, and the narrowed denominator never renders without the
skipped count beside it.

`not-applicable` is also added to `SEVERITY`. Omitting it yields `indexOf` **-1**, which sorts
it ahead of `fail` in `worstResultPerCheck` — "nothing to grade" would have displaced a real
mismatch on a network that had both. That hole is closed here rather than left latent.

Note on scope: `confirm-safe-tx.ts` does not currently render the ledger on `main`
(`b5799792f` removed the render pending EXSC-994, pinned by
`check-ledger-wiring-placement.test.ts`). The faulty **recording** is on main and is what this
fixes; whoever re-wires the render under EXSC-994 inherits the corrected verdict. The render is
deliberately left un-wired here.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: n/a
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] I have checked that any arbitrary calls to external contracts are validated and or restricted — no call paths changed
- [x] I have checked that any privileged calls (i.e. storage modifications) are validated and or restricted — no contract code in this PR
- [x] I have ensured that any new contracts have had AT A MINIMUM 1 preliminary audit — n/a, TypeScript only

## Verification

14 tests written against the defect fail before the change and pass after. Full
`script/deploy/safe/` suite: **2047 pass, 0 fail** (59 files). `tsc-files --noEmit` exit 0,
`eslint` exit 0.

Falsified rather than merely asserted — reverting `green` to `passed === expected` reintroduces
a failure, and the paired positives still hold: a populated all-green run still renders
`ALL CHECKS GREEN — 2/2 checks, 2/2 network results verified`, and a fail beside a skipped
network still renders `VERDICT: BLOCKED`, never `NOTHING TO REVIEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

