### PR TITLE
fix(safe): distinguish the two integrity sections, and let gate G ask instead of refusing

### DIFF
--- a/script/deploy/safe/check-ledger.test.ts
+++ b/script/deploy/safe/check-ledger.test.ts
@@ -1042,3 +1042,107 @@ describe('nothing that would soften the verdict may erase a mismatch', () => {
     expect(rollup?.unverified).toBe(1)
   })
 })
+
+describe('undecidableIsAcknowledgeable', () => {
+  // A gate that reads live state against an expectation the proposer writes can
+  // neither decide a green nor honestly refuse: the operator has no way to make
+  // a record-sourced expectation into a repo-sourced one. The opt-in gives that
+  // one case a signer to answer it, and nothing else.
+  const AUTHORITIES: ICheckDefinition = {
+    checkId: 'storage-authority',
+    section: 'Deployed state',
+    checkClass: 'integrity',
+    gate: 'Z',
+    title: 'Storage authorities',
+    undecidableIsAcknowledgeable: true,
+  }
+
+  const row = (over: Partial<ICheckResult> = {}): ICheckResult => ({
+    checkId: 'storage-authority',
+    network: 'mainnet',
+    status: 'needs-ack',
+    expected: 'the address main declares',
+    actual: 'the address main declares',
+    anchor: 'A-MONGO',
+    ...over,
+  })
+
+  const verdictOf = (
+    definition: ICheckDefinition,
+    over: Partial<ICheckResult> = {}
+  ) => {
+    const ledger = ledgerOf(['mainnet'], [definition])
+    recordCheck(ledger, row(over))
+    return summariseLedger(ledger)
+  }
+
+  it('keeps needs-ack on an integrity check whose anchor only reports', () => {
+    const ledger = ledgerOf(['mainnet'], [AUTHORITIES])
+
+    expect(recordCheck(ledger, row()).status).toBe('needs-ack')
+
+    const verdict = verdictOf(AUTHORITIES)
+    expect(verdict.hardBlocked).toBe(false)
+    expect(verdict.requiresAcknowledgement).toHaveLength(1)
+  })
+
+  it('does nothing without the flag', () => {
+    const { undecidableIsAcknowledgeable: _optIn, ...plain } = AUTHORITIES
+
+    expect(verdictOf(plain).hardBlocked).toBe(true)
+  })
+
+  it('refuses the exemption on A-UNRESOLVED, where nothing answered', () => {
+    const ledger = ledgerOf(['mainnet'], [AUTHORITIES])
+
+    expect(recordCheck(ledger, row({ anchor: 'A-UNRESOLVED' })).status).toBe(
+      'fail'
+    )
+    expect(verdictOf(AUTHORITIES, { anchor: 'A-UNRESOLVED' }).hardBlocked).toBe(
+      true
+    )
+  })
+
+  it('refuses the exemption on an anchor that could have decided', () => {
+    // `A-LOCAL` can grade a pass, so a `needs-ack` on it is not an undecidable
+    // expectation — it is an integrity check asking to be clicked through.
+    expect(verdictOf(AUTHORITIES, { anchor: 'A-LOCAL' }).hardBlocked).toBe(true)
+  })
+
+  it('leaves a real mismatch hard-blocking, on the same anchor', () => {
+    const verdict = verdictOf(AUTHORITIES, {
+      status: 'fail',
+      actual: '0xattacker',
+    })
+
+    expect(verdict.hardBlocked).toBe(true)
+    expect(verdict.requiresAcknowledgement).toHaveLength(0)
+  })
+
+  it('is not what reclassifying the check as semantic would do', () => {
+    // The measured false green this flag exists to avoid: `semantic` sends the
+    // mismatch to acknowledgement too, turning a storage-authority swap into a
+    // prompt.
+    const asSemantic = verdictOf(
+      { ...AUTHORITIES, checkClass: 'semantic' },
+      { status: 'fail', actual: '0xattacker' }
+    )
+
+    expect(asSemantic.hardBlocked).toBe(false)
+    expect(asSemantic.requiresAcknowledgement).toHaveLength(1)
+  })
+
+  it('moves the ledger digest, so it cannot be added off the record', () => {
+    const { undecidableIsAcknowledgeable: _optIn, ...plain } = AUTHORITIES
+    const attest = (definition: ICheckDefinition) => {
+      const ledger = ledgerOf(['mainnet'], [definition])
+      recordCheck(ledger, row({ status: 'pass', anchor: 'A-CHAIN' }))
+      return buildReviewAttestation(ledger, {
+        reviewer: 'signer-1',
+        reviewedAt: '2026-09-13T00:00:00.000Z',
+      }).ledgerDigest
+    }
+
+    expect(attest(AUTHORITIES)).not.toBe(attest(plain))
+  })
+})

--- a/script/deploy/safe/check-ledger.ts
+++ b/script/deploy/safe/check-ledger.ts
@@ -56,6 +56,18 @@ const REPORTING_ONLY_ANCHORS: ReadonlySet<AnchorId> = new Set<AnchorId>([
   'A-UNRESOLVED',
 ])
 
+/**
+ * The reporting-only anchors a signer can be asked to take on.
+ *
+ * Narrower than `REPORTING_ONLY_ANCHORS` on purpose. `A-MONGO` and
+ * `A-PROPOSAL` name a source that answered and whose provenance the row can
+ * state, so there is something a human can decide to trust. `A-UNRESOLVED`
+ * means nothing answered, which leaves nothing to decide about — it keeps
+ * blocking even on a check that opted in below.
+ */
+const ACKNOWLEDGEABLE_REPORTING_ANCHORS: ReadonlySet<AnchorId> =
+  new Set<AnchorId>(['A-MONGO', 'A-PROPOSAL'])
+
 /** Every status a result may carry, for validating a value that bypassed the type. */
 const CHECK_STATUSES: ReadonlySet<string> = new Set<CheckStatus>([
   'pass',
@@ -98,6 +110,17 @@ export interface ICheckDefinition {
    * pair beneath it is there to say.
    */
   title: string
+  /**
+   * Opts this check into grading `needs-ack` when its expectation rests on an
+   * anchor that reports rather than decides, instead of the `fail` the
+   * integrity class gives every other unacknowledgeable status.
+   *
+   * Scoped to that one case, and never to a mismatch: a live value that
+   * disagrees with what the repo declares still hard-blocks. That is the whole
+   * difference from reclassifying the check as `semantic`, which would send the
+   * mismatch to the acknowledgement path too.
+   */
+  undecidableIsAcknowledgeable?: boolean
 }
 
 /**
@@ -268,11 +291,35 @@ export const recordCheck = (
   return stored
 }
 
+/**
+ * Whether one `needs-ack` survives the integrity class's blanket refusal.
+ *
+ * Both halves are re-read wherever the refusal is applied rather than trusted
+ * from an earlier coercion, so a result that entered the log some other way
+ * cannot carry the exemption it was never granted.
+ *
+ * @param definition - The gate the result belongs to.
+ * @param result - The status and anchor being judged.
+ * @returns True only for an opted-in check whose expectation rests on a
+ * reporting anchor that answered.
+ */
+const survivesIntegrityRefusal = (
+  definition: ICheckDefinition,
+  result: Pick<ICheckResult, 'status' | 'anchor'>
+): boolean =>
+  result.status === 'needs-ack' &&
+  definition.undecidableIsAcknowledgeable === true &&
+  ACKNOWLEDGEABLE_REPORTING_ANCHORS.has(result.anchor)
+
 function coerceStatus(
   result: ICheckResult,
   definition: ICheckDefinition
 ): ICheckResult {
-  if (result.status === 'needs-ack' && definition.checkClass === 'integrity')
+  if (
+    result.status === 'needs-ack' &&
+    definition.checkClass === 'integrity' &&
+    !survivesIntegrityRefusal(definition, result)
+  )
     return {
       ...result,
       status: 'fail',
@@ -583,7 +630,10 @@ export const summariseLedger = (
       if (result.status === 'fail') totals.fail += 1
       else totals.needsAck += 1
 
-      if (rollup.checkClass === 'integrity') {
+      if (
+        rollup.checkClass === 'integrity' &&
+        !survivesIntegrityRefusal(rollup, result)
+      ) {
         blocking.push({
           checkId: result.checkId,
           network: result.network,
@@ -713,6 +763,9 @@ export const buildReviewAttestation = (
     // The only text saying what is being checked, so relabelling a check must
     // move the digest.
     definition.title,
+    // Second field that decides whether a non-pass blocks, so it is digested
+    // for the same reason the class is.
+    definition.undecidableIsAcknowledgeable === true ? 'ack-undecidable' : '',
   ])
   const byJson = (left: string[], right: string[]): number =>
     JSON.stringify(left) < JSON.stringify(right) ? -1 : 1

--- a/script/deploy/safe/confirm-check-registry.test.ts
+++ b/script/deploy/safe/confirm-check-registry.test.ts
@@ -8,6 +8,7 @@ import {
   summariseLedger,
   type CheckStatus,
   type ICheckLedger,
+  type ICheckResult,
 } from './check-ledger'
 import {
   ALL_GATE_DEFINITIONS,
@@ -19,6 +20,7 @@ import {
   NOTHING_TO_COMPARE,
   ORDERING_HOLDS,
   RPC_QUORUM_CHECK_ID,
+  STORAGE_AUTHORITY_CHECK,
   STORAGE_AUTHORITY_CHECK_ID,
   storageAuthorityCheckResult,
   TARGET_STATE_CHECK,
@@ -1141,18 +1143,66 @@ describe('storageAuthorityCheckResult', () => {
     expect(result.status).toBe('error')
   })
 
+  const ownerFromRecord = (
+    overrides: Partial<IPreBroadcastAuthority> = {}
+  ): IPreBroadcastAuthority =>
+    entry({
+      label: 'LiFiDiamond.owner()',
+      liveValue: TIMELOCK,
+      expectedValue: TIMELOCK,
+      expectationSource: 'deployments',
+      ...overrides,
+    })
+
+  const verdictFor = (
+    entries: IPreBroadcastAuthority[],
+    anchors?: Map<string, ICheckResult['anchor']>
+  ) => {
+    const ledger = createCheckLedger({
+      checks: [STORAGE_AUTHORITY_CHECK],
+      expectedNetworks: ['mainnet'],
+    })
+    recordCheck(
+      ledger,
+      storageAuthorityCheckResult(
+        entries,
+        'mainnet',
+        anchors ?? authorityExpectationAnchors(entries)
+      )
+    )
+    return summariseLedger(ledger)
+  }
+
   describe('an expectation the proposer writes may report but not decide', () => {
-    it('anchors a deployment-record expectation on A-MONGO even when it matches', () => {
-      const result = resultFor([
-        entry({
-          label: 'LiFiDiamond.owner()',
-          liveValue: TIMELOCK,
-          expectedValue: TIMELOCK,
-          expectationSource: 'deployments',
-        }),
-      ])
-      expect(result.status).toBe('pass')
+    it('grades a matched deployment-record expectation needs-ack on A-MONGO', () => {
+      const result = resultFor([ownerFromRecord()])
+      expect(result.status).toBe('needs-ack')
       expect(result.anchor).toBe('A-MONGO')
+      // The signer is told which expectation they are taking on, not merely
+      // that one of them was weak.
+      expect(result.detail).toContain('LiFiDiamond.owner()')
+    })
+
+    it('routes that row to acknowledgement instead of blocking the run', () => {
+      const verdict = verdictFor([ownerFromRecord()])
+      expect(verdict.hardBlocked).toBe(false)
+      expect(verdict.blocking).toHaveLength(0)
+      expect(
+        verdict.requiresAcknowledgement.map((result) => result.checkId)
+      ).toEqual([STORAGE_AUTHORITY_CHECK_ID])
+    })
+
+    it('refuses to let triage drop that acknowledgement', () => {
+      // The row stays an integrity check, and triage relaxes only semantic
+      // ones — otherwise the opt-in would hand a subtractive op a silent pass.
+      const ledger = createCheckLedger({
+        checks: [STORAGE_AUTHORITY_CHECK],
+        expectedNetworks: ['mainnet'],
+      })
+      recordCheck(ledger, resultFor([ownerFromRecord()]))
+      const verdict = summariseLedger(ledger, { triageProfile: 'subtractive' })
+      expect(verdict.relaxed).toHaveLength(0)
+      expect(verdict.requiresAcknowledgement).toHaveLength(1)
     })
 
     it('takes the weaker anchor when one of two expectations is proposer-written', () => {
@@ -1168,27 +1218,83 @@ describe('storageAuthorityCheckResult', () => {
       expect(result.anchor).toBe('A-MONGO')
     })
 
-    it('is coerced away from a green by the ledger itself', () => {
-      // The point of the anchor: recordCheck refuses a pass claimed on an
-      // anchor the proposer controls, so this row cannot grade the run green
-      // on a value the proposer supplied one side of.
+    it('is kept away from a green by the ledger itself', () => {
+      // The point of the anchor: the run may not be reported as verified on a
+      // value the proposer supplied one side of. The row is answerable, not
+      // decided.
       const ledger = createCheckLedger({
-        checks: [...CONFIRM_CHECK_DEFINITIONS],
+        checks: [STORAGE_AUTHORITY_CHECK],
         expectedNetworks: ['mainnet'],
       })
-      recordCheck(
-        ledger,
-        resultFor([
-          entry({
-            label: 'LiFiDiamond.owner()',
-            liveValue: TIMELOCK,
-            expectedValue: TIMELOCK,
-            expectationSource: 'deployments',
-          }),
-        ])
+      recordCheck(ledger, resultFor([ownerFromRecord()]))
+      const rendered = renderCheckLedger(ledger).join('\n')
+      expect(rendered).not.toContain('ALL CHECKS GREEN')
+      expect(rendered).toContain('ACKNOWLEDGEMENT REQUIRED')
+    })
+  })
+
+  // Each case is a way the gate can be wrong or blind. None of them may reach
+  // the acknowledgement path the matched-on-record case above opened: an
+  // acknowledgement is a prompt a signer clicks through, so a mismatch routed
+  // there is the attack this gate exists to catch, shown as a question.
+  describe('what the acknowledgement path must never swallow', () => {
+    const expectHardBlock = (verdict: ReturnType<typeof verdictFor>): void => {
+      expect(verdict.hardBlocked).toBe(true)
+      expect(verdict.blocking.length).toBeGreaterThan(0)
+      expect(verdict.requiresAcknowledgement).toHaveLength(0)
+    }
+
+    it('a live value that disagrees with a record-sourced expectation', () => {
+      const result = resultFor([ownerFromRecord({ liveValue: ATTACKER })])
+      expect(result.status).toBe('fail')
+      expectHardBlock(verdictFor([ownerFromRecord({ liveValue: ATTACKER })]))
+    })
+
+    it('a live value that disagrees with a globalConfig-sourced expectation', () => {
+      const result = resultFor([entry({ liveValue: ATTACKER })])
+      expect(result.status).toBe('fail')
+      expectHardBlock(verdictFor([entry({ liveValue: ATTACKER })]))
+    })
+
+    it('a live read that failed, so nothing was compared', () => {
+      const unread = ownerFromRecord({
+        liveValue: undefined,
+        readError: 'node unreachable',
+      })
+      expect(resultFor([unread]).status).toBe('error')
+      expectHardBlock(verdictFor([unread]))
+    })
+
+    it('no contract in the proposal declaring an authority at all', () => {
+      expect(resultFor([]).status).toBe('error')
+      expectHardBlock(verdictFor([]))
+    })
+
+    it('an expectation of unknown provenance, even when every value matched', () => {
+      // An anchor map that does not name the label is `A-UNRESOLVED`: nothing
+      // said where the expectation came from, so there is nothing to take on.
+      const anchors = new Map<string, ICheckResult['anchor']>()
+      const result = storageAuthorityCheckResult(
+        [ownerFromRecord()],
+        'mainnet',
+        anchors
       )
-      const rendered = renderCheckLedger(ledger)
-      expect(JSON.stringify(rendered)).not.toContain('"status":"pass"')
+      expect(result.status).toBe('pass')
+      expect(result.anchor).toBe('A-UNRESOLVED')
+      expectHardBlock(verdictFor([ownerFromRecord()], anchors))
+    })
+
+    it('an A-UNRESOLVED expectation sitting before a record-sourced one', () => {
+      // The weakest anchor decides, not whichever the loop happened to see
+      // last — the acknowledgement turns on that answer.
+      const anchors = new Map<string, ICheckResult['anchor']>([
+        ['LiFiDiamond.owner()', 'A-MONGO'],
+      ])
+      const entries = [entry(), ownerFromRecord()]
+      expect(
+        storageAuthorityCheckResult(entries, 'mainnet', anchors).anchor
+      ).toBe('A-UNRESOLVED')
+      expectHardBlock(verdictFor(entries, anchors))
     })
   })
 

--- a/script/deploy/safe/confirm-check-registry.test.ts
+++ b/script/deploy/safe/confirm-check-registry.test.ts
@@ -1310,3 +1310,26 @@ describe('gate letters', () => {
     expect(named).toContain(CODEHASH_CHECK_ID)
   })
 })
+
+describe('section headings', () => {
+  // `renderCheckLedger` groups on the exact string, so two headings a signer
+  // reads as the same subject render as two adjacent near-identical lines with
+  // nothing to tell them apart. A name containing another is the shape that
+  // produced it: `Integrity` alongside `proposal integrity`.
+  it('are distinct, and none contains another', () => {
+    const sections = [
+      ...new Set(
+        ALL_GATE_DEFINITIONS.map((definition) =>
+          definition.section.trim().toLowerCase()
+        )
+      ),
+    ]
+
+    expect(sections.length).toBeGreaterThan(1)
+    for (const section of sections) {
+      expect(section).not.toBe('')
+      for (const other of sections)
+        if (other !== section) expect(other).not.toContain(section)
+    }
+  })
+})

--- a/script/deploy/safe/confirm-check-registry.ts
+++ b/script/deploy/safe/confirm-check-registry.ts
@@ -47,6 +47,11 @@ export const STORAGE_AUTHORITY_CHECK: ICheckDefinition = {
   checkClass: 'integrity',
   gate: 'G',
   title: 'Storage authorities',
+  // Every diamond cut carries `LiFiDiamond.owner`, whose expectation comes from
+  // the deployment record — so without this the one gate that reads live
+  // authorities refuses every honest proposal, and the remedy it prints cannot
+  // be followed. A mismatch is untouched and still hard-blocks.
+  undecidableIsAcknowledgeable: true,
 }
 
 /**
@@ -54,9 +59,9 @@ export const STORAGE_AUTHORITY_CHECK: ICheckDefinition = {
  *
  * `config/global.json` is a repo file the proposer's branch cannot change
  * without review, so it may decide a pass. The deployment record is written by
- * the proposer, so it may only report — the ledger coerces a `pass` on it to
- * `error`, which is the correct reading of "the value matched the one we were
- * handed".
+ * the proposer, so it may only report: a match against it means no more than
+ * "the value matched the one we were handed", which is for the signer to
+ * accept rather than for the gate to grade green.
  *
  * @param authorities - Observation rows from `observeCalldata`.
  * @returns Label → anchor, for `storageAuthorityCheckResult`.
@@ -83,11 +88,15 @@ export const EVERY_AUTHORITY_MATCHES =
  * The comparison is a live chain read against a declaration in `main`, so the
  * live side is `A-CHAIN` — but the row is anchored on the weaker of the two,
  * because a comparison is only as good as its expectation. An authority whose
- * expected value comes from the deployment record is `A-MONGO`, which the
- * ledger treats as reporting-only and so coerces to `error` rather than letting
- * it grade green: the proposer writes that record and therefore owns one side
- * of the comparison. One sourced from `config/global.json` is `A-LOCAL` and may
- * decide.
+ * expected value comes from the deployment record is `A-MONGO`: the proposer
+ * writes that record and therefore owns one side of the comparison, so an
+ * all-matched row on it grades `needs-ack` rather than green, naming the labels
+ * whose expectation it rests on. One sourced from `config/global.json` is
+ * `A-LOCAL` and may decide.
+ *
+ * Only the all-matched case is acknowledgeable. A live value that disagrees, a
+ * read that failed and an expectation of unknown provenance all keep the
+ * integrity class's hard block.
  *
  * An empty set is an `error` on `A-UNRESOLVED`, not a pass. No contract in the
  * calldata carried a declared authority, so nothing was compared, and the
@@ -158,13 +167,28 @@ export const storageAuthorityCheckResult = (
 
   // Every entry passed, so no single finding set the anchor. The row still must
   // not claim `A-CHAIN` when an expectation it compared against was
-  // proposer-written, so it takes the weakest anchor in the set.
-  if (failing.length === 0)
+  // proposer-written, so it takes the weakest anchor in the set. `A-UNRESOLVED`
+  // is decided before `A-MONGO` rather than by whichever comes last in calldata
+  // order, because the acknowledgement below turns on that answer.
+  const recordSourced: string[] = []
+  if (failing.length === 0) {
+    let unresolved = false
     for (const entry of entries) {
       const entryAnchor = expectationAnchors.get(entry.label) ?? 'A-UNRESOLVED'
-      if (entryAnchor === 'A-MONGO' || entryAnchor === 'A-UNRESOLVED')
-        anchor = entryAnchor
+      if (entryAnchor === 'A-UNRESOLVED') unresolved = true
+      else if (entryAnchor === 'A-MONGO') recordSourced.push(entry.label)
     }
+    if (unresolved) anchor = 'A-UNRESOLVED'
+    else if (recordSourced.length > 0) anchor = 'A-MONGO'
+  }
+
+  // `A-MONGO` and nothing else. The record is proposer-written, so the row may
+  // not grade green — but every value was read live and matched, and the signer
+  // can be told exactly which expectations rest on the record and take them on.
+  // `A-UNRESOLVED` is the case where nothing answered, so there is nothing to
+  // take on and it keeps blocking.
+  const acknowledgeable = status === 'pass' && anchor === 'A-MONGO'
+  if (acknowledgeable) status = 'needs-ack'
 
   return {
     checkId: STORAGE_AUTHORITY_CHECK_ID,
@@ -175,6 +199,13 @@ export const storageAuthorityCheckResult = (
       ? failing.join('; ')
       : `${entries.length} declared authority value(s) match config`,
     anchor,
+    ...(acknowledgeable
+      ? {
+          detail: `read live and matched, but the expected value came from the deployment record the proposer writes: ${recordSourced.join(
+            ', '
+          )}`,
+        }
+      : {}),
   }
 }
 

--- a/script/deploy/safe/confirm-check-registry.ts
+++ b/script/deploy/safe/confirm-check-registry.ts
@@ -43,7 +43,7 @@ export const STORAGE_AUTHORITY_CHECK_ID = 'storage-authority'
 
 export const STORAGE_AUTHORITY_CHECK: ICheckDefinition = {
   checkId: STORAGE_AUTHORITY_CHECK_ID,
-  section: 'Integrity',
+  section: 'Deployed state',
   checkClass: 'integrity',
   gate: 'G',
   title: 'Storage authorities',
@@ -473,7 +473,7 @@ export const CODEHASH_CHECK_ID = 'codehash'
  */
 export const CODEHASH_CHECK: ICheckDefinition = {
   checkId: CODEHASH_CHECK_ID,
-  section: 'Integrity',
+  section: 'Deployed state',
   checkClass: 'integrity',
   gate: 'K',
   title: 'Deployed bytecode',

--- a/script/deploy/safe/confirm-integrity-asserts.ts
+++ b/script/deploy/safe/confirm-integrity-asserts.ts
@@ -66,7 +66,7 @@ export const CHECK_FIXED_FIELDS = 'INT-FIXED-FIELDS'
 export const CHECK_TARGET = 'INT-TARGET'
 export const CHECK_TIMELOCK_DELAY = 'INT-TIMELOCK-DELAY'
 
-const SECTION = 'proposal integrity'
+const SECTION = 'Proposal'
 
 /** Why an absent run refuses, stated identically wherever that case is reported. */
 const UNEVALUATED_REASON =


### PR DESCRIPTION
# Which Linear task belongs to this PR?

EXSC-686 — F7 and F9 from the 2026-09-12 signing rehearsal.

**Base is `signing2-integration-0912`, not `main`, because neither defect exists on main**: the
`'Integrity'` section and the `storage-authority` check both arrive via `ba397aaea` on
`claude/exsc-storage-authority-row` and reach here through the integration merge.

# Why did I implement it this way?

## F7 — two adjacent sections both named for integrity

`renderCheckLedger` groups by the exact section string, so the signer saw:

```text
✓ proposal integrity    6/6 checks green · 6/6 network results verified
✓ Integrity             1/1 checks green · 1/1 network results verified
```

Renamed so neither contains "integrity", removing the collision at the root rather than
disambiguating two near-synonyms: `'proposal integrity'` → `'Proposal'` (gates A–F ask what the
proposal *is*), `'Integrity'` → `'Deployed state'` (G and K both compare the live chain against
what main declares). Pinned by a test that refuses any section name containing another, which
fires on the original pair.

## F9 — gate G blocked the honest control with a remedy no signer could follow

`LiFiDiamond.owner`'s expected value is sourced `from: 'deployments'` → anchor `A-MONGO` →
`REPORTING_ONLY_ANCHORS` → `coerceStatus` turns the *pass* into an `error` → a blocking row with
no acknowledgement path. Because the all-matched loop downgrades the row to the weakest anchor in
the set, **every** proposal touching `LiFiDiamond` hit it. The signer was told to "re-run this
check", which could never change the outcome.

`rpc-quorum` already solves the same "cannot decide" case via `checkClass: 'semantic'` +
`needs-ack`. **Flipping gate G to `semantic` was measured and rejected as a false green**: a
semantic `fail` routes to the acknowledgement path, so a genuine storage-authority swap — the
exact attack gate G exists to catch — would become a prompt the signer clicks past. That contrast
is now pinned by a test.

Instead, a per-definition opt-in (`undecidableIsAcknowledgeable`) narrowed to `needs-ack` on an
anchor that can only report, keeping `checkClass: 'integrity'`.

Two hardenings against the obvious version of this fix:

1. Gating on `REPORTING_ONLY_ANCHORS` is **wrong** — `A-UNRESOLVED` is a member, so that version
   would let an expectation of unknown provenance reach the acknowledgement path. Narrowed to
   `ACKNOWLEDGEABLE_REPORTING_ANCHORS = {A-MONGO, A-PROPOSAL}`.
2. The existing all-matched loop assigns `anchor` on each hit, so **calldata order** decided
   between `A-UNRESOLVED` and `A-MONGO`. An unresolved expectation sitting before a
   record-sourced one would have been acknowledgeable. The loop now resolves `A-UNRESOLVED`
   first; the test for that fails without the change.

`undecidableIsAcknowledgeable` is digested into `buildReviewAttestation`, for the same reason
`checkClass` is — so it cannot be added off the record.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] This pull request is as small as possible and only tackles one problem
- [x] I have added tests that cover the functionality / test the bug
- [ ] For new facets: n/a
- [x] I have updated any required documentation

# Checklist for reviewer (DO NOT DEPLOY and contracts BEFORE CHECKING THIS!!!)

- [x] Arbitrary calls to external contracts — none changed
- [x] Privileged calls / storage modifications — no contract code in this PR
- [x] Preliminary audit — n/a, TypeScript only

## Verification

16 tests fail before the change and pass after. Full `script/deploy/safe/`:
**2375 pass, 8 fail** — and those 8 are **pre-existing on `signing2-integration-0912`**
(measured independently at `ee737146a`: 2359 pass, 8 fail, the same 8). This PR neither fixes
nor breaks them. `tsc-files --noEmit`, `eslint`, `prettier --check` all clean.

The false-green battery asserts `hardBlocked === true` **and**
`requiresAcknowledgement.length === 0` for: live ≠ declared on `deployments`; live ≠ declared on
`globalConfig`; read failed / value undefined; no contract declares an authority; and an
`A-UNRESOLVED` expectation in two shapes. All pass.

## Known gap, deliberately not fixed here

Gate G is still graded only inside `recordSignedSet` — i.e. **after** the signature — so the
acknowledgement this PR adds arrives after the decision, and "Do Nothing" leaves the row missing.
That placement is also the single root cause of all 8 pre-existing failures. Moving the
observation into `proposalCheckResults` is ~5 points and requires deciding what gate G means when
there is nothing to observe, which widens "what may proceed" and wants an owner rather than a
side-effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
